### PR TITLE
fix(file_system): improve lock error message by adding PID and OS error details

### DIFF
--- a/src/common/file_system/local_file_system.cpp
+++ b/src/common/file_system/local_file_system.cpp
@@ -145,7 +145,8 @@ std::unique_ptr<FileInfo> LocalFileSystem::openFile(const std::string& path, Fil
         fl.l_len = 0;
         int rc = fcntl(fd, F_SETLK, &fl);
         if (rc == -1) {
-            if (errno == EAGAIN || errno == EACCES) {
+            int original_errno = errno;
+            if (original_errno == EAGAIN || original_errno == EACCES) {
                 struct flock get_fl {};
                 memset(&get_fl, 0, sizeof get_fl);
                 get_fl.l_type = flags.lockType == FileLockType::READ_LOCK ? F_RDLCK : F_WRLCK;
@@ -162,6 +163,7 @@ std::unique_ptr<FileInfo> LocalFileSystem::openFile(const std::string& path, Fil
                     }
                 }
             }
+            errno = original_errno;
             throw IOException("Could not set lock on file : " + fullPath +
                               " (Error: " + posixErrMessage() + ")\n" +
                               "See the docs: https://docs.ladybugdb.com/concurrency for more "

--- a/src/common/file_system/local_file_system.cpp
+++ b/src/common/file_system/local_file_system.cpp
@@ -123,9 +123,11 @@ std::unique_ptr<FileInfo> LocalFileSystem::openFile(const std::string& path, Fil
         BOOL rc = LockFileEx(handle, dwFlags, 0 /*reserved*/, 1 /*numBytesLow*/, 0 /*numBytesHigh*/,
             &overlapped);
         if (!rc) {
-            throw IOException(
-                "Could not set lock on file : " + fullPath + "\n" +
-                "See the docs: https://docs.ladybugdb.com/concurrency for more information.");
+            auto error = GetLastError();
+            throw IOException("Could not set lock on file : " + fullPath +
+                              " (Error: " + std::to_string(error) + ")\n" +
+                              "See the docs: https://docs.ladybugdb.com/concurrency for more "
+                              "information.");
         }
     }
     return std::make_unique<LocalFileInfo>(fullPath, handle, this);
@@ -143,9 +145,27 @@ std::unique_ptr<FileInfo> LocalFileSystem::openFile(const std::string& path, Fil
         fl.l_len = 0;
         int rc = fcntl(fd, F_SETLK, &fl);
         if (rc == -1) {
-            throw IOException(
-                "Could not set lock on file : " + fullPath + "\n" +
-                "See the docs: https://docs.ladybugdb.com/concurrency for more information.");
+            if (errno == EAGAIN || errno == EACCES) {
+                struct flock get_fl {};
+                memset(&get_fl, 0, sizeof get_fl);
+                get_fl.l_type = flags.lockType == FileLockType::READ_LOCK ? F_RDLCK : F_WRLCK;
+                get_fl.l_whence = SEEK_SET;
+                get_fl.l_start = 0;
+                get_fl.l_len = 0;
+                if (fcntl(fd, F_GETLK, &get_fl) != -1) {
+                    if (get_fl.l_type != F_UNLCK) {
+                        throw IOException(
+                            "Could not set lock on file : " + fullPath + " (Lock is held by PID " +
+                            std::to_string(get_fl.l_pid) + ")\n" +
+                            "See the docs: https://docs.ladybugdb.com/concurrency for more "
+                            "information.");
+                    }
+                }
+            }
+            throw IOException("Could not set lock on file : " + fullPath +
+                              " (Error: " + posixErrMessage() + ")\n" +
+                              "See the docs: https://docs.ladybugdb.com/concurrency for more "
+                              "information.");
         }
     }
     return std::make_unique<LocalFileInfo>(fullPath, fd, this);


### PR DESCRIPTION
## Description

Improves the lock error message when a process cannot acquire a lock on the database files by adding the blocking process ID (PID) and OS error details to the POSIX lock failure messages using `fcntl(F_GETLK)`. Adds `posixErrMessage()` or `GetLastError()` details directly to the lock failure messages to make debugging easier.

This fixes confusing lock errors where users could not identify what process was holding the LadybugDB database lock.

## Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation Update

## Checklist

- [ ] I have changed storage version if on disk format has changed.
- [x] I have requested a review from a maintainer.
- [ ] I have updated the documentation (if needed).