### PR TITLE
wasm: handle JSON types as strings

### DIFF
--- a/tools/wasm/src_cpp/main.cpp
+++ b/tools/wasm/src_cpp/main.cpp
@@ -215,6 +215,7 @@ val valueGetAsEmscriptenValue(const Value& value) {
     case LogicalTypeID::DOUBLE: {
         return val(value.getValue<double>());
     }
+    case LogicalTypeID::JSON:
     case LogicalTypeID::UUID:
     case LogicalTypeID::STRING: {
         return val(value.getValue<std::string>());


### PR DESCRIPTION
This should unbreak the wasm lbug shell