### PR TITLE
Unsigned difference expression compared to zero

### DIFF
--- a/tools/shell/linenoise.cpp
+++ b/tools/shell/linenoise.cpp
@@ -2417,9 +2417,10 @@ static void refreshMultiLine(struct linenoiseState* l) {
 
     /* Go up till we reach the expected positon. */
     // printf("rows - new_cursor_row %d\n", rows - new_cursor_row);
-    if (rows > new_cursor_row) {
-        lndebug("go-up %d", rows - new_cursor_row);
-        snprintf(seq, 64, "\x1b[%ldA", (long)(rows - new_cursor_row));
+    if (static_cast<int>(rows) > new_cursor_row) {
+        const int rows_to_go_up = static_cast<int>(rows) - new_cursor_row;
+        lndebug("go-up %d", rows_to_go_up);
+        snprintf(seq, 64, "\x1b[%dA", rows_to_go_up);
         append_buffer.abAppend(seq);
     }
 


### PR DESCRIPTION
Potential fix for [https://github.com/LadybugDB/ladybug/security/code-scanning/75](https://github.com/LadybugDB/ladybug/security/code-scanning/75)

In general, to fix this kind of problem you should avoid using the result of an unsigned subtraction in a relational comparison to zero. Either rewrite the condition to compare the original operands directly, or cast to a sufficiently wide signed type before doing the subtraction if a signed comparison is truly intended.

Here, the intention is to check whether there is a positive number of lines between `rows` and `new_cursor_row`, so the code can move the cursor up that many lines. The clearest and safest way is to compare `rows` and `new_cursor_row` directly. Replace `if (rows - new_cursor_row > 0)` with `if (rows > new_cursor_row)`, and use the difference `rows - new_cursor_row` only inside the `snprintf` call, cast to a signed type to avoid any format or sign issues. Assuming the `%ld` format specifier is correct (it prints a signed long), we should compute the argument as a `long`, e.g. `(long)(rows - new_cursor_row)`. This avoids relying on unsigned underflow in the condition and aligns the argument type with the format string.

The change is localized to the block around lines 2419–2422 in `tools/shell/linenoise.cpp`. No new methods, imports, or type definitions are needed; we only adjust the condition and the type of the argument passed to `snprintf`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
