### PR TITLE
fix: use nightly CI for macos

### DIFF
--- a/.github/workflows/precompiled-bin-workflow.yml
+++ b/.github/workflows/precompiled-bin-workflow.yml
@@ -135,7 +135,7 @@ jobs:
         run: |
           mv install/include/lbug.h .
           mv install/include/lbug.hpp .
-          mv install/lib*/liblbug.so .
+          cp -L install/lib*/liblbug.so .
           mv install/bin/lbug .
 
       - name: Collect artifacts (macOS)
@@ -143,7 +143,7 @@ jobs:
         run: |
           mv install/include/lbug.h .
           mv install/include/lbug.hpp .
-          mv install/lib/liblbug.dylib .
+          cp -L install/lib/liblbug.dylib .
           mv install/bin/lbug .
 
       - name: Verify binary information (macOS)


### PR DESCRIPTION
Before the commit, cmake --install would install liblbug.dylib as a real file. After adding VERSION/SOVERSION via set_target_properties, CMake now installs it as:
- liblbug.0.15.2.1.dylib (real file)
- liblbug.0.dylib (symlink)  
- liblbug.dylib (symlink → liblbug.0.dylib)
The workflow mv install/lib/liblbug.dylib . moves the symlink without its target, resulting in a broken symlink. The fix is to copy the versioned dylib and rename it, or copy the real file instead of the symlink.