### PR TITLE
Avoid syncing empty WAL transactions

### DIFF
--- a/src/include/storage/wal/local_wal.h
+++ b/src/include/storage/wal/local_wal.h
@@ -45,7 +45,6 @@ public:
 
     void logLoadExtension(std::string path);
 
-    void logBeginTransaction();
     void logCommit();
 
     void clear();
@@ -53,11 +52,13 @@ public:
 
 private:
     void addNewWALRecord(const WALRecord& walRecord);
+    void addNewWALRecordNoLock(const WALRecord& walRecord);
 
 private:
     std::mutex mtx;
     std::shared_ptr<common::InMemFileWriter> inMemWriter;
     common::Serializer serializer;
+    bool hasLoggedBegin = false;
 };
 
 } // namespace storage

--- a/src/storage/wal/local_wal.cpp
+++ b/src/storage/wal/local_wal.cpp
@@ -18,14 +18,13 @@ LocalWAL::LocalWAL(MemoryManager& mm, bool enableChecksums)
       serializer(enableChecksums ? std::make_shared<ChecksumWriter>(inMemWriter, mm) :
                                    std::static_pointer_cast<Writer>(inMemWriter)) {}
 
-void LocalWAL::logBeginTransaction() {
-    BeginTransactionRecord walRecord;
-    addNewWALRecord(walRecord);
-}
-
 void LocalWAL::logCommit() {
+    std::unique_lock lck{mtx};
+    if (!hasLoggedBegin) {
+        return;
+    }
     CommitRecord walRecord;
-    addNewWALRecord(walRecord);
+    addNewWALRecordNoLock(walRecord);
 }
 
 void LocalWAL::logCreateCatalogEntryRecord(CatalogEntry* catalogEntry, bool isInternal) {
@@ -93,6 +92,7 @@ void LocalWAL::logLoadExtension(std::string path) {
 void LocalWAL::clear() {
     std::unique_lock lck{mtx};
     serializer.getWriter()->clear();
+    hasLoggedBegin = false;
 }
 
 uint64_t LocalWAL::getSize() {
@@ -103,6 +103,17 @@ uint64_t LocalWAL::getSize() {
 // NOLINTNEXTLINE(readability-make-member-function-const): semantically non-const function.
 void LocalWAL::addNewWALRecord(const WALRecord& walRecord) {
     std::unique_lock lck{mtx};
+    if (!hasLoggedBegin && walRecord.type != WALRecordType::BEGIN_TRANSACTION_RECORD &&
+        walRecord.type != WALRecordType::COMMIT_RECORD) {
+        BeginTransactionRecord beginRecord;
+        addNewWALRecordNoLock(beginRecord);
+        hasLoggedBegin = true;
+    }
+    addNewWALRecordNoLock(walRecord);
+}
+
+// NOLINTNEXTLINE(readability-make-member-function-const): semantically non-const function.
+void LocalWAL::addNewWALRecordNoLock(const WALRecord& walRecord) {
     DASSERT(walRecord.type != WALRecordType::INVALID_RECORD);
     serializer.getWriter()->onObjectBegin();
     walRecord.serialize(serializer);

--- a/src/storage/wal/wal.cpp
+++ b/src/storage/wal/wal.cpp
@@ -107,6 +107,12 @@ void WAL::flushAndSyncNoLock() {
 
 uint64_t WAL::getFileSize() {
     std::unique_lock lck{mtx};
+    if (!serializer) {
+        if (inMemory || !vfs->fileOrPathExists(walPath)) {
+            return 0;
+        }
+        return vfs->openFile(walPath, FileOpenFlags(FileFlags::READ_ONLY))->getFileSize();
+    }
     return serializer->getWriter()->getSize();
 }
 

--- a/src/transaction/transaction_manager.cpp
+++ b/src/transaction/transaction_manager.cpp
@@ -42,9 +42,6 @@ Transaction* TransactionManager::beginTransaction(main::ClientContext& clientCon
         }
         auto transaction =
             std::make_unique<Transaction>(clientContext, type, ++lastTransactionID, lastTimestamp);
-        if (transaction->shouldLogToWAL()) {
-            transaction->getLocalWAL().logBeginTransaction();
-        }
         activeWriteTransactionCount.fetch_add(1, std::memory_order_release);
         activeTransactions.push_back(std::move(transaction));
         return activeTransactions.back().get();

--- a/test/transaction/wal_test.cpp
+++ b/test/transaction/wal_test.cpp
@@ -76,6 +76,18 @@ TEST_F(WalTest, NoWALAfterCheckpoint) {
     ASSERT_FALSE(std::filesystem::exists(walFilePath));
 }
 
+TEST_F(WalTest, EmptyWriteTransactionDoesNotCreateWAL) {
+    if (inMemMode || systemConfig->checkpointThreshold == 0) {
+        GTEST_SKIP();
+    }
+    conn->query("CALL force_checkpoint_on_close=false");
+    auto walFilePath = lbug::storage::StorageUtils::getWALFilePath(databasePath);
+    ASSERT_FALSE(std::filesystem::exists(walFilePath));
+    auto result = conn->query("CALL THREADS=1");
+    ASSERT_TRUE(result->isSuccess()) << result->getErrorMessage();
+    ASSERT_FALSE(std::filesystem::exists(walFilePath));
+}
+
 TEST_F(WalTest, ShadowFileExistsWithoutWAL) {
     if (inMemMode || systemConfig->checkpointThreshold == 0) {
         GTEST_SKIP();


### PR DESCRIPTION
## Summary

Fixes: #302 

Use one fsync() per transaction instead of two. Previously we wrote two WAL records.

- Make LocalWAL log BEGIN lazily when the first real WAL record is added.
- Skip COMMIT logging for write transactions that produced no WAL records.
- Handle WAL size checks when no shared WAL writer/file exists.
- Add a regression for empty write transactions such as CALL THREADS=1.

## Root cause
Write transactions eagerly logged BEGIN at transaction start. If the transaction produced no WAL records, commit still appended COMMIT and flushed/synced an 18-byte BEGIN+COMMIT WAL entry when checksums were enabled. Making BEGIN lazy exposed an auto-checkpoint size check that assumed the shared WAL writer had been initialized; empty transactions now keep the writer uninitialized, so WAL::getFileSize() must treat that as size 0.

## Validation
- git diff --check
- make test-build-release
- build/release/test/transaction/transaction_test --gtest_filter=WalTest.EmptyWriteTransactionDoesNotCreateWAL