### PR TITLE
Fix open graph dynamic property filters

### DIFF
--- a/src/common/json_utils.cpp
+++ b/src/common/json_utils.cpp
@@ -702,7 +702,9 @@ std::string jsonExtractToString(const JsonWrapper& wrapper, uint64_t pos) {
     return jsonToString(yyjson_arr_get(yyjson_doc_get_root(wrapper.ptr), pos));
 }
 
-std::string jsonExtractToString(const JsonWrapper& wrapper, std::string path) {
+namespace {
+
+yyjson_val* extractJsonByPath(const JsonWrapper& wrapper, const std::string& path) {
     std::vector<std::string> actualPath;
     for (auto i = 0u, prvDelim = 0u; i <= path.size(); i++) {
         if (i == path.size() || path[i] == '/' || path[i] == '.') {
@@ -720,13 +722,34 @@ std::string jsonExtractToString(const JsonWrapper& wrapper, std::string path) {
         } else {
             int32_t idx = -1;
             if (!function::trySimpleIntegerCast(item.c_str(), item.length(), idx)) {
-                return "";
+                return nullptr;
             }
             ptr = yyjson_arr_get(ptr, idx);
         }
         if (ptr == nullptr) {
-            return "";
+            return nullptr;
         }
+    }
+    return ptr;
+}
+
+} // namespace
+
+std::string jsonExtractToString(const JsonWrapper& wrapper, std::string path) {
+    auto ptr = extractJsonByPath(wrapper, path);
+    if (ptr == nullptr) {
+        return "";
+    }
+    return jsonToString(ptr);
+}
+
+std::string jsonExtractScalarToString(const JsonWrapper& wrapper, std::string path) {
+    auto ptr = extractJsonByPath(wrapper, path);
+    if (ptr == nullptr) {
+        return "";
+    }
+    if (yyjson_is_str(ptr)) {
+        return yyjson_get_str(ptr);
     }
     return jsonToString(ptr);
 }

--- a/src/include/common/json_utils.h
+++ b/src/include/common/json_utils.h
@@ -66,6 +66,7 @@ LBUG_API JsonWrapper mergeJson(const JsonWrapper& A, const JsonWrapper& B);
 
 LBUG_API std::string jsonExtractToString(const JsonWrapper& wrapper, uint64_t pos);
 LBUG_API std::string jsonExtractToString(const JsonWrapper& wrapper, std::string path);
+LBUG_API std::string jsonExtractScalarToString(const JsonWrapper& wrapper, std::string path);
 
 LBUG_API uint32_t jsonArraySize(const JsonWrapper& wrapper);
 

--- a/src/planner/join_order/cardinality_estimator.cpp
+++ b/src/planner/join_order/cardinality_estimator.cpp
@@ -168,6 +168,9 @@ static std::optional<cardinality_t> getTableStatsIfPossible(main::ClientContext*
             auto transaction = Transaction::Get(*context);
             auto entry =
                 catalog::Catalog::Get(*context)->getTableCatalogEntry(transaction, tableID);
+            if (!entry->containsProperty(propertyExpr.getPropertyName())) {
+                return {};
+            }
             auto columnID = entry->getColumnID(propertyExpr.getPropertyName());
             if (columnID != INVALID_COLUMN_ID && columnID != ROW_IDX_COLUMN_ID) {
                 auto& stats = nodeTableStats.at(tableID);

--- a/src/processor/map/map_extend.cpp
+++ b/src/processor/map/map_extend.cpp
@@ -40,6 +40,12 @@ static ScanRelTableInfo getRelTableScanInfo(const TableCatalogEntry& tableEntry,
         auto& property = expr->constCast<PropertyExpression>();
         if (property.hasProperty(tableEntry.getTableID())) {
             auto propertyName = property.getPropertyName();
+            if (!tableEntry.containsProperty(propertyName) && tableEntry.containsProperty("data")) {
+                auto columnCaster = ColumnCaster(LogicalType::JSON());
+                columnCaster.setJSONExtract(propertyName);
+                tableInfo.addColumnInfo(tableEntry.getColumnID("data"), std::move(columnCaster));
+                continue;
+            }
             auto& columnType = tableEntry.getProperty(propertyName).getType();
             auto columnCaster = ColumnCaster(columnType.copy());
             if (property.getDataType() != columnType) {

--- a/src/processor/operator/scan/scan_rel_table.cpp
+++ b/src/processor/operator/scan/scan_rel_table.cpp
@@ -137,6 +137,7 @@ bool ScanRelTable::getNextTuplesInternal(ExecutionContext* context) {
             while (tableInfo.table->scan(transaction, *scanState)) {
                 const auto outputSize = scanState->outState->getSelVector().getSelSize();
                 if (outputSize > 0) {
+                    tableInfo.castColumns();
                     metrics->numOutputTuple.increase(outputSize);
                     return true;
                 }
@@ -150,7 +151,7 @@ bool ScanRelTable::getNextTuplesInternal(ExecutionContext* context) {
         while (tableInfo.table->scan(transaction, *scanState)) {
             const auto outputSize = scanState->outState->getSelVector().getSelSize();
             if (outputSize > 0) {
-                // No need to perform column cast because this is single table scan.
+                tableInfo.castColumns();
                 metrics->numOutputTuple.increase(outputSize);
                 return true;
             }

--- a/src/processor/operator/scan/scan_table.cpp
+++ b/src/processor/operator/scan/scan_table.cpp
@@ -33,7 +33,8 @@ void ColumnCaster::cast() {
                 vectorAfterCasting->setNull(pos, true);
                 continue;
             }
-            auto extracted = json_extension::jsonExtractToString(json, *jsonExtractPropertyName);
+            auto extracted =
+                json_extension::jsonExtractScalarToString(json, *jsonExtractPropertyName);
             if (extracted.empty()) {
                 vectorAfterCasting->setNull(pos, true);
                 continue;

--- a/test/test_files/graph/any.test
+++ b/test/test_files/graph/any.test
@@ -19,7 +19,7 @@
 ---- ok
 
 -LOG CreateNodesAndRelationship
--STATEMENT CREATE (:User {name: 'Alice', age: 30})-[:LivesIn]->(:City {name: 'New York', population: 8000000})
+-STATEMENT CREATE (:User {name: 'Alice', age: 30})-[:LivesIn {since: 2020}]->(:City {name: 'New York', population: 8000000})
 ---- ok
 
 -LOG QueryAllNodes
@@ -31,7 +31,37 @@
 -LOG QueryDynamicProperties
 -STATEMENT MATCH (u:User)-[:LivesIn]->(c:City) RETURN u.name, c.name
 ---- 1
-"Alice"|"New York"
+Alice|New York
+
+-LOG QueryDynamicNodePropertyInPatternFilter
+-STATEMENT MATCH (u:User {age: 30}) RETURN u.name, u.age
+---- 1
+Alice|30
+
+-LOG QueryDynamicStringNodePropertyInPatternFilter
+-STATEMENT MATCH (u:User {name: 'Alice'}) RETURN u.name, u.age
+---- 1
+Alice|30
+
+-LOG QueryDynamicNodePropertyInWhereFilter
+-STATEMENT MATCH (u:User) WHERE u.age = 30 RETURN u.*
+---- 1
+0|[User]|{"age":30,"name":"Alice"}
+
+-LOG QueryDynamicStringNodePropertyInWhereFilter
+-STATEMENT MATCH (u:User) WHERE u.name = 'Alice' RETURN u.name, u.age
+---- 1
+Alice|30
+
+-LOG QueryDynamicRelPropertyInPatternFilter
+-STATEMENT MATCH (:User)-[e:LivesIn {since: 2020}]->(:City) RETURN e.since
+---- 1
+2020
+
+-LOG QueryDynamicRelPropertyInWhereFilter
+-STATEMENT MATCH (:User)-[e:LivesIn]->(:City) WHERE e.since = 2020 RETURN e.since
+---- 1
+2020
 
 -LOG Cleanup
 -STATEMENT USE GRAPH main


### PR DESCRIPTION
Fixes: #451 

Open type graph dynamic properties are stored in the system data `JSON` column, but filtered scans were treating them like physical table columns. This made pattern predicates and WHERE predicates on labels such as User.age call property metadata lookups that do not exist for _nodes/_edges, which surfaced as unordered_map::at failures instead of behaving like a declared node or edge table.

Route missing dynamic properties through JSON extraction during scan planning, apply the same casting path for relationship scans, and avoid cardinality estimation lookups for properties that are not physical columns. Add ANY graph regressions for node and relationship property filters so open graphs match the behavior users get after creating explicit node and edge tables.