### PR TITLE
Handle latest_stable_version == None case

### DIFF
--- a/scripts/update-nightly-build-version.py
+++ b/scripts/update-nightly-build-version.py
@@ -36,7 +36,7 @@ def main():
     if latest_dev_version is None and latest_stable_version is None:
         print("No versions found. Defaulting to 0.0.1.dev1.")
         dev_version = "0.0.1.dev1"
-    elif latest_dev_version is None or Version(latest_dev_version) < Version(latest_stable_version):
+    elif latest_dev_version is None or latest_stable_version is not None and Version(latest_dev_version) < Version(latest_stable_version):
         print("The latest stable version is newer than dev version or no dev version exists. Bumping dev version from stable version.")
         latest_stable_version_split = latest_stable_version.split(".")
         latest_stable_version_split[-1] = str(int(latest_stable_version_split[-1]) + 1)


### PR DESCRIPTION
This is a rare one time case. Handle it correctly.

Test plan: Run the script and verify that version is `0.0.1.dev2`

Fixes: #26 