### PR TITLE
Arrow CSR zero copy export

### DIFF
--- a/scripts/run-clang-format.py
+++ b/scripts/run-clang-format.py
@@ -254,7 +254,7 @@ def main():
         '--clang-format-executable',
         metavar='EXECUTABLE',
         help='path to the clang-format executable',
-        default='clang-format-11')
+        default='clang-format-18')
     parser.add_argument(
         '--extensions',
         help='comma separated list of file extensions (default: {})'.format(

--- a/src/include/main/query_result/arrow_query_result.h
+++ b/src/include/main/query_result/arrow_query_result.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <memory>
 #include <optional>
 
 #include "main/query_result.h"
@@ -17,6 +18,45 @@ public:
         std::vector<int64_t> indices;
         std::vector<int64_t> edgeIDs;
         bool hasEdgeIDs = false;
+    };
+
+    struct CSRArrowArray {
+        ArrowArray array{};
+        ArrowSchema schema{};
+
+        CSRArrowArray() = default;
+        ~CSRArrowArray() { release(); }
+        CSRArrowArray(CSRArrowArray&& other) noexcept : array{other.array}, schema{other.schema} {
+            other.array.release = nullptr;
+            other.schema.release = nullptr;
+        }
+        CSRArrowArray& operator=(CSRArrowArray&& other) noexcept {
+            if (this != &other) {
+                release();
+                array = other.array;
+                schema = other.schema;
+                other.array.release = nullptr;
+                other.schema.release = nullptr;
+            }
+            return *this;
+        }
+        CSRArrowArray(const CSRArrowArray&) = delete;
+        CSRArrowArray& operator=(const CSRArrowArray&) = delete;
+
+        void release() {
+            if (schema.release) {
+                schema.release(&schema);
+            }
+            if (array.release) {
+                array.release(&array);
+            }
+        }
+    };
+
+    struct CSRArrowArrays {
+        CSRArrowArray indptr;
+        CSRArrowArray indices;
+        std::optional<CSRArrowArray> edgeIDs;
     };
 
     ArrowQueryResult(std::vector<ArrowArray> arrays, int64_t chunkSize);
@@ -39,8 +79,9 @@ public:
 
     std::unique_ptr<ArrowArray> getNextArrowChunk(int64_t chunkSize) override;
 
-    bool hasCSRMetadata() const { return csrMetadata.has_value(); }
+    bool hasCSRMetadata() const { return csrMetadata != nullptr; }
     const CSRMetadata& getCSRMetadata() const { return *csrMetadata; }
+    CSRArrowArrays getCSRArrowArrays() const;
 
 private:
     ArrowArray getArray(processor::FactorizedTableIterator& iterator, int64_t chunkSize);
@@ -50,7 +91,7 @@ private:
     int64_t chunkSize_;
     uint64_t numTuples = 0;
     uint64_t cursor = 0;
-    std::optional<CSRMetadata> csrMetadata;
+    std::shared_ptr<const CSRMetadata> csrMetadata;
 };
 
 } // namespace main

--- a/src/include/processor/operator/arrow_result_collector.h
+++ b/src/include/processor/operator/arrow_result_collector.h
@@ -103,5 +103,33 @@ private:
     ArrowResultCollectorLocalState localState;
 };
 
+class DirectArrowResultCollector final : public Sink {
+    static constexpr PhysicalOperatorType type_ = PhysicalOperatorType::RESULT_COLLECTOR;
+
+public:
+    DirectArrowResultCollector(std::shared_ptr<ArrowResultCollectorSharedState> sharedState,
+        ArrowResultCollectorInfo info, std::unique_ptr<PhysicalOperator> child, physical_op_id id,
+        std::unique_ptr<OPPrintInfo> printInfo)
+        : Sink{type_, std::move(child), id, std::move(printInfo)},
+          sharedState{std::move(sharedState)}, info{std::move(info)} {}
+
+    std::unique_ptr<main::QueryResult> getQueryResult() const override;
+
+    void executeInternal(ExecutionContext* context) override;
+
+    std::unique_ptr<PhysicalOperator> copy() override {
+        return std::make_unique<DirectArrowResultCollector>(sharedState, info.copy(),
+            children[0]->copy(), id, printInfo->copy());
+    }
+
+private:
+    void initLocalStateInternal(ResultSet* resultSet, ExecutionContext*) override;
+
+private:
+    std::shared_ptr<ArrowResultCollectorSharedState> sharedState;
+    ArrowResultCollectorInfo info;
+    ArrowResultCollectorLocalState localState;
+};
+
 } // namespace processor
 } // namespace lbug

--- a/src/main/query_result/arrow_query_result.cpp
+++ b/src/main/query_result/arrow_query_result.cpp
@@ -1,5 +1,7 @@
 #include "main/query_result/arrow_query_result.h"
 
+#include <array>
+
 #include "common/arrow/arrow_row_batch.h"
 #include "common/exception/not_implemented.h"
 #include "common/exception/runtime.h"
@@ -12,6 +14,65 @@ using namespace lbug::processor;
 namespace lbug {
 namespace main {
 
+namespace {
+
+struct CSRArrowArrayHolder {
+    std::shared_ptr<const std::vector<int64_t>> values;
+    std::array<const void*, 2> buffers = {{nullptr, nullptr}};
+};
+
+static void releaseCSRArrowArray(ArrowArray* array) {
+    if (!array || !array->release) {
+        return;
+    }
+    array->release = nullptr;
+    auto holder = static_cast<CSRArrowArrayHolder*>(array->private_data);
+    delete holder;
+    array->private_data = nullptr;
+}
+
+static void releaseCSRArrowSchema(ArrowSchema* schema) {
+    if (!schema || !schema->release) {
+        return;
+    }
+    schema->release = nullptr;
+}
+
+static ArrowQueryResult::CSRArrowArray makeCSRArrowArray(
+    std::shared_ptr<const std::vector<int64_t>> values) {
+    ArrowQueryResult::CSRArrowArray result;
+
+    auto holder = std::make_unique<CSRArrowArrayHolder>();
+    holder->values = std::move(values);
+    holder->buffers[0] = nullptr;
+    holder->buffers[1] = holder->values->data();
+
+    result.array.length = static_cast<int64_t>(holder->values->size());
+    result.array.null_count = 0;
+    result.array.offset = 0;
+    result.array.n_buffers = 2;
+    result.array.n_children = 0;
+    result.array.buffers = holder->buffers.data();
+    result.array.children = nullptr;
+    result.array.dictionary = nullptr;
+    result.array.private_data = holder.release();
+    result.array.release = releaseCSRArrowArray;
+
+    result.schema.format = "l";
+    result.schema.name = nullptr;
+    result.schema.metadata = nullptr;
+    result.schema.flags = 0;
+    result.schema.n_children = 0;
+    result.schema.children = nullptr;
+    result.schema.dictionary = nullptr;
+    result.schema.private_data = nullptr;
+    result.schema.release = releaseCSRArrowSchema;
+
+    return result;
+}
+
+} // namespace
+
 ArrowQueryResult::ArrowQueryResult(std::vector<ArrowArray> arrays, int64_t chunkSize)
     : QueryResult{type_}, arrays{std::move(arrays)}, chunkSize_{chunkSize} {
     for (auto& array : this->arrays) {
@@ -22,7 +83,7 @@ ArrowQueryResult::ArrowQueryResult(std::vector<ArrowArray> arrays, int64_t chunk
 ArrowQueryResult::ArrowQueryResult(std::vector<ArrowArray> arrays, int64_t chunkSize,
     CSRMetadata csrMetadata)
     : QueryResult{type_}, arrays{std::move(arrays)}, chunkSize_{chunkSize},
-      csrMetadata{std::move(csrMetadata)} {
+      csrMetadata{std::make_shared<CSRMetadata>(std::move(csrMetadata))} {
     for (auto& array : this->arrays) {
         numTuples += array.length;
     }
@@ -85,6 +146,22 @@ std::unique_ptr<ArrowArray> ArrowQueryResult::getNextArrowChunk(int64_t chunkSiz
             std::format("Chunk size does not match expected value {}.", chunkSize_));
     }
     return std::make_unique<ArrowArray>(arrays[cursor++]);
+}
+
+ArrowQueryResult::CSRArrowArrays ArrowQueryResult::getCSRArrowArrays() const {
+    if (!hasCSRMetadata()) {
+        throw RuntimeException("Arrow query result does not have CSR metadata.");
+    }
+    CSRArrowArrays result;
+    result.indptr = makeCSRArrowArray(
+        std::shared_ptr<const std::vector<int64_t>>(csrMetadata, &csrMetadata->indptr));
+    result.indices = makeCSRArrowArray(
+        std::shared_ptr<const std::vector<int64_t>>(csrMetadata, &csrMetadata->indices));
+    if (csrMetadata->hasEdgeIDs) {
+        result.edgeIDs = makeCSRArrowArray(
+            std::shared_ptr<const std::vector<int64_t>>(csrMetadata, &csrMetadata->edgeIDs));
+    }
+    return result;
 }
 
 } // namespace main

--- a/src/processor/map/create_arrow_result_collector.cpp
+++ b/src/processor/map/create_arrow_result_collector.cpp
@@ -55,9 +55,17 @@ std::unique_ptr<PhysicalOperator> PlanMapper::createArrowResultCollector(
         columnTypes.push_back(expr->getDataType().copy());
     }
     auto sharedState = std::make_shared<ArrowResultCollectorSharedState>();
+    auto csrTrackingInfo = getCSRTrackingInfo(expressions);
     auto opInfo = ArrowResultCollectorInfo(arrowConfig.chunkSize, columnDataPos,
-        std::move(columnTypes), getCSRTrackingInfo(expressions));
+        std::move(columnTypes), csrTrackingInfo);
     auto printInfo = OPPrintInfo::EmptyInfo();
+    if (csrTrackingInfo.enabled() &&
+        (expressions.size() == 2 || (expressions.size() == 3 && csrTrackingInfo.hasRelRowID()))) {
+        auto op = std::make_unique<DirectArrowResultCollector>(sharedState, std::move(opInfo),
+            std::move(prevOperator), getOperatorID(), std::move(printInfo));
+        op->setDescriptor(std::make_unique<ResultSetDescriptor>(schema));
+        return op;
+    }
     auto op = std::make_unique<ArrowResultCollector>(sharedState, std::move(opInfo),
         std::move(prevOperator), getOperatorID(), std::move(printInfo));
     op->setDescriptor(std::make_unique<ResultSetDescriptor>(schema));

--- a/src/processor/operator/arrow_result_collector.cpp
+++ b/src/processor/operator/arrow_result_collector.cpp
@@ -1,12 +1,121 @@
 #include "processor/operator/arrow_result_collector.h"
 
+#include <array>
+
 #include "common/arrow/arrow_row_batch.h"
+#include "common/exception/runtime.h"
 #include "main/query_result/arrow_query_result.h"
 
 using namespace lbug::common;
 
 namespace lbug {
 namespace processor {
+
+namespace {
+
+struct DirectArrowChunkHolder {
+    std::vector<std::vector<int64_t>> columns;
+    std::array<const void*, 1> rootBuffers = {{nullptr}};
+    std::vector<std::array<const void*, 2>> childBuffers;
+    std::vector<ArrowArray> children;
+    std::vector<ArrowArray*> childPtrs;
+};
+
+static void releaseDirectArrowChunk(ArrowArray* array) {
+    if (!array || !array->release) {
+        return;
+    }
+    array->release = nullptr;
+    auto holder = static_cast<DirectArrowChunkHolder*>(array->private_data);
+    delete holder;
+    array->private_data = nullptr;
+}
+
+static ArrowArray makeDirectInt64ArrowChunk(std::vector<std::vector<int64_t>> columns) {
+    auto holder = std::make_unique<DirectArrowChunkHolder>();
+    holder->columns = std::move(columns);
+    const auto numColumns = holder->columns.size();
+    const auto length = numColumns == 0 ? 0 : holder->columns[0].size();
+    holder->childBuffers.resize(numColumns);
+    holder->children.resize(numColumns);
+    holder->childPtrs.resize(numColumns);
+    for (auto i = 0u; i < numColumns; ++i) {
+        holder->childBuffers[i][0] = nullptr;
+        holder->childBuffers[i][1] = holder->columns[i].data();
+        auto& child = holder->children[i];
+        child.length = static_cast<int64_t>(holder->columns[i].size());
+        child.null_count = 0;
+        child.offset = 0;
+        child.n_buffers = 2;
+        child.n_children = 0;
+        child.buffers = holder->childBuffers[i].data();
+        child.children = nullptr;
+        child.dictionary = nullptr;
+        child.release = nullptr;
+        child.private_data = nullptr;
+        holder->childPtrs[i] = &child;
+    }
+
+    ArrowArray result{};
+    result.length = static_cast<int64_t>(length);
+    result.null_count = 0;
+    result.offset = 0;
+    result.n_buffers = 1;
+    result.n_children = static_cast<int64_t>(numColumns);
+    result.buffers = holder->rootBuffers.data();
+    result.children = holder->childPtrs.data();
+    result.dictionary = nullptr;
+    result.private_data = holder.release();
+    result.release = releaseDirectArrowChunk;
+    return result;
+}
+
+static void updateDirectCSRMetadata(const CSRTrackingInfo& info, const std::vector<int64_t>& values,
+    ArrowResultCollectorLocalState& localState) {
+    if (!info.enabled() || !localState.csrMetadataValid) {
+        return;
+    }
+    const auto srcRowID = values[info.srcRowIDColIdx];
+    const auto dstRowID = values[info.dstRowIDColIdx];
+    if (!localState.csrMetadata.has_value()) {
+        main::ArrowQueryResult::CSRMetadata metadata;
+        metadata.indptr.push_back(0);
+        metadata.hasEdgeIDs = info.hasRelRowID();
+        localState.csrMetadata = std::move(metadata);
+    }
+    auto& metadata = *localState.csrMetadata;
+    if (srcRowID < 0 || dstRowID < 0) {
+        localState.csrMetadataValid = false;
+        localState.csrMetadata.reset();
+        return;
+    }
+    if (localState.currentSourceRowID == -1) {
+        while (localState.nextSourceRowID < srcRowID) {
+            metadata.indptr.push_back(static_cast<int64_t>(metadata.indices.size()));
+            localState.nextSourceRowID++;
+        }
+        localState.currentSourceRowID = srcRowID;
+    } else if (srcRowID != localState.currentSourceRowID) {
+        if (srcRowID < localState.currentSourceRowID) {
+            localState.csrMetadataValid = false;
+            localState.csrMetadata.reset();
+            return;
+        }
+        metadata.indptr.push_back(static_cast<int64_t>(metadata.indices.size()));
+        localState.nextSourceRowID = localState.currentSourceRowID + 1;
+        while (localState.nextSourceRowID < srcRowID) {
+            metadata.indptr.push_back(static_cast<int64_t>(metadata.indices.size()));
+            localState.nextSourceRowID++;
+        }
+        localState.currentSourceRowID = srcRowID;
+    }
+    metadata.indices.push_back(dstRowID);
+    if (info.hasRelRowID()) {
+        metadata.edgeIDs.push_back(values[info.relRowIDColIdx]);
+    }
+}
+
+} // namespace
 
 static void updateCSRMetadata(const CSRTrackingInfo& info, FlatTuple& tuple,
     ArrowResultCollectorLocalState& localState) {
@@ -154,6 +263,77 @@ void ArrowResultCollector::initLocalStateInternal(ResultSet* resultSet, Executio
 }
 
 std::unique_ptr<main::QueryResult> ArrowResultCollector::getQueryResult() const {
+    if (sharedState->csrMetadata.has_value()) {
+        return std::make_unique<main::ArrowQueryResult>(std::move(sharedState->arrays),
+            info.chunkSize, std::move(*sharedState->csrMetadata));
+    }
+    return std::make_unique<main::ArrowQueryResult>(std::move(sharedState->arrays), info.chunkSize);
+}
+
+void DirectArrowResultCollector::initLocalStateInternal(ResultSet* resultSet, ExecutionContext*) {
+    std::unordered_map<idx_t, idx_t> idxMap;
+    for (auto& pos : info.payloadPositions) {
+        auto idx = pos.dataChunkPos;
+        if (idxMap.contains(idx)) {
+            continue;
+        }
+        idxMap.insert({idx, localState.chunks.size()});
+        localState.chunks.push_back(resultSet->getDataChunk(idx).get());
+        localState.chunkCursors.push_back(0);
+    }
+    for (auto& pos : info.payloadPositions) {
+        auto vector = resultSet->getValueVector(pos).get();
+        if (vector->dataType.getLogicalTypeID() != LogicalTypeID::INT64) {
+            throw RuntimeException(
+                "Direct Arrow CSR collector only supports INT64 rowid projections.");
+        }
+        localState.vectors.push_back(vector);
+        localState.vectorsSelPos.push_back(localState.chunkCursors[idxMap.at(pos.dataChunkPos)]);
+    }
+}
+
+void DirectArrowResultCollector::executeInternal(ExecutionContext* context) {
+    std::vector<std::vector<int64_t>> columns(info.payloadPositions.size());
+    std::vector<int64_t> rowValues(info.payloadPositions.size());
+    auto flushChunk = [&]() {
+        if (columns.empty() || columns[0].empty()) {
+            return;
+        }
+        localState.arrays.push_back(makeDirectInt64ArrowChunk(std::move(columns)));
+        columns = std::vector<std::vector<int64_t>>(info.payloadPositions.size());
+    };
+
+    while (children[0]->getNextTuple(context)) {
+        localState.resetCursor();
+        while (true) {
+            for (auto i = 0u; i < localState.vectors.size(); ++i) {
+                auto vector = localState.vectors[i];
+                auto pos = vector->state->getSelVector()[localState.vectorsSelPos[i]];
+                if (vector->isNull(pos)) {
+                    throw RuntimeException(
+                        "Direct Arrow CSR collector cannot export null rowid values.");
+                }
+                rowValues[i] = vector->getValue<int64_t>(pos);
+                columns[i].push_back(rowValues[i]);
+            }
+            updateDirectCSRMetadata(info.csrTrackingInfo, rowValues, localState);
+            if (columns[0].size() == static_cast<uint64_t>(info.chunkSize)) {
+                flushChunk();
+            }
+            if (!localState.advance()) {
+                break;
+            }
+        }
+    }
+    flushChunk();
+    if (localState.csrMetadata.has_value()) {
+        localState.csrMetadata->indptr.push_back(
+            static_cast<int64_t>(localState.csrMetadata->indices.size()));
+    }
+    sharedState->merge(localState.arrays, localState.csrMetadata);
+}
+
+std::unique_ptr<main::QueryResult> DirectArrowResultCollector::getQueryResult() const {
     if (sharedState->csrMetadata.has_value()) {
         return std::make_unique<main::ArrowQueryResult>(std::move(sharedState->arrays),
             info.chunkSize, std::move(*sharedState->csrMetadata));

--- a/src/storage/table/arrow_rel_table.cpp
+++ b/src/storage/table/arrow_rel_table.cpp
@@ -6,6 +6,7 @@
 #include "common/arrow/arrow_nullmask_tree.h"
 #include "common/data_chunk/sel_vector.h"
 #include "common/exception/runtime.h"
+#include "common/system_config.h"
 #include "common/types/internal_id_util.h"
 #include "storage/table/arrow_table_support.h"
 #include "storage/table/csr_node_group.h"
@@ -190,7 +191,10 @@ bool ArrowRelTable::scanInternal(transaction::Transaction* transaction, TableSca
 
     scanState.resetOutVectors();
     auto outputCount = 0u;
-    constexpr uint64_t maxRowsPerCall = 1;
+    constexpr uint64_t maxRowsPerCall = DEFAULT_VECTOR_CAPACITY;
+    auto activeBoundSelPos = INVALID_SEL;
+    auto activeBoundOffset = INVALID_OFFSET;
+    auto hasActiveBound = false;
 
     while (outputCount < maxRowsPerCall && relScanState.currentBatchIdx < arrays.size()) {
         const auto& batch = arrays[relScanState.currentBatchIdx];
@@ -201,13 +205,14 @@ bool ArrowRelTable::scanInternal(transaction::Transaction* transaction, TableSca
             continue;
         }
 
-        auto srcOffsetInBatch = relScanState.currentBatchOffset++;
+        auto srcOffsetInBatch = relScanState.currentBatchOffset;
         auto numChildren = batch.n_children < 0 ? 0u : static_cast<uint64_t>(batch.n_children);
         if (numChildren == 0 || !batch.children || !schema.children ||
             static_cast<uint64_t>(fromColumnIdx) >= numChildren ||
             static_cast<uint64_t>(toColumnIdx) >= numChildren || !batch.children[fromColumnIdx] ||
             !batch.children[toColumnIdx] || !schema.children[fromColumnIdx] ||
             !schema.children[toColumnIdx]) {
+            relScanState.currentBatchOffset++;
             continue;
         }
 
@@ -220,11 +225,13 @@ bool ArrowRelTable::scanInternal(transaction::Transaction* transaction, TableSca
         readSingleArrowValue(srcChildSchema, srcChildArray, *relScanState.srcKeyVector,
             srcOffsetToRead, 0);
         if (relScanState.srcKeyVector->isNull(0)) {
+            relScanState.currentBatchOffset++;
             continue;
         }
         readSingleArrowValue(dstChildSchema, dstChildArray, *relScanState.dstKeyVector,
             dstOffsetToRead, 0);
         if (relScanState.dstKeyVector->isNull(0)) {
+            relScanState.currentBatchOffset++;
             continue;
         }
 
@@ -232,19 +239,29 @@ bool ArrowRelTable::scanInternal(transaction::Transaction* transaction, TableSca
         offset_t dstNodeOffset = INVALID_OFFSET;
         if (!fromNodeTable->lookupPK(transaction, relScanState.srcKeyVector.get(), 0,
                 srcNodeOffset)) {
+            relScanState.currentBatchOffset++;
             continue;
         }
         if (!toNodeTable->lookupPK(transaction, relScanState.dstKeyVector.get(), 0,
                 dstNodeOffset)) {
+            relScanState.currentBatchOffset++;
             continue;
         }
 
         auto isFwd = relScanState.direction != RelDataDirection::BWD;
         auto boundOffset = isFwd ? srcNodeOffset : dstNodeOffset;
-        if (!relScanState.boundNodeOffsetToSelPos.contains(boundOffset)) {
+        auto boundIt = relScanState.boundNodeOffsetToSelPos.find(boundOffset);
+        if (boundIt == relScanState.boundNodeOffsetToSelPos.end()) {
+            relScanState.currentBatchOffset++;
             continue;
         }
-        relScanState.setNodeIDVectorToFlat(relScanState.boundNodeOffsetToSelPos.at(boundOffset));
+        if (!hasActiveBound) {
+            hasActiveBound = true;
+            activeBoundOffset = boundOffset;
+            activeBoundSelPos = boundIt->second;
+        } else if (boundOffset != activeBoundOffset) {
+            break;
+        }
 
         auto nbrOffset = isFwd ? dstNodeOffset : srcNodeOffset;
         auto nbrTableID = isFwd ? getToNodeTableID() : getFromNodeTableID();
@@ -278,6 +295,7 @@ bool ArrowRelTable::scanInternal(transaction::Transaction* transaction, TableSca
                 childArray->offset + srcOffsetInBatch, outputCount);
         }
         outputCount++;
+        relScanState.currentBatchOffset++;
     }
 
     if (outputCount == 0) {
@@ -287,6 +305,7 @@ bool ArrowRelTable::scanInternal(transaction::Transaction* transaction, TableSca
         return false;
     }
 
+    relScanState.setNodeIDVectorToFlat(activeBoundSelPos);
     auto selVector = std::make_shared<SelectionVector>(outputCount);
     selVector->setToFiltered(outputCount);
     for (uint64_t i = 0; i < outputCount; ++i) {

--- a/test/api/arrow_test.cpp
+++ b/test/api/arrow_test.cpp
@@ -8,6 +8,36 @@ using namespace lbug::testing;
 
 class ArrowTest : public ApiTest {};
 
+static void releaseCSRArrowArray(ArrowQueryResult::CSRArrowArray& array) {
+    array.release();
+}
+
+TEST(ArrowQueryResultTest, exportsCSRMetadataAsZeroCopyArrowArrays) {
+    ArrowQueryResult::CSRMetadata metadata;
+    metadata.indptr = {0, 2, 3};
+    metadata.indices = {4, 5, 6};
+    metadata.edgeIDs = {10, 11, 12};
+    metadata.hasEdgeIDs = true;
+
+    ArrowQueryResult result{{}, 8, std::move(metadata)};
+    const auto& storedMetadata = result.getCSRMetadata();
+    auto csrArrays = result.getCSRArrowArrays();
+
+    ASSERT_STREQ(csrArrays.indptr.schema.format, "l");
+    ASSERT_STREQ(csrArrays.indices.schema.format, "l");
+    ASSERT_TRUE(csrArrays.edgeIDs.has_value());
+    ASSERT_STREQ(csrArrays.edgeIDs->schema.format, "l");
+    ASSERT_EQ(csrArrays.indptr.array.length, static_cast<int64_t>(storedMetadata.indptr.size()));
+    ASSERT_EQ(csrArrays.indices.array.length, static_cast<int64_t>(storedMetadata.indices.size()));
+    ASSERT_EQ(csrArrays.edgeIDs->array.length, static_cast<int64_t>(storedMetadata.edgeIDs.size()));
+    ASSERT_EQ(csrArrays.indptr.array.buffers[0], nullptr);
+    ASSERT_EQ(csrArrays.indices.array.buffers[0], nullptr);
+    ASSERT_EQ(csrArrays.edgeIDs->array.buffers[0], nullptr);
+    ASSERT_EQ(csrArrays.indptr.array.buffers[1], storedMetadata.indptr.data());
+    ASSERT_EQ(csrArrays.indices.array.buffers[1], storedMetadata.indices.data());
+    ASSERT_EQ(csrArrays.edgeIDs->array.buffers[1], storedMetadata.edgeIDs.data());
+}
+
 TEST_F(ArrowTest, resultToArrow) {
     auto query = "MATCH (a:person) WHERE a.fName = 'Bob' RETURN a.fName";
     auto result = conn->query(query);
@@ -101,6 +131,21 @@ TEST_F(ArrowTest, queryAsArrowTracksCSRMetadataWithoutRelIDs) {
     ASSERT_FALSE(metadata.hasEdgeIDs);
     ASSERT_TRUE(metadata.edgeIDs.empty());
 
+    auto csrArrays = arrowResult->getCSRArrowArrays();
+    ASSERT_STREQ(csrArrays.indptr.schema.format, "l");
+    ASSERT_STREQ(csrArrays.indices.schema.format, "l");
+    ASSERT_EQ(csrArrays.indptr.array.length, static_cast<int64_t>(metadata.indptr.size()));
+    ASSERT_EQ(csrArrays.indices.array.length, static_cast<int64_t>(metadata.indices.size()));
+    ASSERT_EQ(csrArrays.indptr.array.null_count, 0);
+    ASSERT_EQ(csrArrays.indices.array.null_count, 0);
+    ASSERT_EQ(csrArrays.indptr.array.buffers[0], nullptr);
+    ASSERT_EQ(csrArrays.indices.array.buffers[0], nullptr);
+    ASSERT_EQ(csrArrays.indptr.array.buffers[1], metadata.indptr.data());
+    ASSERT_EQ(csrArrays.indices.array.buffers[1], metadata.indices.data());
+    ASSERT_FALSE(csrArrays.edgeIDs.has_value());
+    releaseCSRArrowArray(csrArrays.indptr);
+    releaseCSRArrowArray(csrArrays.indices);
+
     std::vector<std::pair<int64_t, int64_t>> reconstructed;
     ASSERT_GE(metadata.indptr.size(), 1);
     for (auto srcRowID = 0u; srcRowID + 1 < metadata.indptr.size(); ++srcRowID) {
@@ -132,6 +177,15 @@ TEST_F(ArrowTest, queryAsArrowTracksCSRMetadataWithRelIDsAndExtraColumns) {
     const auto& metadata = arrowResult->getCSRMetadata();
     ASSERT_TRUE(metadata.hasEdgeIDs);
     ASSERT_EQ(metadata.indices.size(), metadata.edgeIDs.size());
+
+    auto csrArrays = arrowResult->getCSRArrowArrays();
+    ASSERT_TRUE(csrArrays.edgeIDs.has_value());
+    ASSERT_EQ(csrArrays.edgeIDs->array.length, static_cast<int64_t>(metadata.edgeIDs.size()));
+    ASSERT_EQ(csrArrays.edgeIDs->array.buffers[0], nullptr);
+    ASSERT_EQ(csrArrays.edgeIDs->array.buffers[1], metadata.edgeIDs.data());
+    releaseCSRArrowArray(csrArrays.indptr);
+    releaseCSRArrowArray(csrArrays.indices);
+    releaseCSRArrowArray(*csrArrays.edgeIDs);
 
     std::vector<std::tuple<int64_t, int64_t, int64_t>> reconstructed;
     ASSERT_GE(metadata.indptr.size(), 1);

--- a/test/api/arrow_test.cpp
+++ b/test/api/arrow_test.cpp
@@ -111,6 +111,58 @@ TEST_F(ArrowTest, getArrowSchema) {
     schema->release(schema.get());
 }
 
+TEST_F(ArrowTest, queryAsArrowDirectCSRRowIDProjection) {
+    ASSERT_TRUE(
+        conn->query("CREATE NODE TABLE DirectPerson(id INT64, PRIMARY KEY(id));")->isSuccess());
+    ASSERT_TRUE(conn->query("CREATE REL TABLE DirectKnows(FROM DirectPerson TO DirectPerson);")
+                    ->isSuccess());
+    ASSERT_TRUE(conn->query("CREATE (:DirectPerson {id: 0});")->isSuccess());
+    ASSERT_TRUE(conn->query("CREATE (:DirectPerson {id: 1});")->isSuccess());
+    ASSERT_TRUE(conn->query("CREATE (:DirectPerson {id: 2});")->isSuccess());
+    ASSERT_TRUE(conn->query("MATCH (a:DirectPerson {id: 0}), (b:DirectPerson {id: 1}) "
+                            "CREATE (a)-[:DirectKnows]->(b);")
+                    ->isSuccess());
+    ASSERT_TRUE(conn->query("MATCH (a:DirectPerson {id: 0}), (b:DirectPerson {id: 2}) "
+                            "CREATE (a)-[:DirectKnows]->(b);")
+                    ->isSuccess());
+    ASSERT_TRUE(conn->query("MATCH (a:DirectPerson {id: 1}), (b:DirectPerson {id: 2}) "
+                            "CREATE (a)-[:DirectKnows]->(b);")
+                    ->isSuccess());
+
+    auto query =
+        "MATCH (a:DirectPerson)-[r:DirectKnows]->(b:DirectPerson) RETURN a.rowid, r.rowid, b.rowid";
+    auto rowResult = conn->query(query);
+    std::vector<std::tuple<int64_t, int64_t, int64_t>> expected;
+    while (rowResult->hasNext()) {
+        auto tuple = rowResult->getNext();
+        expected.emplace_back(tuple->getValue(0)->getValue<int64_t>(),
+            tuple->getValue(1)->getValue<int64_t>(), tuple->getValue(2)->getValue<int64_t>());
+    }
+
+    auto result = conn->queryAsArrow(query, 2);
+    auto* arrowResult = dynamic_cast<ArrowQueryResult*>(result.get());
+    ASSERT_NE(arrowResult, nullptr);
+    ASSERT_TRUE(arrowResult->hasCSRMetadata());
+
+    ASSERT_TRUE(arrowResult->hasNextArrowChunk());
+    auto arrowArray = arrowResult->getNextArrowChunk(2);
+    ASSERT_EQ(arrowArray->n_children, 3);
+    ASSERT_EQ(arrowArray->length, 2);
+    ASSERT_EQ(arrowArray->children[0]->n_buffers, 2);
+    ASSERT_EQ(arrowArray->children[0]->buffers[0], nullptr);
+    arrowArray->release(arrowArray.get());
+
+    const auto& metadata = arrowResult->getCSRMetadata();
+    std::vector<std::tuple<int64_t, int64_t, int64_t>> reconstructed;
+    for (auto srcRowID = 0u; srcRowID + 1 < metadata.indptr.size(); ++srcRowID) {
+        for (auto idx = metadata.indptr[srcRowID]; idx < metadata.indptr[srcRowID + 1]; ++idx) {
+            reconstructed.emplace_back(static_cast<int64_t>(srcRowID), metadata.edgeIDs[idx],
+                metadata.indices[idx]);
+        }
+    }
+    ASSERT_EQ(reconstructed, expected);
+}
+
 TEST_F(ArrowTest, queryAsArrowTracksCSRMetadataWithoutRelIDs) {
     auto query =
         "MATCH (a:person)-[:knows]->(b:person) RETURN a.rowid, b.rowid ORDER BY a.rowid, b.rowid";


### PR DESCRIPTION
For rowid-only CSR projections like `RETURN a.rowid, b.rowid, c.rowid`, the planner now uses a direct Arrow collector. It reads the INT64 result vectors directly into Arrow/CSR buffers, bypassing the FlatTuple and ArrowRowBatch value-conversion path used by general Arrow results.