### PR TITLE
extensions: remove DBConfig from the ABI

### DIFF
--- a/scripts/headers.txt
+++ b/scripts/headers.txt
@@ -61,7 +61,6 @@ src/include/main/client_config.h
 src/include/main/client_context.h
 src/include/main/connection.h
 src/include/main/database.h
-src/include/main/db_config.h
 src/include/main/lbug.h
 src/include/main/lbug_fwd.h
 src/include/main/prepared_statement.h

--- a/src/include/extension/extension_manager.h
+++ b/src/include/extension/extension_manager.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "loaded_extension.h"
+#include "main/option.h"
 #include "storage/storage_extension.h"
 
 namespace lbug {

--- a/src/include/main/database.h
+++ b/src/include/main/database.h
@@ -1,7 +1,10 @@
 #pragma once
 
+#include <functional>
 #include <memory>
 #include <mutex>
+#include <string>
+#include <string_view>
 #include <vector>
 
 #if defined(__APPLE__)
@@ -10,8 +13,9 @@
 
 #include "common/api.h"
 #include "common/database_lifecycle_manager.h"
+#include "common/types/types.h"
+#include "common/types/value/value.h"
 #include "lbug_fwd.h"
-#include "main/db_config.h"
 
 namespace lbug {
 namespace common {
@@ -31,6 +35,7 @@ class StorageExtension;
 } // namespace storage
 
 namespace main {
+struct DBConfig;
 class DatabaseManager;
 /**
  * @brief Stores runtime configuration for creating or opening a Database
@@ -144,7 +149,8 @@ public:
 
     catalog::Catalog* getCatalog() { return catalog.get(); }
 
-    const DBConfig& getConfig() const { return dbConfig; }
+    LBUG_API bool isReadOnly() const;
+    LBUG_API bool isMultiWritesEnabled() const;
 
     std::vector<storage::StorageExtension*> getStorageExtensions();
 
@@ -184,7 +190,7 @@ private:
 
 private:
     std::string databasePath;
-    DBConfig dbConfig;
+    std::unique_ptr<DBConfig> dbConfig;
     std::unique_ptr<common::VirtualFileSystem> vfs;
     std::unique_ptr<storage::BufferManager> bufferManager;
     std::unique_ptr<storage::MemoryManager> memoryManager;

--- a/src/include/main/db_config.h
+++ b/src/include/main/db_config.h
@@ -2,7 +2,8 @@
 
 #include <string>
 
-#include "common/types/value/value.h"
+#include "common/api.h"
+#include "main/option.h"
 
 namespace lbug {
 namespace common {
@@ -13,45 +14,6 @@ namespace main {
 
 class ClientContext;
 struct SystemConfig;
-
-typedef void (*set_context)(ClientContext* context, const common::Value& parameter);
-typedef common::Value (*get_setting)(const ClientContext* context);
-
-enum class OptionType : uint8_t { CONFIGURATION = 0, EXTENSION = 1 };
-
-struct Option {
-    std::string name;
-    common::LogicalTypeID parameterType;
-    OptionType optionType;
-    bool isConfidential;
-
-    Option(std::string name, common::LogicalTypeID parameterType, OptionType optionType,
-        bool isConfidential)
-        : name{std::move(name)}, parameterType{parameterType}, optionType{optionType},
-          isConfidential{isConfidential} {}
-
-    virtual ~Option() = default;
-};
-
-struct ConfigurationOption final : Option {
-    set_context setContext;
-    get_setting getSetting;
-
-    ConfigurationOption(std::string name, common::LogicalTypeID parameterType,
-        set_context setContext, get_setting getSetting)
-        : Option{std::move(name), parameterType, OptionType::CONFIGURATION,
-              false /* isConfidential */},
-          setContext{setContext}, getSetting{getSetting} {}
-};
-
-struct ExtensionOption final : Option {
-    common::Value defaultValue;
-
-    ExtensionOption(std::string name, common::LogicalTypeID parameterType,
-        common::Value defaultValue, bool isConfidential)
-        : Option{std::move(name), parameterType, OptionType::EXTENSION, isConfidential},
-          defaultValue{std::move(defaultValue)} {}
-};
 
 struct DBConfig {
     uint64_t bufferPoolSize;

--- a/src/include/main/option.h
+++ b/src/include/main/option.h
@@ -1,0 +1,58 @@
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <utility>
+
+#include "common/types/value/value.h"
+
+namespace lbug {
+namespace common {
+enum class LogicalTypeID : uint8_t;
+} // namespace common
+
+namespace main {
+
+class ClientContext;
+
+typedef void (*set_context)(ClientContext* context, const common::Value& parameter);
+typedef common::Value (*get_setting)(const ClientContext* context);
+
+enum class OptionType : uint8_t { CONFIGURATION = 0, EXTENSION = 1 };
+
+struct Option {
+    std::string name;
+    common::LogicalTypeID parameterType;
+    OptionType optionType;
+    bool isConfidential;
+
+    Option(std::string name, common::LogicalTypeID parameterType, OptionType optionType,
+        bool isConfidential)
+        : name{std::move(name)}, parameterType{parameterType}, optionType{optionType},
+          isConfidential{isConfidential} {}
+
+    virtual ~Option() = default;
+};
+
+struct ConfigurationOption final : Option {
+    set_context setContext;
+    get_setting getSetting;
+
+    ConfigurationOption(std::string name, common::LogicalTypeID parameterType,
+        set_context setContext, get_setting getSetting)
+        : Option{std::move(name), parameterType, OptionType::CONFIGURATION,
+              false /* isConfidential */},
+          setContext{setContext}, getSetting{getSetting} {}
+};
+
+struct ExtensionOption final : Option {
+    common::Value defaultValue;
+
+    ExtensionOption(std::string name, common::LogicalTypeID parameterType,
+        common::Value defaultValue, bool isConfidential)
+        : Option{std::move(name), parameterType, OptionType::EXTENSION, isConfidential},
+          defaultValue{std::move(defaultValue)} {}
+};
+
+} // namespace main
+} // namespace lbug

--- a/src/include/main/storage_driver.h
+++ b/src/include/main/storage_driver.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "common/types/types.h"
 #include "database.h"
 
 namespace lbug {

--- a/src/main/client_context.cpp
+++ b/src/main/client_context.cpp
@@ -62,7 +62,7 @@ ClientContext::ClientContext(Database* database) : localDatabase{database} {
     clientConfig.fileSearchPath = "";
     clientConfig.enableSemiMask = ClientConfigDefault::ENABLE_SEMI_MASK;
     clientConfig.enableZoneMap = ClientConfigDefault::ENABLE_ZONE_MAP;
-    clientConfig.numThreads = database->dbConfig.maxNumThreads;
+    clientConfig.numThreads = database->dbConfig->maxNumThreads;
     clientConfig.timeoutInMS = ClientConfigDefault::TIMEOUT_IN_MS;
     clientConfig.varLengthMaxDepth = ClientConfigDefault::VAR_LENGTH_MAX_DEPTH;
     clientConfig.enableProgressBar = ClientConfigDefault::ENABLE_PROGRESS_BAR;
@@ -86,11 +86,11 @@ ClientContext::~ClientContext() {
 }
 
 const DBConfig* ClientContext::getDBConfig() const {
-    return &getDatabase()->dbConfig;
+    return getDatabase()->dbConfig.get();
 }
 
 DBConfig* ClientContext::getDBConfigUnsafe() const {
-    return &getDatabase()->dbConfig;
+    return getDatabase()->dbConfig.get();
 }
 
 uint64_t ClientContext::getTimeoutRemainingInMS() const {
@@ -117,7 +117,7 @@ uint64_t ClientContext::getQueryTimeOut() const {
 void ClientContext::setMaxNumThreadForExec(uint64_t numThreads) {
     lock_t lck{mtx};
     if (numThreads == 0) {
-        numThreads = localDatabase->dbConfig.maxNumThreads;
+        numThreads = localDatabase->dbConfig->maxNumThreads;
     }
     clientConfig.numThreads = numThreads;
 }

--- a/src/main/database.cpp
+++ b/src/main/database.cpp
@@ -90,14 +90,14 @@ Database::Database(std::string_view databasePath, SystemConfig systemConfig)
 
 Database::Database(std::string_view databasePath, SystemConfig systemConfig,
     construct_bm_func_t constructBMFunc)
-    : dbConfig(systemConfig) {
+    : dbConfig{std::make_unique<DBConfig>(systemConfig)} {
     initMembers(databasePath, constructBMFunc);
 }
 
 std::unique_ptr<BufferManager> Database::initBufferManager(const Database& db) {
     return std::make_unique<BufferManager>(db.databasePath,
-        StorageUtils::getTmpFilePath(db.databasePath), db.dbConfig.bufferPoolSize,
-        db.dbConfig.maxDBSize, db.vfs.get(), db.dbConfig.readOnly);
+        StorageUtils::getTmpFilePath(db.databasePath), db.dbConfig->bufferPoolSize,
+        db.dbConfig->maxDBSize, db.vfs.get(), db.dbConfig->readOnly);
 }
 
 void Database::initMembers(std::string_view dbPath, construct_bm_func_t initBmFunc) {
@@ -117,14 +117,14 @@ void Database::initMembers(std::string_view dbPath, construct_bm_func_t initBmFu
     memoryManager = std::make_unique<MemoryManager>(bufferManager.get(), vfs.get());
 #if defined(__APPLE__)
     queryProcessor =
-        std::make_unique<processor::QueryProcessor>(dbConfig.maxNumThreads, dbConfig.threadQos);
+        std::make_unique<processor::QueryProcessor>(dbConfig->maxNumThreads, dbConfig->threadQos);
 #else
-    queryProcessor = std::make_unique<processor::QueryProcessor>(dbConfig.maxNumThreads);
+    queryProcessor = std::make_unique<processor::QueryProcessor>(dbConfig->maxNumThreads);
 #endif
 
     catalog = std::make_unique<Catalog>();
-    storageManager = std::make_unique<StorageManager>(databasePath, dbConfig.readOnly,
-        dbConfig.enableChecksums, *memoryManager, dbConfig.enableCompression, vfs.get());
+    storageManager = std::make_unique<StorageManager>(databasePath, dbConfig->readOnly,
+        dbConfig->enableChecksums, *memoryManager, dbConfig->enableCompression, vfs.get());
     transactionManager = std::make_unique<TransactionManager>(storageManager->getWAL());
     databaseManager = std::make_unique<DatabaseManager>();
 
@@ -135,15 +135,15 @@ void Database::initMembers(std::string_view dbPath, construct_bm_func_t initBmFu
         extensionManager->autoLoadLinkedExtensions(&clientContext);
         return;
     }
-    StorageManager::recover(clientContext, dbConfig.throwOnWalReplayFailure,
-        dbConfig.enableChecksums);
+    StorageManager::recover(clientContext, dbConfig->throwOnWalReplayFailure,
+        dbConfig->enableChecksums);
 
     // Load graphs from system catalog
     databaseManager->loadGraphsFromCatalog(memoryManager.get(), &clientContext);
 }
 
 Database::~Database() {
-    if (!dbConfig.readOnly && dbConfig.forceCheckpointOnClose) {
+    if (!dbConfig->readOnly && dbConfig->forceCheckpointOnClose) {
         try {
             ClientContext clientContext(this);
             transactionManager->checkpoint(clientContext);
@@ -224,8 +224,16 @@ std::vector<StorageExtension*> Database::getStorageExtensions() {
     return extensionManager->getStorageExtensions();
 }
 
+bool Database::isReadOnly() const {
+    return dbConfig->readOnly;
+}
+
+bool Database::isMultiWritesEnabled() const {
+    return dbConfig->enableMultiWrites;
+}
+
 void Database::validatePathInReadOnly() const {
-    if (dbConfig.readOnly) {
+    if (dbConfig->readOnly) {
         if (DBConfig::isDBPathInMemory(databasePath)) {
             throw Exception("Cannot open an in-memory database under READ ONLY mode.");
         }

--- a/test/c_api/database_test.cpp
+++ b/test/c_api/database_test.cpp
@@ -102,7 +102,7 @@ TEST_F(CApiDatabaseTest, CreationWithEnableMultiWrites) {
     ASSERT_NE(database._database, nullptr);
 
     auto databaseCpp = static_cast<Database*>(database._database);
-    ASSERT_TRUE(databaseCpp->getConfig().enableMultiWrites);
+    ASSERT_TRUE(databaseCpp->isMultiWritesEnabled());
     lbug_database_destroy(&database);
 }
 

--- a/tools/shell/embedded_shell.cpp
+++ b/tools/shell/embedded_shell.cpp
@@ -520,7 +520,7 @@ std::string decodeEscapeSequences(const std::string& input) {
 
 void EmbeddedShell::checkConfidentialStatement(const std::string& query, QueryResult* queryResult,
     std::string& input) {
-    if (queryResult->isSuccess() && !database->getConfig().readOnly &&
+    if (queryResult->isSuccess() && !database->isReadOnly() &&
         queryResult->getQuerySummary()->getStatementType() == StatementType::STANDALONE_CALL) {
         auto clientContext = conn->getClientContext();
         auto parsedQueries = clientContext->parseQuery(query);


### PR DESCRIPTION
Right now adding a new bool to DBconfig requires all extensions to be recompiled. This is undesirable.

So we take a one time ABI hit for future flexibility