### PR TITLE
CI: fix build-wasm error

### DIFF
--- a/tools/wasm/build.mjs
+++ b/tools/wasm/build.mjs
@@ -11,7 +11,7 @@ const ES_BUILD_CONFIG = {
   entryPoints: ['./build/sync/index.js', './build/index.js', 'build/lbug_wasm_worker.js'],
   bundle: true,
   format: 'esm',
-  external: ['fs', 'path', 'ws', 'crypto', "worker_threads", "os", "util"],
+  external: ['fs', 'path', 'ws', 'crypto', "worker_threads", "os", "util", "node:fs", "node:path", "node:crypto", "node:os", "node:util", "node:ws", "node:worker_threads"],
   outdir: 'package',
   logLevel: 'info',
   define: {


### PR DESCRIPTION
The issue was that esbuild's external configuration only listed the traditional module names (fs, crypto, etc.) but some dependencies may use the modern node: prefixed versions (node:fs, node:crypto, etc.)