### PR TITLE
Initialize ScanMultiRelTable state before first scan

### DIFF
--- a/src/include/processor/operator/scan/scan_multi_rel_tables.h
+++ b/src/include/processor/operator/scan/scan_multi_rel_tables.h
@@ -30,7 +30,7 @@ public:
     bool empty() const { return relInfos.empty(); }
 
     void resetState() {
-        currentTableIdx = 0;
+        currentTableIdx = common::INVALID_IDX;
         nextTableIdx = 0;
     }
 

--- a/src/processor/operator/scan/scan_multi_rel_tables.cpp
+++ b/src/processor/operator/scan/scan_multi_rel_tables.cpp
@@ -27,6 +27,17 @@ bool RelTableCollectionScanner::scan(main::ClientContext* context, RelTableScanS
     const std::vector<ValueVector*>& outVectors) {
     auto transaction = Transaction::Get(*context);
     while (true) {
+        if (currentTableIdx == common::INVALID_IDX) {
+            if (relInfos.empty()) {
+                return false;
+            }
+            currentTableIdx = 0;
+            nextTableIdx = 1;
+            auto& currentInfo = relInfos[currentTableIdx];
+            currentInfo.initScanState(scanState, outVectors, context);
+            currentInfo.table->initScanState(transaction, scanState,
+                true /* resetCachedBoundNodeSelVec */);
+        }
         auto& relInfo = relInfos[currentTableIdx];
         if (relInfo.table->scan(transaction, scanState)) {
             auto& selVector = scanState.outState->getSelVector();


### PR DESCRIPTION
Related: #378 

Initialize the first rel-table scan state when a multi-rel scanner starts scanning a new bound node. Without this, the operator could reuse stale scan state and direction from a previous table, causing incorrect relationship direction behavior in subquery edge-existence checks.