### PR TITLE
release: preserve SONAME/install_name symlinks in liblbug tarballs

### DIFF
--- a/.github/workflows/precompiled-bin-workflow.yml
+++ b/.github/workflows/precompiled-bin-workflow.yml
@@ -183,7 +183,10 @@ jobs:
         run: |
           cp install/include/lbug.h .
           cp install/include/lbug.hpp .
-          cp -L install/lib*/liblbug.so .
+          # Preserve the versioned SONAME symlink chain so that consumers
+          # linking against liblbug.so can resolve the SONAME (liblbug.so.0)
+          # at load time. See precompiled-bin-workflow.yml SONAME check below.
+          cp -P install/lib*/liblbug.so install/lib*/liblbug.so.* .
           cp -L install/lib*/liblbug.a .
           cp install/bin/lbug .
 
@@ -199,7 +202,10 @@ jobs:
         run: |
           cp install/include/lbug.h .
           cp install/include/lbug.hpp .
-          cp -L install/lib/liblbug.dylib .
+          # Preserve the versioned install_name symlink chain so that consumers
+          # linking against liblbug.dylib can resolve @rpath/liblbug.0.dylib
+          # at load time. See precompiled-bin-workflow.yml install_name check below.
+          cp -P install/lib/liblbug.dylib install/lib/liblbug.*.dylib .
           cp -L install/lib/liblbug.a .
           cp install/bin/lbug .
 
@@ -227,7 +233,10 @@ jobs:
       - name: Create tarballs (Linux compat)
         if: runner.os == 'Linux' && matrix.variant == 'compat'
         run: |
-          tar -czvf liblbug-linux-${{ matrix.arch }}.tar.gz lbug.h lbug.hpp liblbug.so
+          # liblbug.so, liblbug.so.0, liblbug.so.0.15.3: unversioned link-time
+          # name, SONAME, and real file. The latter two are symlinks preserved
+          # by tar so that DT_NEEDED resolution works at load time.
+          tar -czvf liblbug-linux-${{ matrix.arch }}.tar.gz lbug.h lbug.hpp liblbug.so liblbug.so.*
           tar -czvf liblbug-static-linux-${{ matrix.arch }}-compat.tar.gz lbug.h lbug.hpp liblbug.a
           tar -czvf lbug_cli-linux-${{ matrix.arch }}.tar.gz lbug
 
@@ -239,7 +248,11 @@ jobs:
       - name: Create tarballs (macOS)
         if: runner.os == 'macOS'
         run: |
-          tar -czvf liblbug-osx-${{ matrix.arch }}.tar.gz lbug.h lbug.hpp liblbug.dylib
+          # liblbug.dylib, liblbug.0.dylib, liblbug.0.15.3.dylib: unversioned
+          # link-time name, install_name, and real file. The latter two are
+          # symlinks preserved by tar so that LC_LOAD_DYLIB resolution works
+          # at load time.
+          tar -czvf liblbug-osx-${{ matrix.arch }}.tar.gz lbug.h lbug.hpp liblbug.dylib liblbug.*.dylib
           tar -czvf liblbug-static-osx-${{ matrix.arch }}.tar.gz lbug.h lbug.hpp liblbug.a
           tar -czvf lbug_cli-osx-${{ matrix.arch }}.tar.gz lbug
 
@@ -250,6 +263,41 @@ jobs:
           Compress-Archive -Path lbug.h, lbug.hpp, lbug_shared.dll, lbug_shared.lib -DestinationPath liblbug-windows-x86_64.zip
           Compress-Archive -Path lbug.h, lbug.hpp, lbug.lib -DestinationPath liblbug-static-windows-x86_64.zip
           Compress-Archive -Path lbug.exe -DestinationPath lbug_cli-windows-x86_64.zip
+
+      # ---- Verify shared-library tarball self-consistency ----
+      # Guards against the class of bug where the tarball's on-disk filenames
+      # don't match the SONAME / install_name embedded in the shared library.
+      # A consumer linking -llbug resolves the link-time name (liblbug.so /
+      # liblbug.dylib) and stamps the SONAME / install_name into its own
+      # binary; that stamped name is what the dynamic loader then looks up at
+      # runtime, so it has to be present in the tarball too.
+
+      - name: Verify tarball SONAME consistency (Linux compat)
+        if: runner.os == 'Linux' && matrix.variant == 'compat'
+        run: |
+          set -euo pipefail
+          tarball=liblbug-linux-${{ matrix.arch }}.tar.gz
+          soname=$(readelf -d liblbug.so | awk '/\(SONAME\)/ {gsub(/[][]/,"",$NF); print $NF}')
+          entries=$(tar -tzf "$tarball" | sort)
+          printf 'SONAME: %s\n%s entries:\n%s\n' "$soname" "$tarball" "$entries"
+          if ! grep -Fxq "$soname" <<<"$entries"; then
+            echo "::error::SONAME '$soname' is not present as an entry in $tarball"
+            exit 1
+          fi
+
+      - name: Verify tarball install_name consistency (macOS)
+        if: runner.os == 'macOS'
+        run: |
+          set -euo pipefail
+          tarball=liblbug-osx-${{ matrix.arch }}.tar.gz
+          install_name=$(otool -D liblbug.dylib | awk 'NR==2')
+          base=$(basename "$install_name")
+          entries=$(tar -tzf "$tarball" | sort)
+          printf 'install_name: %s\nbasename: %s\n%s entries:\n%s\n' "$install_name" "$base" "$tarball" "$entries"
+          if ! grep -Fxq "$base" <<<"$entries"; then
+            echo "::error::install_name '$install_name' (basename '$base') is not present as an entry in $tarball"
+            exit 1
+          fi
 
       # ---- Upload artifacts ----
 


### PR DESCRIPTION
## Summary

The liblbug shared-library release tarballs (`liblbug-linux-{x86_64,aarch64}.tar.gz`, `liblbug-osx-{x86_64,arm64}.tar.gz`) have inconsistent on-disk filenames vs the SONAME / install_name embedded in the library. A consumer that does the obvious thing — untar, link `-llbug`, run — succeeds at link time but fails at load time with

```
# macOS
dyld: Library not loaded: @rpath/liblbug.0.dylib

# Linux
error while loading shared libraries: liblbug.so.0: cannot open shared object file
```

Verified on v0.15.3; the same pattern is present on v0.15.2 and v0.15.1.

### Repro (macOS)

```bash
curl -sSL -o liblbug-osx-arm64.tar.gz \
  https://github.com/LadybugDB/ladybug/releases/download/v0.15.3/liblbug-osx-arm64.tar.gz
tar -xzf liblbug-osx-arm64.tar.gz
otool -D liblbug.dylib
# → liblbug.dylib:
#     @rpath/liblbug.0.dylib        ← advertised name
ls liblbug*
# → liblbug.dylib                    ← but this is the only .dylib present
```

### Repro (Linux)

```bash
readelf -d liblbug.so | grep SONAME
#  (SONAME) Library soname: [liblbug.so.0]     ← advertised name
ls liblbug*
# → liblbug.so                                   ← only entry present
```

### Root cause

`src/CMakeLists.txt:26-29` sets `VERSION`/`SOVERSION` on the `lbug_shared` target, which is semantically correct — CMake emits the standard three-name chain into the install tree:

```
liblbug.so     -> liblbug.so.0 -> liblbug.so.0.15.3    (SONAME=liblbug.so.0)
liblbug.dylib  -> liblbug.0.dylib -> liblbug.0.15.3.dylib   (install_name=@rpath/liblbug.0.dylib)
```

The bug lives in `.github/workflows/precompiled-bin-workflow.yml`: the "Collect artifacts" step uses `cp -L install/lib/liblbug.dylib .` (and the Linux analogue), which dereferences the symlink chain down to the real file — discarding the intermediate SONAME / install_name names. The archive ends up with only the unversioned name, but the library internally still refers to the versioned one.

### Fix

This PR takes **Option B** from the bug report (matching Homebrew/distro convention and what `make install` into `/usr/lib` produces): copy and archive the full symlink chain, so the unversioned link-time name, the versioned SONAME / install_name, and the real file are all present in the tarball.

- Replace `cp -L` with `cp -P` and enumerate both the unversioned name and the versioned glob.
- Expand the `tar` arguments to include `liblbug.so.*` / `liblbug.*.dylib` so symlinks survive into the tarball (`tar` preserves symlinks as symlinks by default).
- Add a new CI verification step that reads the `SONAME` (`readelf`) / `install_name` (`otool -D`) from the built library and asserts a tarball entry with that name exists, so any future regression is caught at build time rather than on a user's machine.

### Scope

- Shared builds only. Linux `perf` variant ships the static library only (unaffected).
- Static libraries have no SONAME / install_name (unaffected).
- Windows shared builds use PE with the DLL name directly, no SONAME indirection (unaffected).
- The `lbug` CLI links the static library, not the shared one (unaffected).

### After the fix, tarballs contain

**macOS (`liblbug-osx-<arch>.tar.gz`):**
```
lbug.h
lbug.hpp
liblbug.dylib           -> liblbug.0.dylib          (symlink, link-time name)
liblbug.0.dylib         -> liblbug.0.15.3.dylib     (symlink, matches install_name)
liblbug.0.15.3.dylib                                 (real file)
```

**Linux (`liblbug-linux-<arch>.tar.gz`):**
```
lbug.h
lbug.hpp
liblbug.so              -> liblbug.so.0             (symlink, link-time name)
liblbug.so.0            -> liblbug.so.0.15.3        (symlink, matches SONAME)
liblbug.so.0.15.3                                    (real file)
```

The new CI verification step reproduces the bug report's one-liner check and fails the workflow if the tarball doesn't contain an entry matching the library's advertised name.

## Test plan

- [ ] `Build Precompiled Binaries` workflow passes on this PR (Linux compat x86_64, Linux compat aarch64, macOS x86_64, macOS arm64).
- [ ] New `Verify tarball SONAME consistency (Linux compat)` steps succeed and print the SONAME + tarball listing.
- [ ] New `Verify tarball install_name consistency (macOS)` steps succeed and print the install_name + tarball listing.
- [ ] After a release using these artifacts, the bug-report reproducer:
  ```bash
  tar -xzf liblbug-osx-arm64.tar.gz
  clang probe.c -L. -llbug -Wl,-rpath,"$PWD" -o probe && ./probe; echo "exit=$?"
  ```
  exits 0 on both platforms.