### PR TITLE
Fix Node QueryResult child-result lifetime after parent close

### DIFF
--- a/tools/nodejs_api/src_cpp/include/node_query_result.h
+++ b/tools/nodejs_api/src_cpp/include/node_query_result.h
@@ -20,6 +20,8 @@ public:
     static Napi::Object Init(Napi::Env env, Napi::Object exports);
     explicit NodeQueryResult(const Napi::CallbackInfo& info);
     void SetQueryResult(QueryResult* queryResult, bool isOwned);
+    void SetOwnedQueryResult(std::unique_ptr<QueryResult> queryResult);
+    std::unique_ptr<QueryResult> DetachNextQueryResult();
     ~NodeQueryResult() override;
 
 private:
@@ -43,8 +45,8 @@ private:
 
 private:
     QueryResult* queryResult = nullptr;
+    std::unique_ptr<QueryResult> ownedQueryResult = nullptr;
     std::unique_ptr<std::vector<std::string>> columnNames = nullptr;
-    bool isOwned = false;
 };
 
 enum GetColumnMetadataType { DATA_TYPE, NAME };
@@ -147,12 +149,21 @@ public:
 
     void Execute() override {
         try {
-            auto nextResult = currQueryResult->queryResult->getNextQueryResult();
+            nextOwnedResult = currQueryResult->DetachNextQueryResult();
+            auto nextResult =
+                nextOwnedResult ? nextOwnedResult.get() : currQueryResult->queryResult->getNextQueryResult();
+            if (nextResult == nullptr) {
+                return;
+            }
             if (!nextResult->isSuccess()) {
                 SetError(nextResult->getErrorMessage());
                 return;
             }
-            nextQueryResult->SetQueryResult(nextResult, false);
+            if (nextOwnedResult) {
+                nextQueryResult->SetOwnedQueryResult(std::move(nextOwnedResult));
+            } else {
+                nextQueryResult->SetQueryResult(nextResult, false);
+            }
         } catch (const std::exception& exc) {
             SetError(std::string(exc.what()));
         }
@@ -165,6 +176,7 @@ public:
 private:
     NodeQueryResult* currQueryResult;
     NodeQueryResult* nextQueryResult;
+    std::unique_ptr<QueryResult> nextOwnedResult;
 };
 
 class NodeQueryResultGetQuerySummaryAsyncWorker : public Napi::AsyncWorker {

--- a/tools/nodejs_api/src_cpp/node_query_result.cpp
+++ b/tools/nodejs_api/src_cpp/node_query_result.cpp
@@ -38,9 +38,27 @@ NodeQueryResult::~NodeQueryResult() {
     this->Close();
 }
 
+void NodeQueryResult::SetOwnedQueryResult(std::unique_ptr<QueryResult> queryResult) {
+    Close();
+    ownedQueryResult = std::move(queryResult);
+    this->queryResult = ownedQueryResult.get();
+}
+
 void NodeQueryResult::SetQueryResult(QueryResult* queryResult, bool isOwned) {
+    Close();
+    if (isOwned) {
+        ownedQueryResult.reset(queryResult);
+        this->queryResult = ownedQueryResult.get();
+        return;
+    }
     this->queryResult = queryResult;
-    this->isOwned = isOwned;
+}
+
+std::unique_ptr<QueryResult> NodeQueryResult::DetachNextQueryResult() {
+    if (ownedQueryResult == nullptr) {
+        return nullptr;
+    }
+    return ownedQueryResult->moveNextResult();
 }
 
 void NodeQueryResult::ResetIterator(const Napi::CallbackInfo& info) {
@@ -90,13 +108,22 @@ Napi::Value NodeQueryResult::GetNextQueryResultSync(const Napi::CallbackInfo& in
     Napi::Env env = info.Env();
     Napi::HandleScope scope(env);
     try {
-        auto nextResult = this->queryResult->getNextQueryResult();
+        auto nextOwnedResult = DetachNextQueryResult();
+        auto nextResult =
+            nextOwnedResult ? nextOwnedResult.get() : this->queryResult->getNextQueryResult();
+        if (nextResult == nullptr) {
+            return env.Undefined();
+        }
         if (!nextResult->isSuccess()) {
             Napi::Error::New(env, nextResult->getErrorMessage()).ThrowAsJavaScriptException();
         }
         auto nodeQueryResult =
             Napi::ObjectWrap<NodeQueryResult>::Unwrap(info[0].As<Napi::Object>());
-        nodeQueryResult->SetQueryResult(nextResult, false);
+        if (nextOwnedResult) {
+            nodeQueryResult->SetOwnedQueryResult(std::move(nextOwnedResult));
+        } else {
+            nodeQueryResult->SetQueryResult(nextResult, false);
+        }
     } catch (const std::exception& exc) {
         Napi::Error::New(env, std::string(exc.what())).ThrowAsJavaScriptException();
     }
@@ -235,8 +262,7 @@ void NodeQueryResult::Close(const Napi::CallbackInfo& info) {
 }
 
 void NodeQueryResult::Close() {
-    if (this->isOwned) {
-        delete this->queryResult;
-        this->queryResult = nullptr;
-    }
+    columnNames.reset();
+    ownedQueryResult.reset();
+    queryResult = nullptr;
 }


### PR DESCRIPTION
## Description

Fixes #290.

This changes the Node.js addon `NodeQueryResult` wrapper so child results detached from a multi-statement result chain keep their own native ownership instead of borrowing a raw pointer into the parent-owned chain.

The reproduced crash was:

```js
const results = conn.querySync("RETURN 1 AS first; RETURN 2 AS second;");
const [parent, child] = Array.isArray(results) ? results : [results];
child.getNextSync();
parent.close();
child.resetIterator(); // before: SIGSEGV
```

With this patch applied locally, that case no longer crashes, and a 5-iteration fork-based stress loop also exits cleanly.

## Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation Update

## Checklist

- [ ] I have changed storage version if on disk format has changed.
- [ ] I have requested a review from a maintainer.
- [ ] I have updated the documentation (if needed).