### PR TITLE
Unsigned difference expression compared to zero

### DIFF
--- a/src/common/checksum.cpp
+++ b/src/common/checksum.cpp
@@ -78,9 +78,9 @@ uint64_t checksum(uint8_t* buffer, size_t size) {
     for (i = 0; i < size / 8; i++) {
         result ^= checksum(ptr[i]);
     }
-    if (size - i * 8 > 0) {
+    if (size % 8 > 0) {
         // the remaining 0-7 bytes we hash using a string hash
-        result ^= checksumRemainder(buffer + i * 8, size - i * 8);
+        result ^= checksumRemainder(buffer + i * 8, size % 8);
     }
     return result;
 }


### PR DESCRIPTION
Potential fix for [https://github.com/LadybugDB/ladybug/security/code-scanning/72](https://github.com/LadybugDB/ladybug/security/code-scanning/72)

In general, to fix this type of problem you should avoid performing relational comparisons directly on the result of unsigned subtraction; instead, structure the logic so that no subtraction is needed, or cast to a wider signed type when you truly need a signed difference.

Here, the intention is to check whether there are leftover bytes after processing `size / 8` full 8‑byte blocks. This is exactly the remainder `size % 8`. The simplest and safest fix is to replace the condition `if (size - i * 8 > 0)` with `if (size % 8 > 0)`. Because after the `for` loop `i == size / 8` always holds, `i * 8` equals `size - size % 8`, so `size - i * 8` is identical to `size % 8`. Using `size % 8` directly removes the unsigned subtraction, expresses the intent clearly, and preserves behavior.

Concretely, in `src/common/checksum.cpp`, at the `if` starting on line 81, change the condition from `size - i * 8 > 0` to `size % 8 > 0`, and adjust the arguments to `checksumRemainder` to match: the pointer offset `buffer + i * 8` is equivalent to `buffer + size - size % 8`, and the length `size - i * 8` is equal to `size % 8`. No additional includes, methods, or type changes are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
