### PR TITLE
Expand C API coverage for Python bindings

### DIFF
--- a/src/c_api/connection.cpp
+++ b/src/c_api/connection.cpp
@@ -32,6 +32,7 @@ void lbug_connection_destroy(lbug_connection* connection) {
     }
     if (connection->_connection != nullptr) {
         delete static_cast<Connection*>(connection->_connection);
+        connection->_connection = nullptr;
     }
 }
 

--- a/src/c_api/data_type.cpp
+++ b/src/c_api/data_type.cpp
@@ -41,6 +41,7 @@ void lbug_data_type_destroy(lbug_logical_type* data_type) {
     }
     if (data_type->_data_type != nullptr) {
         delete static_cast<LogicalType*>(data_type->_data_type);
+        data_type->_data_type = nullptr;
     }
 }
 

--- a/src/c_api/database.cpp
+++ b/src/c_api/database.cpp
@@ -33,6 +33,7 @@ void lbug_database_destroy(lbug_database* database) {
     }
     if (database->_database != nullptr) {
         delete static_cast<Database*>(database->_database);
+        database->_database = nullptr;
     }
 }
 

--- a/src/c_api/prepared_statement.cpp
+++ b/src/c_api/prepared_statement.cpp
@@ -21,10 +21,12 @@ void lbug_prepared_statement_destroy(lbug_prepared_statement* prepared_statement
     }
     if (prepared_statement->_prepared_statement != nullptr) {
         delete static_cast<PreparedStatement*>(prepared_statement->_prepared_statement);
+        prepared_statement->_prepared_statement = nullptr;
     }
     if (prepared_statement->_bound_values != nullptr) {
         delete static_cast<std::unordered_map<std::string, std::unique_ptr<Value>>*>(
             prepared_statement->_bound_values);
+        prepared_statement->_bound_values = nullptr;
     }
 }
 

--- a/src/c_api/query_result.cpp
+++ b/src/c_api/query_result.cpp
@@ -15,6 +15,7 @@ void lbug_query_result_destroy(lbug_query_result* query_result) {
         if (!query_result->_is_owned_by_cpp) {
             delete static_cast<QueryResult*>(query_result->_query_result);
         }
+        query_result->_query_result = nullptr;
     }
 }
 

--- a/src/c_api/value.cpp
+++ b/src/c_api/value.cpp
@@ -12,6 +12,118 @@
 
 using namespace lbug::common;
 
+static bool isEmptyNestedWithAny(const Value& value) {
+    if (!value.getDataType().containsAny()) {
+        return false;
+    }
+    switch (value.getDataType().getPhysicalType()) {
+    case PhysicalTypeID::LIST:
+    case PhysicalTypeID::ARRAY:
+    case PhysicalTypeID::STRUCT:
+        return NestedVal::getChildrenSize(const_cast<Value*>(&value)) == 0;
+    default:
+        return false;
+    }
+}
+
+static bool tryGetMaxParameterType(const LogicalType& left, const LogicalType& right,
+    LogicalType& result) {
+    if (left.getLogicalTypeID() == LogicalTypeID::STRING ||
+        right.getLogicalTypeID() == LogicalTypeID::STRING) {
+        result = LogicalType::STRING();
+        return true;
+    }
+    return LogicalTypeUtils::tryGetMaxLogicalType(left, right, result);
+}
+
+static bool canCopyValueForNested(const Value& value, const LogicalType& targetType) {
+    if (value.getDataType() == targetType) {
+        return true;
+    }
+    if (value.isNull() && value.getDataType().getLogicalTypeID() == LogicalTypeID::ANY) {
+        return true;
+    }
+    if (isEmptyNestedWithAny(value)) {
+        return true;
+    }
+    if (targetType.getLogicalTypeID() == LogicalTypeID::STRING ||
+        targetType.getLogicalTypeID() == LogicalTypeID::DOUBLE ||
+        targetType.getLogicalTypeID() == LogicalTypeID::FLOAT) {
+        return true;
+    }
+    return value.getDataType().getLogicalTypeID() == targetType.getLogicalTypeID() &&
+           value.getDataType().containsAny();
+}
+
+static std::string incompatibleParameterTypeMessage(const LogicalType& left,
+    const LogicalType& right) {
+    return std::format("Runtime exception: Cannot convert Python object to Lbug value : {}  is "
+                       "incompatible with {}",
+        left.toString(), right.toString());
+}
+
+static lbug_value* createCAPIValue(std::unique_ptr<Value> value) {
+    auto* c_value = (lbug_value*)calloc(1, sizeof(lbug_value));
+    c_value->_value = value.release();
+    c_value->_is_owned_by_cpp = false;
+    return c_value;
+}
+
+static std::unique_ptr<Value> copyValueForNested(const Value& value,
+    const LogicalType& targetType) {
+    if (value.isNull() && value.getDataType().getLogicalTypeID() == LogicalTypeID::ANY) {
+        return std::make_unique<Value>(Value::createNullValue(targetType));
+    }
+    if (value.getDataType() != targetType && isEmptyNestedWithAny(value)) {
+        return std::make_unique<Value>(Value::createDefaultValue(targetType));
+    }
+    if (value.getDataType() != targetType &&
+        targetType.getLogicalTypeID() == LogicalTypeID::STRING) {
+        return std::make_unique<Value>(Value::createValue<std::string>(value.toString()));
+    }
+    if (value.getDataType() != targetType &&
+        targetType.getLogicalTypeID() == LogicalTypeID::DOUBLE) {
+        return std::make_unique<Value>(std::stod(value.toString()));
+    }
+    if (value.getDataType() != targetType &&
+        targetType.getLogicalTypeID() == LogicalTypeID::FLOAT) {
+        return std::make_unique<Value>(static_cast<float>(std::stof(value.toString())));
+    }
+    if (value.getDataType() != targetType &&
+        value.getDataType().getLogicalTypeID() == LogicalTypeID::LIST &&
+        targetType.getLogicalTypeID() == LogicalTypeID::LIST) {
+        std::vector<std::unique_ptr<Value>> children;
+        const auto& childType = ListType::getChildType(targetType);
+        for (auto i = 0u; i < NestedVal::getChildrenSize(const_cast<Value*>(&value)); ++i) {
+            children.push_back(copyValueForNested(
+                *NestedVal::getChildVal(const_cast<Value*>(&value), i), childType));
+        }
+        return std::make_unique<Value>(targetType.copy(), std::move(children));
+    }
+    if (value.getDataType() != targetType &&
+        value.getDataType().getLogicalTypeID() == LogicalTypeID::MAP &&
+        targetType.getLogicalTypeID() == LogicalTypeID::MAP) {
+        std::vector<std::unique_ptr<Value>> children;
+        const auto& keyType = MapType::getKeyType(targetType);
+        const auto& valueType = MapType::getValueType(targetType);
+        for (auto i = 0u; i < NestedVal::getChildrenSize(const_cast<Value*>(&value)); ++i) {
+            auto* mapEntry = NestedVal::getChildVal(const_cast<Value*>(&value), i);
+            std::vector<StructField> fields;
+            fields.emplace_back(InternalKeyword::MAP_KEY, keyType.copy());
+            fields.emplace_back(InternalKeyword::MAP_VALUE, valueType.copy());
+            std::vector<std::unique_ptr<Value>> structValues;
+            structValues.push_back(
+                copyValueForNested(*NestedVal::getChildVal(mapEntry, 0), keyType));
+            structValues.push_back(
+                copyValueForNested(*NestedVal::getChildVal(mapEntry, 1), valueType));
+            children.push_back(std::make_unique<Value>(LogicalType::STRUCT(std::move(fields)),
+                std::move(structValues)));
+        }
+        return std::make_unique<Value>(targetType.copy(), std::move(children));
+    }
+    return value.copy();
+}
+
 lbug_value* lbug_value_create_null() {
     auto* c_value = (lbug_value*)calloc(1, sizeof(lbug_value));
     c_value->_value = new Value(Value::createNullValue());
@@ -200,6 +312,12 @@ lbug_value* lbug_value_create_string(const char* val_) {
     return c_value;
 }
 
+lbug_value* lbug_value_create_json(const char* val_) {
+    auto* c_value = (lbug_value*)calloc(1, sizeof(lbug_value));
+    c_value->_value = new Value(LogicalType::JSON(), val_);
+    return c_value;
+}
+
 lbug_value* lbug_value_create_uuid(const char* val_) {
     auto* c_value = (lbug_value*)calloc(1, sizeof(lbug_value));
     c_value->_value =
@@ -209,10 +327,17 @@ lbug_value* lbug_value_create_uuid(const char* val_) {
 
 lbug_state lbug_value_create_list(uint64_t num_elements, lbug_value** elements,
     lbug_value** out_value) {
-    if (num_elements == 0) {
+    if (out_value == nullptr) {
         return LbugError;
     }
-    auto* c_value = (lbug_value*)calloc(1, sizeof(lbug_value));
+    if (num_elements == 0) {
+        *out_value = createCAPIValue(std::make_unique<Value>(LogicalType::LIST(LogicalType::ANY()),
+            std::vector<std::unique_ptr<Value>>{}));
+        return LbugSuccess;
+    }
+    if (elements == nullptr) {
+        return LbugError;
+    }
     std::vector<std::unique_ptr<Value>> children;
 
     auto first_element = static_cast<Value*>(elements[0]->_value);
@@ -220,23 +345,33 @@ lbug_state lbug_value_create_list(uint64_t num_elements, lbug_value** elements,
 
     for (uint64_t i = 0; i < num_elements; ++i) {
         auto child = static_cast<Value*>(elements[i]->_value);
-        if (child->getDataType() != type) {
-            free(c_value);
+        LogicalType resultType;
+        if (!tryGetMaxParameterType(type, child->getDataType(), resultType)) {
+            setLastCAPIErrorMessage(incompatibleParameterTypeMessage(type, child->getDataType()));
             return LbugError;
         }
-        // Copy the value to the list value to transfer ownership to the C++ side.
-        children.push_back(child->copy());
+        type = std::move(resultType);
     }
-    auto list_type = LogicalType::LIST(first_element->getDataType().copy());
-    c_value->_value = new Value(list_type.copy(), std::move(children));
-    c_value->_is_owned_by_cpp = false;
+    for (uint64_t i = 0; i < num_elements; ++i) {
+        auto child = static_cast<Value*>(elements[i]->_value);
+        if (!canCopyValueForNested(*child, type)) {
+            setLastCAPIErrorMessage(incompatibleParameterTypeMessage(child->getDataType(), type));
+            return LbugError;
+        }
+        children.push_back(copyValueForNested(*child, type));
+    }
+    auto* c_value = createCAPIValue(
+        std::make_unique<Value>(LogicalType::LIST(type.copy()), std::move(children)));
     *out_value = c_value;
     return LbugSuccess;
 }
 
 lbug_state lbug_value_create_struct(uint64_t num_fields, const char** field_names,
     lbug_value** field_values, lbug_value** out_value) {
-    if (num_fields == 0) {
+    if (out_value == nullptr) {
+        return LbugError;
+    }
+    if (num_fields == 0 || field_names == nullptr || field_values == nullptr) {
         return LbugError;
     }
     auto* c_value = (lbug_value*)calloc(1, sizeof(lbug_value));
@@ -258,10 +393,18 @@ lbug_state lbug_value_create_struct(uint64_t num_fields, const char** field_name
 
 lbug_state lbug_value_create_map(uint64_t num_fields, lbug_value** keys, lbug_value** values,
     lbug_value** out_value) {
-    if (num_fields == 0) {
+    if (out_value == nullptr) {
         return LbugError;
     }
-    auto* c_value = (lbug_value*)calloc(1, sizeof(lbug_value));
+    if (num_fields == 0) {
+        *out_value = createCAPIValue(
+            std::make_unique<Value>(LogicalType::MAP(LogicalType::ANY(), LogicalType::ANY()),
+                std::vector<std::unique_ptr<Value>>{}));
+        return LbugSuccess;
+    }
+    if (keys == nullptr || values == nullptr) {
+        return LbugError;
+    }
     std::vector<std::unique_ptr<Value>> children;
 
     auto first_key = static_cast<Value*>(keys[0]->_value);
@@ -272,23 +415,44 @@ lbug_state lbug_value_create_map(uint64_t num_fields, lbug_value** keys, lbug_va
     for (uint64_t i = 0; i < num_fields; ++i) {
         auto key = static_cast<Value*>(keys[i]->_value);
         auto value = static_cast<Value*>(values[i]->_value);
-        if (key->getDataType() != key_type || value->getDataType() != value_type) {
-            free(c_value);
+        LogicalType resultKeyType;
+        LogicalType resultValueType;
+        if (!tryGetMaxParameterType(key_type, key->getDataType(), resultKeyType)) {
+            setLastCAPIErrorMessage(incompatibleParameterTypeMessage(key_type, key->getDataType()));
+            return LbugError;
+        }
+        if (!tryGetMaxParameterType(value_type, value->getDataType(), resultValueType)) {
+            setLastCAPIErrorMessage(
+                incompatibleParameterTypeMessage(value_type, value->getDataType()));
+            return LbugError;
+        }
+        key_type = std::move(resultKeyType);
+        value_type = std::move(resultValueType);
+    }
+    for (uint64_t i = 0; i < num_fields; ++i) {
+        auto key = static_cast<Value*>(keys[i]->_value);
+        auto value = static_cast<Value*>(values[i]->_value);
+        if (!canCopyValueForNested(*key, key_type)) {
+            setLastCAPIErrorMessage(incompatibleParameterTypeMessage(key->getDataType(), key_type));
+            return LbugError;
+        }
+        if (!canCopyValueForNested(*value, value_type)) {
+            setLastCAPIErrorMessage(
+                incompatibleParameterTypeMessage(value->getDataType(), value_type));
             return LbugError;
         }
         std::vector<StructField> struct_fields;
         struct_fields.emplace_back(InternalKeyword::MAP_KEY, key_type.copy());
         struct_fields.emplace_back(InternalKeyword::MAP_VALUE, value_type.copy());
         std::vector<std::unique_ptr<Value>> struct_values;
-        struct_values.push_back(key->copy());
-        struct_values.push_back(value->copy());
+        struct_values.push_back(copyValueForNested(*key, key_type));
+        struct_values.push_back(copyValueForNested(*value, value_type));
         auto struct_type = LogicalType::STRUCT(std::move(struct_fields));
         auto struct_value = new Value(std::move(struct_type), std::move(struct_values));
         children.push_back(std::unique_ptr<Value>(struct_value));
     }
-    auto map_type = LogicalType::MAP(key_type.copy(), value_type.copy());
-    c_value->_value = new Value(map_type.copy(), std::move(children));
-    c_value->_is_owned_by_cpp = false;
+    auto* c_value = createCAPIValue(std::make_unique<Value>(
+        LogicalType::MAP(key_type.copy(), value_type.copy()), std::move(children)));
     *out_value = c_value;
     return LbugSuccess;
 }

--- a/src/c_api/version.cpp
+++ b/src/c_api/version.cpp
@@ -4,7 +4,11 @@
 #include "c_api/lbug.h"
 
 char* lbug_get_version() {
-    return convertToOwnedCString(lbug::main::Version::getVersion());
+    auto version = lbug::main::Version::getVersion();
+    if (version == nullptr || version[0] == '\0') {
+        version = "0.16.1";
+    }
+    return convertToOwnedCString(version);
 }
 
 uint64_t lbug_get_storage_version() {

--- a/src/include/c_api/lbug.h
+++ b/src/include/c_api/lbug.h
@@ -996,6 +996,12 @@ LBUG_C_API lbug_value* lbug_value_create_interval(lbug_interval_t val_);
  */
 LBUG_C_API lbug_value* lbug_value_create_string(const char* val_);
 /**
+ * @brief Creates a value with JSON type and the given JSON string representation.
+ * Caller is responsible for destroying the returned value.
+ * @param val_ The JSON string value to create.
+ */
+LBUG_C_API lbug_value* lbug_value_create_json(const char* val_);
+/**
  * @brief Creates a value with UUID type and the given string representation.
  * Caller is responsible for destroying the returned value.
  * @param val_ The UUID string value to create.

--- a/test/c_api/value_test.cpp
+++ b/test/c_api/value_test.cpp
@@ -355,7 +355,20 @@ TEST(CApiValueTestEmptyDB, CreateListDifferentTypes) {
     lbug_value* elements[] = {value1, value2};
     lbug_value* value = nullptr;
     lbug_state state = lbug_value_create_list(2, elements, &value);
-    ASSERT_EQ(state, LbugError);
+    ASSERT_EQ(state, LbugSuccess);
+    lbug_value listElement;
+    char* strResult = nullptr;
+    ASSERT_EQ(lbug_value_get_list_element(value, 0, &listElement), LbugSuccess);
+    ASSERT_EQ(lbug_value_get_string(&listElement, &strResult), LbugSuccess);
+    ASSERT_STREQ(strResult, "123");
+    lbug_destroy_string(strResult);
+    lbug_value_destroy(&listElement);
+    ASSERT_EQ(lbug_value_get_list_element(value, 1, &listElement), LbugSuccess);
+    ASSERT_EQ(lbug_value_get_string(&listElement, &strResult), LbugSuccess);
+    ASSERT_STREQ(strResult, "abcdefg");
+    lbug_destroy_string(strResult);
+    lbug_value_destroy(&listElement);
+    lbug_value_destroy(value);
     lbug_value_destroy(value1);
     lbug_value_destroy(value2);
 }
@@ -364,7 +377,31 @@ TEST(CApiValueTestEmptyDB, CreateListEmpty) {
     lbug_value* elements[] = {nullptr}; // Must be non-empty
     lbug_value* value = nullptr;
     lbug_state state = lbug_value_create_list(0, elements, &value);
-    ASSERT_EQ(state, LbugError);
+    ASSERT_EQ(state, LbugSuccess);
+    ASSERT_FALSE(value->_is_owned_by_cpp);
+    auto cppValue = static_cast<Value*>(value->_value);
+    ASSERT_EQ(cppValue->getDataType().getLogicalTypeID(), LogicalTypeID::LIST);
+    ASSERT_EQ(ListType::getChildType(cppValue->getDataType()).getLogicalTypeID(),
+        LogicalTypeID::ANY);
+    ASSERT_EQ(NestedVal::getChildrenSize(cppValue), 0);
+    lbug_value_destroy(value);
+}
+
+TEST(CApiValueTestEmptyDB, CreateListWithNull) {
+    lbug_value* value1 = lbug_value_create_null();
+    lbug_value* value2 = lbug_value_create_int64(123);
+    lbug_value* elements[] = {value1, value2};
+    lbug_value* value = nullptr;
+    lbug_state state = lbug_value_create_list(2, elements, &value);
+    ASSERT_EQ(state, LbugSuccess);
+    auto cppValue = static_cast<Value*>(value->_value);
+    ASSERT_EQ(ListType::getChildType(cppValue->getDataType()).getLogicalTypeID(),
+        LogicalTypeID::INT64);
+    ASSERT_TRUE(NestedVal::getChildVal(cppValue, 0)->isNull());
+    ASSERT_EQ(NestedVal::getChildVal(cppValue, 1)->getValue<int64_t>(), 123);
+    lbug_value_destroy(value1);
+    lbug_value_destroy(value2);
+    lbug_value_destroy(value);
 }
 
 TEST_F(CApiValueTest, CreateListNested) {
@@ -709,7 +746,45 @@ TEST(CApiValueTestEmptyDB, CreateMapEmpty) {
     lbug_value* values[] = {nullptr}; // Must be non-empty
     lbug_value* map = nullptr;
     lbug_state state = lbug_value_create_map(0, keys, values, &map);
-    ASSERT_EQ(state, LbugError);
+    ASSERT_EQ(state, LbugSuccess);
+    ASSERT_FALSE(map->_is_owned_by_cpp);
+    auto cppValue = static_cast<Value*>(map->_value);
+    ASSERT_EQ(cppValue->getDataType().getLogicalTypeID(), LogicalTypeID::MAP);
+    ASSERT_EQ(MapType::getKeyType(cppValue->getDataType()).getLogicalTypeID(), LogicalTypeID::ANY);
+    ASSERT_EQ(MapType::getValueType(cppValue->getDataType()).getLogicalTypeID(),
+        LogicalTypeID::ANY);
+    ASSERT_EQ(NestedVal::getChildrenSize(cppValue), 0);
+    lbug_value_destroy(map);
+}
+
+TEST(CApiValueTestEmptyDB, CreateMapWithNull) {
+    lbug_value* key1 = lbug_value_create_null();
+    lbug_value* key2 = lbug_value_create_int64(2);
+    lbug_value* value1 = lbug_value_create_string((char*)"one");
+    lbug_value* value2 = lbug_value_create_null();
+    lbug_value* keys[] = {key1, key2};
+    lbug_value* values[] = {value1, value2};
+    lbug_value* map = nullptr;
+    lbug_state state = lbug_value_create_map(2, keys, values, &map);
+    ASSERT_EQ(state, LbugSuccess);
+    auto cppValue = static_cast<Value*>(map->_value);
+    ASSERT_EQ(MapType::getKeyType(cppValue->getDataType()).getLogicalTypeID(),
+        LogicalTypeID::INT64);
+    ASSERT_EQ(MapType::getValueType(cppValue->getDataType()).getLogicalTypeID(),
+        LogicalTypeID::STRING);
+    lbug_value mapKey;
+    lbug_value mapValue;
+    ASSERT_EQ(lbug_value_get_map_key(map, 0, &mapKey), LbugSuccess);
+    ASSERT_EQ(lbug_value_get_map_value(map, 1, &mapValue), LbugSuccess);
+    ASSERT_TRUE(lbug_value_is_null(&mapKey));
+    ASSERT_TRUE(lbug_value_is_null(&mapValue));
+    lbug_value_destroy(&mapKey);
+    lbug_value_destroy(&mapValue);
+    lbug_value_destroy(key1);
+    lbug_value_destroy(key2);
+    lbug_value_destroy(value1);
+    lbug_value_destroy(value2);
+    lbug_value_destroy(map);
 }
 
 TEST(CApiValueTestEmptyDB, Clone) {


### PR DESCRIPTION
Add missing C API behavior needed by the ctypes Python backend:

- make C API object destructors idempotent by clearing destroyed handles

- support empty list/map values, null nested elements, and Python-style list/map type widening

- add JSON value construction for JSON-typed parameters

- expose a non-empty C API version fallback when the core version string is empty

- extend C API value tests to cover empty/null/mixed nested values