### PR TITLE
Fix FTS index creation failing during import with multiple indexes

### DIFF
--- a/extension/fts/src/function/create_fts_index.cpp
+++ b/extension/fts/src/function/create_fts_index.cpp
@@ -105,8 +105,8 @@ static std::string createStopWordsTable([[maybe_unused]] const ClientContext& co
     case StopWordsSource::DEFAULT: {
         // Always generate CREATE TABLE IF NOT EXISTS and MERGE statements.
         // They are idempotent and safe to execute multiple times during import.
-        query +=
-            stringFormat("CREATE NODE TABLE IF NOT EXISTS `{}` (sw STRING, PRIMARY KEY(sw));", info.tableName);
+        query += stringFormat("CREATE NODE TABLE IF NOT EXISTS `{}` (sw STRING, PRIMARY KEY(sw));",
+            info.tableName);
         std::string stopWordList = "[";
         for (auto& stopWord : StopWords::getDefaultStopWords()) {
             stopWordList += stringFormat("\"{}\",", stopWord);

--- a/extension/fts/test/test_files/multi_index.test
+++ b/extension/fts/test/test_files/multi_index.test
@@ -40,4 +40,4 @@ Exported database successfully.
 ---- ok
 -STATEMENT IMPORT DATABASE "${LBUG_EXPORT_DB_DIRECTORY}/fts-db"
 ---- 1
-Imported database successfully.% 
+Imported database successfully.%


### PR DESCRIPTION
Make default stopwords table creation idempotent by adding IF NOT EXISTS to CREATE NODE TABLE and using MERGE instead of CREATE for stopword insertion. This prevents "already exists in catalog" errors when multiple FTS indexes using default stopwords are created during database import.

close: https://github.com/LadybugDB/ladybug/issues/71