### PR TITLE
Fix CI Build Issues

### DIFF
--- a/.github/workflows/python-wheel-workflow.yml
+++ b/.github/workflows/python-wheel-workflow.yml
@@ -64,13 +64,13 @@ jobs:
           - platform: arm64
             runner: macos-latest
             os: macos
-            deployment-target: '11.0'
+            deployment-target: '13.3'
 
           # Job 4: macOS x86_64 build
           - platform: x86_64
             runner: macos-15-intel
             os: macos
-            deployment-target: '10.15'
+            deployment-target: '13.3'
 
           # Job 5: Windows amd64 build
           - platform: amd64

--- a/src/main/plan_printer.cpp
+++ b/src/main/plan_printer.cpp
@@ -1,5 +1,6 @@
 #include "main/plan_printer.h"
 
+#include <algorithm>
 #include <sstream>
 
 #include "planner/operator/logical_plan.h"


### PR DESCRIPTION
1. [Windows Build Failing because algorithm header not included](https://github.com/LadybugDB/ladybug/actions/runs/21093339634/job/60667558765)
2. [MacOS Builds Failing because after using std:format the destination macOs 11.0 or 10.15 doesn't support it](https://github.com/LadybugDB/ladybug/actions/runs/21093339634/job/60667558784)


The error suggests 13.3 so bumping version

```
/Applications/Xcode_16.4.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c++/v1/__format/formatter_floating_point.h:74:30: error: 'to_chars' is unavailable: introduced in macOS 13.3 unknown
```