### PR TITLE
Enable extension test cases

### DIFF
--- a/test/test_files/extension/extension.test
+++ b/test/test_files/extension/extension.test
@@ -16,7 +16,6 @@ Binder exception: The extension sqlitescanner is neither an official extension, 
 Binder exception: The extension /tmp/iceberg is neither an official extension, nor does the extension path: '/tmp/iceberg' exists.
 
 -CASE LoadNotInstalledExtension
--SKIP
 -SKIP_IN_MEM
 -SKIP_WASM
 -STATEMENT INSTALL HTTPFS;
@@ -29,7 +28,6 @@ Binder exception: Extension: httpfs is an official extension and has not been in
 You can install it by: install httpfs.
 
 -CASE UninstallExtensionError
--SKIP
 -SKIP_IN_MEM
 -SKIP_WASM
 -STATEMENT INSTALL fts;
@@ -50,7 +48,6 @@ Binder exception: The extension XXX is not an official extension.
 Only official extensions can be uninstalled.
 
 -CASE ForceInstallExtension
--SKIP
 -SKIP_IN_MEM
 -SKIP_WASM
 -STATEMENT INSTALL neo4j;


### PR DESCRIPTION
Remove -SKIP flags from LoadNotInstalledExtension, UninstallExtensionError, and ForceInstallExtension test cases

Fixes: #40 