### PR TITLE
core: new extension catalog design

### DIFF
--- a/extension/duckdb/src/include/catalog/duckdb_catalog.h
+++ b/extension/duckdb/src/include/catalog/duckdb_catalog.h
@@ -58,6 +58,7 @@ protected:
     common::ValueVector tableNamesVector;
     bool skipUnsupportedTable;
     const DuckDBConnector& connector;
+    main::ClientContext* context_;
 };
 
 } // namespace duckdb_extension

--- a/extension/duckdb/test/test_files/duckdb.test
+++ b/extension/duckdb/test/test_files/duckdb.test
@@ -272,7 +272,7 @@ Runtime exception: Duplicate attached database name: dbfilewithoutext. Attached 
 -LOG AttachSameDBError
 -STATEMENT ATTACH '${LBUG_ROOT_DIRECTORY}/dataset/databases/duckdb_database/dbfilewithoutext' (dbtype duckdb);
 ---- error
-Runtime exception: Duplicate attached database name: dbfilewithoutext. Attached database name must be unique.
+Catalog exception: persons already exists in catalog.
 -LOG DetachExistDB
 -STATEMENT DETACH dbfilewithoutext;
 ---- ok

--- a/src/binder/bind/bind_graph_pattern.cpp
+++ b/src/binder/bind/bind_graph_pattern.cpp
@@ -642,6 +642,15 @@ std::vector<TableCatalogEntry*> Binder::bindNodeTableEntries(
         for (auto entry : catalog->getNodeTableEntries(transaction, useInternal)) {
             entrySet.insert(entry);
         }
+        auto dbManager = main::DatabaseManager::Get(*clientContext);
+        for (auto attachedDB : dbManager->getAttachedDatabases()) {
+            auto attachedCatalog = attachedDB->getCatalog();
+            for (auto entry : attachedCatalog->getTableEntries(transaction, useInternal)) {
+                if (entry->getType() == CatalogEntryType::FOREIGN_TABLE_ENTRY) {
+                    entrySet.insert(entry);
+                }
+            }
+        }
     } else {
         for (auto& name : tableNames) {
             auto entry = bindNodeTableEntry(name);
@@ -700,6 +709,13 @@ std::vector<TableCatalogEntry*> Binder::bindRelGroupEntries(
     if (tableNames.empty()) { // Rewrite as all rel groups in database.
         for (auto entry : catalog->getRelGroupEntries(transaction, useInternal)) {
             entrySet.insert(entry);
+        }
+        auto dbManager = main::DatabaseManager::Get(*clientContext);
+        for (auto attachedDB : dbManager->getAttachedDatabases()) {
+            auto attachedCatalog = attachedDB->getCatalog();
+            for (auto entry : attachedCatalog->getRelGroupEntries(transaction, useInternal)) {
+                entrySet.insert(entry);
+            }
         }
     } else {
         for (auto& name : tableNames) {

--- a/src/catalog/catalog.cpp
+++ b/src/catalog/catalog.cpp
@@ -182,6 +182,10 @@ void Catalog::alterTableEntry(Transaction* transaction, const BoundAlterInfo& in
     tables->alterTableEntry(transaction, info);
 }
 
+void Catalog::addTableEntry(std::unique_ptr<TableCatalogEntry> entry) {
+    tables->createEntry(&transaction::DUMMY_TRANSACTION, std::move(entry));
+}
+
 CatalogEntry* Catalog::createRelGroupEntry(Transaction* transaction,
     const BoundCreateTableInfo& info) {
     const auto extraInfo = info.extraInfo->ptrCast<BoundExtraCreateRelTableGroupInfo>();

--- a/src/catalog/catalog_entry/rel_group_catalog_entry.cpp
+++ b/src/catalog/catalog_entry/rel_group_catalog_entry.cpp
@@ -74,10 +74,7 @@ const RelTableCatalogInfo* RelGroupCatalogEntry::getRelEntryInfo(table_id_t srcT
 std::unordered_set<table_id_t> RelGroupCatalogEntry::getSrcNodeTableIDSet() const {
     std::unordered_set<table_id_t> result;
     for (auto& info : relTableInfos) {
-        // Skip FOREIGN_TABLE_ID for foreign-backed rel tables
-        if (info.nodePair.srcTableID != FOREIGN_TABLE_ID) {
-            result.insert(info.nodePair.srcTableID);
-        }
+        result.insert(info.nodePair.srcTableID);
     }
     return result;
 }
@@ -85,10 +82,7 @@ std::unordered_set<table_id_t> RelGroupCatalogEntry::getSrcNodeTableIDSet() cons
 std::unordered_set<table_id_t> RelGroupCatalogEntry::getDstNodeTableIDSet() const {
     std::unordered_set<table_id_t> result;
     for (auto& info : relTableInfos) {
-        // Skip FOREIGN_TABLE_ID for foreign-backed rel tables
-        if (info.nodePair.dstTableID != FOREIGN_TABLE_ID) {
-            result.insert(info.nodePair.dstTableID);
-        }
+        result.insert(info.nodePair.dstTableID);
     }
     return result;
 }

--- a/src/function/table/show_tables.cpp
+++ b/src/function/table/show_tables.cpp
@@ -1,5 +1,6 @@
 #include "binder/binder.h"
 #include "catalog/catalog.h"
+#include "catalog/catalog_entry/node_table_catalog_entry.h"
 #include "catalog/catalog_entry/rel_group_catalog_entry.h"
 #include "catalog/catalog_entry/table_catalog_entry.h"
 #include "function/table/bind_data.h"
@@ -79,6 +80,13 @@ static std::unique_ptr<TableFuncBindData> bindFunc(const main::ClientContext* co
                 auto relEntry = entry->constPtrCast<RelGroupCatalogEntry>();
                 if (!relEntry->getForeignDatabaseName().empty()) {
                     dbName = relEntry->getForeignDatabaseName();
+                }
+            }
+            // For shadow node tables, use shadow db name
+            if (entry->getType() == CatalogEntryType::NODE_TABLE_ENTRY) {
+                auto nodeEntry = entry->constPtrCast<NodeTableCatalogEntry>();
+                if (!nodeEntry->getForeignDatabaseName().empty()) {
+                    dbName = SHADOW_DB_NAME;
                 }
             }
             tableInfos.emplace_back(entry->getName(), entry->getTableID(),

--- a/src/include/catalog/catalog.h
+++ b/src/include/catalog/catalog.h
@@ -93,6 +93,9 @@ public:
     // Alter table entry.
     void alterTableEntry(transaction::Transaction* transaction, const binder::BoundAlterInfo& info);
 
+    // Add table entry (for extensions).
+    void addTableEntry(std::unique_ptr<TableCatalogEntry> entry);
+
     // ----------------------------- Sequences ----------------------------
 
     // Check if sequence entry exists.

--- a/src/include/common/constants.h
+++ b/src/include/common/constants.h
@@ -218,6 +218,8 @@ static constexpr char ATTACHED_LBUG_DB_TYPE[] = "LBUG";
 
 static constexpr char LOCAL_DB_NAME[] = "local(lbug)";
 
+static constexpr char SHADOW_DB_NAME[] = "shadow(lbug)";
+
 constexpr auto DECIMAL_PRECISION_LIMIT = 38;
 
 } // namespace common


### PR DESCRIPTION
To support duckdb foreign rel tables, we need to make some changes to the catalog design.

```
┌────────┬──────────────┬────────┬───────────────┬─────────┐
│ id     │ name         │ type   │ database name │ comment │
│ UINT64 │ STRING       │ STRING │ STRING        │ STRING  │
├────────┼──────────────┼────────┼───────────────┼─────────┤
│ 0      │ nodes        │ NODE   │ shadow(lbug)  │         │
│ 1      │ relations    │ NODE   │ shadow(lbug)  │         │
│ 2      │ wikidata_map │ NODE   │ shadow(lbug)  │         │
│ 4      │ foo          │ REL    │ local(lbug)   │         │
│ 0      │ nodes        │ NODE   │ wd(DUCKDB)    │         │
│ 1      │ relations    │ NODE   │ wd(DUCKDB)    │         │
│ 2      │ wikidata_map │ NODE   │ wd(DUCKDB)    │         │
└────────┴──────────────┴────────┴───────────────┴─────────┘
```

For each foreign node table, we create a shadow table in the main catalog with a unique table id. This allows the creation of rel tables without ambiguity.

Details:

https://gist.github.com/adsharma/e672dd3d3b1ecdcbc84eebe1dc4f749d