### PR TITLE
chore(ci): Node.js workflow (optional; may be declined)

### DIFF
--- a/.github/workflows/nodejs-workflow.yml
+++ b/.github/workflows/nodejs-workflow.yml
@@ -144,3 +144,40 @@ jobs:
         if: ${{ matrix.platform == 'darwin' }}
         working-directory: tools/nodejs_api/
         run: rm -rf package
+
+  # Push prebuilt/*.node to repo so pnpm add github:user/ladybug#path:tools/nodejs_api uses them without building.
+  # Runs only on manual workflow_dispatch to avoid push loops.
+  update-prebuilt:
+    if: github.event_name == 'workflow_dispatch'
+    needs: build-nodejs
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Download Node.js artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+          pattern: "*nodejs*"
+          merge-multiple: false
+
+      - name: Copy artifacts to prebuilt
+        run: |
+          mkdir -p tools/nodejs_api/prebuilt
+          for d in artifacts/*/; do
+            find "$d" -name "lbugjs-*.node" -exec cp {} tools/nodejs_api/prebuilt/ \;
+          done
+          ls -la tools/nodejs_api/prebuilt/
+
+      - name: Commit and push prebuilt
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add tools/nodejs_api/prebuilt/
+          git diff --staged --quiet && echo "No prebuilt changes" && exit 0
+          git commit -m "chore(nodejs): update prebuilt addons from CI [skip ci]"
+          git push


### PR DESCRIPTION
## Summary
- Add .github/workflows/nodejs-workflow.yml: Node job, timeouts, Windows full-clone, ignore-scripts for tarball, prebuilt build/push.

## Motivation
Run Node addon tests in CI; optional prebuilt publishing. **Upstream may prefer to manage CI themselves** — this PR can be declined; Node and core PRs do not depend on it. Package.json "files" fix for tarball/prebuilt is in the J6 PR (feat-nodejs-install-prebuilt), not in this workflow-only PR.

## Changes
- .github/workflows/nodejs-workflow.yml only.

## Testing
- [ ] Workflow runs on push (or trigger manually); make nodejs && cd tools/nodejs_api && npm test