### PR TITLE
shell: add Makefile targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@
 	benchmark example \
 	extension-test-build extension-test extension-json-test-build extension-json-test \
 	extension-debug extension-release \
-	shell-test \
+	shell shell-debug shell-test \
 	tidy tidy-analyzer clangd-diagnostics \
 	install \
 	clean-extension clean-python-api clean-java clean
@@ -292,6 +292,18 @@ extension-release:
 	$(call run-cmake-release, \
 		-DBUILD_EXTENSIONS="$(EXTENSION_LIST)" \
 		-DBUILD_LBUG=FALSE \
+	)
+
+shell:
+	BM_MALLOC=1 $(call run-cmake-release, \
+		-DBUILD_SHELL=TRUE \
+		-DEXTENSION_STATIC_LINK_LIST=duckdb \
+	)
+
+shell-debug:
+	BM_MALLOC=1 $(call run-cmake-debug, \
+		-DBUILD_SHELL=TRUE \
+		-DEXTENSION_STATIC_LINK_LIST=duckdb \
 	)
 
 shell-test:


### PR DESCRIPTION
`BM_MALLOC`: because the large virtual size causes problems on crash on WSL2, likely on other platforms too.

We want to statically link `duckdb` extension because of the planned usage of duckdb tables as node tables.