### PR TITLE
fix: gate -lopfs.js behind pthreads to fix OPFS crash

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -248,20 +248,23 @@ if(${BUILD_WASM})
     else()
         add_link_options(-sWASMFS)
         add_link_options(-lwasmfs)
-        add_link_options(-lopfs.js)
         add_link_options(-sSINGLE_FILE=1)
         add_link_options(-sALLOW_MEMORY_GROWTH=1)
         add_link_options(-sMODULARIZE=1)
-        # Export the WasmFS OPFS backend factory and directory-creation helper so
-        # the JS wrapper can mount OPFS-backed directories at runtime.
-        # allocateUTF8 is needed to pass path strings across the JS/WASM boundary.
-        # Note: OPFS requires SharedArrayBuffer (cross-origin isolation) and
-        # pthreads; it is compiled into single-threaded builds for API
-        # completeness but will fail at runtime without multi-threading.
-        add_link_options(-sEXPORTED_RUNTIME_METHODS=FS,wasmMemory,allocateUTF8)
-        add_link_options("-sEXPORTED_FUNCTIONS=_free,_wasmfs_create_opfs_backend,_wasmfs_create_directory")
         add_link_options(-sEXPORT_NAME=lbug)
         add_link_options(-sMAXIMUM_MEMORY=4GB)
+        if(NOT __SINGLE_THREADED__)
+            # OPFS requires pthreads — the Emscripten OPFS JS backend
+            # (-lopfs.js) internally uses _emscripten_proxy_finish which is
+            # only defined when pthreads are enabled.  Linking -lopfs.js
+            # without -pthread causes wasmfsOPFSProxyFinish to compile as a
+            # no-op, leading to UNREACHABLE at opfs_backend.cpp:292.
+            add_link_options(-lopfs.js)
+            add_link_options(-sEXPORTED_RUNTIME_METHODS=FS,wasmMemory,allocateUTF8)
+            add_link_options("-sEXPORTED_FUNCTIONS=_free,_wasmfs_create_opfs_backend,_wasmfs_create_directory")
+        else()
+            add_link_options(-sEXPORTED_RUNTIME_METHODS=FS,wasmMemory)
+        endif()
     endif()
     set(__WASM__ TRUE)
     add_compile_options(-fexceptions)


### PR DESCRIPTION
## Summary

Fixes the OPFS `UNREACHABLE` crash at `opfs_backend.cpp:292` by ensuring `-lopfs.js` is only linked when pthreads are enabled.

- Move `-lopfs.js` and OPFS exported functions (`_wasmfs_create_opfs_backend`, `_wasmfs_create_directory`) inside the `NOT __SINGLE_THREADED__` guard
- Single-threaded browser builds still get WasmFS (in-memory) but no longer link the broken OPFS backend
- Multi-threaded browser builds get OPFS with correct pthread pairing

## Root cause

`-lopfs.js` is linked unconditionally in the browser WasmFS build (the `else()` branch), but `-pthread` is only added when `NOT __SINGLE_THREADED__`. The Emscripten OPFS JS backend internally calls `_emscripten_proxy_finish`, which is only defined with pthreads. Without it, `wasmfsOPFSProxyFinish` compiles as a no-op, so at runtime the OPFS backend reads `childType=0` and hits:

```
Unexpected child type
UNREACHABLE executed at opfs_backend.cpp:292
```

## What changes

**`CMakeLists.txt`** — In the `BUILD_WASM` / browser-WasmFS branch:

| Before | After |
|--------|-------|
| `-lopfs.js` linked unconditionally | `-lopfs.js` only linked when `NOT __SINGLE_THREADED__` |
| OPFS exports always present | OPFS exports only in multi-threaded build |
| `allocateUTF8` always exported | `allocateUTF8` only exported when OPFS is available |

The companion JS-side fixes (WasmFS C API usage, runtime detection, OPFS tests) are already merged in [ladybug-wasm](https://github.com/LadybugDB/ladybug-wasm) — see commits [`6305367`](https://github.com/LadybugDB/ladybug-wasm/commit/6305367) and [`c495097`](https://github.com/LadybugDB/ladybug-wasm/commit/c495097).

## Test plan

- [ ] Multi-threaded browser build (`SINGLE_THREADED=false`): verify OPFS mounts and persists data
- [ ] Single-threaded browser build (`SINGLE_THREADED=true`): verify build succeeds, `mountOpfs()` returns a clear error instead of crashing
- [ ] Node.js build (`WASM_NODEFS=true`): verify no regression (unaffected code path)
- [ ] WASM test build (`BUILD_TESTS=true`): verify no regression (NODERAWFS path)

Ref: https://github.com/LadybugDB/ladybug/discussions/305