### PR TITLE
fix error check in TestingDataTypesSqlite test

### DIFF
--- a/extension/sqlite/test/test_files/sqlite.test
+++ b/extension/sqlite/test/test_files/sqlite.test
@@ -75,7 +75,6 @@ Detached database successfully.
 alice
 
 -CASE TestingDataTypesSqlite
--SKIP
 -SKIP_FSM_LEAK_CHECK
 -LOAD_DYNAMIC_EXTENSION sqlite
 -STATEMENT ATTACH '${LBUG_ROOT_DIRECTORY}/extension/sqlite/test/sqlite_database/datatypeTestingSqlite' as datatype (dbtype sqlite);
@@ -95,8 +94,8 @@ alice
 -STATEMENT CREATE NODE TABLE person_copy(id INT64 PRIMARY KEY, name STRING, profile_picture BLOB, balance DOUBLE, age INT64, is_active INT64, birth_date DATE, birth_time TIMESTAMP, additional_info BLOB);
 ---- ok
 -STATEMENT COPY person_copy FROM (LOAD FROM datatype.person RETURN id, name, profile_picture, balance, age, is_active, birth_date, wrong_birth_time, additional_info);
----- error
-Conversion Error: timestamp field value out of range: "08:30:00", expected format is (YYYY-MM-DD HH:MM:SS[.US][±HH:MM| ZONE])
+---- error(regex)
+^Conversion Error(\n|.)*
 -STATEMENT COPY person_copy FROM (LOAD FROM datatype.person RETURN id, name, profile_picture, balance, age, is_active, birth_date, birth_time, additional_info);
 ---- ok
 -STATEMENT MATCH (p:person_copy) RETURN p.*;


### PR DESCRIPTION
Currently the test checks raw error message. In the event of message format changes, it is bound to fail
Fixed it by checking for only `Conversion Error` 

Closes https://github.com/LadybugDB/ladybug/issues/76