### PR TITLE
Honor node visibility in recursive graph scans

### DIFF
--- a/src/graph/on_disk_graph.cpp
+++ b/src/graph/on_disk_graph.cpp
@@ -200,6 +200,7 @@ std::unique_ptr<NbrScanState> OnDiskGraph::prepareRelScan(const TableCatalogEntr
     auto& info = graphEntry.getRelInfo(entry.getTableID());
     auto state = std::make_unique<OnDiskGraphNbrScanState>(context, entry, relTableID,
         info.predicate, relProperties, randomLookup);
+    state->nbrNodeTable = nodeIDToNodeTable.at(nbrTableID);
     if (nodeOffsetMaskMap != nullptr && nodeOffsetMaskMap->containsTableID(nbrTableID)) {
         state->nbrNodeMask = nodeOffsetMaskMap->getOffsetMask(nbrTableID);
     }
@@ -235,7 +236,7 @@ std::unique_ptr<VertexScanState> OnDiskGraph::prepareVertexScan(TableCatalogEntr
 }
 
 bool OnDiskGraphNbrScanState::InnerIterator::next(evaluator::ExpressionEvaluator* predicate,
-    SemiMask* nbrNodeMask_) {
+    SemiMask* nbrNodeMask_, NodeTable* nbrNodeTable_) {
     bool hasAtLeastOneSelectedValue = false;
     do {
         restoreSelVector(*tableScanState->outState);
@@ -261,6 +262,19 @@ bool OnDiskGraphNbrScanState::InnerIterator::next(evaluator::ExpressionEvaluator
             tableScanState->outState->getSelVectorUnsafe().setToFiltered(selectedSize);
             hasAtLeastOneSelectedValue = selectedSize > 0;
         }
+        if (nbrNodeTable_ != nullptr) {
+            auto selectedSize = 0u;
+            auto buffer = tableScanState->outState->getSelVectorUnsafe().getMutableBuffer();
+            auto transaction = transaction::Transaction::Get(*context);
+            for (auto i = 0u; i < tableScanState->outState->getSelSize(); ++i) {
+                auto pos = tableScanState->outState->getSelVector()[i];
+                buffer[selectedSize] = pos;
+                auto nbrNodeID = tableScanState->outputVectors[0]->getValue<nodeID_t>(pos);
+                selectedSize += nbrNodeTable_->isVisible(transaction, nbrNodeID.offset);
+            }
+            tableScanState->outState->getSelVectorUnsafe().setToFiltered(selectedSize);
+            hasAtLeastOneSelectedValue = selectedSize > 0;
+        }
     } while (!hasAtLeastOneSelectedValue);
     return true;
 }
@@ -282,7 +296,7 @@ void OnDiskGraphNbrScanState::startScan(RelDataDirection direction) {
 
 bool OnDiskGraphNbrScanState::next() {
     DASSERT(currentIter != nullptr);
-    if (currentIter->next(relPredicateEvaluator.get(), nbrNodeMask)) {
+    if (currentIter->next(relPredicateEvaluator.get(), nbrNodeMask, nbrNodeTable)) {
         return true;
     }
     return false;

--- a/src/include/graph/on_disk_graph.h
+++ b/src/include/graph/on_disk_graph.h
@@ -63,7 +63,8 @@ public:
             return tableScanState->outState->getSelVector();
         }
 
-        bool next(evaluator::ExpressionEvaluator* predicate, common::SemiMask* nbrNodeMask);
+        bool next(evaluator::ExpressionEvaluator* predicate, common::SemiMask* nbrNodeMask,
+            storage::NodeTable* nbrNodeTable);
         void initScan() const;
 
         common::RelDataDirection getDirection() const { return tableScanState->direction; }
@@ -83,6 +84,7 @@ private:
 
     std::unique_ptr<evaluator::ExpressionEvaluator> relPredicateEvaluator;
     common::SemiMask* nbrNodeMask = nullptr;
+    storage::NodeTable* nbrNodeTable = nullptr;
 
     std::vector<InnerIterator> directedIterators;
     InnerIterator* currentIter = nullptr;

--- a/src/include/storage/local_storage/local_node_table.h
+++ b/src/include/storage/local_storage/local_node_table.h
@@ -41,13 +41,13 @@ public:
 
     TableStats getStats() const { return nodeGroups.getStats(); }
     common::offset_t getStartOffset() const { return startOffset; }
+    bool isVisible(const transaction::Transaction* transaction, common::offset_t offset) const;
 
     static std::vector<common::LogicalType> getNodeTableColumnTypes(
         const catalog::TableCatalogEntry& table);
 
 private:
     void initLocalHashIndex(MemoryManager& mm);
-    bool isVisible(const transaction::Transaction* transaction, common::offset_t offset) const;
 
 private:
     // This is equivalent to the num of committed nodes in the table.

--- a/src/processor/operator/recursive_extend.cpp
+++ b/src/processor/operator/recursive_extend.cpp
@@ -7,6 +7,8 @@
 #include "function/gds/gds_function_collection.h"
 #include "function/gds/gds_utils.h"
 #include "processor/execution_context.h"
+#include "storage/storage_manager.h"
+#include "storage/table/node_table.h"
 #include "transaction/transaction.h"
 
 using namespace lbug::common;
@@ -94,7 +96,13 @@ void RecursiveExtend::executeInternal(ExecutionContext* context) {
         totalNumNodes = inputNodeMaskMap->getNumMaskedNode();
     } else {
         for (auto& tableID : graph->getNodeTableIDs()) {
-            totalNumNodes += graph->getMaxOffset(transaction, tableID);
+            auto nodeTable = storage::StorageManager::Get(*clientContext)
+                                 ->getTable(tableID)
+                                 ->ptrCast<storage::NodeTable>();
+            auto maxOffset = graph->getMaxOffset(transaction, tableID);
+            for (auto offset = 0u; offset < maxOffset; ++offset) {
+                totalNumNodes += nodeTable->isVisible(transaction, offset);
+            }
         }
     }
     std::vector<std::string> propertyNames;
@@ -143,7 +151,13 @@ void RecursiveExtend::executeInternal(ExecutionContext* context) {
                 }
             }
         } else {
+            auto nodeTable = storage::StorageManager::Get(*clientContext)
+                                 ->getTable(tableID)
+                                 ->ptrCast<storage::NodeTable>();
             for (auto offset = 0u; offset < maxOffset; ++offset) {
+                if (!nodeTable->isVisible(transaction, offset)) {
+                    continue;
+                }
                 calcFunc(offset);
                 progressBar->updateProgress(context->queryID,
                     getRJProgress(totalNumNodes, completedNumNodes++));

--- a/src/storage/table/node_table.cpp
+++ b/src/storage/table/node_table.cpp
@@ -740,12 +740,25 @@ TableStats NodeTable::getStats(const Transaction* transaction) const {
 }
 
 bool NodeTable::isVisible(const Transaction* transaction, offset_t offset) const {
+    if (transaction && transaction->isUnCommitted(tableID, offset)) {
+        const auto localTable = transaction->getLocalStorage()->getLocalTable(tableID);
+        DASSERT(localTable);
+        return localTable->cast<LocalNodeTable>().isVisible(transaction, offset);
+    }
     auto [nodeGroupIdx, offsetInGroup] = StorageUtils::getNodeGroupIdxAndOffsetInChunk(offset);
+    if (nodeGroupIdx >= nodeGroups->getNumNodeGroups()) {
+        return false;
+    }
     const auto* nodeGroup = getNodeGroup(nodeGroupIdx);
     return nodeGroup->isVisible(transaction, offsetInGroup);
 }
 
 bool NodeTable::isVisibleNoLock(const Transaction* transaction, offset_t offset) const {
+    if (transaction && transaction->isUnCommitted(tableID, offset)) {
+        const auto localTable = transaction->getLocalStorage()->getLocalTable(tableID);
+        DASSERT(localTable);
+        return localTable->cast<LocalNodeTable>().isVisible(transaction, offset);
+    }
     auto [nodeGroupIdx, offsetInGroup] = StorageUtils::getNodeGroupIdxAndOffsetInChunk(offset);
     if (nodeGroupIdx >= nodeGroups->getNumNodeGroupsNoLock()) {
         return false;


### PR DESCRIPTION
Fixes: #456 

Recursive joins were iterating raw node offset ranges and OnDiskGraph neighbor scans only applied relationship visibility, so paths could be enumerated through deleted nodes and later fail when rels(p) tried to materialize deleted relationship property tuples. Filter recursive source offsets and scanned neighbor IDs through NodeTable visibility so recursive enumeration matches direct scan semantics and avoids stale path elements.