### PR TITLE
Update NodeJS package name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ The database was formerly known as [Kuzu](https://github.com/kuzudb/kuzu).
 | Language | Installation                                                           |
 | -------- |------------------------------------------------------------------------|
 | Python   | `pip install ladybug`                                             |
-| NodeJS   | `npm install @ladybug/core`                                            |
+| NodeJS   | `npm install @ladybugdb/core`                                            |
 | Rust     | `cargo add lbug`                                                       |
 | Go       | `go get github.com/LadybugDB/go-ladybug`                                     |
 | Swift    | [lbug-swift](https://github.com/LadybugDB/swift-ladybug)                     |


### PR DESCRIPTION
I really am not sure why is the official docs giving a non-existent `npm` package name.

Kindly fix to avoid confusion as between the site, docs and Github, there is 3 different variations: `lbug`, `@ladybug/core` and `@ladybugdb/core`. It seems like `@ladybugdb/core` is the correct one so far: https://www.npmjs.com/package/@ladybugdb/core