### PR TITLE
Add ROWID() for node and rel tables

### DIFF
--- a/src/binder/bind/bind_projection_clause.cpp
+++ b/src/binder/bind/bind_projection_clause.cpp
@@ -129,7 +129,8 @@ std::pair<expression_vector, std::vector<std::string>> Binder::bindProjectionLis
             } else {
                 auto expr = expressionBinder.bindExpression(*parsedExpr);
                 projectionExprs.push_back(expr);
-                aliases.push_back(parsedExpr->getAlias());
+                aliases.push_back(
+                    parsedExpr->hasAlias() ? parsedExpr->getAlias() : expr->getAlias());
             }
         } else {
             auto expr = expressionBinder.bindExpression(*parsedExpr);

--- a/src/function/function_collection.cpp
+++ b/src/function/function_collection.cpp
@@ -190,10 +190,10 @@ FunctionCollection* FunctionCollection::getFunctions() {
         SCALAR_FUNCTION(UnionExtractFunction),
 
         // Node/rel functions
-        SCALAR_FUNCTION(OffsetFunction), REWRITE_FUNCTION(IDFunction),
-        REWRITE_FUNCTION(StartNodeFunction), REWRITE_FUNCTION(EndNodeFunction),
-        REWRITE_FUNCTION(LabelFunction), REWRITE_FUNCTION_ALIAS(LabelsFunction),
-        REWRITE_FUNCTION(CostFunction),
+        SCALAR_FUNCTION(OffsetFunction), REWRITE_FUNCTION(RowIDFunction),
+        REWRITE_FUNCTION(IDFunction), REWRITE_FUNCTION(StartNodeFunction),
+        REWRITE_FUNCTION(EndNodeFunction), REWRITE_FUNCTION(LabelFunction),
+        REWRITE_FUNCTION_ALIAS(LabelsFunction), REWRITE_FUNCTION(CostFunction),
 
         // Path functions
         SCALAR_FUNCTION(NodesFunction), SCALAR_FUNCTION(RelsFunction),

--- a/src/function/pattern/CMakeLists.txt
+++ b/src/function/pattern/CMakeLists.txt
@@ -3,6 +3,7 @@ add_library(lbug_function_pattern
         cost_function.cpp
         id_function.cpp
         label_function.cpp
+        rowid_function.cpp
         start_end_node_function.cpp)
 
 set(ALL_OBJECT_FILES

--- a/src/function/pattern/rowid_function.cpp
+++ b/src/function/pattern/rowid_function.cpp
@@ -1,0 +1,43 @@
+#include "binder/expression/expression_util.h"
+#include "binder/expression/node_expression.h"
+#include "binder/expression/rel_expression.h"
+#include "binder/expression_binder.h"
+#include "function/rewrite_function.h"
+#include "function/schema/vector_node_rel_functions.h"
+#include "function/struct/vector_struct_functions.h"
+
+using namespace lbug::common;
+using namespace lbug::binder;
+
+namespace lbug {
+namespace function {
+
+static std::shared_ptr<binder::Expression> rewriteFunc(const RewriteFunctionBindInput& input) {
+    KU_ASSERT(input.arguments.size() == 1);
+    std::shared_ptr<Expression> idExpr;
+    auto param = input.arguments[0].get();
+    if (ExpressionUtil::isNodePattern(*param)) {
+        auto node = param->constPtrCast<NodeExpression>();
+        idExpr = node->getInternalID()->copy();
+    } else if (ExpressionUtil::isRelPattern(*param)) {
+        auto rel = param->constPtrCast<RelExpression>();
+        idExpr = rel->getPropertyExpression(InternalKeyword::ID)->copy();
+    } else {
+        auto extractKey = input.expressionBinder->createLiteralExpression(InternalKeyword::ID);
+        idExpr = input.expressionBinder->bindScalarFunctionExpression(
+            {input.arguments[0], extractKey}, StructExtractFunctions::name);
+    }
+    return input.expressionBinder->bindScalarFunctionExpression({idExpr}, OffsetFunction::name);
+}
+
+function_set RowIDFunction::getFunctionSet() {
+    function_set functionSet;
+    functionSet.push_back(std::make_unique<RewriteFunction>(name,
+        std::vector<LogicalTypeID>{LogicalTypeID::NODE}, rewriteFunc));
+    functionSet.push_back(std::make_unique<RewriteFunction>(name,
+        std::vector<LogicalTypeID>{LogicalTypeID::REL}, rewriteFunc));
+    return functionSet;
+}
+
+} // namespace function
+} // namespace lbug

--- a/src/include/function/schema/vector_node_rel_functions.h
+++ b/src/include/function/schema/vector_node_rel_functions.h
@@ -13,6 +13,12 @@ struct OffsetFunction {
     static function_set getFunctionSet();
 };
 
+struct RowIDFunction {
+    static constexpr const char* name = "ROWID";
+
+    static function_set getFunctionSet();
+};
+
 struct IDFunction {
     static constexpr const char* name = "ID";
 

--- a/test/test_files/function/rowid.test
+++ b/test/test_files/function/rowid.test
@@ -1,0 +1,59 @@
+-DATASET CSV tinysnb
+
+--
+
+-CASE FunctionRowID
+
+-LOG NodeRowIDTest1
+-STATEMENT MATCH (a:person) RETURN id(a), a.rowid
+---- 8
+0:0|0
+0:1|1
+0:2|2
+0:3|3
+0:4|4
+0:5|5
+0:6|6
+0:7|7
+
+-LOG NodeRowIDTest2
+-STATEMENT MATCH (a:person) WHERE rowid(a)=0 RETURN a.fName
+---- 1
+Alice
+
+-LOG NodeRowIDPseudoCol
+-STATEMENT MATCH (a:person) RETURN id(a), a.rowid
+---- 8
+0:0|0
+0:1|1
+0:2|2
+0:3|3
+0:4|4
+0:5|5
+0:6|6
+0:7|7
+
+-LOG RelRowIDTest1
+-STATEMENT MATCH (:person)-[e:studyAt]->(:organisation) RETURN id(e), rowid(e)
+---- 3
+5:0|0
+5:1|1
+5:2|2
+
+-LOG RelRowIDPseudoCol
+-STATEMENT MATCH (:person)-[e:studyAt]->(:organisation) RETURN id(e), e.rowid
+---- 3
+5:0|0
+5:1|1
+5:2|2
+
+-LOG SingleQueryNodeRelRowID
+-STATEMENT MATCH (n), ()-[e]->() WHERE rowid(n)=0 AND rowid(e)=0 RETURN count(*)
+---- 1
+15
+
+-LOG SingleStatementUnionForExport
+-STATEMENT MATCH (n) WHERE rowid(n)=0 RETURN 'node', count(*) UNION ALL MATCH ()-[r]->() WHERE rowid(r)=0 RETURN 'rel', count(*)
+---- 2
+node|3
+rel|5


### PR DESCRIPTION
These work similar to concepts in DuckDB.

```
bug> match (a: user)-[b: LivesIn]->(c) return a.rowid, b.rowid, c.rowid;
┌─────────┬─────────┬─────────┐
│ a.rowid │ b.rowid │ c.rowid │
│ INT64   │ INT64   │ INT64   │
├─────────┼─────────┼─────────┤
│ 0       │ 0       │ 0       │
│ 1       │ 1       │ 2       │
│ 2       │ 2       │ 2       │
│ 3       │ 3       │ 1       │
└─────────┴─────────┴─────────┘

lbug> match (a: user) return a.rowid;
┌─────────┐
│ a.rowid │
│ INT64   │
├─────────┤
│ 0       │
│ 1       │
│ 2       │
│ 3       │
└─────────┘
```