### PR TITLE
fix: allow importing parquet files into node tables with index disabled

### DIFF
--- a/src/include/processor/operator/index_lookup.h
+++ b/src/include/processor/operator/index_lookup.h
@@ -6,6 +6,12 @@
 #include "processor/operator/physical_operator.h"
 
 namespace lbug {
+namespace main {
+class ClientContext;
+} // namespace main
+namespace common {
+class ValueVector;
+} // namespace common
 namespace transaction {
 class Transaction;
 }
@@ -15,22 +21,31 @@ class NodeTable;
 namespace processor {
 
 struct BatchInsertSharedState;
+struct NoIndexLookupCache {
+    virtual ~NoIndexLookupCache() = default;
+    virtual void buildIfNeeded(storage::NodeTable* nodeTable, transaction::Transaction* transaction,
+        main::ClientContext* context) = 0;
+    virtual bool lookup(common::ValueVector* keyVector, common::sel_t pos,
+        common::offset_t& result) const = 0;
+};
+
 struct IndexLookupInfo {
     storage::NodeTable* nodeTable;
     std::unique_ptr<evaluator::ExpressionEvaluator> keyEvaluator;
     DataPos resultVectorPos;
+    std::shared_ptr<NoIndexLookupCache> noIndexLookupCache;
 
     IndexLookupInfo(storage::NodeTable* nodeTable,
         std::unique_ptr<evaluator::ExpressionEvaluator> keyEvaluator,
         const DataPos& resultVectorPos)
         : nodeTable{nodeTable}, keyEvaluator{std::move(keyEvaluator)},
-          resultVectorPos{resultVectorPos} {}
+          resultVectorPos{resultVectorPos}, noIndexLookupCache{nullptr} {}
     EXPLICIT_COPY_DEFAULT_MOVE(IndexLookupInfo);
 
 private:
     IndexLookupInfo(const IndexLookupInfo& other)
         : nodeTable{other.nodeTable}, keyEvaluator{other.keyEvaluator->copy()},
-          resultVectorPos{other.resultVectorPos} {}
+          resultVectorPos{other.resultVectorPos}, noIndexLookupCache{other.noIndexLookupCache} {}
 };
 
 struct IndexLookupPrintInfo final : OPPrintInfo {
@@ -63,9 +78,7 @@ class IndexLookup final : public PhysicalOperator {
 public:
     IndexLookup(std::vector<IndexLookupInfo> infos, std::vector<DataPos> warningDataVectorPos,
         std::unique_ptr<PhysicalOperator> child, common::idx_t id,
-        std::unique_ptr<OPPrintInfo> printInfo)
-        : PhysicalOperator{type_, std::move(child), id, std::move(printInfo)},
-          infos{std::move(infos)}, warningDataVectorPos{std::move(warningDataVectorPos)} {}
+        std::unique_ptr<OPPrintInfo> printInfo);
 
     void initLocalStateInternal(ResultSet* resultSet, ExecutionContext* context) override;
 

--- a/src/include/processor/operator/persistent/node_batch_insert.h
+++ b/src/include/processor/operator/persistent/node_batch_insert.h
@@ -10,14 +10,21 @@
 
 namespace lbug {
 namespace storage {
+class ColumnChunkData;
 class MemoryManager;
-}
+} // namespace storage
 namespace transaction {
 class Transaction;
 } // namespace transaction
 
 namespace processor {
 struct ExecutionContext;
+
+struct NoIndexPKValidator {
+    virtual ~NoIndexPKValidator() = default;
+    virtual void validate(const storage::ColumnChunkData& pkChunk, common::offset_t startOffset,
+        common::length_t numValues) = 0;
+};
 
 struct NodeBatchInsertPrintInfo final : OPPrintInfo {
     std::string tableName;
@@ -59,6 +66,7 @@ struct NodeBatchInsertSharedState final : BatchInsertSharedState {
     common::column_id_t pkColumnID;
     common::LogicalType pkType;
     std::optional<IndexBuilder> globalIndexBuilder;
+    std::unique_ptr<NoIndexPKValidator> noIndexPKValidator;
 
     function::TableFuncSharedState* tableFuncSharedState;
 
@@ -70,8 +78,8 @@ struct NodeBatchInsertSharedState final : BatchInsertSharedState {
 
     explicit NodeBatchInsertSharedState(std::shared_ptr<FactorizedTable> fTable)
         : BatchInsertSharedState{std::move(fTable)}, pkColumnID{0},
-          globalIndexBuilder(std::nullopt), tableFuncSharedState{nullptr},
-          sharedNodeGroup{nullptr} {}
+          globalIndexBuilder(std::nullopt), noIndexPKValidator{nullptr},
+          tableFuncSharedState{nullptr}, sharedNodeGroup{nullptr} {}
 
     void initPKIndex(const ExecutionContext* context);
 };

--- a/src/include/storage/index/hash_index.h
+++ b/src/include/storage/index/hash_index.h
@@ -43,7 +43,6 @@ public:
     virtual bool checkpointInMemory() = 0;
     virtual bool rollbackInMemory() = 0;
     virtual void rollbackCheckpoint() = 0;
-    virtual void bulkReserve(uint64_t numValuesToAppend) = 0;
     virtual void reclaimStorage(PageAllocator& pageAllocator) = 0;
     virtual bool tryLock() = 0;
     virtual std::unique_lock<std::shared_mutex> adoptLock() = 0;
@@ -232,8 +231,6 @@ private:
     void splitSlots(PageAllocator& pageAllocator, const transaction::Transaction* transaction,
         HashIndexHeader& header, slot_id_t numSlotsToSplit);
 
-    // Resizes the local storage to support the given number of new entries
-    void bulkReserve(uint64_t newEntries) override;
     // Resizes the on-disk index to support the given number of new entries
     void reserve(PageAllocator& pageAllocator, const transaction::Transaction* transaction,
         uint64_t newEntries);
@@ -431,13 +428,6 @@ public:
         }));
         return getTypedHashIndexByPos<HashIndexType<T>>(indexPos)->appendNoLock(transaction, buffer,
             bufferOffset, isVisible);
-    }
-
-    void bulkReserve(uint64_t numValuesToAppend) {
-        uint32_t eachSize = numValuesToAppend / NUM_HASH_INDEXES + 1;
-        for (auto i = 0u; i < NUM_HASH_INDEXES; i++) {
-            hashIndices[i]->bulkReserve(eachSize);
-        }
     }
 
     void delete_(common::string_t key) { return delete_(key.getAsStringView()); }

--- a/src/processor/operator/index_lookup.cpp
+++ b/src/processor/operator/index_lookup.cpp
@@ -1,14 +1,23 @@
 #include "processor/operator/index_lookup.h"
 
+#include <mutex>
+#include <unordered_map>
+
 #include "binder/expression/expression_util.h"
 #include "common/assert.h"
 #include "common/exception/message.h"
+#include "common/type_utils.h"
 #include "common/types/types.h"
 #include "common/utils.h"
 #include "common/vector/value_vector.h"
+#include "main/client_context.h"
 #include "processor/warning_context.h"
+#include "storage/buffer_manager/memory_manager.h"
 #include "storage/index/hash_index.h"
+#include "storage/storage_utils.h"
+#include "storage/table/node_group.h"
 #include "storage/table/node_table.h"
+#include "storage/table/table.h"
 
 using namespace lbug::common;
 using namespace lbug::storage;
@@ -17,6 +26,112 @@ namespace lbug {
 namespace processor {
 
 namespace {
+
+template<typename T>
+using StoredPKValue = std::conditional_t<std::same_as<T, string_t>, std::string, T>;
+
+template<typename T>
+StoredPKValue<T> readPKValue(const ValueVector& vector, sel_t pos) {
+    if constexpr (std::same_as<T, string_t>) {
+        return vector.getValue<string_t>(pos).getAsString();
+    } else {
+        return vector.getValue<T>(pos);
+    }
+}
+
+template<typename T>
+struct PKHash {
+    size_t operator()(const T& value) const { return std::hash<T>{}(value); }
+};
+
+template<>
+struct PKHash<int128_t> {
+    size_t operator()(const int128_t& value) const {
+        return std::hash<uint64_t>{}(value.low) ^ (std::hash<int64_t>{}(value.high) << 1);
+    }
+};
+
+template<>
+struct PKHash<uint128_t> {
+    size_t operator()(const uint128_t& value) const {
+        return std::hash<uint64_t>{}(value.low) ^ (std::hash<uint64_t>{}(value.high) << 1);
+    }
+};
+
+template<typename T>
+struct NoIndexLookupCacheImpl final : NoIndexLookupCache {
+    void buildIfNeeded(NodeTable* nodeTable, transaction::Transaction* transaction,
+        main::ClientContext* context) override {
+        std::lock_guard lck{mtx};
+        if (built) {
+            return;
+        }
+        offsets.reserve(nodeTable->getNumTotalRows(transaction));
+        std::vector<LogicalType> dataTypes;
+        dataTypes.push_back(nodeTable->getColumn(nodeTable->getPKColumnID()).getDataType().copy());
+        auto dataChunk =
+            Table::constructDataChunk(MemoryManager::Get(*context), std::move(dataTypes));
+        std::vector<ValueVector*> outVectors = {&dataChunk.getValueVectorMutable(0)};
+        auto scanState =
+            std::make_unique<NodeTableScanState>(nullptr, std::move(outVectors), dataChunk.state);
+        scanState->source = TableScanSource::COMMITTED;
+        scanState->setToTable(transaction, nodeTable, {nodeTable->getPKColumnID()}, {});
+        const auto numNodeGroups = nodeTable->getNumNodeGroups();
+        for (node_group_idx_t nodeGroupIdx = 0; nodeGroupIdx < numNodeGroups; ++nodeGroupIdx) {
+            auto* nodeGroup = nodeTable->getNodeGroupNoLock(nodeGroupIdx);
+            if (nodeGroup->getNumChunkedGroups() == 0) {
+                continue;
+            }
+            scanState->nodeGroup = nodeGroup;
+            scanState->nodeGroupIdx = nodeGroupIdx;
+            nodeGroup->initializeScanState(transaction, *scanState);
+            while (true) {
+                const auto scanResult = nodeGroup->scan(transaction, *scanState);
+                if (scanResult == NODE_GROUP_SCAN_EMPTY_RESULT) {
+                    break;
+                }
+                auto* scannedVector = scanState->outputVectors[0];
+                for (idx_t i = 0; i < scannedVector->state->getSelSize(); ++i) {
+                    const auto pos = scannedVector->state->getSelVector()[i];
+                    if (scannedVector->isNull(pos)) {
+                        continue;
+                    }
+                    const auto offset = StorageUtils::getStartOffsetOfNodeGroup(nodeGroupIdx) +
+                                        scanResult.startRow + pos;
+                    if (nodeTable->isVisibleNoLock(transaction, offset)) {
+                        offsets.emplace(readPKValue<T>(*scannedVector, pos), offset);
+                    }
+                }
+            }
+        }
+        built = true;
+    }
+
+    bool lookup(ValueVector* keyVector, sel_t pos, offset_t& result) const override {
+        auto entry = offsets.find(readPKValue<T>(*keyVector, pos));
+        if (entry == offsets.end()) {
+            return false;
+        }
+        result = entry->second;
+        return true;
+    }
+
+    std::mutex mtx;
+    bool built = false;
+    // Temporary in-memory lookup index for no-hash-index rel COPY. This can be replaced by an
+    // on-disk persistent index in the future; until then, rel ingest is limited by the node PKs
+    // that fit in RAM.
+    std::unordered_map<StoredPKValue<T>, offset_t, PKHash<StoredPKValue<T>>> offsets;
+};
+
+std::shared_ptr<NoIndexLookupCache> createNoIndexLookupCache(const LogicalType& pkType) {
+    return TypeUtils::visit(
+        pkType,
+        []<IndexHashable T>(T) -> std::shared_ptr<NoIndexLookupCache> {
+            return std::make_shared<NoIndexLookupCacheImpl<T>>();
+        },
+        [](auto) -> std::shared_ptr<NoIndexLookupCache> { UNREACHABLE_CODE; });
+}
 
 std::optional<WarningSourceData> getWarningSourceData(
     const std::vector<ValueVector*>& warningDataVectors, sel_t pos) {
@@ -87,7 +202,13 @@ void fillOffsetArraysFromVectorInternal(transaction::Transaction* transaction,
                     }
                 }
                 offset_t lookupOffset = 0;
-                if (!info.nodeTable->lookupPK(transaction, keyVector, pos, lookupOffset)) {
+                auto found = info.noIndexLookupCache ?
+                                 info.noIndexLookupCache->lookup(keyVector, pos, lookupOffset) :
+                                 false;
+                if (!found) {
+                    found = info.nodeTable->lookupPK(transaction, keyVector, pos, lookupOffset);
+                }
+                if (!found) {
                     errorHandler->handleError(ExceptionMessage::nonExistentPKException(
                                                   keyVector->getAsValue(pos)->toString()),
                         getWarningSourceData(warningDataVectors, pos));
@@ -128,6 +249,24 @@ std::string IndexLookupPrintInfo::toString() const {
     return result;
 }
 
+IndexLookup::IndexLookup(std::vector<IndexLookupInfo> infos,
+    std::vector<DataPos> warningDataVectorPos, std::unique_ptr<PhysicalOperator> child, idx_t id,
+    std::unique_ptr<OPPrintInfo> printInfo)
+    : PhysicalOperator{type_, std::move(child), id, std::move(printInfo)}, infos{std::move(infos)},
+      warningDataVectorPos{std::move(warningDataVectorPos)} {
+    std::unordered_map<NodeTable*, std::shared_ptr<NoIndexLookupCache>> noIndexLookupCaches;
+    for (auto& info : this->infos) {
+        if (!info.nodeTable->tryGetPKIndex()) {
+            auto& cache = noIndexLookupCaches[info.nodeTable];
+            if (!cache) {
+                cache = createNoIndexLookupCache(
+                    info.nodeTable->getColumn(info.nodeTable->getPKColumnID()).getDataType());
+            }
+            info.noIndexLookupCache = cache;
+        }
+    }
+}
+
 bool IndexLookup::getNextTuplesInternal(ExecutionContext* context) {
     if (!children[0]->getNextTuple(context)) {
         return false;
@@ -149,6 +288,10 @@ void IndexLookup::initLocalStateInternal(ResultSet* resultSet, ExecutionContext*
     }
     for (auto& info : infos) {
         info.keyEvaluator->init(*resultSet, context->clientContext);
+        if (info.noIndexLookupCache) {
+            info.noIndexLookupCache->buildIfNeeded(info.nodeTable,
+                transaction::Transaction::Get(*context->clientContext), context->clientContext);
+        }
     }
 }
 

--- a/src/processor/operator/persistent/node_batch_insert.cpp
+++ b/src/processor/operator/persistent/node_batch_insert.cpp
@@ -1,10 +1,15 @@
 #include "processor/operator/persistent/node_batch_insert.h"
 
+#include <mutex>
+#include <set>
+
 #include "catalog/catalog.h"
 #include "catalog/catalog_entry/node_table_catalog_entry.h"
 #include "common/cast.h"
+#include "common/exception/message.h"
 #include "common/exception/runtime.h"
 #include "common/finally_wrapper.h"
+#include "common/type_utils.h"
 #include "processor/execution_context.h"
 #include "processor/operator/persistent/index_builder.h"
 #include "processor/result/factorized_table_util.h"
@@ -14,6 +19,7 @@
 #include "storage/storage_manager.h"
 #include "storage/table/chunked_node_group.h"
 #include "storage/table/node_table.h"
+#include "storage/table/string_chunk_data.h"
 #include "transaction/transaction.h"
 #include <format>
 
@@ -25,6 +31,72 @@ using namespace lbug::transaction;
 namespace lbug {
 namespace processor {
 
+namespace {
+
+template<typename T>
+using StoredPKValue = std::conditional_t<std::same_as<T, string_t>, std::string, T>;
+
+template<typename T>
+StoredPKValue<T> readPKValue(const ColumnChunkData& pkChunk, offset_t pos) {
+    if constexpr (std::same_as<T, string_t>) {
+        return pkChunk.cast<StringChunkData>().getValue<std::string>(pos);
+    } else {
+        return pkChunk.getValue<T>(pos);
+    }
+}
+
+template<typename T>
+std::string pkValueToString(const StoredPKValue<T>& value) {
+    if constexpr (std::same_as<T, string_t>) {
+        return value;
+    } else {
+        return TypeUtils::toString(value);
+    }
+}
+
+template<typename T>
+struct NoIndexPKValidatorImpl final : NoIndexPKValidator {
+    void validate(const ColumnChunkData& pkChunk, offset_t startOffset,
+        length_t numValues) override {
+        std::lock_guard lck{mtx};
+        for (auto i = 0u; i < numValues; ++i) {
+            const auto pos = startOffset + i;
+            if (pkChunk.isNull(pos)) {
+                throw RuntimeException(ExceptionMessage::nullPKException());
+            }
+            const auto value = readPKValue<T>(pkChunk, pos);
+            if (!seenValues.insert(value).second) {
+                throw RuntimeException(
+                    ExceptionMessage::duplicatePKException(pkValueToString<T>(value)));
+            }
+        }
+    }
+
+    std::mutex mtx;
+    // Temporary in-memory uniqueness index for no-hash-index COPY. This can be replaced by an
+    // on-disk persistent index in the future; until then, it is a scalability limitation because
+    // ingest is limited to the primary keys that fit in RAM.
+    std::set<StoredPKValue<T>> seenValues;
+};
+
+std::unique_ptr<NoIndexPKValidator> createNoIndexPKValidator(const LogicalType& pkType) {
+    return TypeUtils::visit(pkType, []<typename T>(T) -> std::unique_ptr<NoIndexPKValidator> {
+        if constexpr (std::same_as<T, bool> || std::same_as<T, int8_t> ||
+                      std::same_as<T, int16_t> || std::same_as<T, int32_t> ||
+                      std::same_as<T, int64_t> || std::same_as<T, uint8_t> ||
+                      std::same_as<T, uint16_t> || std::same_as<T, uint32_t> ||
+                      std::same_as<T, uint64_t> || std::same_as<T, int128_t> ||
+                      std::same_as<T, uint128_t> || std::same_as<T, float> ||
+                      std::same_as<T, double> || std::same_as<T, string_t>) {
+            return std::make_unique<NoIndexPKValidatorImpl<T>>();
+        } else {
+            return nullptr;
+        }
+    });
+}
+
+} // namespace
+
 std::string NodeBatchInsertPrintInfo::toString() const {
     std::string result = "Table Name: ";
     result += tableName;
@@ -35,10 +107,19 @@ void NodeBatchInsertSharedState::initPKIndex(const ExecutionContext* context) {
     auto* nodeTable = dynamic_cast_checked<NodeTable*>(table);
     auto* pkIndex = nodeTable->tryGetPKIndex();
     if (!pkIndex) {
-        throw RuntimeException(
-            "COPY into node tables requires enable_default_hash_index=true for primary-key "
-            "validation.");
+        if (nodeTable->getNumTotalRows(Transaction::Get(*context->clientContext)) != 0) {
+            throw RuntimeException(
+                "COPY into a non-empty primary-key node table without a hash index is not "
+                "supported.");
+        }
+        globalIndexBuilder.reset();
+        noIndexPKValidator = createNoIndexPKValidator(pkType);
+        if (!noIndexPKValidator) {
+            throw RuntimeException(ExceptionMessage::invalidPKType(pkType.toString()));
+        }
+        return;
     }
+    noIndexPKValidator.reset();
     globalIndexBuilder = IndexBuilder(std::make_shared<IndexBuilderSharedState>(
         Transaction::Get(*context->clientContext), nodeTable));
 }
@@ -81,8 +162,9 @@ void NodeBatchInsert::initLocalStateInternal(ResultSet* resultSet, ExecutionCont
     localState = std::make_unique<NodeBatchInsertLocalState>(
         std::span{nodeInfo->columnTypes.begin(), nodeInfo->outputDataColumns.size()});
     const auto nodeLocalState = localState->ptrCast<NodeBatchInsertLocalState>();
-    DASSERT(nodeSharedState->globalIndexBuilder);
-    nodeLocalState->localIndexBuilder = nodeSharedState->globalIndexBuilder->clone();
+    if (nodeSharedState->globalIndexBuilder) {
+        nodeLocalState->localIndexBuilder = nodeSharedState->globalIndexBuilder->clone();
+    }
     nodeLocalState->errorHandler = createErrorHandler(context);
     nodeLocalState->optimisticAllocator =
         Transaction::Get(*context->clientContext)->getLocalStorage()->addOptimisticAllocator();
@@ -230,6 +312,9 @@ void NodeBatchInsert::writeAndResetNodeGroup(transaction::Transaction* transacti
         }
         indexBuilder->insert(nodeGroup->getColumnChunk(nodeSharedState->pkColumnID),
             warningChunkData, nodeOffset, numRowsWritten, errorHandler);
+    } else if (nodeSharedState->noIndexPKValidator) {
+        nodeSharedState->noIndexPKValidator->validate(
+            nodeGroup->getColumnChunk(nodeSharedState->pkColumnID), 0, numRowsWritten);
     }
     if (numRowsWritten == nodeGroup->getNumRows()) {
         nodeGroup->resetToEmpty();

--- a/src/processor/operator/persistent/node_batch_insert.cpp
+++ b/src/processor/operator/persistent/node_batch_insert.cpp
@@ -39,11 +39,6 @@ void NodeBatchInsertSharedState::initPKIndex(const ExecutionContext* context) {
             "COPY into node tables requires enable_default_hash_index=true for primary-key "
             "validation.");
     }
-    uint64_t numRows = 0;
-    if (tableFuncSharedState != nullptr) {
-        numRows = tableFuncSharedState->getNumRows();
-    }
-    pkIndex->bulkReserve(numRows);
     globalIndexBuilder = IndexBuilder(std::make_shared<IndexBuilderSharedState>(
         Transaction::Get(*context->clientContext), nodeTable));
 }

--- a/src/storage/disk_array_collection.cpp
+++ b/src/storage/disk_array_collection.cpp
@@ -91,7 +91,7 @@ size_t DiskArrayCollection::addDiskArray() {
     auto oldSize = numHeaders++;
     // This may not be the last header page. If we rollback there may be header pages which are
     // empty
-    auto pageIdx = numHeaders % HeaderPage::NUM_HEADERS_PER_PAGE;
+    auto pageIdx = oldSize / HeaderPage::NUM_HEADERS_PER_PAGE;
     if (pageIdx >= headersForWriteTrx.size()) {
 
         headersForWriteTrx.emplace_back(std::make_unique<HeaderPage>());

--- a/src/storage/index/hash_index.cpp
+++ b/src/storage/index/hash_index.cpp
@@ -416,11 +416,6 @@ size_t HashIndex<T>::mergeSlot(PageAllocator& pageAllocator, const Transaction* 
 }
 
 template<typename T>
-void HashIndex<T>::bulkReserve(uint64_t newEntries) {
-    return localStorage->reserveInserts(newEntries);
-}
-
-template<typename T>
 HashIndex<T>::~HashIndex() = default;
 
 template<>

--- a/src/storage/table/node_table.cpp
+++ b/src/storage/table/node_table.cpp
@@ -6,6 +6,7 @@
 #include "common/cast.h"
 #include "common/exception/message.h"
 #include "common/exception/runtime.h"
+#include "common/type_utils.h"
 #include "common/types/types.h"
 #include "main/client_context.h"
 #include "storage/local_storage/local_node_table.h"

--- a/test/copy/copy_test.cpp
+++ b/test/copy/copy_test.cpp
@@ -1,3 +1,8 @@
+#include <algorithm>
+#include <filesystem>
+#include <fstream>
+
+#include "common/file_system/local_file_system.h"
 #include "common/file_system/virtual_file_system.h"
 #include "graph_test/base_graph_test.h"
 #include "main/database.h"
@@ -111,6 +116,20 @@ public:
     }
     std::string getInputDir() override { UNREACHABLE_CODE; }
     void BMExceptionRecoveryTest(BMExceptionRecoveryTestConfig cfg);
+    std::string writeCSV(const std::string& fileName, const std::vector<std::string>& rows) {
+        auto tempDir = TestHelper::getTempDir(getTestGroupAndName());
+        auto filePath = common::LocalFileSystem::joinPath(tempDir, fileName);
+#if defined(_WIN32)
+        std::replace(filePath.begin(), filePath.end(), '\\', '/');
+#endif
+        std::filesystem::create_directories(tempDir);
+        std::ofstream file(filePath);
+        for (const auto& row : rows) {
+            file << row << "\n";
+        }
+        file.close();
+        return filePath;
+    }
     std::atomic<uint64_t> failureFrequency;
     FlakyBufferManager* currentBM;
 };
@@ -164,6 +183,77 @@ void CopyTest::BMExceptionRecoveryTest(BMExceptionRecoveryTestConfig cfg) {
     if (!inMemMode && !cfg.canFailDuringCheckpoint) {
         FSMLeakChecker::checkForLeakedPages(conn.get());
     }
+}
+
+TEST_F(CopyTest, NodeCopyWithoutDefaultHashIndexSorted) {
+    createDBAndConn();
+    auto result = conn->query("CALL enable_default_hash_index=false");
+    ASSERT_TRUE(result->isSuccess()) << result->getErrorMessage();
+    result = conn->query("CREATE NODE TABLE Account(id INT64, PRIMARY KEY(id))");
+    ASSERT_TRUE(result->isSuccess()) << result->getErrorMessage();
+
+    const auto filePath = writeCSV("sorted.csv", {"1", "2", "3"});
+    result = conn->query(std::format("COPY Account FROM '{}'", filePath));
+    ASSERT_TRUE(result->isSuccess()) << result->getErrorMessage();
+
+    result = conn->query("MATCH (a:Account) RETURN COUNT(*)");
+    ASSERT_TRUE(result->isSuccess()) << result->getErrorMessage();
+    ASSERT_TRUE(result->hasNext());
+    ASSERT_EQ(result->getNext()->getValue(0)->getValue<int64_t>(), 3);
+}
+
+TEST_F(CopyTest, NodeCopyWithoutDefaultHashIndexRejectsDuplicate) {
+    createDBAndConn();
+    auto result = conn->query("CALL enable_default_hash_index=false");
+    ASSERT_TRUE(result->isSuccess()) << result->getErrorMessage();
+    result = conn->query("CREATE NODE TABLE Account(id INT64, PRIMARY KEY(id))");
+    ASSERT_TRUE(result->isSuccess()) << result->getErrorMessage();
+
+    const auto filePath = writeCSV("duplicate.csv", {"1", "2", "2"});
+    result = conn->query(std::format("COPY Account FROM '{}'", filePath));
+    ASSERT_FALSE(result->isSuccess());
+    ASSERT_NE(result->getErrorMessage().find("duplicated primary key"), std::string::npos);
+
+    result = conn->query("MATCH (a:Account) RETURN COUNT(*)");
+    ASSERT_TRUE(result->isSuccess()) << result->getErrorMessage();
+    ASSERT_TRUE(result->hasNext());
+    ASSERT_EQ(result->getNext()->getValue(0)->getValue<int64_t>(), 0);
+}
+
+TEST_F(CopyTest, NodeCopyWithoutDefaultHashIndexRejectsNull) {
+    createDBAndConn();
+    auto result = conn->query("CALL enable_default_hash_index=false");
+    ASSERT_TRUE(result->isSuccess()) << result->getErrorMessage();
+    result = conn->query("CREATE NODE TABLE Account(id INT64, PRIMARY KEY(id))");
+    ASSERT_TRUE(result->isSuccess()) << result->getErrorMessage();
+
+    const auto filePath = writeCSV("null.csv", {"1", "", "3"});
+    result = conn->query(std::format("COPY Account FROM '{}'", filePath));
+    ASSERT_FALSE(result->isSuccess());
+    ASSERT_NE(result->getErrorMessage().find("violates the non-null constraint"),
+        std::string::npos);
+
+    result = conn->query("MATCH (a:Account) RETURN COUNT(*)");
+    ASSERT_TRUE(result->isSuccess()) << result->getErrorMessage();
+    ASSERT_TRUE(result->hasNext());
+    ASSERT_EQ(result->getNext()->getValue(0)->getValue<int64_t>(), 0);
+}
+
+TEST_F(CopyTest, NodeCopyWithoutDefaultHashIndexAllowsUnsortedUniqueNodeGroup) {
+    createDBAndConn();
+    auto result = conn->query("CALL enable_default_hash_index=false");
+    ASSERT_TRUE(result->isSuccess()) << result->getErrorMessage();
+    result = conn->query("CREATE NODE TABLE Account(id INT64, PRIMARY KEY(id))");
+    ASSERT_TRUE(result->isSuccess()) << result->getErrorMessage();
+
+    const auto filePath = writeCSV("unsorted.csv", {"2", "1", "3"});
+    result = conn->query(std::format("COPY Account FROM '{}'", filePath));
+    ASSERT_TRUE(result->isSuccess()) << result->getErrorMessage();
+
+    result = conn->query("MATCH (a:Account) RETURN COUNT(*)");
+    ASSERT_TRUE(result->isSuccess()) << result->getErrorMessage();
+    ASSERT_TRUE(result->hasNext());
+    ASSERT_EQ(result->getNext()->getValue(0)->getValue<int64_t>(), 3);
 }
 
 TEST_F(CopyTest, NodeCopyBMExceptionRecoverySameConnection) {

--- a/test/copy/copy_test.cpp
+++ b/test/copy/copy_test.cpp
@@ -256,6 +256,54 @@ TEST_F(CopyTest, NodeCopyWithoutDefaultHashIndexAllowsUnsortedUniqueNodeGroup) {
     ASSERT_EQ(result->getNext()->getValue(0)->getValue<int64_t>(), 3);
 }
 
+TEST_F(CopyTest, RelCopyWithoutDefaultHashIndex) {
+    createDBAndConn();
+    auto result = conn->query("CALL enable_default_hash_index=false");
+    ASSERT_TRUE(result->isSuccess()) << result->getErrorMessage();
+    result = conn->query("CREATE NODE TABLE Account(id INT64, PRIMARY KEY(id))");
+    ASSERT_TRUE(result->isSuccess()) << result->getErrorMessage();
+    result = conn->query("CREATE REL TABLE Follows(FROM Account TO Account)");
+    ASSERT_TRUE(result->isSuccess()) << result->getErrorMessage();
+
+    const auto nodePath = writeCSV("rel_nodes.csv", {"1", "2", "3"});
+    result = conn->query(std::format("COPY Account FROM '{}'", nodePath));
+    ASSERT_TRUE(result->isSuccess()) << result->getErrorMessage();
+
+    const auto relPath = writeCSV("rels.csv", {"1,2", "2,3", "3,1"});
+    result = conn->query(std::format("COPY Follows FROM '{}'", relPath));
+    ASSERT_TRUE(result->isSuccess()) << result->getErrorMessage();
+
+    result = conn->query("MATCH (:Account)-[f:Follows]->(:Account) RETURN COUNT(f)");
+    ASSERT_TRUE(result->isSuccess()) << result->getErrorMessage();
+    ASSERT_TRUE(result->hasNext());
+    ASSERT_EQ(result->getNext()->getValue(0)->getValue<int64_t>(), 3);
+}
+
+TEST_F(CopyTest, RelCopyWithoutDefaultHashIndexRejectsMissingEndpoint) {
+    createDBAndConn();
+    auto result = conn->query("CALL enable_default_hash_index=false");
+    ASSERT_TRUE(result->isSuccess()) << result->getErrorMessage();
+    result = conn->query("CREATE NODE TABLE Account(id INT64, PRIMARY KEY(id))");
+    ASSERT_TRUE(result->isSuccess()) << result->getErrorMessage();
+    result = conn->query("CREATE REL TABLE Follows(FROM Account TO Account)");
+    ASSERT_TRUE(result->isSuccess()) << result->getErrorMessage();
+
+    const auto nodePath = writeCSV("missing_endpoint_nodes.csv", {"1", "2"});
+    result = conn->query(std::format("COPY Account FROM '{}'", nodePath));
+    ASSERT_TRUE(result->isSuccess()) << result->getErrorMessage();
+
+    const auto relPath = writeCSV("missing_endpoint_rels.csv", {"1,2", "2,3"});
+    result = conn->query(std::format("COPY Follows FROM '{}'", relPath));
+    ASSERT_FALSE(result->isSuccess());
+    ASSERT_NE(result->getErrorMessage().find("Unable to find primary key value"),
+        std::string::npos);
+
+    result = conn->query("MATCH (:Account)-[f:Follows]->(:Account) RETURN COUNT(f)");
+    ASSERT_TRUE(result->isSuccess()) << result->getErrorMessage();
+    ASSERT_TRUE(result->hasNext());
+    ASSERT_EQ(result->getNext()->getValue(0)->getValue<int64_t>(), 0);
+}
+
 TEST_F(CopyTest, NodeCopyBMExceptionRecoverySameConnection) {
     if (inMemMode) {
         GTEST_SKIP();


### PR DESCRIPTION
For the livejournal dataset:

node table only:

- before: 130MB
- after: 8.3MB

node + rel table:

- before: 634MB
- after: 511MB (bi-directional edges)
- after: 260MB (fwd-only edges)

Repro:

```
CALL enable_default_hash_index=false;
CREATE NODE TABLE User(id INT64, PRIMARY KEY (id));
CREATE REL TABLE edges(FROM User TO User) WITH (STORAGE_DIRECTION='fwd');
COPY USER from "/tmp/livejournal/nodes_user.parquet";
COPY edges from "/tmp/livejournal/edges.parquet";
```