### PR TITLE
Preserve correlated rel scan orientation during join planning

### DIFF
--- a/src/include/planner/planner.h
+++ b/src/include/planner/planner.h
@@ -164,7 +164,7 @@ public:
     void planCorrelatedExpressionsScan(const QueryGraphPlanningInfo& info);
     void planNodeScan(uint32_t nodePos);
     void planNodeIDScan(uint32_t nodePos);
-    void planRelScan(uint32_t relPos);
+    void planRelScan(uint32_t relPos, const QueryGraphPlanningInfo& info);
     void appendExtend(std::shared_ptr<binder::NodeExpression> boundNode,
         std::shared_ptr<binder::NodeExpression> nbrNode, std::shared_ptr<binder::RelExpression> rel,
         common::ExtendDirection direction, const binder::expression_vector& properties,
@@ -347,6 +347,7 @@ private:
     PropertyExprCollection propertyExprCollection;
     CardinalityEstimator cardinalityEstimator;
     JoinOrderEnumeratorContext context;
+    const QueryGraphPlanningInfo* currentQueryGraphPlanningInfo = nullptr;
     std::vector<extension::PlannerExtension*> plannerExtensions;
 };
 

--- a/src/planner/plan/plan_join_order.cpp
+++ b/src/planner/plan/plan_join_order.cpp
@@ -125,6 +125,8 @@ LogicalPlan Planner::planQueryGraphCollection(const QueryGraphCollection& queryG
 
 LogicalPlan Planner::planQueryGraph(const QueryGraph& queryGraph,
     const QueryGraphPlanningInfo& info) {
+    auto prevPlanningInfo = currentQueryGraphPlanningInfo;
+    currentQueryGraphPlanningInfo = &info;
     context.init(&queryGraph, info.predicates);
     cardinalityEstimator.init(queryGraph);
     if (info.hint != nullptr) {
@@ -132,6 +134,7 @@ LogicalPlan Planner::planQueryGraph(const QueryGraph& queryGraph,
             JoinTreeConstructor(queryGraph, propertyExprCollection, info.predicates, info);
         auto joinTree = constructor.construct(info.hint);
         auto plan = JoinPlanSolver(this).solve(joinTree);
+        currentQueryGraphPlanningInfo = prevPlanningInfo;
         return plan.copy();
     }
     planBaseTableScans(info);
@@ -151,6 +154,7 @@ LogicalPlan Planner::planQueryGraph(const QueryGraph& queryGraph,
     if (queryGraph.isEmpty()) {
         appendEmptyResult(bestPlan);
     }
+    currentQueryGraphPlanningInfo = prevPlanningInfo;
     return bestPlan;
 }
 
@@ -219,7 +223,7 @@ void Planner::planBaseTableScans(const QueryGraphPlanningInfo& info) {
         UNREACHABLE_CODE;
     }
     for (auto relPos = 0u; relPos < queryGraph->getNumQueryRels(); ++relPos) {
-        planRelScan(relPos);
+        planRelScan(relPos, info);
     }
 }
 
@@ -298,12 +302,35 @@ static ExtendDirection getExtendDirection(const binder::RelExpression& relExpres
     }
 }
 
-void Planner::planRelScan(uint32_t relPos) {
+void Planner::planRelScan(uint32_t relPos, const QueryGraphPlanningInfo& info) {
     const auto rel = context.queryGraph->getQueryRel(relPos);
     auto newSubgraph = context.getEmptySubqueryGraph();
     newSubgraph.addQueryRel(relPos);
     const auto predicates = getNewlyMatchedExprs(context.getEmptySubqueryGraph(), newSubgraph,
         context.getWhereExpressions());
+
+    const auto srcNode = rel->getSrcNode();
+    const auto dstNode = rel->getDstNode();
+    const auto srcCorrelated = info.containsCorrExpr(*srcNode->getInternalID());
+    const auto dstCorrelated = info.containsCorrExpr(*dstNode->getInternalID());
+
+    // In correlated planning, prefer anchoring rel scan on the correlated endpoint if
+    // exactly one endpoint is correlated. This keeps the planner/binder contract (semantic
+    // correlation info) while avoiding syntax-driven special handling.
+    if (info.subqueryType != SubqueryPlanningType::NONE) {
+        if (srcCorrelated != dstCorrelated) {
+            auto boundNode = srcCorrelated ? srcNode : dstNode;
+            auto nbrNode = srcCorrelated ? dstNode : srcNode;
+            auto plan = LogicalPlan();
+            const auto extendDirection = getExtendDirection(*rel, *boundNode);
+            appendScanNodeTable(boundNode->getInternalID(), boundNode->getTableIDs(), {}, plan);
+            appendExtend(boundNode, nbrNode, rel, extendDirection, getProperties(*rel), plan);
+            appendFilters(predicates, plan);
+            context.addPlan(newSubgraph, std::move(plan));
+            return;
+        }
+    }
+
     for (const auto direction : rel->getExtendDirections()) {
         auto plan = LogicalPlan();
         auto [boundNode, nbrNode] = getBoundAndNbrNodes(*rel, direction);
@@ -549,6 +576,19 @@ bool Planner::tryPlanINLJoin(const SubqueryGraph& subgraph, const SubqueryGraph&
     auto nbrNode =
         boundNode->getUniqueName() == rel->getSrcNodeName() ? rel->getDstNode() : rel->getSrcNode();
     auto extendDirection = getExtendDirection(*rel, *boundNode);
+    if (currentQueryGraphPlanningInfo != nullptr &&
+        currentQueryGraphPlanningInfo->subqueryType != SubqueryPlanningType::NONE) {
+        const auto srcCorrelated =
+            currentQueryGraphPlanningInfo->containsCorrExpr(*rel->getSrcNode()->getInternalID());
+        const auto dstCorrelated =
+            currentQueryGraphPlanningInfo->containsCorrExpr(*rel->getDstNode()->getInternalID());
+        if (srcCorrelated != dstCorrelated) {
+            const auto expectedBoundNode = srcCorrelated ? rel->getSrcNode() : rel->getDstNode();
+            if (*boundNode != *expectedBoundNode) {
+                return false;
+            }
+        }
+    }
     if (extendDirection != common::ExtendDirection::BOTH &&
         !common::containsValue(rel->getExtendDirections(), extendDirection)) {
         return false;


### PR DESCRIPTION
Fixes: #378

Problematic query:

```
match (x:E { r: false })-[:RB]->(rq:R)-[:T]->(target:D)
where not exists { match ()-[]->(x) }
with x, collect({ hid: target.hid, rid: rq.id }) as ts

match (x)-[:PB]->(pf:D)
optional match (x)-[:RL]->(rl:D)
return x, ts, pf, rl;
```

There are two stages in this query pipeline. The first stage has `x` as the target (implies scan_dir=BWD) and the second stage has `x` as the source (implies scan_dir=FWD). However, due to improper scoping in the query planner, the latter overwrote the former and we scanned the storage with the wrong direction.

Fixed by implementing proper scoping during planning.