### PR TITLE
chore: move applySemiMask to columnar base

### DIFF
--- a/src/include/storage/table/columnar_node_table_base.h
+++ b/src/include/storage/table/columnar_node_table_base.h
@@ -5,6 +5,7 @@
 
 #include "catalog/catalog_entry/node_table_catalog_entry.h"
 #include "common/exception/runtime.h"
+#include "common/mask.h"
 #include "common/types/internal_id_util.h"
 #include "storage/table/node_table.h"
 
@@ -86,6 +87,13 @@ protected:
         std::string tableName = nodeTableCatalogEntry->getName();
         return prefix + "_nodes_" + tableName + suffix;
     }
+
+public:
+    // Apply semi-mask filter to selection vector
+    // startNodeOffset: starting node offset in the table for this scan batch
+    // numRowsToScan: number of rows being scanned
+    void applySemiMaskFilter(const TableScanState& state, common::row_idx_t startNodeOffset,
+        common::row_idx_t numRowsToScan, common::SelectionVector& selVector) const;
 };
 
 } // namespace storage

--- a/src/storage/table/columnar_node_table_base.cpp
+++ b/src/storage/table/columnar_node_table_base.cpp
@@ -1,5 +1,6 @@
 #include "storage/table/columnar_node_table_base.h"
 
+#include "common/data_chunk/sel_vector.h"
 #include "common/exception/runtime.h"
 #include "main/client_context.h"
 #include "transaction/transaction.h"
@@ -19,6 +20,35 @@ void ColumnarNodeTableBase::initializeScanCoordination(const Transaction* transa
 
 common::row_idx_t ColumnarNodeTableBase::getNumTotalRows(const Transaction* transaction) {
     return getTotalRowCount(transaction);
+}
+
+void ColumnarNodeTableBase::applySemiMaskFilter(const TableScanState& state,
+    row_idx_t startNodeOffset, row_idx_t numRowsToScan, SelectionVector& selVector) const {
+    if (!state.semiMask || !state.semiMask->isEnabled()) {
+        return;
+    }
+    const auto endNodeOffset = startNodeOffset + numRowsToScan;
+    const auto& arr = state.semiMask->range(startNodeOffset, endNodeOffset);
+    if (arr.empty()) {
+        selVector.setSelSize(0);
+    } else {
+        auto stat = selVector.getMutableBuffer();
+        uint64_t numSelectedValues = 0;
+        size_t i = 0, j = 0;
+        while (i < numRowsToScan && j < arr.size()) {
+            auto temp = arr[j] - startNodeOffset;
+            if (selVector[i] < temp) {
+                ++i;
+            } else if (selVector[i] > temp) {
+                ++j;
+            } else {
+                stat[numSelectedValues++] = temp;
+                ++i;
+                ++j;
+            }
+        }
+        selVector.setToFiltered(numSelectedValues);
+    }
 }
 
 } // namespace storage

--- a/src/storage/table/node_group.cpp
+++ b/src/storage/table/node_group.cpp
@@ -9,6 +9,7 @@
 #include "storage/table/chunked_node_group.h"
 #include "storage/table/column_chunk.h"
 #include "storage/table/column_chunk_scanner.h"
+#include "storage/table/columnar_node_table_base.h"
 #include "storage/table/csr_chunked_node_group.h"
 #include "storage/table/csr_node_group.h"
 #include "storage/table/lazy_segment_scanner.h"
@@ -183,35 +184,6 @@ void NodeGroup::initializeScanState(const Transaction*, const UniqLock& lock,
     initializeScanStateForChunkedGroup(state, firstChunkedGroup);
 }
 
-void applySemiMaskFilter(const TableScanState& state, row_idx_t numRowsToScan,
-    SelectionVector& selVector) {
-    auto& nodeGroupScanState = *state.nodeGroupScanState;
-    const auto startNodeOffset = nodeGroupScanState.nextRowToScan +
-                                 StorageUtils::getStartOffsetOfNodeGroup(state.nodeGroupIdx);
-    const auto endNodeOffset = startNodeOffset + numRowsToScan;
-    const auto& arr = state.semiMask->range(startNodeOffset, endNodeOffset);
-    if (arr.empty()) {
-        selVector.setSelSize(0);
-    } else {
-        auto stat = selVector.getMutableBuffer();
-        uint64_t numSelectedValues = 0;
-        size_t i = 0, j = 0;
-        while (i < numRowsToScan && j < arr.size()) {
-            auto temp = arr[j] - startNodeOffset;
-            if (selVector[i] < temp) {
-                ++i;
-            } else if (selVector[i] > temp) {
-                ++j;
-            } else {
-                stat[numSelectedValues++] = temp;
-                ++i;
-                ++j;
-            }
-        }
-        selVector.setToFiltered(numSelectedValues);
-    }
-}
-
 NodeGroupScanResult NodeGroup::scan(const Transaction* transaction, TableScanState& state) const {
     // TODO(Guodong): Move the locked part of figuring out the chunked group to initScan.
     const auto lock = chunkedGroups.lock();
@@ -238,7 +210,12 @@ NodeGroupScanResult NodeGroup::scan(const Transaction* transaction, TableScanSta
     bool enableSemiMask =
         state.source == TableScanSource::COMMITTED && state.semiMask && state.semiMask->isEnabled();
     if (enableSemiMask) {
-        applySemiMaskFilter(state, numRowsToScan, state.outState->getSelVectorUnsafe());
+        auto& nodeGroupScanState = *state.nodeGroupScanState;
+        const auto startNodeOffset = nodeGroupScanState.nextRowToScan +
+                                     StorageUtils::getStartOffsetOfNodeGroup(state.nodeGroupIdx);
+        static_cast<const ColumnarNodeTableBase*>(state.table)
+            ->applySemiMaskFilter(state, startNodeOffset, numRowsToScan,
+                state.outState->getSelVectorUnsafe());
         if (state.outState->getSelVector().getSelSize() == 0) {
             state.nodeGroupScanState->nextRowToScan += numRowsToScan;
             return NodeGroupScanResult{nodeGroupScanState.nextRowToScan, 0};
@@ -256,7 +233,11 @@ NodeGroupScanResult NodeGroup::scan(Transaction* transaction, TableScanState& st
     bool enableSemiMask =
         state.source == TableScanSource::COMMITTED && state.semiMask && state.semiMask->isEnabled();
     if (enableSemiMask) {
-        applySemiMaskFilter(state, numRowsToScan, state.outState->getSelVectorUnsafe());
+        const auto startNodeOffset =
+            startOffsetInGroup + StorageUtils::getStartOffsetOfNodeGroup(state.nodeGroupIdx);
+        static_cast<const ColumnarNodeTableBase*>(state.table)
+            ->applySemiMaskFilter(state, startNodeOffset, numRowsToScan,
+                state.outState->getSelVectorUnsafe());
         if (state.outState->getSelVector().getSelSize() == 0) {
             state.nodeGroupScanState->nextRowToScan += numRowsToScan;
             return NodeGroupScanResult{state.nodeGroupScanState->nextRowToScan, 0};


### PR DESCRIPTION
Where it could be reused by parquet and arrow subclasses