### PR TITLE
Fix inline property filter support for ANY graph queries

### DIFF
--- a/src/common/json_utils.cpp
+++ b/src/common/json_utils.cpp
@@ -702,7 +702,7 @@ std::string jsonExtractToString(const JsonWrapper& wrapper, uint64_t pos) {
     return jsonToString(yyjson_arr_get(yyjson_doc_get_root(wrapper.ptr), pos));
 }
 
-std::string jsonExtractToString(const JsonWrapper& wrapper, std::string path) {
+static yyjson_val* jsonNavigatePath(const JsonWrapper& wrapper, const std::string& path) {
     std::vector<std::string> actualPath;
     for (auto i = 0u, prvDelim = 0u; i <= path.size(); i++) {
         if (i == path.size() || path[i] == '/' || path[i] == '.') {
@@ -720,14 +720,39 @@ std::string jsonExtractToString(const JsonWrapper& wrapper, std::string path) {
         } else {
             int32_t idx = -1;
             if (!function::trySimpleIntegerCast(item.c_str(), item.length(), idx)) {
-                return "";
+                return nullptr;
             }
             ptr = yyjson_arr_get(ptr, idx);
         }
         if (ptr == nullptr) {
-            return "";
+            return nullptr;
         }
     }
+    return ptr;
+}
+
+std::string jsonExtractToString(const JsonWrapper& wrapper, std::string path) {
+    auto ptr = jsonNavigatePath(wrapper, path);
+    if (ptr == nullptr) {
+        return "";
+    }
+    return jsonToString(ptr);
+}
+
+std::string jsonExtractScalarToString(const JsonWrapper& wrapper, std::string path) {
+    auto ptr = jsonNavigatePath(wrapper, path);
+
+    if (ptr == nullptr) {
+        return "";
+    }
+
+    // For JSON string values return the raw string content (without JSON quote delimiters) so
+    // comparisons match what CAST(T -> JSON/STRING) produces on the RHS of a filter predicate.
+    if (yyjson_get_type(ptr) == YYJSON_TYPE_STR) {
+        auto raw = yyjson_get_str(ptr);
+        return raw ? std::string(raw) : "";
+    }
+
     return jsonToString(ptr);
 }
 

--- a/src/include/common/json_utils.h
+++ b/src/include/common/json_utils.h
@@ -66,6 +66,9 @@ LBUG_API JsonWrapper mergeJson(const JsonWrapper& A, const JsonWrapper& B);
 
 LBUG_API std::string jsonExtractToString(const JsonWrapper& wrapper, uint64_t pos);
 LBUG_API std::string jsonExtractToString(const JsonWrapper& wrapper, std::string path);
+// Like jsonExtractToString but returns the raw scalar value for JSON strings (no JSON delimiters),
+// matching what CAST(T -> JSON/STRING) produces. Used for inline property filter comparisons.
+LBUG_API std::string jsonExtractScalarToString(const JsonWrapper& wrapper, std::string path);
 
 LBUG_API uint32_t jsonArraySize(const JsonWrapper& wrapper);
 

--- a/src/planner/join_order/cardinality_estimator.cpp
+++ b/src/planner/join_order/cardinality_estimator.cpp
@@ -168,6 +168,12 @@ static std::optional<cardinality_t> getTableStatsIfPossible(main::ClientContext*
             auto transaction = Transaction::Get(*context);
             auto entry =
                 catalog::Catalog::Get(*context)->getTableCatalogEntry(transaction, tableID);
+
+            // Dynamic properties (e.g., in ANY graphs stored as JSON) are not real columns.
+            if (!entry->containsProperty(propertyExpr.getPropertyName())) {
+                return {};
+            }
+
             auto columnID = entry->getColumnID(propertyExpr.getPropertyName());
             if (columnID != INVALID_COLUMN_ID && columnID != ROW_IDX_COLUMN_ID) {
                 auto& stats = nodeTableStats.at(tableID);

--- a/src/processor/operator/scan/scan_table.cpp
+++ b/src/processor/operator/scan/scan_table.cpp
@@ -33,7 +33,8 @@ void ColumnCaster::cast() {
                 vectorAfterCasting->setNull(pos, true);
                 continue;
             }
-            auto extracted = json_extension::jsonExtractToString(json, *jsonExtractPropertyName);
+            auto extracted =
+                json_extension::jsonExtractScalarToString(json, *jsonExtractPropertyName);
             if (extracted.empty()) {
                 vectorAfterCasting->setNull(pos, true);
                 continue;

--- a/test/test_files/graph/any.test
+++ b/test/test_files/graph/any.test
@@ -31,7 +31,26 @@
 -LOG QueryDynamicProperties
 -STATEMENT MATCH (u:User)-[:LivesIn]->(c:City) RETURN u.name, c.name
 ---- 1
-"Alice"|"New York"
+Alice|New York
+
+-LOG InlineIntPropertyFilter
+-STATEMENT MATCH (a:User {age: 30}) RETURN a.name
+---- 1
+Alice
+
+-LOG InlineStringPropertyFilter
+-STATEMENT MATCH (a:User {name: 'Alice'}) RETURN a.age
+---- 1
+30
+
+-LOG InlinePropertyFilterReturnStar
+-STATEMENT MATCH (a:User {age: 30}) RETURN a.*
+---- 1
+0|[User]|{"age":30,"name":"Alice"}
+
+-LOG InlinePropertyFilterNoMatch
+-STATEMENT MATCH (a:User {age: 99}) RETURN a.name
+---- 0
 
 -LOG Cleanup
 -STATEMENT USE GRAPH main


### PR DESCRIPTION
Two bugs prevented MATCH (a:Label { prop: val }) from working in ANY graphs:

1. JSON string serialization mismatch in ColumnCaster (scan_table.cpp): yyjson_val_write() serialized JSON strings as '"Alice"' (with JSON quote delimiters), but CAST(STRING → JSON) on the RHS produced 'Alice' (no delimiters). Numbers accidentally worked because both sides produced '30'. Fix: add jsonExtractScalarToString() which uses yyjson_get_str() for string JSON values (returns raw string content), falling back to jsonToString() for numbers and booleans.

2. Cardinality estimator crash (cardinality_estimator.cpp): getTableStatsIfPossible() called entry->getColumnID(propertyName) without checking whether the property actually exists as a column. In ANY graphs, properties like 'age' are stored as JSON in the 'data' column — not as individual columns — so nameToPropertyIDMap.at('age') threw unordered_map::at. Fix: add entry->containsProperty(propertyName) guard before getColumnID call.

Also updates the QueryDynamicProperties test expectation: with the scan fix, string properties now return unquoted values (e.g., Alice instead of "Alice"), consistent with regular graph property access.

Adds four new test cases to test/test_files/graph/any.test:
- InlineIntPropertyFilter
- InlineStringPropertyFilter
- InlinePropertyFilterReturnStar
- InlinePropertyFilterNoMatch

Closes https://github.com/LadybugDB/ladybug/issues/451