### PR TITLE
ci: publish @ladybugdb/core-darwin-x64 to npm (follow-up to #427)

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -430,7 +430,7 @@ jobs:
           if [ "${{ github.event.inputs.isNightly }}" = "true" ]; then
             TAG=next
           fi
-          for tarball in lbug-source.tar.gz lbug-linux-x64.tar.gz lbug-linux-arm64.tar.gz lbug-darwin-arm64.tar.gz lbug-win32-x64.tar.gz; do
+          for tarball in lbug-source.tar.gz lbug-linux-x64.tar.gz lbug-linux-arm64.tar.gz lbug-darwin-arm64.tar.gz lbug-darwin-x64.tar.gz lbug-win32-x64.tar.gz; do
             [ -f "$tarball" ] || continue
             PACKAGE_NAME="$(tar -xOf "$tarball" package/package.json | node -e "const fs=require('fs'); const pkg=JSON.parse(fs.readFileSync(0,'utf8')); process.stdout.write(pkg.name)")"
             PACKAGE_VERSION="$(tar -xOf "$tarball" package/package.json | node -e "const fs=require('fs'); const pkg=JSON.parse(fs.readFileSync(0,'utf8')); process.stdout.write(pkg.version)")"
@@ -447,7 +447,7 @@ jobs:
         if: ${{ github.event_name == 'schedule' || (github.event.inputs.isDeploy == 'true' && github.event.inputs.isNightly == 'true') }}
         run: |
           NIGHTLY_TAG="nightly-$(date -u +%Y%m%d)"
-          for tarball in lbug-linux-x64.tar.gz lbug-linux-arm64.tar.gz lbug-darwin-arm64.tar.gz lbug-win32-x64.tar.gz lbug-source.tar.gz; do
+          for tarball in lbug-linux-x64.tar.gz lbug-linux-arm64.tar.gz lbug-darwin-arm64.tar.gz lbug-darwin-x64.tar.gz lbug-win32-x64.tar.gz lbug-source.tar.gz; do
             [ -f "$tarball" ] || continue
             PACKAGE_NAME="$(tar -xOf "$tarball" package/package.json | node -e "const fs=require('fs'); const pkg=JSON.parse(fs.readFileSync(0,'utf8')); process.stdout.write(pkg.name)")"
             PACKAGE_VERSION="$(tar -xOf "$tarball" package/package.json | node -e "const fs=require('fs'); const pkg=JSON.parse(fs.readFileSync(0,'utf8')); process.stdout.write(pkg.version)")"
@@ -466,7 +466,7 @@ jobs:
       - name: Deploy to npm.js
         if: ${{ github.event.inputs.isDeploy == 'true' && github.event.inputs.isNightly != 'true' }}
         run: |
-          for tarball in lbug-linux-x64.tar.gz lbug-linux-arm64.tar.gz lbug-darwin-arm64.tar.gz lbug-win32-x64.tar.gz lbug-source.tar.gz; do
+          for tarball in lbug-linux-x64.tar.gz lbug-linux-arm64.tar.gz lbug-darwin-arm64.tar.gz lbug-darwin-x64.tar.gz lbug-win32-x64.tar.gz lbug-source.tar.gz; do
             [ -f "$tarball" ] || continue
             npm publish "$tarball" --access public --tag latest
           done

--- a/.github/workflows/nodejs-workflow.yml
+++ b/.github/workflows/nodejs-workflow.yml
@@ -32,10 +32,6 @@ on:
 
 jobs:
   build-nodejs:
-    # Temporary: macOS x64 does not have binary extensions published yet.
-    # Keep that matrix leg visible, but do not fail the overall workflow until
-    # the next release fills the server-side gap.
-    continue-on-error: ${{ matrix.os == 'macos-15-intel' }}
     runs-on: ${{ matrix.os }}
     env:
       LBUG_LINUX_VARIANT: compat


### PR DESCRIPTION
## Summary

Fixes #436. Follow-up to the recently merged #427.

`@ladybugdb/core@0.16.0`'s `package.json` declares
`@ladybugdb/core-darwin-x64@0.16.0` in `optionalDependencies`, but
the sub-package was never actually published — `npm view
@ladybugdb/core-darwin-x64` returns 404. PR #427 wired the
artifact download and tarball verification, but the three
`npm publish` loops further down in `build-and-deploy.yml` still
skip `lbug-darwin-x64.tar.gz`. This PR closes that last gap.

3 insertions / 7 deletions across 2 files.

## Changes

1. **`.github/workflows/build-and-deploy.yml`** — add
   `lbug-darwin-x64.tar.gz` to the dry-run, nightly and latest
   `npm publish` loops, alongside the other per-platform tarballs
   that #427 had already added to the verification loop just above.
2. **`.github/workflows/nodejs-workflow.yml`** — drop the
   `continue-on-error: matrix.os == 'macos-15-intel'` guard on
   `build-nodejs`. With the publish path now wired up end-to-end,
   a darwin-x64 build break should be a real CI signal, not a
   silent gap.

## Why this is safe

| Stage | Already in place? |
|---|---|
| `precompiled-bin-workflow.yml` produces darwin-x64 `liblbug.a` | ✅ (matrix line 39-40) |
| `nodejs-workflow.yml` builds `lbugjs-darwin-x64.node` | ✅ (matrix line 63-68) |
| `deploy-nodejs` downloads `mac-nodejs-module-x64` | ✅ (added by #427) |
| Packaging emits `lbug-darwin-x64.tar.gz` | ✅ (line 407) |
| Tarball verification covers darwin-x64 | ✅ (added by #427) |
| `package.json` declares the optional dep | ✅ (already in 0.16.0) |
| **`npm publish` actually uploads it** | ❌ — fixed by this PR |

This PR doesn't add any new build work; it only consumes an
artifact that the matrix is already producing today and that #427
already validated.

The publish loops keep their existing `[ -f \"$tarball\" ] || continue`
guard, so even if the artifact were missing the loop would just
skip it — graceful degradation is preserved.

## Test plan

CI changes can't really be unit-tested; the workflow itself is the
test harness. Verification path:

- [ ] CI: `Build, Deploy, and Test` → `build-nodejs` job goes green
      for `macos-15-intel`. (It was already building successfully
      under the old `continue-on-error`; this PR just stops hiding
      failures.)
- [ ] CI: `deploy-nodejs` step \"Deploy to npm.js dry run\" log shows
      `lbug-darwin-x64.tar.gz` being processed in the loop.
- [ ] Post-merge, after the next release tag publishes:
      `npm view @ladybugdb/core-darwin-x64 version` returns the
      released version instead of 404.
- [ ] Post-merge: `npm install @ladybugdb/core` on an Intel Mac
      (macOS 13.3+, Node 22) succeeds **without** falling back to
      source build.

## Notes for maintainers

I read #299 about the Intel Mac platform winding down. Worth
flagging that all the heavy lifting (precompiled lib, native
module build, packaging, verification) is already happening on
every release thanks to #427 and earlier work — the incremental
cost of publishing the sub-package is essentially zero. Happy to
iterate on the patch if you'd prefer a different shape (e.g.
driving the publish list off a shared variable rather than
repeating it three times).