### PR TITLE
Add native Arrow CSR query result path

### DIFF
--- a/src/include/main/query_result/arrow_query_result.h
+++ b/src/include/main/query_result/arrow_query_result.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <optional>
+
 #include "main/query_result.h"
 #include "materialized_query_result.h"
 
@@ -10,7 +12,15 @@ class ArrowQueryResult : public QueryResult {
     static constexpr QueryResultType type_ = QueryResultType::ARROW;
 
 public:
+    struct CSRMetadata {
+        std::vector<int64_t> indptr;
+        std::vector<int64_t> indices;
+        std::vector<int64_t> edgeIDs;
+        bool hasEdgeIDs = false;
+    };
+
     ArrowQueryResult(std::vector<ArrowArray> arrays, int64_t chunkSize);
+    ArrowQueryResult(std::vector<ArrowArray> arrays, int64_t chunkSize, CSRMetadata csrMetadata);
     ArrowQueryResult(std::vector<std::string> columnNames,
         std::vector<common::LogicalType> columnTypes, processor::FactorizedTable& table,
         int64_t chunkSize);
@@ -29,6 +39,9 @@ public:
 
     std::unique_ptr<ArrowArray> getNextArrowChunk(int64_t chunkSize) override;
 
+    bool hasCSRMetadata() const { return csrMetadata.has_value(); }
+    const CSRMetadata& getCSRMetadata() const { return *csrMetadata; }
+
 private:
     ArrowArray getArray(processor::FactorizedTableIterator& iterator, int64_t chunkSize);
 
@@ -37,6 +50,7 @@ private:
     int64_t chunkSize_;
     uint64_t numTuples = 0;
     uint64_t cursor = 0;
+    std::optional<CSRMetadata> csrMetadata;
 };
 
 } // namespace main

--- a/src/include/processor/operator/arrow_result_collector.h
+++ b/src/include/processor/operator/arrow_result_collector.h
@@ -1,8 +1,10 @@
 #pragma once
 
 #include <mutex>
+#include <optional>
 
 #include "common/arrow/arrow.h"
+#include "main/query_result/arrow_query_result.h"
 #include "processor/operator/sink.h"
 #include "processor/result/flat_tuple.h"
 
@@ -12,11 +14,24 @@ namespace processor {
 class ArrowResultCollectorSharedState {
 public:
     std::vector<ArrowArray> arrays;
+    std::optional<main::ArrowQueryResult::CSRMetadata> csrMetadata;
 
-    void merge(const std::vector<ArrowArray>& localArrays);
+    void merge(const std::vector<ArrowArray>& localArrays,
+        const std::optional<main::ArrowQueryResult::CSRMetadata>& localCSRMetadata);
 
 private:
     std::mutex mutex;
+};
+
+struct CSRTrackingInfo {
+    common::idx_t srcRowIDColIdx = common::INVALID_IDX;
+    common::idx_t dstRowIDColIdx = common::INVALID_IDX;
+    common::idx_t relRowIDColIdx = common::INVALID_IDX;
+
+    bool enabled() const {
+        return srcRowIDColIdx != common::INVALID_IDX && dstRowIDColIdx != common::INVALID_IDX;
+    }
+    bool hasRelRowID() const { return relRowIDColIdx != common::INVALID_IDX; }
 };
 
 struct ArrowResultCollectorLocalState {
@@ -26,6 +41,10 @@ struct ArrowResultCollectorLocalState {
     std::vector<common::DataChunk*> chunks;
     std::vector<common::sel_t> chunkCursors;
     std::unique_ptr<FlatTuple> tuple;
+    std::optional<main::ArrowQueryResult::CSRMetadata> csrMetadata;
+    int64_t nextSourceRowID = 0;
+    int64_t currentSourceRowID = -1;
+    bool csrMetadataValid = true;
 
     // Advance cursor.
     bool advance();
@@ -39,17 +58,18 @@ struct ArrowResultCollectorInfo {
     int64_t chunkSize;
     std::vector<DataPos> payloadPositions;
     std::vector<common::LogicalType> columnTypes;
+    CSRTrackingInfo csrTrackingInfo;
 
     ArrowResultCollectorInfo(int64_t chunkSize, std::vector<DataPos> payloadPositions,
-        std::vector<common::LogicalType> columnTypes)
+        std::vector<common::LogicalType> columnTypes, CSRTrackingInfo csrTrackingInfo = {})
         : chunkSize{chunkSize}, payloadPositions{std::move(payloadPositions)},
-          columnTypes{std::move(columnTypes)} {}
+          columnTypes{std::move(columnTypes)}, csrTrackingInfo{csrTrackingInfo} {}
     EXPLICIT_COPY_DEFAULT_MOVE(ArrowResultCollectorInfo);
 
 private:
     ArrowResultCollectorInfo(const ArrowResultCollectorInfo& other)
         : chunkSize{other.chunkSize}, payloadPositions{other.payloadPositions},
-          columnTypes{copyVector(other.columnTypes)} {}
+          columnTypes{copyVector(other.columnTypes)}, csrTrackingInfo{other.csrTrackingInfo} {}
 };
 
 class ArrowResultCollector final : public Sink {

--- a/src/main/query_result/arrow_query_result.cpp
+++ b/src/main/query_result/arrow_query_result.cpp
@@ -19,6 +19,15 @@ ArrowQueryResult::ArrowQueryResult(std::vector<ArrowArray> arrays, int64_t chunk
     }
 }
 
+ArrowQueryResult::ArrowQueryResult(std::vector<ArrowArray> arrays, int64_t chunkSize,
+    CSRMetadata csrMetadata)
+    : QueryResult{type_}, arrays{std::move(arrays)}, chunkSize_{chunkSize},
+      csrMetadata{std::move(csrMetadata)} {
+    for (auto& array : this->arrays) {
+        numTuples += array.length;
+    }
+}
+
 ArrowQueryResult::ArrowQueryResult(std::vector<std::string> columnNames,
     std::vector<LogicalType> columnTypes, FactorizedTable& table, int64_t chunkSize)
     : QueryResult{type_, std::move(columnNames), std::move(columnTypes)}, chunkSize_{chunkSize} {

--- a/src/processor/map/create_arrow_result_collector.cpp
+++ b/src/processor/map/create_arrow_result_collector.cpp
@@ -1,3 +1,6 @@
+#include "binder/expression/property_expression.h"
+#include "binder/expression/scalar_function_expression.h"
+#include "function/schema/vector_node_rel_functions.h"
 #include "processor/operator/arrow_result_collector.h"
 #include "processor/plan_mapper.h"
 
@@ -5,6 +8,42 @@ using namespace lbug::common;
 
 namespace lbug {
 namespace processor {
+
+static bool isProjectedRowIDExpr(const binder::Expression& expr) {
+    if (expr.expressionType != ExpressionType::FUNCTION) {
+        return false;
+    }
+    const auto& scalarFunc = expr.constCast<binder::ScalarFunctionExpression>();
+    if (scalarFunc.getFunction().name != function::OffsetFunction::name ||
+        scalarFunc.getNumChildren() != 1) {
+        return false;
+    }
+    const auto child = scalarFunc.getChild(0);
+    if (child->expressionType != ExpressionType::PROPERTY) {
+        return false;
+    }
+    const auto& property = child->constCast<binder::PropertyExpression>();
+    return property.isInternalID();
+}
+
+static CSRTrackingInfo getCSRTrackingInfo(const binder::expression_vector& expressions) {
+    CSRTrackingInfo info;
+    std::vector<idx_t> rowIDExprPositions;
+    for (auto i = 0u; i < expressions.size(); ++i) {
+        if (isProjectedRowIDExpr(*expressions[i])) {
+            rowIDExprPositions.push_back(i);
+        }
+    }
+    if (rowIDExprPositions.size() == 2) {
+        info.srcRowIDColIdx = rowIDExprPositions[0];
+        info.dstRowIDColIdx = rowIDExprPositions[1];
+    } else if (rowIDExprPositions.size() == 3) {
+        info.srcRowIDColIdx = rowIDExprPositions[0];
+        info.relRowIDColIdx = rowIDExprPositions[1];
+        info.dstRowIDColIdx = rowIDExprPositions[2];
+    }
+    return info;
+}
 
 std::unique_ptr<PhysicalOperator> PlanMapper::createArrowResultCollector(
     ArrowResultConfig arrowConfig, const binder::expression_vector& expressions,
@@ -16,8 +55,8 @@ std::unique_ptr<PhysicalOperator> PlanMapper::createArrowResultCollector(
         columnTypes.push_back(expr->getDataType().copy());
     }
     auto sharedState = std::make_shared<ArrowResultCollectorSharedState>();
-    auto opInfo =
-        ArrowResultCollectorInfo(arrowConfig.chunkSize, columnDataPos, std::move(columnTypes));
+    auto opInfo = ArrowResultCollectorInfo(arrowConfig.chunkSize, columnDataPos,
+        std::move(columnTypes), getCSRTrackingInfo(expressions));
     auto printInfo = OPPrintInfo::EmptyInfo();
     auto op = std::make_unique<ArrowResultCollector>(sharedState, std::move(opInfo),
         std::move(prevOperator), getOperatorID(), std::move(printInfo));

--- a/src/processor/operator/arrow_result_collector.cpp
+++ b/src/processor/operator/arrow_result_collector.cpp
@@ -8,6 +8,51 @@ using namespace lbug::common;
 namespace lbug {
 namespace processor {
 
+static void updateCSRMetadata(const CSRTrackingInfo& info, FlatTuple& tuple,
+    ArrowResultCollectorLocalState& localState) {
+    if (!info.enabled() || !localState.csrMetadataValid) {
+        return;
+    }
+    const auto srcRowID = tuple.getValue(info.srcRowIDColIdx)->getValue<int64_t>();
+    const auto dstRowID = tuple.getValue(info.dstRowIDColIdx)->getValue<int64_t>();
+    if (!localState.csrMetadata.has_value()) {
+        main::ArrowQueryResult::CSRMetadata metadata;
+        metadata.indptr.push_back(0);
+        metadata.hasEdgeIDs = info.hasRelRowID();
+        localState.csrMetadata = std::move(metadata);
+    }
+    auto& metadata = *localState.csrMetadata;
+    if (srcRowID < 0 || dstRowID < 0) {
+        localState.csrMetadataValid = false;
+        localState.csrMetadata.reset();
+        return;
+    }
+    if (localState.currentSourceRowID == -1) {
+        while (localState.nextSourceRowID < srcRowID) {
+            metadata.indptr.push_back(static_cast<int64_t>(metadata.indices.size()));
+            localState.nextSourceRowID++;
+        }
+        localState.currentSourceRowID = srcRowID;
+    } else if (srcRowID != localState.currentSourceRowID) {
+        if (srcRowID < localState.currentSourceRowID) {
+            localState.csrMetadataValid = false;
+            localState.csrMetadata.reset();
+            return;
+        }
+        metadata.indptr.push_back(static_cast<int64_t>(metadata.indices.size()));
+        localState.nextSourceRowID = localState.currentSourceRowID + 1;
+        while (localState.nextSourceRowID < srcRowID) {
+            metadata.indptr.push_back(static_cast<int64_t>(metadata.indices.size()));
+            localState.nextSourceRowID++;
+        }
+        localState.currentSourceRowID = srcRowID;
+    }
+    metadata.indices.push_back(dstRowID);
+    if (info.hasRelRowID()) {
+        metadata.edgeIDs.push_back(tuple.getValue(info.relRowIDColIdx)->getValue<int64_t>());
+    }
+}
+
 bool ArrowResultCollectorLocalState::advance() {
     for (int64_t i = static_cast<int64_t>(chunks.size()) - 1; i >= 0; --i) {
         chunkCursors[i]++;
@@ -35,10 +80,19 @@ void ArrowResultCollectorLocalState::resetCursor() {
     }
 }
 
-void ArrowResultCollectorSharedState::merge(const std::vector<ArrowArray>& localArrays) {
+void ArrowResultCollectorSharedState::merge(const std::vector<ArrowArray>& localArrays,
+    const std::optional<main::ArrowQueryResult::CSRMetadata>& localCSRMetadata) {
     std::unique_lock lck{mutex};
     for (auto i = 0u; i < localArrays.size(); ++i) {
         arrays.push_back(localArrays[i]);
+    }
+    if (!csrMetadata.has_value() && localCSRMetadata.has_value()) {
+        csrMetadata = localCSRMetadata;
+    } else if (csrMetadata.has_value() && localCSRMetadata.has_value()) {
+        // Multiple local collectors can merge in nondeterministic order, which makes the source
+        // row grouping required for CSR invalid. Fall back to the non-CSR Arrow result in that
+        // case.
+        csrMetadata.reset();
     }
 }
 
@@ -60,12 +114,17 @@ void ArrowResultCollector::executeInternal(ExecutionContext* context) {
     if (rowBatch->size() > 0) {
         localState.arrays.push_back(rowBatch->toArray(info.columnTypes));
     }
-    sharedState->merge(localState.arrays);
+    if (localState.csrMetadata.has_value()) {
+        localState.csrMetadata->indptr.push_back(
+            static_cast<int64_t>(localState.csrMetadata->indices.size()));
+    }
+    sharedState->merge(localState.arrays, localState.csrMetadata);
 }
 
 bool ArrowResultCollector::fillRowBatch(ArrowRowBatch& rowBatch) {
     while (rowBatch.size() < info.chunkSize) {
         localState.fillTuple();
+        updateCSRMetadata(info.csrTrackingInfo, *localState.tuple, localState);
         rowBatch.append(*localState.tuple);
         if (!localState.advance()) {
             return false;
@@ -95,6 +154,10 @@ void ArrowResultCollector::initLocalStateInternal(ResultSet* resultSet, Executio
 }
 
 std::unique_ptr<main::QueryResult> ArrowResultCollector::getQueryResult() const {
+    if (sharedState->csrMetadata.has_value()) {
+        return std::make_unique<main::ArrowQueryResult>(std::move(sharedState->arrays),
+            info.chunkSize, std::move(*sharedState->csrMetadata));
+    }
     return std::make_unique<main::ArrowQueryResult>(std::move(sharedState->arrays), info.chunkSize);
 }
 

--- a/test/api/arrow_test.cpp
+++ b/test/api/arrow_test.cpp
@@ -1,7 +1,9 @@
 #include "api_test/api_test.h"
 #include "common/exception/runtime.h"
+#include "main/query_result/arrow_query_result.h"
 
 using namespace lbug::common;
+using namespace lbug::main;
 using namespace lbug::testing;
 
 class ArrowTest : public ApiTest {};
@@ -77,4 +79,75 @@ TEST_F(ArrowTest, getArrowSchema) {
     ASSERT_EQ(schema->n_children, 1);
     ASSERT_EQ(std::string(schema->children[0]->name), "NAME");
     schema->release(schema.get());
+}
+
+TEST_F(ArrowTest, queryAsArrowTracksCSRMetadataWithoutRelIDs) {
+    auto query =
+        "MATCH (a:person)-[:knows]->(b:person) RETURN a.rowid, b.rowid ORDER BY a.rowid, b.rowid";
+    auto rowResult = conn->query(query);
+    std::vector<std::pair<int64_t, int64_t>> expected;
+    while (rowResult->hasNext()) {
+        auto tuple = rowResult->getNext();
+        expected.emplace_back(tuple->getValue(0)->getValue<int64_t>(),
+            tuple->getValue(1)->getValue<int64_t>());
+    }
+
+    auto result = conn->queryAsArrow(query, 8);
+    auto* arrowResult = dynamic_cast<ArrowQueryResult*>(result.get());
+    ASSERT_NE(arrowResult, nullptr);
+    ASSERT_TRUE(arrowResult->hasCSRMetadata());
+
+    const auto& metadata = arrowResult->getCSRMetadata();
+    ASSERT_FALSE(metadata.hasEdgeIDs);
+    ASSERT_TRUE(metadata.edgeIDs.empty());
+
+    std::vector<std::pair<int64_t, int64_t>> reconstructed;
+    ASSERT_GE(metadata.indptr.size(), 1);
+    for (auto srcRowID = 0u; srcRowID + 1 < metadata.indptr.size(); ++srcRowID) {
+        for (auto idx = metadata.indptr[srcRowID]; idx < metadata.indptr[srcRowID + 1]; ++idx) {
+            reconstructed.emplace_back(static_cast<int64_t>(srcRowID), metadata.indices[idx]);
+        }
+    }
+    ASSERT_EQ(reconstructed, expected);
+}
+
+TEST_F(ArrowTest, queryAsArrowTracksCSRMetadataWithRelIDsAndExtraColumns) {
+    auto query = "MATCH (a:person)-[e:knows]->(b:person) "
+                 "RETURN a.rowid, e.rowid, b.rowid, e.date, b.fName "
+                 "ORDER BY a.rowid, e.rowid, b.rowid";
+    auto rowResult = conn->query(query);
+    std::vector<std::tuple<int64_t, int64_t, int64_t>> expected;
+    while (rowResult->hasNext()) {
+        auto tuple = rowResult->getNext();
+        expected.emplace_back(tuple->getValue(0)->getValue<int64_t>(),
+            tuple->getValue(1)->getValue<int64_t>(), tuple->getValue(2)->getValue<int64_t>());
+    }
+
+    auto result = conn->queryAsArrow(query, 8);
+    auto* arrowResult = dynamic_cast<ArrowQueryResult*>(result.get());
+    ASSERT_NE(arrowResult, nullptr);
+    ASSERT_TRUE(arrowResult->hasCSRMetadata());
+    ASSERT_EQ(result->getColumnNames().size(), 5);
+
+    const auto& metadata = arrowResult->getCSRMetadata();
+    ASSERT_TRUE(metadata.hasEdgeIDs);
+    ASSERT_EQ(metadata.indices.size(), metadata.edgeIDs.size());
+
+    std::vector<std::tuple<int64_t, int64_t, int64_t>> reconstructed;
+    ASSERT_GE(metadata.indptr.size(), 1);
+    for (auto srcRowID = 0u; srcRowID + 1 < metadata.indptr.size(); ++srcRowID) {
+        for (auto idx = metadata.indptr[srcRowID]; idx < metadata.indptr[srcRowID + 1]; ++idx) {
+            reconstructed.emplace_back(static_cast<int64_t>(srcRowID), metadata.edgeIDs[idx],
+                metadata.indices[idx]);
+        }
+    }
+    ASSERT_EQ(reconstructed, expected);
+}
+
+TEST_F(ArrowTest, queryAsArrowDoesNotTrackCSRMetadataForNonCSRShape) {
+    auto query = "MATCH (a:person)-[e:knows]->(b:person) RETURN a.rowid, e.date ORDER BY a.rowid";
+    auto result = conn->queryAsArrow(query, 8);
+    auto* arrowResult = dynamic_cast<ArrowQueryResult*>(result.get());
+    ASSERT_NE(arrowResult, nullptr);
+    ASSERT_FALSE(arrowResult->hasCSRMetadata());
 }


### PR DESCRIPTION
Detect CSR-compatible rowid projections in the Arrow collector path and attach CSR metadata directly to ArrowQueryResult instead of rebuilding it later from a materialized row result.

This adds collector-side tracking for:
- src,dst rowid projections
- src,rel,dst rowid projections

The Arrow result still preserves any additional projected columns in the Arrow table, while exposing CSR metadata alongside the chunked Arrow batches for the relationship-shaped prefix.

On the Python side, query_as_arrow() now maps to the native Arrow execution path and the dedicated Arrow result type in the submodule can read CSR from ArrowQueryResult metadata without going through the older row-oriented QueryResult path.

CSR metadata is intentionally dropped when multiple local Arrow collectors merge, because unordered fan-in would make the grouped CSR structure invalid.