### PR TITLE
feat: expose prepared statement read-only status in C API

### DIFF
--- a/src/c_api/prepared_statement.cpp
+++ b/src/c_api/prepared_statement.cpp
@@ -34,6 +34,10 @@ bool lbug_prepared_statement_is_success(lbug_prepared_statement* prepared_statem
     return static_cast<PreparedStatement*>(prepared_statement->_prepared_statement)->isSuccess();
 }
 
+bool lbug_prepared_statement_is_read_only(lbug_prepared_statement* prepared_statement) {
+    return static_cast<PreparedStatement*>(prepared_statement->_prepared_statement)->isReadOnly();
+}
+
 char* lbug_prepared_statement_get_error_message(lbug_prepared_statement* prepared_statement) {
     auto error_message =
         static_cast<PreparedStatement*>(prepared_statement->_prepared_statement)->getErrorMessage();

--- a/src/include/c_api/lbug.h
+++ b/src/include/c_api/lbug.h
@@ -467,6 +467,10 @@ LBUG_C_API void lbug_prepared_statement_destroy(lbug_prepared_statement* prepare
  */
 LBUG_C_API bool lbug_prepared_statement_is_success(lbug_prepared_statement* prepared_statement);
 /**
+ * @return true if the prepared statement only performs read operations.
+ */
+LBUG_C_API bool lbug_prepared_statement_is_read_only(lbug_prepared_statement* prepared_statement);
+/**
  * @brief Returns the error message if the prepared statement is not prepared successfully.
  * The caller is responsible for freeing the returned string with `lbug_destroy_string`.
  * @param prepared_statement The prepared statement instance.

--- a/test/c_api/prepared_statement_test.cpp
+++ b/test/c_api/prepared_statement_test.cpp
@@ -29,6 +29,24 @@ TEST_F(CApiPreparedStatementTest, IsSuccess) {
     lbug_prepared_statement_destroy(&preparedStatement);
 }
 
+TEST_F(CApiPreparedStatementTest, IsReadOnly) {
+    lbug_prepared_statement preparedStatement;
+    auto connection = getConnection();
+
+    auto state = lbug_connection_prepare(connection, "RETURN 1", &preparedStatement);
+    ASSERT_EQ(state, LbugSuccess);
+    ASSERT_TRUE(lbug_prepared_statement_is_success(&preparedStatement));
+    ASSERT_TRUE(lbug_prepared_statement_is_read_only(&preparedStatement));
+    lbug_prepared_statement_destroy(&preparedStatement);
+
+    state = lbug_connection_prepare(connection,
+        "CREATE NODE TABLE Person(name STRING, PRIMARY KEY(name))", &preparedStatement);
+    ASSERT_EQ(state, LbugSuccess);
+    ASSERT_TRUE(lbug_prepared_statement_is_success(&preparedStatement));
+    ASSERT_FALSE(lbug_prepared_statement_is_read_only(&preparedStatement));
+    lbug_prepared_statement_destroy(&preparedStatement);
+}
+
 TEST_F(CApiPreparedStatementTest, GetErrorMessage) {
     lbug_prepared_statement preparedStatement;
     lbug_state state;


### PR DESCRIPTION
This will hopefully allow ladybug-rust to be compiled without access to ladybug main repo