### PR TITLE
CI: avoid manual work

### DIFF
--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -1,0 +1,35 @@
+name: Release
+
+on:
+  release:
+    types: [created]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag/Release to upload to'
+        required: true
+        type: string
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download liblbug artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: 'liblbug*'
+          path: artifacts
+          merge-multiple: true
+
+      - name: Download lbug_cli artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: 'lbug_cli*'
+          path: artifacts
+          merge-multiple: true
+
+      - name: Upload to Release
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: ${{ inputs.tag || github.ref_name }}
+          files: artifacts/**/*


### PR DESCRIPTION
This will upload CLI binaries and libraries for major platforms to the release page when the tree is tagged or when the workflow is manually run.