### PR TITLE
Fix nullptr dereference when consuming mixed type json

### DIFF
--- a/src/common/types/value/nested.cpp
+++ b/src/common/types/value/nested.cpp
@@ -11,7 +11,7 @@ uint32_t NestedVal::getChildrenSize(const Value* val) {
 }
 
 Value* NestedVal::getChildVal(const Value* val, uint32_t idx) {
-    if (idx > val->childrenSize) {
+    if (idx >= val->childrenSize) {
         throw RuntimeException("NestedVal::getChildVal index out of bound.");
     }
     return val->children[idx].get();

--- a/src/common/vector/value_vector.cpp
+++ b/src/common/vector/value_vector.cpp
@@ -216,17 +216,27 @@ void ValueVector::copyFromValue(uint64_t pos, const Value& value) {
         auto dstDataVector = ListVector::getDataVector(this);
         for (auto i = 0u; i < numValues; ++i) {
             auto childVal = NestedVal::getChildVal(&value, i);
-            dstDataVector->setNull(listEntry->offset + i, childVal->isNull());
-            if (!childVal->isNull()) {
-                dstDataVector->copyFromValue(listEntry->offset + i,
-                    *NestedVal::getChildVal(&value, i));
+            if (childVal) {
+                dstDataVector->setNull(listEntry->offset + i, childVal->isNull());
+                if (!childVal->isNull()) {
+                    dstDataVector->copyFromValue(listEntry->offset + i, *childVal);
+                }
+            } else {
+                dstDataVector->setNull(listEntry->offset + i, true);
             }
         }
     } break;
     case PhysicalTypeID::STRUCT: {
         auto structFields = StructVector::getFieldVectors(this);
         for (auto i = 0u; i < structFields.size(); ++i) {
-            structFields[i]->copyFromValue(pos, *NestedVal::getChildVal(&value, i));
+            if (i < value.childrenSize) {
+                auto childVal = NestedVal::getChildVal(&value, i);
+                if (childVal) {
+                    structFields[i]->copyFromValue(pos, *childVal);
+                }
+            } else {
+                structFields[i]->setNull(pos, true);
+            }
         }
     } break;
     case PhysicalTypeID::INTERNAL_ID: {


### PR DESCRIPTION
Fixes: #233 

The issue was caused by:

1. Off-by-one error in getChildVal bounds check (> instead of >=)
2. Missing null checks when accessing nested child values

Changes:
- Fixed bounds check in nested.cpp to prevent out-of-bounds access
- Added defensive checks in copyFromValue for both LIST and STRUCT cases
- Missing children are now treated as null values instead of crashing