### PR TITLE
improve code format workflow

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -897,10 +897,6 @@ jobs:
 
   clang-format:
     runs-on: ubuntu-24.04
-    strategy:
-      fail-fast: false
-      matrix:
-        directory: ['src/', 'test/', 'tools/', 'extension/']
     steps:
       - uses: actions/checkout@v4
         with:
@@ -913,7 +909,7 @@ jobs:
           sudo apt-get install -y clang-format-18
           
       - name: Clang Format (${{ matrix.directory }})
-        run: python3 scripts/run-clang-format.py --clang-format-executable /usr/bin/clang-format-18 -r ${{ matrix.directory }}
+        run: python3 scripts/run-clang-format.py --clang-format-executable /usr/bin/clang-format-18 -r src/ test/ tools/ extension/
 
   python-format:
     runs-on: ubuntu-24.04


### PR DESCRIPTION
Changed the `code-format` workflow from `fix the format and push the changes` to `print the changes required`

Additionally:
- split code-format workflow into `clang-format`, `python-format` and `rust-format`
- removed redundant python-lint-check workflow

Closes https://github.com/LadybugDB/ladybug/issues/156