### PR TITLE
Fix ANY graph dynamic property scans

### DIFF
--- a/src/include/processor/operator/scan/scan_table.h
+++ b/src/include/processor/operator/scan/scan_table.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <optional>
+
 #include "binder/expression/expression.h"
 #include "processor/operator/physical_operator.h"
 #include "storage/table/table.h"
@@ -30,7 +32,11 @@ public:
     EXPLICIT_COPY_DEFAULT_MOVE(ColumnCaster);
 
     void setCastExpr(std::shared_ptr<binder::Expression> expr) { castExpr = std::move(expr); }
+    void setJSONExtract(std::string propertyName) {
+        jsonExtractPropertyName = std::move(propertyName);
+    }
     bool hasCast() const { return castExpr != nullptr; }
+    bool hasJSONExtract() const { return jsonExtractPropertyName.has_value(); }
 
     // Generate temporary vectors for scanning
     void init(common::ValueVector* vectorAfterCasting, storage::MemoryManager* memoryManager);
@@ -41,10 +47,12 @@ public:
 
 private:
     ColumnCaster(const ColumnCaster& other)
-        : columnType{other.columnType.copy()}, castExpr{other.castExpr} {}
+        : columnType{other.columnType.copy()}, castExpr{other.castExpr},
+          jsonExtractPropertyName{other.jsonExtractPropertyName} {}
 
     common::LogicalType columnType;
     std::shared_ptr<binder::Expression> castExpr;
+    std::optional<std::string> jsonExtractPropertyName;
 
     // vector for scanning; same data type as column
     std::shared_ptr<common::ValueVector> vectorBeforeCasting = nullptr;

--- a/src/processor/map/map_scan_node_table.cpp
+++ b/src/processor/map/map_scan_node_table.cpp
@@ -44,6 +44,14 @@ std::unique_ptr<PhysicalOperator> PlanMapper::mapScanNodeTable(
             auto& property = expr->constCast<PropertyExpression>();
             if (property.hasProperty(tableEntry->getTableID())) {
                 auto propertyName = property.getPropertyName();
+                if (!tableEntry->containsProperty(propertyName) &&
+                    tableEntry->containsProperty("data")) {
+                    auto columnCaster = ColumnCaster(LogicalType::JSON());
+                    columnCaster.setJSONExtract(propertyName);
+                    tableInfo.addColumnInfo(tableEntry->getColumnID("data"),
+                        std::move(columnCaster));
+                    continue;
+                }
                 auto& columnType = tableEntry->getProperty(propertyName).getType();
                 auto columnCaster = ColumnCaster(columnType.copy());
                 if (property.getDataType() != columnType) {

--- a/src/processor/operator/scan/scan_table.cpp
+++ b/src/processor/operator/scan/scan_table.cpp
@@ -1,6 +1,8 @@
 #include "processor/operator/scan/scan_table.h"
 
 #include "binder/expression/scalar_function_expression.h"
+#include "common/json_utils.h"
+#include "common/vector/value_vector.h"
 
 using namespace lbug::common;
 using namespace lbug::storage;
@@ -17,6 +19,30 @@ void ColumnCaster::init(ValueVector* vectorAfterCasting, storage::MemoryManager*
 }
 
 void ColumnCaster::cast() {
+    if (jsonExtractPropertyName.has_value()) {
+        auto& selVector = vectorAfterCasting->state->getSelVector();
+        for (auto i = 0u; i < selVector.getSelSize(); ++i) {
+            auto pos = selVector[i];
+            if (vectorBeforeCasting->isNull(pos)) {
+                vectorAfterCasting->setNull(pos, true);
+                continue;
+            }
+            auto data = vectorBeforeCasting->getValue<common::string_t>(pos).getAsString();
+            auto json = json_extension::stringToJsonNoError(data);
+            if (json.ptr == nullptr) {
+                vectorAfterCasting->setNull(pos, true);
+                continue;
+            }
+            auto extracted = json_extension::jsonExtractToString(json, *jsonExtractPropertyName);
+            if (extracted.empty()) {
+                vectorAfterCasting->setNull(pos, true);
+                continue;
+            }
+            vectorAfterCasting->setNull(pos, false);
+            common::StringVector::addString(vectorAfterCasting, pos, extracted);
+        }
+        return;
+    }
     auto& funcExpr = castExpr->constCast<binder::ScalarFunctionExpression>();
     funcExpr.getFunction().execFunc(funcInputVectors, funcInputSelVectors, *vectorAfterCasting,
         &vectorAfterCasting->state->getSelVectorUnsafe(), funcExpr.getBindData());
@@ -24,14 +50,14 @@ void ColumnCaster::cast() {
 
 void ScanTableInfo::castColumns() {
     for (auto& caster : columnCasters) {
-        if (caster.hasCast()) {
+        if (caster.hasCast() || caster.hasJSONExtract()) {
             caster.cast();
         }
     }
 }
 
 void ScanTableInfo::addColumnInfo(column_id_t columnID, ColumnCaster caster) {
-    if (caster.hasCast()) {
+    if (caster.hasCast() || caster.hasJSONExtract()) {
         hasColumnCaster = true;
     }
     columnIDs.push_back(columnID);
@@ -49,7 +75,7 @@ void ScanTableInfo::initScanStateVectors(TableScanState& scanState,
     for (auto i = 0u; i < columnCasters.size(); ++i) {
         auto& caster = columnCasters[i];
         auto vector = outVectors[i];
-        if (!caster.hasCast()) {
+        if (!caster.hasCast() && !caster.hasJSONExtract()) {
             // No need to cast
             scanState.outputVectors.push_back(vector);
         } else {

--- a/test/test_files/graph/any.test
+++ b/test/test_files/graph/any.test
@@ -28,6 +28,11 @@
 0|[User]|{"age":30,"name":"Alice"}
 1|[City]|{"population":8000000,"name":"New York"}
 
+-LOG QueryDynamicProperties
+-STATEMENT MATCH (u:User)-[:LivesIn]->(c:City) RETURN u.name, c.name
+---- 1
+"Alice"|"New York"
+
 -LOG Cleanup
 -STATEMENT USE GRAPH main
 ---- ok


### PR DESCRIPTION
ANY graph node patterns bind labels like User and City to the internal _nodes table, where user-defined properties are stored inside the JSON data column. Scan planning was still trying to read dynamic properties such as name as physical columns, so MATCH ... RETURN u.name either failed during mapping or produced no useful result after CREATE.

Teach ScanNodeTable mapping to scan the data column for missing physical properties on ANY graph tables, and extend ColumnCaster to extract the requested JSON key into the projected result vector. This keeps normal physical-column scans unchanged while allowing dynamic properties to be returned from ANY graphs.

Add regression coverage for creating a User-[:LivesIn]->City pattern and returning u.name and c.name.