### PR TITLE
ci: fix nightly extension builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -300,6 +300,7 @@ extension-release:
 	$(call run-cmake-release, \
 		-DBUILD_EXTENSIONS="$(EXTENSION_LIST)" \
 		-DBUILD_LBUG=FALSE \
+		-DBUILD_SHELL=FALSE \
 	)
 
 shell:


### PR DESCRIPTION
BUILD_LBUG=false and BUILD_SHELL=true causes errors.