### PR TITLE
fix(planner): use getNumGroups() in planCopyRelFrom

### DIFF
--- a/src/planner/plan/plan_copy.cpp
+++ b/src/planner/plan/plan_copy.cpp
@@ -96,7 +96,7 @@ LogicalPlan Planner::planCopyRelFrom(const BoundCopyFromInfo* info) {
         auto& querySource = info->source->constCast<BoundQueryScanSource>();
         plan = planQuery(*querySource.statement);
         auto schema = plan.getSchema();
-        if (schema->getGroupsPosInScope().size() == 1) {
+        if (schema->getNumGroups() <= 1) {
             break;
         }
         // Copy operator assumes all input are in the same data chunk. If this is not the case,


### PR DESCRIPTION
Got dropped because of merge conflicts in #185

The Accumulate check for COPY rel from query was incorrectly using getGroupsPosInScope().size() == 1 instead of getNumGroups() <= 1. LogicalPartitioner requires exactly one group (getNumGroups() == 1), but the old check only verified one group had projected expressions, missing cases where multiple groups existed with only one in scope.