### PR TITLE
Add config to disable default node hash index

### DIFF
--- a/src/c_api/database.cpp
+++ b/src/c_api/database.cpp
@@ -13,7 +13,7 @@ lbug_state lbug_database_init(const char* database_path, lbug_system_config conf
         auto systemConfig = SystemConfig(config.buffer_pool_size, config.max_num_threads,
             config.enable_compression, config.read_only, config.max_db_size, config.auto_checkpoint,
             config.checkpoint_threshold, true, config.throw_on_wal_replay_failure,
-            config.enable_checksums, config.enable_multi_writes);
+            config.enable_checksums, config.enable_multi_writes, config.enable_default_hash_index);
 
 #if defined(__APPLE__)
         systemConfig.threadQos = config.thread_qos;
@@ -49,6 +49,7 @@ lbug_system_config lbug_default_system_config() {
     cSystemConfig.throw_on_wal_replay_failure = config.throwOnWalReplayFailure;
     cSystemConfig.enable_checksums = config.enableChecksums;
     cSystemConfig.enable_multi_writes = config.enableMultiWrites;
+    cSystemConfig.enable_default_hash_index = config.enableDefaultHashIndex;
 #if defined(__APPLE__)
     cSystemConfig.thread_qos = config.threadQos;
 #endif

--- a/src/function/table/disk_size_info.cpp
+++ b/src/function/table/disk_size_info.cpp
@@ -204,7 +204,7 @@ static std::vector<DiskSizeEntry> collectDiskSizeInfo(const ClientContext* conte
             {"node_table", tableEntry->getName(), tablePages, tablePages * LBUG_PAGE_SIZE});
 
         // Count primary key index header pages (rough estimate for overhead)
-        auto* pkIndex = nodeTable.getPKIndex();
+        auto* pkIndex = nodeTable.tryGetPKIndex();
         uint64_t indexPages = estimateHashIndexPages(pkIndex);
         if (indexPages > 0) {
             entries.push_back({"pk_index_overhead", tableEntry->getName() + "_pk", indexPages,

--- a/src/include/c_api/lbug.h
+++ b/src/include/c_api/lbug.h
@@ -138,6 +138,8 @@ typedef struct {
     bool enable_checksums;
     // If true, multiple concurrent write transactions are allowed.
     bool enable_multi_writes;
+    // If true, node tables create the default primary-key hash index.
+    bool enable_default_hash_index;
 
 #if defined(__APPLE__)
     // The thread quality of service (QoS) for the worker threads.

--- a/src/include/main/database.h
+++ b/src/include/main/database.h
@@ -64,12 +64,15 @@ struct LBUG_API SystemConfig {
      * WAL file.
      * @param enableMultiWrites If true, multiple concurrent write transactions are allowed.
      * Default to false.
+     * @param enableDefaultHashIndex If true, node tables create the default primary-key hash
+     * index.
      */
     explicit SystemConfig(uint64_t bufferPoolSize = -1u, uint64_t maxNumThreads = 0,
         bool enableCompression = true, bool readOnly = false, uint64_t maxDBSize = -1u,
         bool autoCheckpoint = true, uint64_t checkpointThreshold = 16777216 /* 16MB */,
         bool forceCheckpointOnClose = true, bool throwOnWalReplayFailure = true,
-        bool enableChecksums = true, bool enableMultiWrites = false
+        bool enableChecksums = true, bool enableMultiWrites = false,
+        bool enableDefaultHashIndex = true
 #if defined(__APPLE__)
         ,
         uint32_t threadQos = QOS_CLASS_DEFAULT
@@ -87,6 +90,7 @@ struct LBUG_API SystemConfig {
     bool throwOnWalReplayFailure;
     bool enableChecksums;
     bool enableMultiWrites;
+    bool enableDefaultHashIndex;
 #if defined(__APPLE__)
     uint32_t threadQos;
 #endif

--- a/src/include/main/db_config.h
+++ b/src/include/main/db_config.h
@@ -65,6 +65,7 @@ struct DBConfig {
     bool forceCheckpointOnClose;
     bool throwOnWalReplayFailure;
     bool enableChecksums;
+    bool enableDefaultHashIndex;
     bool enableSpillingToDisk;
 #if defined(__APPLE__)
     uint32_t threadQos;

--- a/src/include/main/settings.h
+++ b/src/include/main/settings.h
@@ -124,6 +124,13 @@ struct ForceCheckpointClosingDBSetting {
     static common::Value getSetting(const ClientContext* context);
 };
 
+struct EnableDefaultHashIndexSetting {
+    static constexpr auto name = "enable_default_hash_index";
+    static constexpr auto inputType = common::LogicalTypeID::BOOL;
+    static void setContext(ClientContext* context, const common::Value& parameter);
+    static common::Value getSetting(const ClientContext* context);
+};
+
 struct SpillToDiskSetting {
     static constexpr auto name = "spill_to_disk";
     static constexpr auto inputType = common::LogicalTypeID::BOOL;

--- a/src/include/storage/storage_manager.h
+++ b/src/include/storage/storage_manager.h
@@ -31,7 +31,8 @@ struct DatabaseHeader;
 class LBUG_API StorageManager {
 public:
     StorageManager(const std::string& databasePath, bool readOnly, bool enableChecksums,
-        MemoryManager& memoryManager, bool enableCompression, common::VirtualFileSystem* vfs);
+        MemoryManager& memoryManager, bool enableCompression, bool enableDefaultHashIndex,
+        common::VirtualFileSystem* vfs);
     ~StorageManager();
 
     Table* getTable(common::table_id_t tableID);
@@ -61,6 +62,8 @@ public:
     bool isReadOnly() const { return readOnly; }
     bool compressionEnabled() const { return enableCompression; }
     bool isInMemory() const { return inMemory; }
+    bool defaultHashIndexEnabled() const { return enableDefaultHashIndex; }
+    void setDefaultHashIndexEnabled(bool enabled) { enableDefaultHashIndex = enabled; }
 
     void registerIndexType(IndexType indexType) {
         registeredIndexTypes.push_back(std::move(indexType));
@@ -108,6 +111,7 @@ private:
     std::unique_ptr<WAL> wal;
     std::unique_ptr<ShadowFile> shadowFile;
     bool enableCompression;
+    bool enableDefaultHashIndex;
     bool inMemory;
     std::vector<IndexType> registeredIndexTypes;
     std::unordered_map<common::table_id_t, std::string> tableNameCache;

--- a/src/include/storage/table/node_table.h
+++ b/src/include/storage/table/node_table.h
@@ -4,6 +4,7 @@
 
 #include "common/types/types.h"
 #include "storage/index/hash_index.h"
+#include "storage/predicate/column_predicate.h"
 #include "storage/table/node_group_collection.h"
 #include "storage/table/table.h"
 
@@ -156,10 +157,11 @@ public:
     void dropIndex(const std::string& name);
 
     common::column_id_t getPKColumnID() const { return pkColumnID; }
+    PrimaryKeyIndex* tryGetPKIndex() const;
     PrimaryKeyIndex* getPKIndex() const {
-        const auto index = getIndex(PrimaryKeyIndex::DEFAULT_NAME);
-        DASSERT(index.has_value());
-        return &index.value()->cast<PrimaryKeyIndex>();
+        auto* index = tryGetPKIndex();
+        DASSERT(index);
+        return index;
     }
     std::optional<std::reference_wrapper<IndexHolder>> getIndexHolder(const std::string& name);
     std::optional<Index*> getIndex(const std::string& name) const;
@@ -234,6 +236,8 @@ private:
     visible_func getVisibleFunc(const transaction::Transaction* transaction) const;
     common::DataChunk constructDataChunkForColumns(
         const std::vector<common::column_id_t>& columnIDs) const;
+    bool scanPKColumn(const transaction::Transaction* transaction, const common::Value& keyToLookup,
+        std::vector<ColumnPredicateSet> columnPredicateSets, common::offset_t& result) const;
     void scanIndexColumns(main::ClientContext* context, IndexScanHelper& scanHelper,
         const NodeGroupCollection& nodeGroups_) const;
 

--- a/src/main/attached_database.cpp
+++ b/src/main/attached_database.cpp
@@ -67,7 +67,8 @@ AttachedLbugDatabase::AttachedLbugDatabase(std::string dbPath, std::string dbNam
     validateEmptyWAL(path, clientContext);
     storageManager = std::make_unique<storage::StorageManager>(path, true /* isReadOnly */,
         clientContext->getDBConfig()->enableChecksums, *storage::MemoryManager::Get(*clientContext),
-        clientContext->getDBConfig()->enableCompression, vfs);
+        clientContext->getDBConfig()->enableCompression,
+        clientContext->getDBConfig()->enableDefaultHashIndex, vfs);
     transactionManager =
         std::make_unique<transaction::TransactionManager>(storageManager->getWAL());
 

--- a/src/main/database.cpp
+++ b/src/main/database.cpp
@@ -35,7 +35,7 @@ namespace main {
 SystemConfig::SystemConfig(uint64_t bufferPoolSize_, uint64_t maxNumThreads, bool enableCompression,
     bool readOnly, uint64_t maxDBSize, bool autoCheckpoint, uint64_t checkpointThreshold,
     bool forceCheckpointOnClose, bool throwOnWalReplayFailure, bool enableChecksums,
-    bool enableMultiWrites
+    bool enableMultiWrites, bool enableDefaultHashIndex
 #if defined(__APPLE__)
     ,
     uint32_t threadQos
@@ -45,7 +45,7 @@ SystemConfig::SystemConfig(uint64_t bufferPoolSize_, uint64_t maxNumThreads, boo
       autoCheckpoint{autoCheckpoint}, checkpointThreshold{checkpointThreshold},
       forceCheckpointOnClose{forceCheckpointOnClose},
       throwOnWalReplayFailure(throwOnWalReplayFailure), enableChecksums(enableChecksums),
-      enableMultiWrites{enableMultiWrites} {
+      enableMultiWrites{enableMultiWrites}, enableDefaultHashIndex{enableDefaultHashIndex} {
 #if defined(__APPLE__)
     this->threadQos = threadQos;
 #endif
@@ -123,8 +123,9 @@ void Database::initMembers(std::string_view dbPath, construct_bm_func_t initBmFu
 #endif
 
     catalog = std::make_unique<Catalog>();
-    storageManager = std::make_unique<StorageManager>(databasePath, dbConfig.readOnly,
-        dbConfig.enableChecksums, *memoryManager, dbConfig.enableCompression, vfs.get());
+    storageManager =
+        std::make_unique<StorageManager>(databasePath, dbConfig.readOnly, dbConfig.enableChecksums,
+            *memoryManager, dbConfig.enableCompression, dbConfig.enableDefaultHashIndex, vfs.get());
     transactionManager = std::make_unique<TransactionManager>(storageManager->getWAL());
     databaseManager = std::make_unique<DatabaseManager>();
 

--- a/src/main/database_manager.cpp
+++ b/src/main/database_manager.cpp
@@ -136,7 +136,8 @@ void DatabaseManager::createGraph(const std::string& graphName,
                          ":" + graphName :
                          storage::StorageUtils::getGraphPath(dbPath, graphName);
     auto storageManager = std::make_unique<storage::StorageManager>(graphPath, false, false,
-        *memoryManager, false, common::VirtualFileSystem::GetUnsafe(*clientContext));
+        *memoryManager, false, clientContext->getDBConfig()->enableDefaultHashIndex,
+        common::VirtualFileSystem::GetUnsafe(*clientContext));
     storageManager->initDataFileHandle(common::VirtualFileSystem::GetUnsafe(*clientContext),
         clientContext);
     catalog->setStorageManager(std::move(storageManager));
@@ -316,7 +317,7 @@ void DatabaseManager::loadGraphsFromCatalog(storage::MemoryManager* memoryManage
         }
 
         auto storageManager = std::make_unique<storage::StorageManager>(graphPath, false, false,
-            *memoryManager, false, vfs);
+            *memoryManager, false, clientContext->getDBConfig()->enableDefaultHashIndex, vfs);
         storageManager->initDataFileHandle(vfs, clientContext);
         catalog->setStorageManager(std::move(storageManager));
 

--- a/src/main/db_config.cpp
+++ b/src/main/db_config.cpp
@@ -21,7 +21,8 @@ static ConfigurationOption options[] = { // NOLINT(cert-err58-cpp):
     GET_CONFIGURATION(ProgressBarSetting), GET_CONFIGURATION(RecursivePatternSemanticSetting),
     GET_CONFIGURATION(RecursivePatternFactorSetting), GET_CONFIGURATION(EnableMVCCSetting),
     GET_CONFIGURATION(CheckpointThresholdSetting), GET_CONFIGURATION(AutoCheckpointSetting),
-    GET_CONFIGURATION(ForceCheckpointClosingDBSetting), GET_CONFIGURATION(SpillToDiskSetting),
+    GET_CONFIGURATION(ForceCheckpointClosingDBSetting),
+    GET_CONFIGURATION(EnableDefaultHashIndexSetting), GET_CONFIGURATION(SpillToDiskSetting),
     GET_CONFIGURATION(EnableOptimizerSetting), GET_CONFIGURATION(EnableInternalCatalogSetting)};
 
 DBConfig::DBConfig(const SystemConfig& systemConfig)
@@ -32,7 +33,8 @@ DBConfig::DBConfig(const SystemConfig& systemConfig)
       checkpointThreshold{systemConfig.checkpointThreshold},
       forceCheckpointOnClose{systemConfig.forceCheckpointOnClose},
       throwOnWalReplayFailure(systemConfig.throwOnWalReplayFailure),
-      enableChecksums(systemConfig.enableChecksums), enableSpillingToDisk{true} {
+      enableChecksums(systemConfig.enableChecksums),
+      enableDefaultHashIndex{systemConfig.enableDefaultHashIndex}, enableSpillingToDisk{true} {
 #if defined(__APPLE__)
     this->threadQos = systemConfig.threadQos;
 #endif

--- a/src/main/settings.cpp
+++ b/src/main/settings.cpp
@@ -2,7 +2,10 @@
 
 #include "common/exception/runtime.h"
 #include "common/task_system/progress_bar.h"
+#include "main/attached_database.h"
 #include "main/client_context.h"
+#include "main/database.h"
+#include "main/database_manager.h"
 #include "main/db_config.h"
 #include "storage/buffer_manager/buffer_manager.h"
 #include "storage/buffer_manager/memory_manager.h"
@@ -10,6 +13,25 @@
 
 namespace lbug {
 namespace main {
+
+namespace {
+
+void setDefaultHashIndexEnabledOnStorageManagers(ClientContext* context, bool enabled) {
+    context->getDatabase()->getStorageManager()->setDefaultHashIndexEnabled(enabled);
+    auto* databaseManager = context->getDatabase()->getDatabaseManager();
+    for (auto* graphCatalog : databaseManager->getGraphs()) {
+        if (auto* storageManager = graphCatalog->getStorageManager()) {
+            storageManager->setDefaultHashIndexEnabled(enabled);
+        }
+    }
+    for (auto* attachedDatabase : databaseManager->getAttachedDatabases()) {
+        if (auto* attachedLbugDatabase = dynamic_cast<AttachedLbugDatabase*>(attachedDatabase)) {
+            attachedLbugDatabase->getStorageManager()->setDefaultHashIndexEnabled(enabled);
+        }
+    }
+}
+
+} // namespace
 
 void ThreadsSetting::setContext(ClientContext* context, const common::Value& parameter) {
     parameter.validateType(inputType);
@@ -176,6 +198,18 @@ void ForceCheckpointClosingDBSetting::setContext(ClientContext* context,
 
 common::Value ForceCheckpointClosingDBSetting::getSetting(const ClientContext* context) {
     return common::Value(context->getDBConfig()->forceCheckpointOnClose);
+}
+
+void EnableDefaultHashIndexSetting::setContext(ClientContext* context,
+    const common::Value& parameter) {
+    parameter.validateType(inputType);
+    const auto enabled = parameter.getValue<bool>();
+    context->getDBConfigUnsafe()->enableDefaultHashIndex = enabled;
+    setDefaultHashIndexEnabledOnStorageManagers(context, enabled);
+}
+
+common::Value EnableDefaultHashIndexSetting::getSetting(const ClientContext* context) {
+    return common::Value(context->getDBConfig()->enableDefaultHashIndex);
 }
 
 void EnableOptimizerSetting::setContext(ClientContext* context, const common::Value& parameter) {

--- a/src/processor/operator/persistent/node_batch_insert.cpp
+++ b/src/processor/operator/persistent/node_batch_insert.cpp
@@ -3,6 +3,7 @@
 #include "catalog/catalog.h"
 #include "catalog/catalog_entry/node_table_catalog_entry.h"
 #include "common/cast.h"
+#include "common/exception/runtime.h"
 #include "common/finally_wrapper.h"
 #include "processor/execution_context.h"
 #include "processor/operator/persistent/index_builder.h"
@@ -31,12 +32,18 @@ std::string NodeBatchInsertPrintInfo::toString() const {
 }
 
 void NodeBatchInsertSharedState::initPKIndex(const ExecutionContext* context) {
+    auto* nodeTable = dynamic_cast_checked<NodeTable*>(table);
+    auto* pkIndex = nodeTable->tryGetPKIndex();
+    if (!pkIndex) {
+        throw RuntimeException(
+            "COPY into node tables requires enable_default_hash_index=true for primary-key "
+            "validation.");
+    }
     uint64_t numRows = 0;
     if (tableFuncSharedState != nullptr) {
         numRows = tableFuncSharedState->getNumRows();
     }
-    auto* nodeTable = dynamic_cast_checked<NodeTable*>(table);
-    nodeTable->getPKIndex()->bulkReserve(numRows);
+    pkIndex->bulkReserve(numRows);
     globalIndexBuilder = IndexBuilder(std::make_shared<IndexBuilderSharedState>(
         Transaction::Get(*context->clientContext), nodeTable));
 }

--- a/src/storage/storage_manager.cpp
+++ b/src/storage/storage_manager.cpp
@@ -35,9 +35,10 @@ namespace lbug {
 namespace storage {
 
 StorageManager::StorageManager(const std::string& databasePath, bool readOnly, bool enableChecksums,
-    MemoryManager& memoryManager, bool enableCompression, VirtualFileSystem* vfs)
+    MemoryManager& memoryManager, bool enableCompression, bool enableDefaultHashIndex,
+    VirtualFileSystem* vfs)
     : databasePath{databasePath}, readOnly{readOnly}, dataFH{nullptr}, memoryManager{memoryManager},
-      enableCompression{enableCompression} {
+      enableCompression{enableCompression}, enableDefaultHashIndex{enableDefaultHashIndex} {
     wal = std::make_unique<WAL>(databasePath, readOnly, enableChecksums, vfs);
     shadowFile =
         std::make_unique<ShadowFile>(*memoryManager.getBufferManager(), vfs, this->databasePath);

--- a/src/storage/table/node_table.cpp
+++ b/src/storage/table/node_table.cpp
@@ -11,6 +11,7 @@
 #include "storage/local_storage/local_node_table.h"
 #include "storage/local_storage/local_storage.h"
 #include "storage/local_storage/local_table.h"
+#include "storage/predicate/constant_predicate.h"
 #include "storage/storage_manager.h"
 #include "storage/wal/local_wal.h"
 #include "transaction/transaction.h"
@@ -245,8 +246,10 @@ NodeTable::NodeTable(const StorageManager* storageManager,
         {pkColumnID}, {pkDefinition.getType().getPhysicalType()},
         hashIndexType.constraintType == IndexConstraintType::PRIMARY,
         hashIndexType.definitionType == IndexDefinitionType::BUILTIN};
-    indexes.push_back(IndexHolder{PrimaryKeyIndex::createNewIndex(indexInfo,
-        storageManager->isInMemory(), *mm, pageAllocator, shadowFile)});
+    if (storageManager->defaultHashIndexEnabled()) {
+        indexes.push_back(IndexHolder{PrimaryKeyIndex::createNewIndex(indexInfo,
+            storageManager->isInMemory(), *mm, pageAllocator, shadowFile)});
+    }
     nodeGroups = std::make_unique<NodeGroupCollection>(*mm,
         LocalNodeTable::getNodeTableColumnTypes(*nodeTableEntry), enableCompression,
         storageManager->getDataFH() ? ResidencyState::ON_DISK : ResidencyState::IN_MEMORY,
@@ -381,8 +384,7 @@ offset_t NodeTable::validateUniquenessConstraint(const Transaction* transaction,
     DASSERT(pkVector->state->getSelVector().getSelSize() == 1);
     const auto pkVectorPos = pkVector->state->getSelVector()[0];
     if (offset_t offset = INVALID_OFFSET;
-        getPKIndex()->lookup(transaction, propertyVectors[pkColumnID], pkVectorPos, offset,
-            [&](offset_t offset_) { return isVisible(transaction, offset_); })) {
+        lookupPK(transaction, propertyVectors[pkColumnID], pkVectorPos, offset)) {
         return offset;
     }
     if (const auto localTable = transaction->getLocalStorage()->getLocalTable(tableID)) {
@@ -399,8 +401,7 @@ void NodeTable::validatePkNotExists(const Transaction* transaction, ValueVector*
     if (pkVector->isNull(selVector[0])) {
         throw RuntimeException(ExceptionMessage::nullPKException());
     }
-    if (getPKIndex()->lookup(transaction, pkVector, selVector[0], dummyOffset,
-            [&](offset_t offset) { return isVisible(transaction, offset); })) {
+    if (lookupPK(transaction, pkVector, selVector[0], dummyOffset)) {
         throw RuntimeException(
             ExceptionMessage::duplicatePKException(pkVector->getAsValue(selVector[0])->toString()));
     }
@@ -476,8 +477,7 @@ void NodeTable::update(Transaction* transaction, TableUpdateState& updateState) 
     if (nodeUpdateState.nodeIDVector.isNull(pos)) {
         return;
     }
-    const auto pkIndex = getPKIndex();
-    if (nodeUpdateState.columnID == pkColumnID && pkIndex) {
+    if (nodeUpdateState.columnID == pkColumnID) {
         throw RuntimeException("Cannot update pk.");
     }
     const auto nodeOffset = nodeUpdateState.nodeIDVector.readNodeOffset(pos);
@@ -701,10 +701,14 @@ bool NodeTable::checkpoint(main::ClientContext* context, TableCatalogEntry* tabl
 
 void NodeTable::rollbackPKIndexInsert(main::ClientContext* context, row_idx_t startRow,
     row_idx_t numRows_, node_group_idx_t nodeGroupIdx_) {
+    auto* pkIndex = tryGetPKIndex();
+    if (!pkIndex) {
+        return;
+    }
     const row_idx_t startNodeOffset =
         startRow + StorageUtils::getStartOffsetOfNodeGroup(nodeGroupIdx_);
 
-    RollbackPKDeleter pkDeleter{startNodeOffset, numRows_, this, getPKIndex()};
+    RollbackPKDeleter pkDeleter{startNodeOffset, numRows_, this, pkIndex};
     scanIndexColumns(context, pkDeleter, *nodeGroups);
 }
 
@@ -721,7 +725,9 @@ void NodeTable::rollbackCheckpoint() {
 
 void NodeTable::reclaimStorage(PageAllocator& pageAllocator) const {
     nodeGroups->reclaimStorage(pageAllocator);
-    getPKIndex()->reclaimStorage(pageAllocator);
+    if (auto* pkIndex = tryGetPKIndex()) {
+        pkIndex->reclaimStorage(pageAllocator);
+    }
 }
 
 TableStats NodeTable::getStats(const Transaction* transaction) const {
@@ -748,6 +754,14 @@ bool NodeTable::isVisibleNoLock(const Transaction* transaction, offset_t offset)
     return nodeGroup->isVisibleNoLock(transaction, offsetInGroup);
 }
 
+PrimaryKeyIndex* NodeTable::tryGetPKIndex() const {
+    const auto index = getIndex(PrimaryKeyIndex::DEFAULT_NAME);
+    if (!index.has_value()) {
+        return nullptr;
+    }
+    return &index.value()->cast<PrimaryKeyIndex>();
+}
+
 bool NodeTable::lookupPK(const Transaction* transaction, ValueVector* keyVector, uint64_t vectorPos,
     offset_t& result) const {
     if (transaction->getLocalStorage()) {
@@ -757,8 +771,61 @@ bool NodeTable::lookupPK(const Transaction* transaction, ValueVector* keyVector,
             return true;
         }
     }
-    return getPKIndex()->lookup(transaction, keyVector, vectorPos, result,
-        [&](offset_t offset) { return isVisibleNoLock(transaction, offset); });
+    if (auto* pkIndex = tryGetPKIndex()) {
+        return pkIndex->lookup(transaction, keyVector, vectorPos, result,
+            [&](offset_t offset) { return isVisibleNoLock(transaction, offset); });
+    }
+    auto keyToLookup = keyVector->getAsValue(vectorPos);
+    ColumnPredicateSet predicateSet;
+    predicateSet.addPredicate(std::make_unique<ColumnConstantPredicate>(
+        std::string{getColumn(pkColumnID).getName()}, ExpressionType::EQUALS, *keyToLookup));
+    std::vector<ColumnPredicateSet> predicateSets;
+    predicateSets.push_back(std::move(predicateSet));
+    return scanPKColumn(transaction, *keyToLookup, std::move(predicateSets), result);
+}
+
+bool NodeTable::scanPKColumn(const Transaction* transaction, const Value& keyToLookup,
+    std::vector<ColumnPredicateSet> columnPredicateSets, offset_t& result) const {
+    auto dataChunk = constructDataChunkForColumns({pkColumnID});
+    std::vector<ValueVector*> outVectors = {&dataChunk.getValueVectorMutable(0)};
+    auto scanState =
+        std::make_unique<NodeTableScanState>(nullptr, std::move(outVectors), dataChunk.state);
+    scanState->source = TableScanSource::COMMITTED;
+    scanState->setToTable(transaction, const_cast<NodeTable*>(this), {pkColumnID},
+        std::move(columnPredicateSets));
+    const auto numNodeGroups = nodeGroups->getNumNodeGroupsNoLock();
+    for (node_group_idx_t nodeGroupIdx = 0; nodeGroupIdx < numNodeGroups; ++nodeGroupIdx) {
+        auto* nodeGroup = nodeGroups->getNodeGroupNoLock(nodeGroupIdx);
+        if (nodeGroup->getNumChunkedGroups() == 0) {
+            continue;
+        }
+        scanState->nodeGroup = nodeGroup;
+        scanState->nodeGroupIdx = nodeGroupIdx;
+        nodeGroup->initializeScanState(transaction, *scanState);
+        while (true) {
+            const auto scanResult = nodeGroup->scan(transaction, *scanState);
+            if (scanResult == NODE_GROUP_SCAN_EMPTY_RESULT) {
+                break;
+            }
+            auto* scannedVector = scanState->outputVectors[0];
+            for (idx_t i = 0; i < scannedVector->state->getSelSize(); ++i) {
+                const auto pos = scannedVector->state->getSelVector()[i];
+                if (scannedVector->isNull(pos)) {
+                    continue;
+                }
+                if (!(*scannedVector->getAsValue(pos) == keyToLookup)) {
+                    continue;
+                }
+                const auto offset = StorageUtils::getStartOffsetOfNodeGroup(nodeGroupIdx) +
+                                    scanResult.startRow + pos;
+                if (isVisibleNoLock(transaction, offset)) {
+                    result = offset;
+                    return true;
+                }
+            }
+        }
+    }
+    return false;
 }
 
 void NodeTable::scanIndexColumns(main::ClientContext* context, IndexScanHelper& scanHelper,

--- a/test/api/system_config_test.cpp
+++ b/test/api/system_config_test.cpp
@@ -1,10 +1,18 @@
 #include "api_test/api_test.h"
+#include "catalog/catalog.h"
+#include "catalog/catalog_entry/node_table_catalog_entry.h"
 #include "common/exception/buffer_manager.h"
 #include "common/system_config.h"
+#include "storage/storage_manager.h"
+#include "storage/table/node_table.h"
+#include "transaction/transaction.h"
 
 using namespace lbug::common;
+using namespace lbug::catalog;
+using namespace lbug::storage;
 using namespace lbug::testing;
 using namespace lbug::main;
+using namespace lbug::transaction;
 
 class SystemConfigTest : public ApiTest {
     void SetUp() override { BaseGraphTest::SetUp(); }
@@ -104,4 +112,39 @@ TEST_F(SystemConfigTest, testBufferPoolSize) {
     }
     systemConfig->bufferPoolSize = TestHelper::DEFAULT_BUFFER_POOL_SIZE_FOR_TESTING;
     EXPECT_NO_THROW(auto db = std::make_unique<Database>(databasePath, *systemConfig));
+}
+
+TEST_F(SystemConfigTest, testDisableDefaultHashIndexFromSystemConfig) {
+    systemConfig->enableDefaultHashIndex = false;
+    auto db = std::make_unique<Database>(databasePath, *systemConfig);
+    auto con = std::make_unique<Connection>(db.get());
+    assertQuery(*con->query("CREATE NODE TABLE PersonNoIdx(name STRING, PRIMARY KEY(name))"));
+    assertQuery(*con->query("CREATE (:PersonNoIdx {name: 'Alice'})"));
+
+    auto result = con->query("CALL current_setting('enable_default_hash_index') RETURN *");
+    ASSERT_TRUE(result->isSuccess());
+    ASSERT_EQ(TestHelper::convertResultToString(*result), std::vector<std::string>{"False"});
+
+    auto* entry = db->getCatalog()
+                      ->getTableCatalogEntry(&DUMMY_CHECKPOINT_TRANSACTION, "PersonNoIdx")
+                      ->ptrCast<NodeTableCatalogEntry>();
+    auto& nodeTable = db->getStorageManager()->getTable(entry->getTableID())->cast<NodeTable>();
+    ASSERT_EQ(nodeTable.tryGetPKIndex(), nullptr);
+}
+
+TEST_F(SystemConfigTest, testDisableDefaultHashIndexFromDBConfig) {
+    auto db = std::make_unique<Database>(databasePath, *systemConfig);
+    auto con = std::make_unique<Connection>(db.get());
+    assertQuery(*con->query("CALL enable_default_hash_index=false;"));
+    assertQuery(*con->query("CREATE NODE TABLE PersonNoIdx2(name STRING, PRIMARY KEY(name))"));
+    assertQuery(*con->query("CREATE (:PersonNoIdx2 {name: 'Alice'})"));
+    auto result = con->query("CALL current_setting('enable_default_hash_index') RETURN *");
+    ASSERT_TRUE(result->isSuccess());
+    ASSERT_EQ(TestHelper::convertResultToString(*result), std::vector<std::string>{"False"});
+
+    auto* entry = db->getCatalog()
+                      ->getTableCatalogEntry(&DUMMY_CHECKPOINT_TRANSACTION, "PersonNoIdx2")
+                      ->ptrCast<NodeTableCatalogEntry>();
+    auto& nodeTable = db->getStorageManager()->getTable(entry->getTableID())->cast<NodeTable>();
+    ASSERT_EQ(nodeTable.tryGetPKIndex(), nullptr);
 }


### PR DESCRIPTION
Related: #97 

```
  CALL enable_default_hash_index=false;
  CREATE NODE TABLE `User` (`name` STRING,`age` INT64, PRIMARY KEY(`name`));
  UNWIND range(1, 10000) AS i
  CREATE (:User {name: CAST(i AS STRING), age: i});
```

  and verified to contain 10000 rows.

  The persisted on-disk result is now clearly different:

  - test10k.db: 3.1M
  - test10k-nohash.db: 116K

  CALL disk_size_info() after reopening shows:

  - test10k-nohash.db: only header, catalog, metadata, node_table, total=29 pages
  - test10k.db: also has pk_index_overhead and index_data, total=801 pages