### PR TITLE
fix parquet table scans

### DIFF
--- a/src/graph/on_disk_graph.cpp
+++ b/src/graph/on_disk_graph.cpp
@@ -19,6 +19,7 @@
 #include "storage/storage_manager.h"
 #include "storage/storage_utils.h"
 #include "storage/table/node_table.h"
+#include "storage/table/parquet_rel_table.h"
 #include "storage/table/rel_table.h"
 
 using namespace lbug::catalog;
@@ -126,8 +127,16 @@ OnDiskGraphNbrScanState::OnDiskGraphNbrScanState(ClientContext* context,
             auto pos = DataPos(schema.getExpressionPos(*property));
             outVectors.push_back(resultSet.getValueVector(pos).get());
         }
-        auto scanState = std::make_unique<RelTableScanState>(*MemoryManager::Get(*context),
-            srcNodeIDVector.get(), outVectors, dstNodeIDVector->state, randomLookup);
+
+        std::unique_ptr<RelTableScanState> scanState;
+        if (dynamic_cast<ParquetRelTable*>(table) != nullptr) {
+            scanState = std::make_unique<ParquetRelTableScanState>(*mm, srcNodeIDVector.get(),
+                outVectors, state);
+        } else {
+            scanState = std::make_unique<RelTableScanState>(*MemoryManager::Get(*context),
+                srcNodeIDVector.get(), outVectors, dstNodeIDVector->state, randomLookup);
+        }
+
         scanState->setToTable(transaction::Transaction::Get(*context), table, columnIDs, {},
             dataDirection);
         directedIterators.emplace_back(context, table, std::move(scanState));

--- a/src/include/processor/operator/persistent/reader/parquet/parquet_reader.h
+++ b/src/include/processor/operator/persistent/reader/parquet/parquet_reader.h
@@ -48,7 +48,7 @@ public:
         common::VirtualFileSystem* vfs);
     bool scanInternal(ParquetReaderScanState& state, common::DataChunk& result);
     void scan(ParquetReaderScanState& state, common::DataChunk& result);
-    uint64_t getNumRowsGroups() { return metadata->row_groups.size(); }
+    uint64_t getNumRowGroups() { return metadata->row_groups.size(); }
 
     uint32_t getNumColumns() const { return columnNames.size(); }
     std::string getColumnName(uint32_t idx) const { return columnNames[idx]; }

--- a/src/include/storage/table/parquet_node_table.h
+++ b/src/include/storage/table/parquet_node_table.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <atomic>
 #include <mutex>
 #include <vector>
 
@@ -69,6 +70,11 @@ public:
 
     bool scanInternal(transaction::Transaction* transaction, TableScanState& scanState) override;
 
+    bool isVisible(const transaction::Transaction* transaction,
+        common::offset_t offset) const override;
+    bool isVisibleNoLock(const transaction::Transaction* transaction,
+        common::offset_t offset) const override;
+
     const std::string& getParquetFilePath() const { return parquetFilePath; }
 
 protected:
@@ -80,6 +86,7 @@ protected:
 
 private:
     std::string parquetFilePath;
+    mutable std::atomic<common::row_idx_t> cachedRowCount{common::INVALID_ROW_IDX};
 
     void initializeParquetReader(transaction::Transaction* transaction) const;
     void initParquetScanForRowGroup(transaction::Transaction* transaction,

--- a/src/include/storage/table/parquet_rel_table.h
+++ b/src/include/storage/table/parquet_rel_table.h
@@ -12,13 +12,6 @@ namespace storage {
 
 struct ParquetRelTableScanState final : RelTableScanState {
     std::unique_ptr<processor::ParquetReaderScanState> parquetScanState;
-    // For CSR format: store matching rows for current bound node
-    size_t nextRowToProcess = 0;
-
-    // Row group range for morsel-driven parallelism
-    uint64_t startRowGroup = 0;
-    uint64_t endRowGroup = 0;
-    uint64_t currentRowGroup = 0;
 
     // Per-scan-state readers for thread safety
     std::unique_ptr<processor::ParquetReader> indicesReader;

--- a/src/include/storage/table/parquet_rel_table.h
+++ b/src/include/storage/table/parquet_rel_table.h
@@ -13,6 +13,10 @@ namespace storage {
 struct ParquetRelTableScanState final : RelTableScanState {
     std::unique_ptr<processor::ParquetReaderScanState> parquetScanState;
 
+    // Row group range for morsel-driven parallelism
+    uint64_t currentRowGroup = 0;
+    uint64_t endRowGroup = 0;
+
     // Per-scan-state readers for thread safety
     std::unique_ptr<processor::ParquetReader> indicesReader;
     std::unique_ptr<processor::ParquetReader> indptrReader;
@@ -63,7 +67,7 @@ private:
     bool scanRowGroupForBoundNodes(transaction::Transaction* transaction,
         ParquetRelTableScanState& parquetRelScanState,
         const std::vector<uint64_t>& rowGroupsToProcess,
-        const std::unordered_set<common::offset_t>& boundNodeOffsets);
+        const std::unordered_map<common::offset_t, common::sel_t>& boundNodeOffsets);
     common::offset_t findSourceNodeForRow(common::offset_t globalRowIdx) const;
 };
 

--- a/src/processor/operator/persistent/reader/parquet/parquet_reader.cpp
+++ b/src/processor/operator/persistent/reader/parquet/parquet_reader.cpp
@@ -596,7 +596,7 @@ ParquetScanSharedState::ParquetScanSharedState(FileScanInfo fileScanInfo, uint64
     for (auto i = fileIdx.load(); i < this->fileScanInfo.getNumFiles(); i++) {
         auto reader =
             std::make_unique<ParquetReader>(this->fileScanInfo.filePaths[i], columnSkips, context);
-        totalRowsGroups += reader->getNumRowsGroups();
+        totalRowsGroups += reader->getNumRowGroups();
     }
     numBlocksReadByFiles = 0;
 }
@@ -608,7 +608,7 @@ static bool parquetSharedStateNext(ParquetScanLocalState& localState,
         if (sharedState.fileIdx >= sharedState.fileScanInfo.getNumFiles()) {
             return false;
         }
-        if (sharedState.blockIdx < sharedState.readers[sharedState.fileIdx]->getNumRowsGroups()) {
+        if (sharedState.blockIdx < sharedState.readers[sharedState.fileIdx]->getNumRowGroups()) {
             localState.reader = sharedState.readers[sharedState.fileIdx].get();
             localState.reader->initializeScan(*localState.state, {sharedState.blockIdx},
                 VirtualFileSystem::GetUnsafe(*sharedState.context));
@@ -616,7 +616,7 @@ static bool parquetSharedStateNext(ParquetScanLocalState& localState,
             return true;
         } else {
             sharedState.numBlocksReadByFiles +=
-                sharedState.readers[sharedState.fileIdx]->getNumRowsGroups();
+                sharedState.readers[sharedState.fileIdx]->getNumRowGroups();
             sharedState.blockIdx = 0;
             sharedState.fileIdx++;
             if (sharedState.fileIdx >= sharedState.fileScanInfo.getNumFiles()) {

--- a/src/processor/operator/scan/scan_node_table.cpp
+++ b/src/processor/operator/scan/scan_node_table.cpp
@@ -65,7 +65,7 @@ void ScanNodeTableSharedState::initialize(const transaction::Transaction* transa
                 common::VirtualFileSystem::resolvePath(context, parquetTable->getParquetFilePath());
             auto tempReader =
                 std::make_unique<processor::ParquetReader>(resolvedPath, columnSkips, context);
-            this->numCommittedNodeGroups = tempReader->getNumRowsGroups();
+            this->numCommittedNodeGroups = tempReader->getNumRowGroups();
         } catch (const std::exception& e) {
             this->numCommittedNodeGroups = 1;
         }

--- a/src/storage/table/parquet_node_table.cpp
+++ b/src/storage/table/parquet_node_table.cpp
@@ -98,7 +98,7 @@ common::node_group_idx_t ParquetNodeTable::getNumBatches(const Transaction* tran
     try {
         auto resolvedPath = VirtualFileSystem::resolvePath(context, parquetFilePath);
         auto tempReader = std::make_unique<ParquetReader>(resolvedPath, columnSkips, context);
-        return tempReader->getNumRowsGroups();
+        return tempReader->getNumRowGroups();
     } catch (const std::exception& e) {
         return 1; // Fallback
     }
@@ -313,6 +313,10 @@ bool ParquetNodeTable::scanInternal(Transaction* transaction, TableScanState& sc
 }
 
 row_idx_t ParquetNodeTable::getTotalRowCount(const Transaction* transaction) const {
+    const auto cached = cachedRowCount.load(std::memory_order_relaxed);
+    if (cached != INVALID_ROW_IDX) {
+        return cached;
+    }
     // Create a temporary reader to get metadata
     auto context = transaction->getClientContext();
     if (!context) {
@@ -328,11 +332,23 @@ row_idx_t ParquetNodeTable::getTotalRowCount(const Transaction* transaction) con
             return 0;
         }
         auto metadata = tempReader->getMetadata();
-        return metadata ? metadata->num_rows : 0;
+        const auto count = metadata ? metadata->num_rows : 0;
+        cachedRowCount.store(static_cast<row_idx_t>(count), std::memory_order_relaxed);
+        return count;
     } catch (const std::exception& e) {
         // If parquet file is corrupted or invalid, return 0 instead of crashing
         return 0;
     }
+}
+
+bool ParquetNodeTable::isVisible(const transaction::Transaction* transaction,
+    common::offset_t offset) const {
+    return offset < getTotalRowCount(transaction);
+}
+
+bool ParquetNodeTable::isVisibleNoLock(const transaction::Transaction* transaction,
+    common::offset_t offset) const {
+    return offset < getTotalRowCount(transaction);
 }
 
 } // namespace storage

--- a/src/storage/table/parquet_rel_table.cpp
+++ b/src/storage/table/parquet_rel_table.cpp
@@ -1,7 +1,5 @@
 #include "storage/table/parquet_rel_table.h"
 
-#include <thread>
-
 #include "catalog/catalog_entry/rel_group_catalog_entry.h"
 #include "common/data_chunk/sel_vector.h"
 #include "common/exception/runtime.h"
@@ -103,14 +101,7 @@ void ParquetRelTable::initScanState(Transaction* transaction, TableScanState& sc
             relScanState.nodeIDVector->state->getSelVector().getSelSize());
     }
 
-    // Initialize row group ranges for morsel-driven parallelism
-    // For now, assign all row groups to this scan state (will be partitioned by the scan operator)
-    parquetRelScanState.startRowGroup = 0;
-    parquetRelScanState.endRowGroup = parquetRelScanState.indicesReader ?
-                                          parquetRelScanState.indicesReader->getNumRowsGroups() :
-                                          0;
-    parquetRelScanState.currentRowGroup = parquetRelScanState.startRowGroup;
-    parquetRelScanState.nextRowToProcess = 0;
+    parquetRelScanState.currBoundNodeIdx = 0;
 }
 
 void ParquetRelTable::initializeParquetReaders(Transaction* transaction) const {
@@ -149,7 +140,7 @@ void ParquetRelTable::loadIndptrData(Transaction* transaction) const {
             auto context = transaction->getClientContext();
             auto vfs = VirtualFileSystem::GetUnsafe(*context);
             std::vector<uint64_t> groupsToRead;
-            for (uint64_t i = 0; i < indptrReader->getNumRowsGroups(); ++i) {
+            for (uint64_t i = 0; i < indptrReader->getNumRowGroups(); ++i) {
                 groupsToRead.push_back(i);
             }
 
@@ -208,35 +199,54 @@ bool ParquetRelTable::scanInternal(Transaction* transaction, TableScanState& sca
 
 bool ParquetRelTable::scanInternalByRowGroups(Transaction* transaction,
     ParquetRelTableScanState& parquetRelScanState) {
-    // True morsel-driven parallelism: process assigned row groups and collect relationships for
-    // bound nodes
+    auto& relScanState = static_cast<RelTableScanState&>(parquetRelScanState);
+    const auto numBoundNodes = parquetRelScanState.cachedBoundNodeSelVector.getSelSize();
+    const bool isFwd = parquetRelScanState.direction != RelDataDirection::BWD;
 
-    // Check if we have any row groups left to process
-    if (parquetRelScanState.currentRowGroup >= parquetRelScanState.endRowGroup) {
-        // No more row groups to process
+    auto numRowGroups = parquetRelScanState.indicesReader ?
+                            parquetRelScanState.indicesReader->getNumRowGroups() :
+                            0;
+    // Build list of all row groups to scan once
+    std::vector<uint64_t> allRowGroups;
+    for (uint64_t rg = 0; rg < numRowGroups; ++rg) {
+        allRowGroups.push_back(rg);
+    }
+    if (allRowGroups.empty()) {
         parquetRelScanState.outState->getSelVectorUnsafe().setToFiltered(0);
         return false;
     }
 
-    // Process the current row group
-    std::vector<uint64_t> rowGroupsToProcess = {parquetRelScanState.currentRowGroup};
+    // Iterate sources one at a time; factorized execution requires FLAT source per scan() call.
+    while (relScanState.currBoundNodeIdx < numBoundNodes) {
+        const sel_t selPos =
+            parquetRelScanState.cachedBoundNodeSelVector[relScanState.currBoundNodeIdx];
+        relScanState.currBoundNodeIdx++;
 
-    // Create a set of bound node IDs for fast lookup
-    std::unordered_set<common::offset_t> boundNodeOffsets;
-    for (size_t i = 0; i < parquetRelScanState.cachedBoundNodeSelVector.getSelSize(); ++i) {
-        common::sel_t boundNodeIdx = parquetRelScanState.cachedBoundNodeSelVector[i];
-        const auto boundNodeID = parquetRelScanState.nodeIDVector->getValue<nodeID_t>(boundNodeIdx);
-        boundNodeOffsets.insert(boundNodeID.offset);
+        const auto sourceNodeID = parquetRelScanState.nodeIDVector->getValue<nodeID_t>(selPos);
+        const offset_t boundOffset = sourceNodeID.offset;
+
+        // For FWD, skip sources with no outgoing edges using the preloaded CSR indptr.
+        if (isFwd && !indptrData.empty()) {
+            if (boundOffset + 1 >= indptrData.size() ||
+                indptrData[boundOffset] >= indptrData[boundOffset + 1]) {
+                continue;
+            }
+        }
+
+        std::unordered_set<offset_t> boundNodeOffsets = {boundOffset};
+        bool hasData = scanRowGroupForBoundNodes(transaction, parquetRelScanState, allRowGroups,
+            boundNodeOffsets);
+
+        if (hasData) {
+            // Make the source node ID flat so downstream operators (IntersectBuild, etc.)
+            // see exactly one source key per scan() call.
+            relScanState.setNodeIDVectorToFlat(selPos);
+            return true;
+        }
     }
 
-    // Scan the current row group and collect relationships for bound nodes
-    bool hasData = scanRowGroupForBoundNodes(transaction, parquetRelScanState, rowGroupsToProcess,
-        boundNodeOffsets);
-
-    // Move to next row group for next call
-    parquetRelScanState.currentRowGroup++;
-
-    return hasData;
+    parquetRelScanState.outState->getSelVectorUnsafe().setToFiltered(0);
+    return false;
 }
 
 common::offset_t ParquetRelTable::findSourceNodeForRow(common::offset_t globalRowIdx) const {
@@ -250,10 +260,6 @@ bool ParquetRelTable::scanRowGroupForBoundNodes(Transaction* transaction,
 
     // Initialize readers if needed
     initializeParquetReaders(transaction);
-
-    if (!parquetRelScanState.indicesReader) {
-        return false;
-    }
 
     // Initialize scan state for the assigned row groups
     auto context = transaction->getClientContext();

--- a/src/storage/table/parquet_rel_table.cpp
+++ b/src/storage/table/parquet_rel_table.cpp
@@ -101,7 +101,12 @@ void ParquetRelTable::initScanState(Transaction* transaction, TableScanState& sc
             relScanState.nodeIDVector->state->getSelVector().getSelSize());
     }
 
-    parquetRelScanState.currBoundNodeIdx = 0;
+    // Initialize row group ranges for morsel-driven parallelism
+    // For now, assign all row groups to this scan state (will be partitioned by the scan operator)
+    parquetRelScanState.currentRowGroup = 0;
+    parquetRelScanState.endRowGroup = parquetRelScanState.indicesReader ?
+                                          parquetRelScanState.indicesReader->getNumRowGroups() :
+                                          0;
 }
 
 void ParquetRelTable::initializeParquetReaders(Transaction* transaction) const {
@@ -199,54 +204,35 @@ bool ParquetRelTable::scanInternal(Transaction* transaction, TableScanState& sca
 
 bool ParquetRelTable::scanInternalByRowGroups(Transaction* transaction,
     ParquetRelTableScanState& parquetRelScanState) {
-    auto& relScanState = static_cast<RelTableScanState&>(parquetRelScanState);
-    const auto numBoundNodes = parquetRelScanState.cachedBoundNodeSelVector.getSelSize();
-    const bool isFwd = parquetRelScanState.direction != RelDataDirection::BWD;
+    // True morsel-driven parallelism: process assigned row groups and collect relationships for
+    // bound nodes
 
-    auto numRowGroups = parquetRelScanState.indicesReader ?
-                            parquetRelScanState.indicesReader->getNumRowGroups() :
-                            0;
-    // Build list of all row groups to scan once
-    std::vector<uint64_t> allRowGroups;
-    for (uint64_t rg = 0; rg < numRowGroups; ++rg) {
-        allRowGroups.push_back(rg);
-    }
-    if (allRowGroups.empty()) {
+    // Check if we have any row groups left to process
+    if (parquetRelScanState.currentRowGroup >= parquetRelScanState.endRowGroup) {
+        // No more row groups to process
         parquetRelScanState.outState->getSelVectorUnsafe().setToFiltered(0);
         return false;
     }
 
-    // Iterate sources one at a time; factorized execution requires FLAT source per scan() call.
-    while (relScanState.currBoundNodeIdx < numBoundNodes) {
-        const sel_t selPos =
-            parquetRelScanState.cachedBoundNodeSelVector[relScanState.currBoundNodeIdx];
-        relScanState.currBoundNodeIdx++;
+    // Process the current row group
+    std::vector<uint64_t> rowGroupsToProcess = {parquetRelScanState.currentRowGroup};
 
-        const auto sourceNodeID = parquetRelScanState.nodeIDVector->getValue<nodeID_t>(selPos);
-        const offset_t boundOffset = sourceNodeID.offset;
-
-        // For FWD, skip sources with no outgoing edges using the preloaded CSR indptr.
-        if (isFwd && !indptrData.empty()) {
-            if (boundOffset + 1 >= indptrData.size() ||
-                indptrData[boundOffset] >= indptrData[boundOffset + 1]) {
-                continue;
-            }
-        }
-
-        std::unordered_set<offset_t> boundNodeOffsets = {boundOffset};
-        bool hasData = scanRowGroupForBoundNodes(transaction, parquetRelScanState, allRowGroups,
-            boundNodeOffsets);
-
-        if (hasData) {
-            // Make the source node ID flat so downstream operators (IntersectBuild, etc.)
-            // see exactly one source key per scan() call.
-            relScanState.setNodeIDVectorToFlat(selPos);
-            return true;
-        }
+    // Create a set of bound node IDs for fast lookup
+    std::unordered_map<common::offset_t, common::sel_t> boundNodeOffsets;
+    for (size_t i = 0; i < parquetRelScanState.cachedBoundNodeSelVector.getSelSize(); ++i) {
+        common::sel_t boundNodeIdx = parquetRelScanState.cachedBoundNodeSelVector[i];
+        const auto boundNodeID = parquetRelScanState.nodeIDVector->getValue<nodeID_t>(boundNodeIdx);
+        boundNodeOffsets.insert({boundNodeID.offset, boundNodeIdx});
     }
 
-    parquetRelScanState.outState->getSelVectorUnsafe().setToFiltered(0);
-    return false;
+    // Scan the current row group and collect relationships for bound nodes
+    bool hasData = scanRowGroupForBoundNodes(transaction, parquetRelScanState, rowGroupsToProcess,
+        boundNodeOffsets);
+
+    // Move to next row group for next call
+    parquetRelScanState.currentRowGroup++;
+
+    return hasData;
 }
 
 common::offset_t ParquetRelTable::findSourceNodeForRow(common::offset_t globalRowIdx) const {
@@ -256,7 +242,7 @@ common::offset_t ParquetRelTable::findSourceNodeForRow(common::offset_t globalRo
 
 bool ParquetRelTable::scanRowGroupForBoundNodes(Transaction* transaction,
     ParquetRelTableScanState& parquetRelScanState, const std::vector<uint64_t>& rowGroupsToProcess,
-    const std::unordered_set<common::offset_t>& boundNodeOffsets) {
+    const std::unordered_map<common::offset_t, common::sel_t>& boundNodeOffsets) {
 
     // Initialize readers if needed
     initializeParquetReaders(transaction);
@@ -285,6 +271,9 @@ bool ParquetRelTable::scanRowGroupForBoundNodes(Transaction* transaction,
     uint64_t totalRowsCollected = 0;
     const uint64_t maxRowsPerCall = DEFAULT_VECTOR_CAPACITY;
     uint64_t currentGlobalRowIdx = 0;
+    auto activeBoundSelPos = INVALID_SEL;
+    auto activeBoundOffset = INVALID_OFFSET;
+    auto hasActiveBound = false;
 
     // Calculate the starting global row index for the first row group
     if (!rowGroupsToProcess.empty()) {
@@ -313,6 +302,14 @@ bool ParquetRelTable::scanRowGroupForBoundNodes(Transaction* transaction,
             const auto boundOffset = isFwd ? sourceNodeOffset : dstOffset;
             if (boundNodeOffsets.find(boundOffset) == boundNodeOffsets.end()) {
                 continue; // Not a bound node, skip
+            }
+
+            if (!hasActiveBound) {
+                hasActiveBound = true;
+                activeBoundOffset = boundOffset;
+                activeBoundSelPos = boundNodeOffsets.at(boundOffset);
+            } else if (boundOffset != activeBoundOffset) {
+                break;
             }
 
             // This row belongs to a bound node, collect the relationship
@@ -346,6 +343,7 @@ bool ParquetRelTable::scanRowGroupForBoundNodes(Transaction* transaction,
         for (uint64_t i = 0; i < totalRowsCollected; ++i) {
             selVector[i] = i;
         }
+        parquetRelScanState.setNodeIDVectorToFlat(activeBoundSelPos);
 
         return true;
     } else {

--- a/src/storage/table/parquet_rel_table.cpp
+++ b/src/storage/table/parquet_rel_table.cpp
@@ -323,13 +323,28 @@ bool ParquetRelTable::scanRowGroupForBoundNodes(Transaction* transaction,
                 parquetRelScanState.outputVectors[0]->setValue(totalRowsCollected, nbrNodeID);
             }
 
-            // If there are additional columns (e.g., weight), copy them to subsequent output
-            // vectors These are property columns and should have matching types
-            for (uint32_t colIdx = 1;
-                 colIdx < numIndicesColumns && colIdx < parquetRelScanState.outputVectors.size();
-                 ++colIdx) {
-                parquetRelScanState.outputVectors[colIdx]->copyFromVectorData(totalRowsCollected,
-                    &indicesChunk.getValueVector(colIdx), i);
+            // Copy edge properties to output vectors.
+            // Catalog col IDs: NBR_ID=0, REL_ID=1 (virtual), user props=2,3,...
+            // Parquet cols:     target=0,              user props=1,2,...
+            // So parquet_col = catalog_col_id - 1 for user properties.
+            for (uint64_t outCol = 1; outCol < parquetRelScanState.outputVectors.size(); ++outCol) {
+                if (outCol >= parquetRelScanState.columnIDs.size()) {
+                    continue;
+                }
+                const auto colID = parquetRelScanState.columnIDs[outCol];
+                if (colID == INVALID_COLUMN_ID || colID == ROW_IDX_COLUMN_ID ||
+                    colID == NBR_ID_COLUMN_ID) {
+                    continue;
+                }
+                if (colID == REL_ID_COLUMN_ID) {
+                    // REL_ID is not stored in parquet; synthesize from the global row index.
+                    parquetRelScanState.outputVectors[outCol]->setValue<internalID_t>(
+                        totalRowsCollected, internalID_t{currentGlobalRowIdx, getTableID()});
+                    continue;
+                }
+
+                parquetRelScanState.outputVectors[outCol]->copyFromVectorData(totalRowsCollected,
+                    &indicesChunk.getValueVector(colID - 1), i);
             }
 
             totalRowsCollected++;

--- a/test/test_files/demo_db/demo_db_graph_std.test
+++ b/test/test_files/demo_db/demo_db_graph_std.test
@@ -35,6 +35,11 @@ Adam|Zhang|2020
 Karissa|Zhang|2021
 Zhang|Noura|2022
 
+-LOG CountRelTableFollows
+-STATEMENT MATCH ()-[:follows]->() RETURN COUNT(*);
+---- 1
+4
+
 -LOG MatchLivesInWithCityPopulation
 -STATEMENT MATCH (u:user)-[l:livesin]->(c:city) RETURN u.name, c.name, c.population ORDER BY c.population DESC;
 ---- 4
@@ -114,18 +119,31 @@ Zhang|Kitchener
 ---- 1
 Adam|Karissa|Zhang
 
--LOG VarLenOneToTwo
--STATEMENT MATCH (a:user)-[:follows*1..2]->(b:user) RETURN a.name, b.name ORDER BY a.name, b.name;
----- 7
-Adam|Karissa
-Adam|Noura
-Adam|Zhang
-Adam|Zhang
-Karissa|Noura
-Karissa|Zhang
-Zhang|Noura
+-LOG SemiMaskerVarLen
+-STATEMENT MATCH (a:user {id: 100})-[:follows*1..2 (r, n | WHERE n.age > 40)]->(b:user) RETURN b.name ORDER BY b.name;
+---- 3
+Karissa
+Zhang
+Noura
 
 -LOG VarLenThreeHop
 -STATEMENT MATCH (a:user)-[:follows*3..3]->(b:user) RETURN a.name, b.name ORDER BY a.name, b.name;
 ---- 1
 Adam|Noura
+
+-LOG FlattenMultiPartMatch
+-STATEMENT MATCH (a:user)-[:follows]->(b:user) WITH a, b MATCH (b)-[:livesin]->(c:city) RETURN a.name, b.name, c.name ORDER BY a.name, b.name;
+---- 4
+Adam|Karissa|Waterloo
+Adam|Zhang|Kitchener
+Karissa|Zhang|Kitchener
+Zhang|Noura|Guelph
+
+-LOG HashJoinSharedFollowee
+-STATEMENT MATCH (a:user)-[:follows]->(b:user), (c:user)-[:follows]->(b) WHERE a.id < c.id RETURN a.name, b.name, c.name;
+---- 1
+Adam|Zhang|Karissa
+
+-LOG ProfileQuery
+-STATEMENT PROFILE MATCH (u:user)-[:follows]->(v:user) RETURN u.name, v.name;
+---- ok

--- a/test/test_files/demo_db/demo_db_graph_std.test
+++ b/test/test_files/demo_db/demo_db_graph_std.test
@@ -43,6 +43,12 @@ Adam|Waterloo|150000
 Karissa|Waterloo|150000
 Noura|Guelph|75000
 
+-LOG MatchLivesInFilterById
+-STATEMENT MATCH (u:user)-[l:livesin]->(c:city) WHERE c.id = 700 RETURN u.name, c.name;
+---- 2
+Adam|Waterloo
+Karissa|Waterloo
+
 -LOG MatchLivesInFilterByCity
 -STATEMENT MATCH (u:user)-[l:livesin]->(c:city) WHERE c.name = 'Waterloo' RETURN u.name, u.age;
 ---- 2
@@ -75,3 +81,51 @@ Adam|Karissa|40
 ---- 2
 Adam|Karissa
 Adam|Zhang
+
+-LOG AggregateAvgFolloweeAge
+-STATEMENT MATCH (u:user)-[:follows]->(v) RETURN u.name, avg(v.age) ORDER BY u.name;
+---- 3
+Adam|45.000000
+Karissa|50.000000
+Zhang|25.000000
+
+-LOG TwoHopCrossRel
+-STATEMENT MATCH (a:user {id: 100})-[:follows]->(b)-[:livesin]->(c:city) RETURN b.name, c.name ORDER BY b.name;
+---- 2
+Karissa|Waterloo
+Zhang|Kitchener
+
+-LOG BackwardInNeighbors
+-STATEMENT MATCH (u)<-[:follows]-(v) WHERE u.id = 300 RETURN v.name ORDER BY v.name;
+---- 2
+Adam
+Karissa
+
+-LOG UndirectedLivesIn
+-STATEMENT MATCH (a:user)-[:livesin]-(c:city) RETURN a.name, c.name ORDER BY a.name;
+---- 4
+Adam|Waterloo
+Karissa|Waterloo
+Noura|Guelph
+Zhang|Kitchener
+
+-LOG CyclicTriangle
+-STATEMENT MATCH (a:user)-[:follows]->(b:user)-[:follows]->(c:user), (a)-[:follows]->(c) RETURN a.name, b.name, c.name;
+---- 1
+Adam|Karissa|Zhang
+
+-LOG VarLenOneToTwo
+-STATEMENT MATCH (a:user)-[:follows*1..2]->(b:user) RETURN a.name, b.name ORDER BY a.name, b.name;
+---- 7
+Adam|Karissa
+Adam|Noura
+Adam|Zhang
+Adam|Zhang
+Karissa|Noura
+Karissa|Zhang
+Zhang|Noura
+
+-LOG VarLenThreeHop
+-STATEMENT MATCH (a:user)-[:follows*3..3]->(b:user) RETURN a.name, b.name ORDER BY a.name, b.name;
+---- 1
+Adam|Noura


### PR DESCRIPTION
- fixed multi-hop, var-len query scans in parquet tables by adding isVisible funcs and setting selVectorToFlat in each scan
- refactored parquet_rel_table scan to return only rows of a single boundNode
- removed unnecessary scanState data
- expanded test suite