### PR TITLE
extension build fixes

### DIFF
--- a/.github/workflows/build-and-deploy-extension.yml
+++ b/.github/workflows/build-and-deploy-extension.yml
@@ -69,38 +69,31 @@ jobs:
           mkdir -p extension-artifacts/linux_amd64
           mkdir -p extension-artifacts/linux_arm64
           mkdir -p extension-artifacts/linux_x86
-          mkdir -p extension-artifacts/osx_amd64
           mkdir -p extension-artifacts/osx_arm64
           mkdir -p extension-artifacts/win_amd64
 
       - name: Download built artifacts for linux-x86_64
         uses: actions/download-artifact@v4
         with:
-          name: lbug-extensions_linux-x86_64
+          name: lbug-extensions-linux-x86_64
           path: extension-artifacts/linux_amd64
 
       - name: Download built artifacts for linux-aarch64
         uses: actions/download-artifact@v4
         with:
-          name: lbug-extensions_linux-aarch64
+          name: lbug-extensions-linux-aarch64
           path: extension-artifacts/linux_arm64
-
-      - name: Download built artifacts for osx-x86_64
-        uses: actions/download-artifact@v4
-        with:
-          name: lbug-extensions_osx-x86_64
-          path: extension-artifacts/osx_amd64
 
       - name: Download built artifacts for osx-aarch64
         uses: actions/download-artifact@v4
         with:
-          name: lbug-extensions_osx-arm64
+          name: lbug-extensions-osx-arm64
           path: extension-artifacts/osx_arm64
 
       - name: Download built artifacts for windows-x86_64
         uses: actions/download-artifact@v4
         with:
-          name: lbug-extensions_win-x86_64
+          name: lbug-extensions-win-x86_64
           path: extension-artifacts/win_amd64
 
       - name: Copy built artifacts


### PR DESCRIPTION
- remove mac x64 (not supported)
- use hyphens to match to extension name