### PR TITLE
More local rel table fixes for MVCC and read-your-writes

### DIFF
--- a/src/planner/operator/persistent/logical_insert.cpp
+++ b/src/planner/operator/persistent/logical_insert.cpp
@@ -1,6 +1,7 @@
 #include "planner/operator/persistent/logical_insert.h"
 
 #include "binder/expression/node_expression.h"
+#include "binder/expression/rel_expression.h"
 #include "common/cast.h"
 #include "planner/operator/factorization/flatten_resolver.h"
 
@@ -23,6 +24,9 @@ void LogicalInsert::computeFactorizedSchema() {
         if (info.tableType == TableType::NODE) {
             auto node = dynamic_cast_checked<NodeExpression*>(info.pattern.get());
             schema->insertToGroupAndScopeMayRepeat(node->getInternalID(), groupPos);
+        } else if (info.tableType == TableType::REL) {
+            auto rel = dynamic_cast_checked<RelExpression*>(info.pattern.get());
+            schema->insertToGroupAndScopeMayRepeat(rel->getInternalID(), groupPos);
         }
     }
 }
@@ -38,6 +42,9 @@ void LogicalInsert::computeFlatSchema() {
         if (info.tableType == TableType::NODE) {
             auto node = dynamic_cast_checked<NodeExpression*>(info.pattern.get());
             schema->insertToGroupAndScopeMayRepeat(node->getInternalID(), 0);
+        } else if (info.tableType == TableType::REL) {
+            auto rel = dynamic_cast_checked<RelExpression*>(info.pattern.get());
+            schema->insertToGroupAndScopeMayRepeat(rel->getInternalID(), 0);
         }
     }
 }

--- a/src/planner/operator/persistent/logical_merge.cpp
+++ b/src/planner/operator/persistent/logical_merge.cpp
@@ -1,6 +1,7 @@
 #include "planner/operator/persistent/logical_merge.h"
 
 #include "binder/expression/node_expression.h"
+#include "binder/expression/rel_expression.h"
 #include "common/cast.h"
 #include "planner/operator/factorization/flatten_resolver.h"
 
@@ -21,6 +22,14 @@ void LogicalMerge::computeFactorizedSchema() {
             schema->insertToGroupAndScope(node->getInternalID(), groupPos);
         }
     }
+    for (auto& info : insertRelInfos) {
+        auto rel = dynamic_cast_checked<RelExpression*>(info.pattern.get());
+        if (!schema->isExpressionInScope(*rel->getInternalID())) {
+            auto groupPos = schema->createGroup();
+            schema->setGroupAsSingleState(groupPos);
+            schema->insertToGroupAndScope(rel->getInternalID(), groupPos);
+        }
+    }
 }
 
 void LogicalMerge::computeFlatSchema() {
@@ -28,6 +37,10 @@ void LogicalMerge::computeFlatSchema() {
     for (auto& info : insertNodeInfos) {
         auto node = dynamic_cast_checked<NodeExpression*>(info.pattern.get());
         schema->insertToGroupAndScopeMayRepeat(node->getInternalID(), 0);
+    }
+    for (auto& info : insertRelInfos) {
+        auto rel = dynamic_cast_checked<RelExpression*>(info.pattern.get());
+        schema->insertToGroupAndScopeMayRepeat(rel->getInternalID(), 0);
     }
 }
 

--- a/src/storage/local_storage/local_rel_table.cpp
+++ b/src/storage/local_storage/local_rel_table.cpp
@@ -42,12 +42,11 @@ bool LocalRelTable::insert(Transaction*, TableInsertState& state) {
     DASSERT(relIDVector->dataType.getPhysicalType() == PhysicalTypeID::INTERNAL_ID);
     const auto numRowsToAppend = relIDVector->state->getSelVector().getSelSize();
 
-    const auto getPosToRead = [numRowsToAppend](const ValueVector& vector, uint64_t i) -> sel_t {
+    const auto getPosToRead = [](const ValueVector& vector, uint64_t i) -> sel_t {
         const auto& selVector = vector.state->getSelVector();
         if (vector.state->isFlat()) {
             return selVector[0];
         }
-        DASSERT(selVector.getSelSize() == numRowsToAppend);
         return selVector[i];
     };
 
@@ -246,7 +245,8 @@ bool LocalRelTable::scan(const Transaction* transaction, TableScanState& state) 
             localScanState.rowIdxVector->setValue<row_idx_t>(i,
                 localScanState.rowIndices[localScanState.nextRowToScan + i]);
         }
-        localScanState.rowIdxVector->state->getSelVectorUnsafe().setSelSize(numToScan);
+        localScanState.outState->setToUnflat();
+        localScanState.rowIdxVector->state->getSelVectorUnsafe().setToUnfiltered(numToScan);
         [[maybe_unused]] auto lookupRes =
             localNodeGroup->lookupMultiple(transaction, localScanState);
         localScanState.nextRowToScan += numToScan;

--- a/src/storage/table/rel_table.cpp
+++ b/src/storage/table/rel_table.cpp
@@ -51,6 +51,7 @@ void RelTableScanState::setToTable(const Transaction* transaction, Table* table_
     RelDataDirection direction_) {
     TableScanState::setToTable(transaction, table_, std::move(columnIDs_),
         std::move(columnPredicateSets_));
+    localTableScanState.reset();
     columns.resize(columnIDs.size());
     direction = direction_;
     for (size_t i = 0; i < columnIDs.size(); ++i) {


### PR DESCRIPTION
Fixes: #378 

- Failure to propagate the flat vs factorized schema during planning stage for rel tables
- Two localScanState management bugs.
  - reset on moving a different table
  - setToUnflat() when dealing with factorized tables