### PR TITLE
Infer JSON for ambiguous nested values

### DIFF
--- a/src/common/type_utils.cpp
+++ b/src/common/type_utils.cpp
@@ -75,6 +75,7 @@ std::string TypeUtils::entryToString(const LogicalType& dataType, const uint8_t*
     case LogicalTypeID::BLOB:
         return TypeUtils::toString(*reinterpret_cast<const blob_t*>(value));
     case LogicalTypeID::STRING:
+    case LogicalTypeID::JSON:
         return TypeUtils::toString(*reinterpret_cast<const string_t*>(value));
     case LogicalTypeID::INTERNAL_ID:
         return TypeUtils::toString(*reinterpret_cast<const internalID_t*>(value));

--- a/src/common/types/types.cpp
+++ b/src/common/types/types.cpp
@@ -265,6 +265,8 @@ std::string PhysicalTypeUtils::toString(PhysicalTypeID physicalType) {
         return "UINT128";
     case PhysicalTypeID::STRING:
         return "STRING";
+    case PhysicalTypeID::JSON:
+        return "JSON";
     case PhysicalTypeID::STRUCT:
         return "STRUCT";
     case PhysicalTypeID::LIST:
@@ -315,6 +317,8 @@ uint32_t PhysicalTypeUtils::getFixedTypeSize(PhysicalTypeID physicalType) {
         return sizeof(internalID_t);
     case PhysicalTypeID::UINT128:
         return sizeof(uint128_t);
+    case PhysicalTypeID::JSON:
+        return sizeof(string_t);
     case PhysicalTypeID::ALP_EXCEPTION_FLOAT:
         return storage::EncodeException<float>::sizeInBytes();
     case PhysicalTypeID::ALP_EXCEPTION_DOUBLE:
@@ -889,9 +893,11 @@ PhysicalTypeID LogicalType::getPhysicalType(LogicalTypeID typeID,
         return PhysicalTypeID::UINT128;
     }
     case LogicalTypeID::BLOB:
-    case LogicalTypeID::STRING:
-    case LogicalTypeID::JSON: {
+    case LogicalTypeID::STRING: {
         return PhysicalTypeID::STRING;
+    }
+    case LogicalTypeID::JSON: {
+        return PhysicalTypeID::JSON;
     }
     case LogicalTypeID::MAP:
     case LogicalTypeID::LIST: {
@@ -1086,7 +1092,8 @@ std::string LogicalTypeUtils::toString(const std::vector<LogicalTypeID>& dataTyp
 
 uint32_t LogicalTypeUtils::getRowLayoutSize(const LogicalType& type) {
     switch (type.getPhysicalType()) {
-    case PhysicalTypeID::STRING: {
+    case PhysicalTypeID::STRING:
+    case PhysicalTypeID::JSON: {
         return sizeof(string_t);
     }
     case PhysicalTypeID::ARRAY:

--- a/src/common/types/value/value.cpp
+++ b/src/common/types/value/value.cpp
@@ -56,6 +56,7 @@ bool Value::operator==(const Value& rhs) const {
     case PhysicalTypeID::UINT128:
         return val.uint128Val == rhs.val.uint128Val;
     case PhysicalTypeID::STRING:
+    case PhysicalTypeID::JSON:
         return strVal == rhs.strVal;
     case PhysicalTypeID::ARRAY:
     case PhysicalTypeID::LIST:
@@ -493,7 +494,8 @@ void Value::copyFromColLayout(const uint8_t* value, ValueVector* vector) {
     case PhysicalTypeID::INTERVAL: {
         val.intervalVal = *((interval_t*)value);
     } break;
-    case PhysicalTypeID::STRING: {
+    case PhysicalTypeID::STRING:
+    case PhysicalTypeID::JSON: {
         strVal = ((string_t*)value)->getAsString();
     } break;
     case PhysicalTypeID::ARRAY:
@@ -567,7 +569,8 @@ void Value::copyValueFrom(const Value& other) {
     case PhysicalTypeID::UINT128: {
         val.uint128Val = other.val.uint128Val;
     } break;
-    case PhysicalTypeID::STRING: {
+    case PhysicalTypeID::STRING:
+    case PhysicalTypeID::JSON: {
         strVal = other.strVal;
     } break;
     case PhysicalTypeID::ARRAY:
@@ -828,7 +831,8 @@ void Value::serialize(Serializer& serializer) const {
     case PhysicalTypeID::UINT128: {
         serializer.serializeValue(val.uint128Val);
     } break;
-    case PhysicalTypeID::STRING: {
+    case PhysicalTypeID::STRING:
+    case PhysicalTypeID::JSON: {
         serializer.serializeValue(strVal);
     } break;
     case PhysicalTypeID::ARRAY:
@@ -901,7 +905,8 @@ std::unique_ptr<Value> Value::deserialize(Deserializer& deserializer) {
     case PhysicalTypeID::UINT128: {
         deserializer.deserializeValue(val->val.uint128Val);
     } break;
-    case PhysicalTypeID::STRING: {
+    case PhysicalTypeID::STRING:
+    case PhysicalTypeID::JSON: {
         deserializer.deserializeValue(val->strVal);
     } break;
     case PhysicalTypeID::ARRAY:
@@ -1039,7 +1044,8 @@ uint64_t Value::computeHash() const {
     case PhysicalTypeID::UINT128: {
         function::Hash::operation(val.uint128Val, hashValue);
     } break;
-    case PhysicalTypeID::STRING: {
+    case PhysicalTypeID::STRING:
+    case PhysicalTypeID::JSON: {
         function::Hash::operation(strVal, hashValue);
     } break;
     case PhysicalTypeID::ARRAY:

--- a/src/common/vector/auxiliary_buffer.cpp
+++ b/src/common/vector/auxiliary_buffer.cpp
@@ -79,6 +79,7 @@ std::unique_ptr<AuxiliaryBuffer> AuxiliaryBufferFactory::getAuxiliaryBuffer(Logi
     storage::MemoryManager* memoryManager) {
     switch (type.getPhysicalType()) {
     case PhysicalTypeID::STRING:
+    case PhysicalTypeID::JSON:
         return std::make_unique<StringAuxiliaryBuffer>(memoryManager);
     case PhysicalTypeID::STRUCT:
         return std::make_unique<StructAuxiliaryBuffer>(type, memoryManager);

--- a/src/common/vector/value_vector.cpp
+++ b/src/common/vector/value_vector.cpp
@@ -98,7 +98,8 @@ void ValueVector::copyFromRowData(uint32_t pos, const uint8_t* rowData) {
     case PhysicalTypeID::LIST: {
         ListVector::copyFromRowData(this, pos, rowData);
     } break;
-    case PhysicalTypeID::STRING: {
+    case PhysicalTypeID::STRING:
+    case PhysicalTypeID::JSON: {
         StringVector::addString(this, pos, *(string_t*)rowData);
     } break;
     default: {
@@ -118,7 +119,8 @@ void ValueVector::copyToRowData(uint32_t pos, uint8_t* rowData,
     case PhysicalTypeID::LIST: {
         ListVector::copyToRowData(this, pos, rowData, rowOverflowBuffer);
     } break;
-    case PhysicalTypeID::STRING: {
+    case PhysicalTypeID::STRING:
+    case PhysicalTypeID::JSON: {
         StringVector::copyToRowData(this, pos, rowData, rowOverflowBuffer);
     } break;
     default: {
@@ -139,7 +141,8 @@ void ValueVector::copyFromVectorData(uint8_t* dstData, const ValueVector* srcVec
     case PhysicalTypeID::LIST: {
         ListVector::copyFromVectorData(this, dstData, srcVector, srcVectorData);
     } break;
-    case PhysicalTypeID::STRING: {
+    case PhysicalTypeID::STRING:
+    case PhysicalTypeID::JSON: {
         StringVector::addString(this, *(string_t*)dstData, *(string_t*)srcVectorData);
     } break;
     default: {
@@ -204,7 +207,8 @@ void ValueVector::copyFromValue(uint64_t pos, const Value& value) {
     case PhysicalTypeID::INTERVAL: {
         memcpy(dstValue, &value.val.intervalVal, numBytesPerValue);
     } break;
-    case PhysicalTypeID::STRING: {
+    case PhysicalTypeID::STRING:
+    case PhysicalTypeID::JSON: {
         StringVector::addString(this, *(string_t*)dstValue, value.strVal.data(),
             value.strVal.length());
     } break;
@@ -298,7 +302,8 @@ std::unique_ptr<Value> ValueVector::getAsValue(uint64_t pos) const {
     case PhysicalTypeID::INTERVAL: {
         value->val.intervalVal = getValue<interval_t>(pos);
     } break;
-    case PhysicalTypeID::STRING: {
+    case PhysicalTypeID::STRING:
+    case PhysicalTypeID::JSON: {
         value->strVal = getValue<string_t>(pos).getAsString();
     } break;
     case PhysicalTypeID::ARRAY:
@@ -338,7 +343,8 @@ std::unique_ptr<Value> ValueVector::getAsValue(uint64_t pos) const {
 
 void ValueVector::resetAuxiliaryBuffer() {
     switch (dataType.getPhysicalType()) {
-    case PhysicalTypeID::STRING: {
+    case PhysicalTypeID::STRING:
+    case PhysicalTypeID::JSON: {
         dynamic_cast_checked<StringAuxiliaryBuffer*>(auxiliaryBuffer.get())->resetOverflowBuffer();
         return;
     }
@@ -365,7 +371,8 @@ void ValueVector::resetAuxiliaryBuffer() {
 
 uint32_t ValueVector::getDataTypeSize(const LogicalType& type) {
     switch (type.getPhysicalType()) {
-    case PhysicalTypeID::STRING: {
+    case PhysicalTypeID::STRING:
+    case PhysicalTypeID::JSON: {
         return sizeof(string_t);
     }
     case PhysicalTypeID::STRUCT: {
@@ -476,7 +483,8 @@ void ValueVector::setNull(uint32_t pos, bool isNull) {
 }
 
 void StringVector::addString(ValueVector* vector, uint32_t vectorPos, string_t& srcStr) {
-    DASSERT(vector->dataType.getPhysicalType() == PhysicalTypeID::STRING);
+    DASSERT(vector->dataType.getPhysicalType() == PhysicalTypeID::STRING ||
+            vector->dataType.getPhysicalType() == PhysicalTypeID::JSON);
     auto stringBuffer = dynamic_cast_checked<StringAuxiliaryBuffer*>(vector->auxiliaryBuffer.get());
     auto& dstStr = vector->getValue<string_t>(vectorPos);
     if (string_t::isShortString(srcStr.len)) {
@@ -489,7 +497,8 @@ void StringVector::addString(ValueVector* vector, uint32_t vectorPos, string_t& 
 
 void StringVector::addString(ValueVector* vector, uint32_t vectorPos, const char* srcStr,
     uint64_t length) {
-    DASSERT(vector->dataType.getPhysicalType() == PhysicalTypeID::STRING);
+    DASSERT(vector->dataType.getPhysicalType() == PhysicalTypeID::STRING ||
+            vector->dataType.getPhysicalType() == PhysicalTypeID::JSON);
     auto stringBuffer = dynamic_cast_checked<StringAuxiliaryBuffer*>(vector->auxiliaryBuffer.get());
     auto& dstStr = vector->getValue<string_t>(vectorPos);
     if (string_t::isShortString(length)) {
@@ -505,7 +514,8 @@ void StringVector::addString(ValueVector* vector, uint32_t vectorPos, std::strin
 }
 
 string_t& StringVector::reserveString(ValueVector* vector, uint32_t vectorPos, uint64_t length) {
-    DASSERT(vector->dataType.getPhysicalType() == PhysicalTypeID::STRING);
+    DASSERT(vector->dataType.getPhysicalType() == PhysicalTypeID::STRING ||
+            vector->dataType.getPhysicalType() == PhysicalTypeID::JSON);
     auto stringBuffer = dynamic_cast_checked<StringAuxiliaryBuffer*>(vector->auxiliaryBuffer.get());
     auto& dstStr = vector->getValue<string_t>(vectorPos);
     dstStr.len = length;
@@ -516,7 +526,8 @@ string_t& StringVector::reserveString(ValueVector* vector, uint32_t vectorPos, u
 }
 
 void StringVector::reserveString(ValueVector* vector, string_t& dstStr, uint64_t length) {
-    DASSERT(vector->dataType.getPhysicalType() == PhysicalTypeID::STRING);
+    DASSERT(vector->dataType.getPhysicalType() == PhysicalTypeID::STRING ||
+            vector->dataType.getPhysicalType() == PhysicalTypeID::JSON);
     auto stringBuffer = dynamic_cast_checked<StringAuxiliaryBuffer*>(vector->auxiliaryBuffer.get());
     dstStr.len = length;
     if (!string_t::isShortString(length)) {
@@ -525,7 +536,8 @@ void StringVector::reserveString(ValueVector* vector, string_t& dstStr, uint64_t
 }
 
 void StringVector::addString(ValueVector* vector, string_t& dstStr, string_t& srcStr) {
-    DASSERT(vector->dataType.getPhysicalType() == PhysicalTypeID::STRING);
+    DASSERT(vector->dataType.getPhysicalType() == PhysicalTypeID::STRING ||
+            vector->dataType.getPhysicalType() == PhysicalTypeID::JSON);
     auto stringBuffer = dynamic_cast_checked<StringAuxiliaryBuffer*>(vector->auxiliaryBuffer.get());
     if (string_t::isShortString(srcStr.len)) {
         dstStr.setShortString(srcStr);
@@ -537,7 +549,8 @@ void StringVector::addString(ValueVector* vector, string_t& dstStr, string_t& sr
 
 void StringVector::addString(ValueVector* vector, string_t& dstStr, const char* srcStr,
     uint64_t length) {
-    DASSERT(vector->dataType.getPhysicalType() == PhysicalTypeID::STRING);
+    DASSERT(vector->dataType.getPhysicalType() == PhysicalTypeID::STRING ||
+            vector->dataType.getPhysicalType() == PhysicalTypeID::JSON);
     auto stringBuffer = dynamic_cast_checked<StringAuxiliaryBuffer*>(vector->auxiliaryBuffer.get());
     if (string_t::isShortString(length)) {
         dstStr.setShortString(srcStr, length);

--- a/src/function/built_in_function_utils.cpp
+++ b/src/function/built_in_function_utils.cpp
@@ -79,7 +79,7 @@ uint32_t BuiltInFunctionsUtils::getCastCost(LogicalTypeID inputTypeID, LogicalTy
         // anything can be cast to ANY type for (almost no) cost
         return 1;
     }
-    if (targetTypeID == LogicalTypeID::STRING) {
+    if (targetTypeID == LogicalTypeID::STRING || targetTypeID == LogicalTypeID::JSON) {
         return castFromString(inputTypeID);
     }
     switch (inputTypeID) {

--- a/src/function/cast_string_non_nested_functions.cpp
+++ b/src/function/cast_string_non_nested_functions.cpp
@@ -128,6 +128,9 @@ static LogicalType inferMapOrStruct(std::string_view str) {
             childValueType =
                 LogicalTypeUtils::combineTypes(childValueType, inferMinimalTypeFromString(value));
         }
+        if (childKeyType.containsAny() || childValueType.containsAny()) {
+            return LogicalType::JSON();
+        }
         return LogicalType::MAP(std::move(childKeyType), std::move(childValueType));
     } else if (isStruct) {
         std::vector<StructField> fields;
@@ -142,6 +145,11 @@ static LogicalType inferMapOrStruct(std::string_view str) {
             }
             auto fieldType = inferMinimalTypeFromString(split[1]);
             fields.emplace_back(std::string(fieldKey), std::move(fieldType));
+        }
+        for (const auto& field : fields) {
+            if (field.getType().containsAny()) {
+                return LogicalType::JSON();
+            }
         }
         return LogicalType::STRUCT(std::move(fields));
     } else {
@@ -258,6 +266,9 @@ LogicalType inferMinimalTypeFromString(std::string_view str) {
         auto childType = LogicalType::ANY();
         for (auto& ele : split) {
             childType = LogicalTypeUtils::combineTypes(childType, inferMinimalTypeFromString(ele));
+        }
+        if (childType.containsAny()) {
+            return LogicalType::JSON();
         }
         return LogicalType::LIST(std::move(childType));
     }

--- a/src/function/cast_string_non_nested_functions.cpp
+++ b/src/function/cast_string_non_nested_functions.cpp
@@ -128,9 +128,6 @@ static LogicalType inferMapOrStruct(std::string_view str) {
             childValueType =
                 LogicalTypeUtils::combineTypes(childValueType, inferMinimalTypeFromString(value));
         }
-        if (childKeyType.containsAny() || childValueType.containsAny()) {
-            return LogicalType::JSON();
-        }
         return LogicalType::MAP(std::move(childKeyType), std::move(childValueType));
     } else if (isStruct) {
         std::vector<StructField> fields;
@@ -145,11 +142,6 @@ static LogicalType inferMapOrStruct(std::string_view str) {
             }
             auto fieldType = inferMinimalTypeFromString(split[1]);
             fields.emplace_back(std::string(fieldKey), std::move(fieldType));
-        }
-        for (const auto& field : fields) {
-            if (field.getType().containsAny()) {
-                return LogicalType::JSON();
-            }
         }
         return LogicalType::STRUCT(std::move(fields));
     } else {
@@ -266,9 +258,6 @@ LogicalType inferMinimalTypeFromString(std::string_view str) {
         auto childType = LogicalType::ANY();
         for (auto& ele : split) {
             childType = LogicalTypeUtils::combineTypes(childType, inferMinimalTypeFromString(ele));
-        }
-        if (childType.containsAny()) {
-            return LogicalType::JSON();
         }
         return LogicalType::LIST(std::move(childType));
     }

--- a/src/function/comparison_functions.cpp
+++ b/src/function/comparison_functions.cpp
@@ -71,7 +71,8 @@ static void executeNestedOperation(uint8_t& result, ValueVector* leftVector,
         OP::operation(leftVector->getValue<float>(leftPos), rightVector->getValue<float>(rightPos),
             result, nullptr /* left */, nullptr /* right */);
     } break;
-    case PhysicalTypeID::STRING: {
+    case PhysicalTypeID::STRING:
+    case PhysicalTypeID::JSON: {
         OP::operation(leftVector->getValue<string_t>(leftPos),
             rightVector->getValue<string_t>(rightPos), result, nullptr /* left */,
             nullptr /* right */);

--- a/src/function/list/list_creation.cpp
+++ b/src/function/list/list_creation.cpp
@@ -59,6 +59,9 @@ static std::unique_ptr<FunctionBindData> bindFunc(const ScalarBindFuncInput& inp
             combinedType = LogicalType::INT64();
         }
     }
+    if (combinedType.containsAny()) {
+        combinedType = LogicalType::JSON();
+    }
     auto resultType = LogicalType::LIST(combinedType.copy());
     auto bindData = std::make_unique<FunctionBindData>(std::move(resultType));
     for (auto& _ : input.arguments) {

--- a/src/function/map/map_creation_function.cpp
+++ b/src/function/map/map_creation_function.cpp
@@ -9,9 +9,15 @@ namespace lbug {
 namespace function {
 
 static std::unique_ptr<FunctionBindData> bindFunc(const ScalarBindFuncInput& input) {
-    const auto& keyType = ListType::getChildType(input.arguments[0]->dataType);
-    const auto& valueType = ListType::getChildType(input.arguments[1]->dataType);
-    auto resultType = LogicalType::MAP(keyType.copy(), valueType.copy());
+    auto keyType = ListType::getChildType(input.arguments[0]->dataType).copy();
+    auto valueType = ListType::getChildType(input.arguments[1]->dataType).copy();
+    if (keyType.containsAny()) {
+        keyType = LogicalType::JSON();
+    }
+    if (valueType.containsAny()) {
+        valueType = LogicalType::JSON();
+    }
+    auto resultType = LogicalType::MAP(std::move(keyType), std::move(valueType));
     return FunctionBindData::getSimpleBindData(input.arguments, resultType);
 }
 

--- a/src/function/table/disk_size_info.cpp
+++ b/src/function/table/disk_size_info.cpp
@@ -55,7 +55,8 @@ static uint64_t countChunkDataPages(const ColumnChunkData& chunkData) {
             pages += countChunkDataPages(structChunk.getChild(i));
         }
     } break;
-    case PhysicalTypeID::STRING: {
+    case PhysicalTypeID::STRING:
+    case PhysicalTypeID::JSON: {
         auto& stringChunk = chunkData.cast<StringChunkData>();
         pages += countChunkDataPages(*stringChunk.getIndexColumnChunk());
         auto& dictionaryChunk = stringChunk.getDictionaryChunk();

--- a/src/function/table/storage_info.cpp
+++ b/src/function/table/storage_info.cpp
@@ -152,7 +152,8 @@ static void appendStorageInfoForChunkData(StorageInfoLocalState* localState, Dat
                 *structColumn.getChild(i), structChunk.getChild(i));
         }
     } break;
-    case PhysicalTypeID::STRING: {
+    case PhysicalTypeID::STRING:
+    case PhysicalTypeID::JSON: {
         auto& stringChunk = chunkData.cast<StringChunkData>();
         auto& dictionaryChunk = stringChunk.getDictionaryChunk();
         const auto& stringColumn = dynamic_cast_checked<const StringColumn&>(column);

--- a/src/include/common/type_utils.h
+++ b/src/include/common/type_utils.h
@@ -196,6 +196,7 @@ public:
         case LogicalTypeID::UINT128:
             return func(uint128_t());
         case LogicalTypeID::STRING:
+        case LogicalTypeID::JSON:
             return func(string_t());
         case LogicalTypeID::DATE:
             return func(date_t());
@@ -270,6 +271,7 @@ public:
         case PhysicalTypeID::UINT128:
             return func(uint128_t());
         case PhysicalTypeID::STRING:
+        case PhysicalTypeID::JSON:
             return func(string_t());
         case PhysicalTypeID::ARRAY:
         case PhysicalTypeID::LIST:

--- a/src/include/common/types/types.h
+++ b/src/include/common/types/types.h
@@ -253,6 +253,7 @@ enum class PhysicalTypeID : uint8_t {
 
     // Variable size types.
     STRING = 20,
+    JSON = 21,
     LIST = 22,
     ARRAY = 23,
     STRUCT = 24,

--- a/src/include/common/vector/value_vector.h
+++ b/src/include/common/vector/value_vector.h
@@ -155,7 +155,8 @@ private:
 class LBUG_API StringVector {
 public:
     static inline InMemOverflowBuffer* getInMemOverflowBuffer(ValueVector* vector) {
-        DASSERT(vector->dataType.getPhysicalType() == PhysicalTypeID::STRING);
+        DASSERT(vector->dataType.getPhysicalType() == PhysicalTypeID::STRING ||
+                vector->dataType.getPhysicalType() == PhysicalTypeID::JSON);
         return dynamic_cast_checked<StringAuxiliaryBuffer*>(vector->auxiliaryBuffer.get())
             ->getOverflowBuffer();
     }

--- a/src/include/function/comparison/vector_comparison_functions.h
+++ b/src/include/function/comparison/vector_comparison_functions.h
@@ -120,7 +120,8 @@ private:
         case common::PhysicalTypeID::BOOL: {
             func = BinaryComparisonExecFunction<uint8_t, uint8_t, uint8_t, FUNC>;
         } break;
-        case common::PhysicalTypeID::STRING: {
+        case common::PhysicalTypeID::STRING:
+        case common::PhysicalTypeID::JSON: {
             func = BinaryComparisonExecFunction<common::string_t, common::string_t, uint8_t, FUNC>;
         } break;
         case common::PhysicalTypeID::INTERNAL_ID: {
@@ -191,7 +192,8 @@ private:
         case common::PhysicalTypeID::BOOL: {
             func = BinaryComparisonSelectFunction<uint8_t, uint8_t, FUNC>;
         } break;
-        case common::PhysicalTypeID::STRING: {
+        case common::PhysicalTypeID::STRING:
+        case common::PhysicalTypeID::JSON: {
             func = BinaryComparisonSelectFunction<common::string_t, common::string_t, FUNC>;
         } break;
         case common::PhysicalTypeID::INTERNAL_ID: {

--- a/src/include/storage/table/string_chunk_data.h
+++ b/src/include/storage/table/string_chunk_data.h
@@ -19,7 +19,8 @@ public:
 
     StringChunkData(MemoryManager& mm, common::LogicalType dataType, uint64_t capacity,
         bool enableCompression, ResidencyState residencyState);
-    StringChunkData(MemoryManager& mm, bool enableCompression, const ColumnChunkMetadata& metadata);
+    StringChunkData(MemoryManager& mm, common::LogicalType dataType, bool enableCompression,
+        const ColumnChunkMetadata& metadata);
     void resetToEmpty() override;
 
     void append(common::ValueVector* vector, const common::SelectionView& selView) override;

--- a/src/processor/operator/order_by/order_by_key_encoder.cpp
+++ b/src/processor/operator/order_by/order_by_key_encoder.cpp
@@ -76,6 +76,7 @@ uint32_t OrderByKeyEncoder::getEncodingSize(const LogicalType& dataType) {
     // Add one more byte for null flag.
     switch (dataType.getPhysicalType()) {
     case PhysicalTypeID::STRING:
+    case PhysicalTypeID::JSON:
         // 1 byte for null flag + 1 byte to indicate long/short string + 12 bytes for string prefix
         return 2 + string_t::SHORT_STR_LENGTH;
     default:
@@ -251,7 +252,8 @@ void OrderByKeyEncoder::getEncodingFunction(PhysicalTypeID physicalType, encode_
         func = encodeTemplate<float>;
         return;
     }
-    case PhysicalTypeID::STRING: {
+    case PhysicalTypeID::STRING:
+    case PhysicalTypeID::JSON: {
         func = encodeTemplate<string_t>;
         return;
     }

--- a/src/processor/operator/order_by/sort_state.cpp
+++ b/src/processor/operator/order_by/sort_state.cpp
@@ -14,7 +14,8 @@ void SortSharedState::init(const OrderByDataInfo& orderByDataInfo) {
     auto encodedKeyBlockColOffset = 0ul;
     for (auto i = 0u; i < orderByDataInfo.keysPos.size(); ++i) {
         const auto& dataType = orderByDataInfo.keyTypes[i];
-        if (PhysicalTypeID::STRING == dataType.getPhysicalType()) {
+        if (PhysicalTypeID::STRING == dataType.getPhysicalType() ||
+            PhysicalTypeID::JSON == dataType.getPhysicalType()) {
             // If this is a string column, we need to find the factorizedTable offset for this
             // column.
             auto ftColIdx = orderByDataInfo.keyInPayloadPos[i];

--- a/src/storage/compression/compression.cpp
+++ b/src/storage/compression/compression.cpp
@@ -60,6 +60,7 @@ uint32_t getDataTypeSizeInChunk(const common::LogicalType& dataType) {
 uint32_t getDataTypeSizeInChunk(const common::PhysicalTypeID& dataType) {
     switch (dataType) {
     case PhysicalTypeID::STRING:
+    case PhysicalTypeID::JSON:
     case PhysicalTypeID::ARRAY:
     case PhysicalTypeID::LIST:
     case PhysicalTypeID::STRUCT: {
@@ -1115,6 +1116,7 @@ bool StorageValue::gt(const StorageValue& other, common::PhysicalTypeID type) co
     case common::PhysicalTypeID::ARRAY:
     case common::PhysicalTypeID::INTERNAL_ID:
     case common::PhysicalTypeID::STRING:
+    case common::PhysicalTypeID::JSON:
     case common::PhysicalTypeID::UINT64:
     case common::PhysicalTypeID::UINT32:
     case common::PhysicalTypeID::UINT16:

--- a/src/storage/index/hash_index.cpp
+++ b/src/storage/index/hash_index.cpp
@@ -515,7 +515,8 @@ PrimaryKeyIndex::PrimaryKeyIndex(IndexInfo indexInfo, std::unique_ptr<IndexStora
 void PrimaryKeyIndex::initOverflowAndSubIndices(bool inMemMode, MemoryManager& mm,
     PageAllocator& pageAllocator, PrimaryKeyIndexStorageInfo& storageInfo) {
     DASSERT(indexInfo.keyDataTypes.size() == 1);
-    if (indexInfo.keyDataTypes[0] == PhysicalTypeID::STRING) {
+    if (indexInfo.keyDataTypes[0] == PhysicalTypeID::STRING ||
+        indexInfo.keyDataTypes[0] == PhysicalTypeID::JSON) {
         if (inMemMode) {
             overflowFile = std::make_unique<InMemOverflowFile>(mm);
         } else {

--- a/src/storage/predicate/constant_predicate.cpp
+++ b/src/storage/predicate/constant_predicate.cpp
@@ -78,6 +78,7 @@ ZoneMapCheckResult ColumnConstantPredicate::checkZoneMap(
 std::string ColumnConstantPredicate::toString() {
     std::string valStr;
     if (value.getDataType().getPhysicalType() == PhysicalTypeID::STRING ||
+        value.getDataType().getPhysicalType() == PhysicalTypeID::JSON ||
         value.getDataType().getPhysicalType() == PhysicalTypeID::LIST ||
         value.getDataType().getPhysicalType() == PhysicalTypeID::ARRAY ||
         value.getDataType().getPhysicalType() == PhysicalTypeID::STRUCT ||

--- a/src/storage/storage_utils.cpp
+++ b/src/storage/storage_utils.cpp
@@ -67,7 +67,8 @@ std::string StorageUtils::expandPath(const main::ClientContext* context, const s
 
 uint32_t StorageUtils::getDataTypeSize(const LogicalType& type) {
     switch (type.getPhysicalType()) {
-    case PhysicalTypeID::STRING: {
+    case PhysicalTypeID::STRING:
+    case PhysicalTypeID::JSON: {
         return sizeof(string_t);
     }
     case PhysicalTypeID::ARRAY:

--- a/src/storage/table/column.cpp
+++ b/src/storage/table/column.cpp
@@ -150,7 +150,8 @@ std::unique_ptr<ColumnChunkData> Column::flushChunkData(const ColumnChunkData& c
     case PhysicalTypeID::STRUCT: {
         return StructColumn::flushChunkData(chunkData, pageAllocator);
     }
-    case PhysicalTypeID::STRING: {
+    case PhysicalTypeID::STRING:
+    case PhysicalTypeID::JSON: {
         return StringColumn::flushChunkData(chunkData, pageAllocator);
     }
     case PhysicalTypeID::ARRAY:
@@ -557,7 +558,8 @@ std::unique_ptr<Column> ColumnFactory::createColumn(std::string name, LogicalTyp
     case PhysicalTypeID::INTERNAL_ID: {
         return std::make_unique<InternalIDColumn>(name, dataFH, mm, shadowFile, enableCompression);
     }
-    case PhysicalTypeID::STRING: {
+    case PhysicalTypeID::STRING:
+    case PhysicalTypeID::JSON: {
         return std::make_unique<StringColumn>(name, std::move(dataType), dataFH, mm, shadowFile,
             enableCompression);
     }

--- a/src/storage/table/column_chunk_data.cpp
+++ b/src/storage/table/column_chunk_data.cpp
@@ -149,6 +149,7 @@ ColumnChunkData::flush_buffer_func_t ColumnChunkData::initializeFlushBufferFunct
         return uncompressedFlushBuffer;
     }
     case PhysicalTypeID::STRING:
+    case PhysicalTypeID::JSON:
     case PhysicalTypeID::INT64:
     case PhysicalTypeID::INT32:
     case PhysicalTypeID::INT16:
@@ -618,7 +619,8 @@ std::unique_ptr<ColumnChunkData> ColumnChunkData::deserialize(MemoryManager& mem
     case PhysicalTypeID::STRUCT: {
         StructChunkData::deserialize(deSer, *chunkData);
     } break;
-    case PhysicalTypeID::STRING: {
+    case PhysicalTypeID::STRING:
+    case PhysicalTypeID::JSON: {
         StringChunkData::deserialize(deSer, *chunkData);
     } break;
     case PhysicalTypeID::ARRAY:
@@ -921,7 +923,8 @@ std::unique_ptr<ColumnChunkData> ColumnChunkFactory::createColumnChunkData(Memor
         return std::make_unique<InternalIDChunkData>(mm, capacity, enableCompression,
             residencyState);
     }
-    case PhysicalTypeID::STRING: {
+    case PhysicalTypeID::STRING:
+    case PhysicalTypeID::JSON: {
         return std::make_unique<StringChunkData>(mm, std::move(dataType), capacity,
             enableCompression, residencyState);
     }
@@ -967,8 +970,10 @@ std::unique_ptr<ColumnChunkData> ColumnChunkFactory::createColumnChunkData(Memor
         // INTERNAL_ID should never have nulls.
         return std::make_unique<InternalIDChunkData>(mm, enableCompression, metadata);
     }
-    case PhysicalTypeID::STRING: {
-        return std::make_unique<StringChunkData>(mm, enableCompression, metadata);
+    case PhysicalTypeID::STRING:
+    case PhysicalTypeID::JSON: {
+        return std::make_unique<StringChunkData>(mm, std::move(dataType), enableCompression,
+            metadata);
     }
     case PhysicalTypeID::ARRAY:
     case PhysicalTypeID::LIST: {

--- a/src/storage/table/column_chunk_metadata.cpp
+++ b/src/storage/table/column_chunk_metadata.cpp
@@ -25,6 +25,7 @@ ColumnChunkMetadata GetCompressionMetadata::operator()(std::span<const uint8_t> 
         return booleanGetMetadata(numValues, min, max);
     }
     case PhysicalTypeID::STRING:
+    case PhysicalTypeID::JSON:
     case PhysicalTypeID::INT64:
     case PhysicalTypeID::INT32:
     case PhysicalTypeID::INT16:

--- a/src/storage/table/string_chunk_data.cpp
+++ b/src/storage/table/string_chunk_data.cpp
@@ -25,9 +25,9 @@ StringChunkData::StringChunkData(MemoryManager& mm, LogicalType dataType, uint64
           std::make_unique<DictionaryChunk>(mm, capacity, enableCompression, residencyState)},
       needFinalize{false} {}
 
-StringChunkData::StringChunkData(MemoryManager& mm, bool enableCompression,
+StringChunkData::StringChunkData(MemoryManager& mm, LogicalType dataType, bool enableCompression,
     const ColumnChunkMetadata& metadata)
-    : ColumnChunkData{mm, LogicalType::STRING(), enableCompression, metadata, true /*hasNullData*/},
+    : ColumnChunkData{mm, std::move(dataType), enableCompression, metadata, true /*hasNullData*/},
       dictionaryChunk{
           std::make_unique<DictionaryChunk>(mm, 0, enableCompression, ResidencyState::IN_MEMORY)},
       needFinalize{false} {
@@ -74,7 +74,8 @@ void StringChunkData::resetToEmpty() {
 void StringChunkData::append(ValueVector* vector, const SelectionView& selView) {
     selView.forEach([&](auto pos) {
         // index is stored in main chunk, data is stored in the data chunk
-        DASSERT(vector->dataType.getPhysicalType() == PhysicalTypeID::STRING);
+        DASSERT(vector->dataType.getPhysicalType() == PhysicalTypeID::STRING ||
+                vector->dataType.getPhysicalType() == PhysicalTypeID::JSON);
         // index is stored in main chunk, data is stored in the data chunk
         nullData->setNull(numValues, vector->isNull(pos));
         auto dstPos = numValues;
@@ -149,7 +150,8 @@ void StringChunkData::initializeScanState(SegmentState& state, const Column* col
 
 void StringChunkData::write(const ValueVector* vector, offset_t offsetInVector,
     offset_t offsetInChunk) {
-    DASSERT(vector->dataType.getPhysicalType() == PhysicalTypeID::STRING);
+    DASSERT(vector->dataType.getPhysicalType() == PhysicalTypeID::STRING ||
+            vector->dataType.getPhysicalType() == PhysicalTypeID::JSON);
     if (!needFinalize && offsetInChunk < numValues) [[unlikely]] {
         needFinalize = true;
     }
@@ -164,7 +166,8 @@ void StringChunkData::write(const ValueVector* vector, offset_t offsetInVector,
 }
 
 void StringChunkData::write(ColumnChunkData* chunk, ColumnChunkData* dstOffsets, RelMultiplicity) {
-    DASSERT(chunk->getDataType().getPhysicalType() == PhysicalTypeID::STRING &&
+    DASSERT((chunk->getDataType().getPhysicalType() == PhysicalTypeID::STRING ||
+                chunk->getDataType().getPhysicalType() == PhysicalTypeID::JSON) &&
             dstOffsets->getDataType().getPhysicalType() == PhysicalTypeID::INTERNAL_ID &&
             chunk->getNumValues() == dstOffsets->getNumValues());
     auto& stringChunk = chunk->cast<StringChunkData>();
@@ -186,7 +189,8 @@ void StringChunkData::write(ColumnChunkData* chunk, ColumnChunkData* dstOffsets,
 
 void StringChunkData::write(const ColumnChunkData* srcChunk, offset_t srcOffsetInChunk,
     offset_t dstOffsetInChunk, offset_t numValuesToCopy) {
-    DASSERT(srcChunk->getDataType().getPhysicalType() == PhysicalTypeID::STRING);
+    DASSERT(srcChunk->getDataType().getPhysicalType() == PhysicalTypeID::STRING ||
+            srcChunk->getDataType().getPhysicalType() == PhysicalTypeID::JSON);
     if ((dstOffsetInChunk + numValuesToCopy) >= numValues) {
         updateNumValues(dstOffsetInChunk + numValuesToCopy);
     }

--- a/src/storage/table/string_column.cpp
+++ b/src/storage/table/string_column.cpp
@@ -127,7 +127,8 @@ void StringColumn::scanSegment(const SegmentState& state, offset_t startOffsetIn
             offsetInResult);
     }
 
-    DASSERT(resultVector->dataType.getPhysicalType() == PhysicalTypeID::STRING);
+    DASSERT(resultVector->dataType.getPhysicalType() == PhysicalTypeID::STRING ||
+            resultVector->dataType.getPhysicalType() == PhysicalTypeID::JSON);
     if (!resultVector->state || resultVector->state->getSelVector().isUnfiltered()) {
         scanUnfiltered(state, startOffsetInChunk, numValuesToScan, resultVector, offsetInResult);
     } else {
@@ -139,7 +140,8 @@ void StringColumn::scanSegment(const SegmentState& state, ColumnChunkData* resul
     common::offset_t startOffsetInSegment, common::row_idx_t numValuesToScan) const {
     auto startOffsetInResult = resultChunk->getNumValues();
     Column::scanSegment(state, resultChunk, startOffsetInSegment, numValuesToScan);
-    DASSERT(resultChunk->getDataType().getPhysicalType() == PhysicalTypeID::STRING);
+    DASSERT(resultChunk->getDataType().getPhysicalType() == PhysicalTypeID::STRING ||
+            resultChunk->getDataType().getPhysicalType() == PhysicalTypeID::JSON);
 
     auto* stringResultChunk = dynamic_cast_checked<StringChunkData*>(resultChunk);
     // Revert change to numValues from Column::scanSegment (see note in list_column.cpp)


### PR DESCRIPTION
Fixes: #391 

Improve plumbing of `JSON` types through out the stack
Handle ambiguous types correctly as `LogicalTypeID::JSON` instead of `LogicalTypeID::ANY`
Add `PhysicalTypeID::JSON`