### PR TITLE
Implement Adaptive Radix Tree (ART) Indexes

### DIFF
--- a/docs/art_index.md
+++ b/docs/art_index.md
@@ -110,3 +110,10 @@ serialized into the existing index catalog storage-info buffer.
 On reload, the ART index deserializes the key/offset pairs and rebuilds the
 in-memory tree. Built-in `ART` catalog entries are marked as loaded in the same
 way as built-in `HASH` entries so inserts can continue after reload.
+
+The persisted ART is not currently page-backed or demand loaded. Opening a
+database with an ART index materializes the full in-memory tree by replaying all
+stored key/offset entries. Memory use is therefore O(number of indexed keys),
+not O(number of queried index pages or blocks). A production disk-backed ART
+would need buffer-managed index pages and lazy traversal instead of loading the
+entire index at startup.

--- a/docs/art_index.md
+++ b/docs/art_index.md
@@ -1,0 +1,84 @@
+# ART Index
+
+Ladybug supports a built-in adaptive radix tree index for node primary keys:
+
+```cypher
+CREATE ART INDEX person_pk FOR (p:Person) ON (p.ID);
+```
+
+This is implemented by `storage::ArtPrimaryKeyIndex`, registered as the built-in
+`ART` index type. It is parallel to the existing `HASH` primary-key index in the
+DDL and table lookup paths, but it uses a radix tree keyed by encoded primary-key
+bytes instead of a hash table.
+
+## Scope
+
+The ART index currently supports Ladybug's primary-key index workflow:
+
+- building the index from an existing node table during `CREATE ART INDEX`
+- checking uniqueness for committed inserts
+- primary-key lookup through `NodeTable::lookupPK`
+- rollback cleanup for failed insert batches
+- checkpoint and reload
+
+It does not currently provide secondary-index scans, range scans, prefix
+compression, duplicate row-id leaves, or DuckDB's parallel local-ART merge
+builder.
+
+## Key Encoding
+
+`ArtKey::encode` converts a primary-key value into a byte vector. Null keys are
+not valid primary keys and are rejected during insert.
+
+Strings are encoded using the same escaping idea as DuckDB's ART keys:
+
+- bytes `0x00` and `0x01` are prefixed with `0x01`
+- a trailing `0x00` terminator is appended
+
+Fixed-width numeric values are encoded as their in-memory bytes. This is enough
+for the current equality-only primary-key lookup path. If ART is later extended
+to ordered scans, numeric encodings will need to become order-preserving.
+
+## Tree Shape
+
+Each tree node may store an optional node-table offset for a complete key and a
+set of byte-labeled children. Children use adaptive layouts:
+
+- `Node4`: up to 4 children
+- `Node16`: up to 16 children
+- `Node48`: up to 48 children, with a 256-byte indirection table
+- `Node256`: direct child pointer array for all byte values
+
+Nodes grow as children are inserted. Lookups walk one encoded key byte at a time
+from the root to a terminal node and then verify visibility before returning the
+stored offset.
+
+## Inserts And Uniqueness
+
+`ArtPrimaryKeyIndex::commitInsert` is called through the generic index commit
+path. For each row, it encodes the primary-key value and inserts the key into
+the radix tree with the row offset from the node ID vector.
+
+If the terminal node already has a visible offset, insertion fails with the same
+duplicate-primary-key error used by the hash index. If the existing offset is not
+visible to the caller, the stored offset may be replaced.
+
+## Lookup Path
+
+`NodeTable::lookupPK` now asks the loaded primary-key index to perform a generic
+`lookupPrimaryKey` operation. The hash index implements this by delegating to
+its existing lookup code. The ART index encodes the lookup key, walks the tree,
+and returns the offset only if the supplied visibility function accepts it.
+
+This keeps the planner and table lookup path independent of whether the physical
+primary-key index is `HASH` or `ART`.
+
+## Checkpoint And Reload
+
+During checkpoint, the ART index collects all terminal key/offset pairs from the
+tree and stores them in `ArtPrimaryKeyIndexStorageInfo`. The storage info is
+serialized into the existing index catalog storage-info buffer.
+
+On reload, the ART index deserializes the key/offset pairs and rebuilds the
+in-memory tree. Built-in `ART` catalog entries are marked as loaded in the same
+way as built-in `HASH` entries so inserts can continue after reload.

--- a/docs/art_index.md
+++ b/docs/art_index.md
@@ -18,12 +18,16 @@ The ART index currently supports Ladybug's primary-key index workflow:
 - building the index from an existing node table during `CREATE ART INDEX`
 - checking uniqueness for committed inserts
 - primary-key lookup through `NodeTable::lookupPK`
+- bounded primary-key range scans for constant inequality predicates
 - rollback cleanup for failed insert batches
 - checkpoint and reload
 
-It does not currently provide secondary-index scans, range scans, prefix
-compression, duplicate row-id leaves, or DuckDB's parallel local-ART merge
-builder.
+It does not currently provide secondary indexes, prefix compression, duplicate
+row-id leaves, or DuckDB's parallel local-ART merge builder. Range scans are
+used only for single-table constant predicates over an ART-backed primary key.
+The optimizer keeps the original range predicates as residual filters, so the
+range scan is an access-path optimization rather than a replacement for general
+predicate evaluation.
 
 ## Key Encoding
 
@@ -35,9 +39,17 @@ Strings are encoded using the same escaping idea as DuckDB's ART keys:
 - bytes `0x00` and `0x01` are prefixed with `0x01`
 - a trailing `0x00` terminator is appended
 
-Fixed-width numeric values are encoded as their in-memory bytes. This is enough
-for the current equality-only primary-key lookup path. If ART is later extended
-to ordered scans, numeric encodings will need to become order-preserving.
+Fixed-width numeric values are encoded in order-preserving byte order:
+
+- unsigned integers use big-endian bytes
+- signed integers flip the sign bit and then use big-endian bytes
+- floating-point values transform IEEE bytes so negative values sort before
+  positive values, then use big-endian bytes
+- `INT128` and `UINT128` use high-word then low-word big-endian encoding, with
+  the signed high-word sign bit flipped for `INT128`
+
+This makes lexicographic key order match value order for supported scalar
+primary-key types.
 
 ## Tree Shape
 
@@ -52,6 +64,11 @@ set of byte-labeled children. Children use adaptive layouts:
 Nodes grow as children are inserted. Lookups walk one encoded key byte at a time
 from the root to a terminal node and then verify visibility before returning the
 stored offset.
+
+Range scans traverse children in byte order and collect terminal offsets whose
+encoded keys fall between the requested lower and upper bounds. The scan returns
+candidate row offsets in key order, but query output order is not guaranteed;
+queries still need `ORDER BY` for ordered results.
 
 ## Inserts And Uniqueness
 
@@ -72,6 +89,11 @@ and returns the offset only if the supplied visibility function accepts it.
 
 This keeps the planner and table lookup path independent of whether the physical
 primary-key index is `HASH` or `ART`.
+
+For constant primary-key inequalities such as `p.ID > 10` or
+`p.ID >= 10 AND p.ID < 20`, the filter pushdown optimizer can select the ART
+range path when the table has an ART primary-key index. Hash indexes remain
+equality-only.
 
 ## Checkpoint And Reload
 

--- a/docs/art_index.md
+++ b/docs/art_index.md
@@ -23,11 +23,17 @@ The ART index currently supports Ladybug's primary-key index workflow:
 - checkpoint and reload
 
 It does not currently provide secondary indexes, prefix compression, duplicate
-row-id leaves, or DuckDB's parallel local-ART merge builder. Range scans are
-used only for single-table constant predicates over an ART-backed primary key.
-The optimizer keeps the original range predicates as residual filters, so the
-range scan is an access-path optimization rather than a replacement for general
-predicate evaluation.
+row-id leaves, multi-key indexes, partial indexes, expression indexes, or
+DuckDB's parallel local-ART merge builder. `CREATE ART INDEX` is intentionally
+limited to one native node-table primary-key property. Unsupported index shapes
+are rejected during index creation instead of being accepted and failing later
+in lookup or insert paths.
+
+Range scans are used only for single-table constant predicates over an
+ART-backed primary key. The optimizer uses the range path only after validating
+that the query has at most one constant lower-bound predicate and at most one
+constant upper-bound predicate. Multiple predicates for the same bound,
+non-constant bounds, and complex predicates remain regular filters.
 
 ## Key Encoding
 

--- a/src/binder/bind/bind_ddl.cpp
+++ b/src/binder/bind/bind_ddl.cpp
@@ -403,8 +403,10 @@ std::unique_ptr<BoundStatement> Binder::bindCreateIndex(const Statement& stateme
     if (!indexTypeOptional.has_value()) {
         throw BinderException(std::format("Index type {} does not exist.", info.indexType));
     }
-    if (indexType != storage::PrimaryKeyIndex::getIndexType().typeName) {
-        throw BinderException(std::format("Only HASH indexes are supported by CREATE INDEX."));
+    const auto& registeredIndexType = indexTypeOptional.value().get();
+    if (registeredIndexType.constraintType != storage::IndexConstraintType::PRIMARY) {
+        throw BinderException(
+            std::format("Only primary-key indexes are supported by CREATE INDEX."));
     }
     auto catalog = Catalog::Get(*clientContext);
     auto transaction = transaction::Transaction::Get(*clientContext);
@@ -418,11 +420,12 @@ std::unique_ptr<BoundStatement> Binder::bindCreateIndex(const Statement& stateme
     }
     if (!StringUtils::caseInsensitiveEquals(nodeTableEntry->getPrimaryKeyName(),
             info.propertyName)) {
-        throw BinderException("HASH indexes are currently supported only on node primary keys.");
+        throw BinderException(std::format(
+            "{} indexes are currently supported only on node primary keys.", indexType));
     }
     auto boundOptions = bindParsingOptions(info.options);
     if (!boundOptions.empty()) {
-        throw BinderException("CREATE HASH INDEX does not support OPTIONS.");
+        throw BinderException(std::format("CREATE {} INDEX does not support OPTIONS.", indexType));
     }
     auto& property = tableEntry->getProperty(info.propertyName);
     std::vector<PropertyDefinition> propertyDefinitions;

--- a/src/catalog/catalog_entry/index_catalog_entry.cpp
+++ b/src/catalog/catalog_entry/index_catalog_entry.cpp
@@ -77,6 +77,9 @@ std::unique_ptr<IndexCatalogEntry> IndexCatalogEntry::deserialize(
     indexEntry->auxBuffer = std::make_unique<uint8_t[]>(auxBufferSize);
     indexEntry->auxBufferSize = auxBufferSize;
     deserializer.read(indexEntry->auxBuffer.get(), auxBufferSize);
+    if (type == "HASH" || type == "ART") {
+        indexEntry->setAuxInfo(std::make_unique<BuiltinIndexAuxInfo>());
+    }
     return indexEntry;
 }
 

--- a/src/include/optimizer/filter_push_down_optimizer.h
+++ b/src/include/optimizer/filter_push_down_optimizer.h
@@ -8,6 +8,15 @@ class ClientContext;
 }
 namespace optimizer {
 
+struct PrimaryKeyRangePredicate {
+    std::shared_ptr<binder::Expression> lowerBound;
+    std::shared_ptr<binder::Expression> upperBound;
+    bool lowerInclusive = true;
+    bool upperInclusive = true;
+
+    bool hasBound() const { return lowerBound != nullptr || upperBound != nullptr; }
+};
+
 struct PredicateSet {
     binder::expression_vector equalityPredicates;
     binder::expression_vector nonEqualityPredicates;
@@ -24,6 +33,7 @@ struct PredicateSet {
     void addPredicate(std::shared_ptr<binder::Expression> predicate);
     std::shared_ptr<binder::Expression> popNodePKEqualityComparison(
         const binder::Expression& nodeID);
+    PrimaryKeyRangePredicate popNodePKRangeComparison(const binder::Expression& nodeID);
     binder::expression_vector getAllPredicates();
 
 private:

--- a/src/include/planner/operator/scan/logical_scan_node_table.h
+++ b/src/include/planner/operator/scan/logical_scan_node_table.h
@@ -24,10 +24,23 @@ struct ExtraScanNodeTableInfo {
 
 struct PrimaryKeyScanInfo final : ExtraScanNodeTableInfo {
     std::shared_ptr<binder::Expression> key;
+    std::shared_ptr<binder::Expression> lowerBound;
+    std::shared_ptr<binder::Expression> upperBound;
+    bool lowerInclusive = true;
+    bool upperInclusive = true;
+    bool isRange = false;
 
     explicit PrimaryKeyScanInfo(std::shared_ptr<binder::Expression> key) : key{std::move(key)} {}
+    PrimaryKeyScanInfo(std::shared_ptr<binder::Expression> lowerBound, bool lowerInclusive,
+        std::shared_ptr<binder::Expression> upperBound, bool upperInclusive)
+        : lowerBound{std::move(lowerBound)}, upperBound{std::move(upperBound)},
+          lowerInclusive{lowerInclusive}, upperInclusive{upperInclusive}, isRange{true} {}
 
     std::unique_ptr<ExtraScanNodeTableInfo> copy() const override {
+        if (isRange) {
+            return std::make_unique<PrimaryKeyScanInfo>(lowerBound, lowerInclusive, upperBound,
+                upperInclusive);
+        }
         return std::make_unique<PrimaryKeyScanInfo>(key);
     }
 };

--- a/src/include/processor/operator/persistent/node_batch_insert.h
+++ b/src/include/processor/operator/persistent/node_batch_insert.h
@@ -67,6 +67,7 @@ struct NodeBatchInsertSharedState final : BatchInsertSharedState {
     common::LogicalType pkType;
     std::optional<IndexBuilder> globalIndexBuilder;
     std::unique_ptr<NoIndexPKValidator> noIndexPKValidator;
+    bool usePrimaryKeyIndexCommitInsert;
 
     function::TableFuncSharedState* tableFuncSharedState;
 
@@ -79,7 +80,8 @@ struct NodeBatchInsertSharedState final : BatchInsertSharedState {
     explicit NodeBatchInsertSharedState(std::shared_ptr<FactorizedTable> fTable)
         : BatchInsertSharedState{std::move(fTable)}, pkColumnID{0},
           globalIndexBuilder(std::nullopt), noIndexPKValidator{nullptr},
-          tableFuncSharedState{nullptr}, sharedNodeGroup{nullptr} {}
+          usePrimaryKeyIndexCommitInsert{false}, tableFuncSharedState{nullptr},
+          sharedNodeGroup{nullptr} {}
 
     void initPKIndex(const ExecutionContext* context);
 };

--- a/src/include/processor/operator/scan/primary_key_scan_node_table.h
+++ b/src/include/processor/operator/scan/primary_key_scan_node_table.h
@@ -10,10 +10,12 @@ struct PrimaryKeyScanPrintInfo final : OPPrintInfo {
     binder::expression_vector expressions;
     std::string key;
     std::string alias;
+    std::string indexType;
 
     PrimaryKeyScanPrintInfo(binder::expression_vector expressions, std::string key,
-        std::string alias)
-        : expressions(std::move(expressions)), key(std::move(key)), alias{std::move(alias)} {}
+        std::string alias, std::string indexType)
+        : expressions(std::move(expressions)), key(std::move(key)), alias{std::move(alias)},
+          indexType{std::move(indexType)} {}
 
     std::string toString() const override;
 
@@ -23,7 +25,8 @@ struct PrimaryKeyScanPrintInfo final : OPPrintInfo {
 
 private:
     PrimaryKeyScanPrintInfo(const PrimaryKeyScanPrintInfo& other)
-        : OPPrintInfo(other), expressions(other.expressions), alias(other.alias) {}
+        : OPPrintInfo(other), expressions(other.expressions), key(other.key), alias(other.alias),
+          indexType(other.indexType) {}
 };
 
 struct PrimaryKeyScanSharedState {

--- a/src/include/processor/operator/scan/primary_key_scan_node_table.h
+++ b/src/include/processor/operator/scan/primary_key_scan_node_table.h
@@ -43,11 +43,15 @@ class PrimaryKeyScanNodeTable : public ScanTable {
 public:
     PrimaryKeyScanNodeTable(ScanOpInfo opInfo, std::vector<ScanNodeTableInfo> tableInfos,
         std::unique_ptr<evaluator::ExpressionEvaluator> indexEvaluator,
+        std::unique_ptr<evaluator::ExpressionEvaluator> upperBoundEvaluator, bool isRange,
+        bool lowerInclusive, bool upperInclusive,
         std::shared_ptr<PrimaryKeyScanSharedState> sharedState, physical_op_id id,
         std::unique_ptr<OPPrintInfo> printInfo)
         : ScanTable{type_, std::move(opInfo), id, std::move(printInfo)}, scanState{nullptr},
           tableInfos{std::move(tableInfos)}, indexEvaluator{std::move(indexEvaluator)},
-          sharedState{std::move(sharedState)} {}
+          upperBoundEvaluator{std::move(upperBoundEvaluator)}, sharedState{std::move(sharedState)},
+          isRange{isRange}, lowerInclusive{lowerInclusive}, upperInclusive{upperInclusive},
+          currentRangeTableIdx{0}, rangeOffsetCursor{0} {}
 
     bool isSource() const override { return true; }
 
@@ -59,14 +63,26 @@ public:
 
     std::unique_ptr<PhysicalOperator> copy() override {
         return std::make_unique<PrimaryKeyScanNodeTable>(opInfo.copy(), copyVector(tableInfos),
-            indexEvaluator->copy(), sharedState, id, printInfo->copy());
+            indexEvaluator == nullptr ? nullptr : indexEvaluator->copy(),
+            upperBoundEvaluator == nullptr ? nullptr : upperBoundEvaluator->copy(), isRange,
+            lowerInclusive, upperInclusive, sharedState, id, printInfo->copy());
     }
+
+private:
+    bool lookupRange(ExecutionContext* context);
 
 private:
     std::unique_ptr<storage::NodeTableScanState> scanState;
     std::vector<ScanNodeTableInfo> tableInfos;
     std::unique_ptr<evaluator::ExpressionEvaluator> indexEvaluator;
+    std::unique_ptr<evaluator::ExpressionEvaluator> upperBoundEvaluator;
     std::shared_ptr<PrimaryKeyScanSharedState> sharedState;
+    bool isRange;
+    bool lowerInclusive;
+    bool upperInclusive;
+    common::idx_t currentRangeTableIdx;
+    std::vector<common::offset_t> rangeOffsets;
+    common::idx_t rangeOffsetCursor;
 };
 
 } // namespace processor

--- a/src/include/storage/index/art_index.h
+++ b/src/include/storage/index/art_index.h
@@ -123,19 +123,32 @@ private:
         };
 
         Node();
-        ~Node();
         Node* getChild(uint8_t byte) const;
-        Node* getOrInsertChild(uint8_t byte);
+        Node* getOrInsertChild(ArtPrimaryKeyIndex& index, uint8_t byte);
         void removeChild(uint8_t byte);
-        void moveChildrenTo(std::vector<Node*>& children);
         bool empty() const { return !offset.has_value() && count == 0; }
+    };
+
+    static constexpr uint64_t NODE_BLOCK_CAPACITY = 16 * 1024;
+
+    struct NodeBlock {
+        Node* nodes = nullptr;
+        uint64_t used = 0;
+
+        NodeBlock();
+        ~NodeBlock();
+        NodeBlock(const NodeBlock&) = delete;
+        NodeBlock& operator=(const NodeBlock&) = delete;
+        NodeBlock(NodeBlock&& other) noexcept;
+        NodeBlock& operator=(NodeBlock&& other) noexcept;
     };
 
     bool insertInternal(const ArtKey& key, common::offset_t offset, visible_func isVisible);
     bool lookup(const ArtKey& key, common::offset_t& result, visible_func isVisible) const;
     bool eraseInternal(Node& node, const std::vector<uint8_t>& key, uint64_t depth);
     void erase(const ArtKey& key);
-    static void deleteTree(Node* root);
+    Node* allocateNode();
+    void recordKindChange(Node& node, Node::Kind newKind);
     void collectRange(const Node& node, std::vector<uint8_t>& key, const ArtKey* lowerBound,
         bool lowerInclusive, const ArtKey* upperBound, bool upperInclusive,
         common::idx_t maxResults, std::vector<common::offset_t>& results,
@@ -147,6 +160,9 @@ private:
 
 private:
     Node root;
+    std::vector<NodeBlock> nodeBlocks;
+    uint64_t numAllocatedNodes = 1;
+    std::array<uint64_t, 4> numNodesByKind{1, 0, 0, 0};
     mutable std::mutex mutex;
 };
 

--- a/src/include/storage/index/art_index.h
+++ b/src/include/storage/index/art_index.h
@@ -101,20 +101,33 @@ private:
         static constexpr uint8_t EMPTY_MARKER = UINT8_MAX;
 
         enum class Kind : uint8_t { NODE4 = 0, NODE16 = 1, NODE48 = 2, NODE256 = 3 };
+        struct SmallChildren {
+            std::array<uint8_t, 16> keys{};
+            std::array<Node*, 16> children{};
+        };
+        struct Node48Children {
+            std::array<uint8_t, 256> childIndex{};
+            std::array<Node*, 48> children{};
+        };
+        struct Node256Children {
+            std::array<Node*, 256> children{};
+        };
 
         std::optional<common::offset_t> offset;
         Kind kind = Kind::NODE4;
         uint16_t count = 0;
-        std::array<uint8_t, 16> keys{};
-        std::array<std::unique_ptr<Node>, 16> smallChildren{};
-        std::array<uint8_t, 256> childIndex{};
-        std::array<std::unique_ptr<Node>, 48> node48Children{};
-        std::array<std::unique_ptr<Node>, 256> node256Children{};
+        union {
+            SmallChildren small;
+            Node48Children node48;
+            Node256Children node256;
+        };
 
         Node();
+        ~Node();
         Node* getChild(uint8_t byte) const;
         Node* getOrInsertChild(uint8_t byte);
         void removeChild(uint8_t byte);
+        void moveChildrenTo(std::vector<Node*>& children);
         bool empty() const { return !offset.has_value() && count == 0; }
     };
 
@@ -122,10 +135,12 @@ private:
     bool lookup(const ArtKey& key, common::offset_t& result, visible_func isVisible) const;
     bool eraseInternal(Node& node, const std::vector<uint8_t>& key, uint64_t depth);
     void erase(const ArtKey& key);
+    static void deleteTree(Node* root);
     void collectRange(const Node& node, std::vector<uint8_t>& key, const ArtKey* lowerBound,
         bool lowerInclusive, const ArtKey* upperBound, bool upperInclusive,
         common::idx_t maxResults, std::vector<common::offset_t>& results,
         visible_func isVisible) const;
+    void clear();
     void collectEntries(const Node& node, std::vector<uint8_t>& key,
         std::vector<std::pair<std::vector<uint8_t>, common::offset_t>>& entries) const;
     void loadEntries(const ArtPrimaryKeyIndexStorageInfo& storageInfo);

--- a/src/include/storage/index/art_index.h
+++ b/src/include/storage/index/art_index.h
@@ -1,0 +1,128 @@
+#pragma once
+
+#include <array>
+#include <memory>
+#include <optional>
+#include <vector>
+
+#include "common/type_utils.h"
+#include "common/types/int128_t.h"
+#include "common/types/string_t.h"
+#include "common/types/uint128_t.h"
+#include "storage/index/index.h"
+
+namespace lbug {
+namespace common {
+struct BufferReader;
+}
+namespace storage {
+
+class ArtKey {
+public:
+    ArtKey() = default;
+    explicit ArtKey(std::vector<uint8_t> bytes) : bytes{std::move(bytes)} {}
+
+    bool empty() const { return bytes.empty(); }
+    const std::vector<uint8_t>& getBytes() const { return bytes; }
+
+    static ArtKey encode(common::ValueVector* vector, uint64_t vectorPos);
+
+private:
+    std::vector<uint8_t> bytes;
+};
+
+struct ArtPrimaryKeyIndexStorageInfo final : IndexStorageInfo {
+    std::vector<std::pair<std::vector<uint8_t>, common::offset_t>> entries;
+
+    ArtPrimaryKeyIndexStorageInfo() = default;
+    explicit ArtPrimaryKeyIndexStorageInfo(
+        std::vector<std::pair<std::vector<uint8_t>, common::offset_t>> entries)
+        : entries{std::move(entries)} {}
+    DELETE_COPY_DEFAULT_MOVE(ArtPrimaryKeyIndexStorageInfo);
+
+    std::shared_ptr<common::BufferWriter> serialize() const override;
+
+    static std::unique_ptr<IndexStorageInfo> deserialize(
+        std::unique_ptr<common::BufferReader> reader);
+};
+
+class ArtPrimaryKeyIndex final : public Index {
+public:
+    struct InsertState final : Index::InsertState {
+        visible_func isVisible;
+
+        explicit InsertState(visible_func isVisible) : isVisible{std::move(isVisible)} {}
+    };
+
+    explicit ArtPrimaryKeyIndex(IndexInfo indexInfo, std::unique_ptr<IndexStorageInfo> storageInfo);
+    ~ArtPrimaryKeyIndex() override;
+
+    static std::unique_ptr<ArtPrimaryKeyIndex> createNewIndex(IndexInfo indexInfo);
+
+    std::unique_ptr<Index::InsertState> initInsertState(main::ClientContext*,
+        visible_func isVisible) override {
+        return std::make_unique<InsertState>(std::move(isVisible));
+    }
+    bool needCommitInsert() const override { return true; }
+    void commitInsert(transaction::Transaction* transaction,
+        const common::ValueVector& nodeIDVector,
+        const std::vector<common::ValueVector*>& indexVectors,
+        Index::InsertState& insertState) override;
+
+    std::unique_ptr<DeleteState> initDeleteState(const transaction::Transaction*, MemoryManager*,
+        visible_func) override {
+        return std::make_unique<DeleteState>();
+    }
+    void delete_(transaction::Transaction*, const common::ValueVector&, DeleteState&) override {
+        // Visibility rules filter deleted rows. Physical removal is used only for rollback cleanup.
+    }
+
+    bool lookupPrimaryKey(const transaction::Transaction* transaction,
+        common::ValueVector* keyVector, uint64_t vectorPos, common::offset_t& result,
+        visible_func isVisible) override;
+    void discardPrimaryKey(common::ValueVector* keyVector) override;
+
+    void checkpoint(main::ClientContext*, PageAllocator&) override;
+
+    static std::unique_ptr<Index> load(main::ClientContext* context, StorageManager* storageManager,
+        IndexInfo indexInfo, std::span<uint8_t> storageInfoBuffer);
+
+    static IndexType getIndexType() {
+        static const IndexType ART_INDEX_TYPE{"ART", IndexConstraintType::PRIMARY,
+            IndexDefinitionType::BUILTIN, load};
+        return ART_INDEX_TYPE;
+    }
+
+private:
+    struct Node {
+        static constexpr uint8_t EMPTY_MARKER = UINT8_MAX;
+
+        enum class Kind : uint8_t { NODE4 = 0, NODE16 = 1, NODE48 = 2, NODE256 = 3 };
+
+        std::optional<common::offset_t> offset;
+        Kind kind = Kind::NODE4;
+        uint16_t count = 0;
+        std::array<uint8_t, 16> keys{};
+        std::array<std::unique_ptr<Node>, 16> smallChildren{};
+        std::array<uint8_t, 256> childIndex{};
+        std::array<std::unique_ptr<Node>, 48> node48Children{};
+        std::array<std::unique_ptr<Node>, 256> node256Children{};
+
+        Node();
+        Node* getChild(uint8_t byte) const;
+        Node* getOrInsertChild(uint8_t byte);
+    };
+
+    bool insertInternal(const ArtKey& key, common::offset_t offset, visible_func isVisible);
+    bool lookup(const ArtKey& key, common::offset_t& result, visible_func isVisible) const;
+    void erase(const ArtKey& key);
+    void collectEntries(const Node& node, std::vector<uint8_t>& key,
+        std::vector<std::pair<std::vector<uint8_t>, common::offset_t>>& entries) const;
+    void loadEntries(const ArtPrimaryKeyIndexStorageInfo& storageInfo);
+
+private:
+    Node root;
+};
+
+} // namespace storage
+} // namespace lbug

--- a/src/include/storage/index/art_index.h
+++ b/src/include/storage/index/art_index.h
@@ -80,6 +80,10 @@ public:
     bool lookupPrimaryKey(const transaction::Transaction* transaction,
         common::ValueVector* keyVector, uint64_t vectorPos, common::offset_t& result,
         visible_func isVisible) override;
+    bool scanPrimaryKeyRange(common::ValueVector* lowerBoundVector, uint64_t lowerBoundPos,
+        bool lowerInclusive, common::ValueVector* upperBoundVector, uint64_t upperBoundPos,
+        bool upperInclusive, common::idx_t maxResults, std::vector<common::offset_t>& results,
+        visible_func isVisible) override;
     void discardPrimaryKey(common::ValueVector* keyVector) override;
 
     void checkpoint(main::ClientContext*, PageAllocator&) override;
@@ -116,6 +120,10 @@ private:
     bool insertInternal(const ArtKey& key, common::offset_t offset, visible_func isVisible);
     bool lookup(const ArtKey& key, common::offset_t& result, visible_func isVisible) const;
     void erase(const ArtKey& key);
+    void collectRange(const Node& node, std::vector<uint8_t>& key, const ArtKey* lowerBound,
+        bool lowerInclusive, const ArtKey* upperBound, bool upperInclusive,
+        common::idx_t maxResults, std::vector<common::offset_t>& results,
+        visible_func isVisible) const;
     void collectEntries(const Node& node, std::vector<uint8_t>& key,
         std::vector<std::pair<std::vector<uint8_t>, common::offset_t>>& entries) const;
     void loadEntries(const ArtPrimaryKeyIndexStorageInfo& storageInfo);

--- a/src/include/storage/index/art_index.h
+++ b/src/include/storage/index/art_index.h
@@ -2,6 +2,7 @@
 
 #include <array>
 #include <memory>
+#include <mutex>
 #include <optional>
 #include <vector>
 
@@ -60,9 +61,7 @@ public:
     static std::unique_ptr<ArtPrimaryKeyIndex> createNewIndex(IndexInfo indexInfo);
 
     std::unique_ptr<Index::InsertState> initInsertState(main::ClientContext*,
-        visible_func isVisible) override {
-        return std::make_unique<InsertState>(std::move(isVisible));
-    }
+        visible_func isVisible) override;
     bool needCommitInsert() const override { return true; }
     void commitInsert(transaction::Transaction* transaction,
         const common::ValueVector& nodeIDVector,
@@ -88,8 +87,8 @@ public:
 
     void checkpoint(main::ClientContext*, PageAllocator&) override;
 
-    static std::unique_ptr<Index> load(main::ClientContext* context, StorageManager* storageManager,
-        IndexInfo indexInfo, std::span<uint8_t> storageInfoBuffer);
+    static LBUG_API std::unique_ptr<Index> load(main::ClientContext* context,
+        StorageManager* storageManager, IndexInfo indexInfo, std::span<uint8_t> storageInfoBuffer);
 
     static IndexType getIndexType() {
         static const IndexType ART_INDEX_TYPE{"ART", IndexConstraintType::PRIMARY,
@@ -115,10 +114,13 @@ private:
         Node();
         Node* getChild(uint8_t byte) const;
         Node* getOrInsertChild(uint8_t byte);
+        void removeChild(uint8_t byte);
+        bool empty() const { return !offset.has_value() && count == 0; }
     };
 
     bool insertInternal(const ArtKey& key, common::offset_t offset, visible_func isVisible);
     bool lookup(const ArtKey& key, common::offset_t& result, visible_func isVisible) const;
+    bool eraseInternal(Node& node, const std::vector<uint8_t>& key, uint64_t depth);
     void erase(const ArtKey& key);
     void collectRange(const Node& node, std::vector<uint8_t>& key, const ArtKey* lowerBound,
         bool lowerInclusive, const ArtKey* upperBound, bool upperInclusive,
@@ -130,6 +132,7 @@ private:
 
 private:
     Node root;
+    mutable std::mutex mutex;
 };
 
 } // namespace storage

--- a/src/include/storage/index/hash_index.h
+++ b/src/include/storage/index/hash_index.h
@@ -386,6 +386,11 @@ public:
 
     bool lookup(const transaction::Transaction* trx, common::ValueVector* keyVector,
         uint64_t vectorPos, common::offset_t& result, visible_func isVisible);
+    bool lookupPrimaryKey(const transaction::Transaction* transaction,
+        common::ValueVector* keyVector, uint64_t vectorPos, common::offset_t& result,
+        visible_func isVisible) override {
+        return lookup(transaction, keyVector, vectorPos, result, std::move(isVisible));
+    }
 
     std::unique_ptr<Index::InsertState> initInsertState(main::ClientContext*,
         visible_func isVisible) override {
@@ -453,6 +458,7 @@ public:
     }
 
     void delete_(common::ValueVector* keyVector);
+    void discardPrimaryKey(common::ValueVector* keyVector) override { delete_(keyVector); }
 
     void checkpointInMemory() override;
     void checkpoint(main::ClientContext*, storage::PageAllocator& pageAllocator) override;

--- a/src/include/storage/index/index.h
+++ b/src/include/storage/index/index.h
@@ -145,6 +145,14 @@ public:
         const transaction::Transaction* transaction, MemoryManager* mm, visible_func isVisible) = 0;
     virtual void delete_(transaction::Transaction* transaction,
         const common::ValueVector& nodeIDVector, DeleteState& deleteState) = 0;
+    virtual bool lookupPrimaryKey(const transaction::Transaction* /*transaction*/,
+        common::ValueVector* /*keyVector*/, uint64_t /*vectorPos*/, common::offset_t& /*result*/,
+        visible_func /*isVisible*/) {
+        return false;
+    }
+    virtual void discardPrimaryKey(common::ValueVector* /*keyVector*/) {
+        // DO NOTHING.
+    }
     virtual bool needCommitInsert() const { return false; }
     virtual void commitInsert(transaction::Transaction*, const common::ValueVector&,
         const std::vector<common::ValueVector*>&, InsertState&) {

--- a/src/include/storage/index/index.h
+++ b/src/include/storage/index/index.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <functional>
+#include <vector>
 
 #include "common/serializer/buffer_writer.h"
 #include "common/types/types.h"
@@ -148,6 +149,13 @@ public:
     virtual bool lookupPrimaryKey(const transaction::Transaction* /*transaction*/,
         common::ValueVector* /*keyVector*/, uint64_t /*vectorPos*/, common::offset_t& /*result*/,
         visible_func /*isVisible*/) {
+        return false;
+    }
+    virtual bool scanPrimaryKeyRange(common::ValueVector* /*lowerBoundVector*/,
+        uint64_t /*lowerBoundPos*/, bool /*lowerInclusive*/,
+        common::ValueVector* /*upperBoundVector*/, uint64_t /*upperBoundPos*/,
+        bool /*upperInclusive*/, common::idx_t /*maxResults*/,
+        std::vector<common::offset_t>& /*results*/, visible_func /*isVisible*/) {
         return false;
     }
     virtual void discardPrimaryKey(common::ValueVector* /*keyVector*/) {

--- a/src/include/storage/table/node_table.h
+++ b/src/include/storage/table/node_table.h
@@ -160,6 +160,7 @@ public:
     void dropIndex(const std::string& name);
 
     common::column_id_t getPKColumnID() const { return pkColumnID; }
+    Index* tryGetPrimaryKeyIndex() const;
     PrimaryKeyIndex* tryGetPKIndex() const;
     PrimaryKeyIndex* getPKIndex() const {
         auto* index = tryGetPKIndex();

--- a/src/include/storage/table/node_table.h
+++ b/src/include/storage/table/node_table.h
@@ -154,6 +154,10 @@ public:
 
     virtual bool lookupPK(const transaction::Transaction* transaction,
         common::ValueVector* keyVector, uint64_t vectorPos, common::offset_t& result) const;
+    bool lookupPKRange(const transaction::Transaction* transaction,
+        common::ValueVector* lowerBoundVector, uint64_t lowerBoundPos, bool lowerInclusive,
+        common::ValueVector* upperBoundVector, uint64_t upperBoundPos, bool upperInclusive,
+        common::idx_t maxResults, std::vector<common::offset_t>& results) const;
 
     void addIndex(std::unique_ptr<Index> index);
     void buildIndexAndAdd(main::ClientContext* context, std::unique_ptr<Index> index);

--- a/src/optimizer/filter_push_down_optimizer.cpp
+++ b/src/optimizer/filter_push_down_optimizer.cpp
@@ -1,5 +1,9 @@
 #include "optimizer/filter_push_down_optimizer.h"
 
+#include <algorithm>
+#include <array>
+#include <functional>
+
 #include "binder/expression/literal_expression.h"
 #include "binder/expression/property_expression.h"
 #include "binder/expression/scalar_function_expression.h"
@@ -344,6 +348,8 @@ std::shared_ptr<Expression> PredicateSet::popNodePKEqualityComparison(const Expr
 
 PrimaryKeyRangePredicate PredicateSet::popNodePKRangeComparison(const Expression& nodeID) {
     PrimaryKeyRangePredicate result;
+    auto lowerPredicateIdx = INVALID_IDX;
+    auto upperPredicateIdx = INVALID_IDX;
     for (auto i = 0u; i < nonEqualityPredicates.size(); ++i) {
         auto predicate = nonEqualityPredicates[i];
         if (!ExpressionTypeUtil::isComparison(predicate->expressionType) ||
@@ -365,23 +371,46 @@ PrimaryKeyRangePredicate PredicateSet::popNodePKRangeComparison(const Expression
         }
         switch (comparisonType) {
         case ExpressionType::GREATER_THAN:
+            if (lowerPredicateIdx != INVALID_IDX) {
+                return {};
+            }
             result.lowerBound = bound;
             result.lowerInclusive = false;
+            lowerPredicateIdx = i;
             break;
         case ExpressionType::GREATER_THAN_EQUALS:
+            if (lowerPredicateIdx != INVALID_IDX) {
+                return {};
+            }
             result.lowerBound = bound;
             result.lowerInclusive = true;
+            lowerPredicateIdx = i;
             break;
         case ExpressionType::LESS_THAN:
+            if (upperPredicateIdx != INVALID_IDX) {
+                return {};
+            }
             result.upperBound = bound;
             result.upperInclusive = false;
+            upperPredicateIdx = i;
             break;
         case ExpressionType::LESS_THAN_EQUALS:
+            if (upperPredicateIdx != INVALID_IDX) {
+                return {};
+            }
             result.upperBound = bound;
             result.upperInclusive = true;
+            upperPredicateIdx = i;
             break;
         default:
             break;
+        }
+    }
+    std::array<idx_t, 2> predicateIndices{lowerPredicateIdx, upperPredicateIdx};
+    std::sort(predicateIndices.begin(), predicateIndices.end(), std::greater<>());
+    for (auto predicateIdx : predicateIndices) {
+        if (predicateIdx != INVALID_IDX) {
+            nonEqualityPredicates.erase(nonEqualityPredicates.begin() + predicateIdx);
         }
     }
     return result;

--- a/src/optimizer/filter_push_down_optimizer.cpp
+++ b/src/optimizer/filter_push_down_optimizer.cpp
@@ -196,8 +196,10 @@ std::shared_ptr<LogicalOperator> FilterPushDownOptimizer::visitScanNodeTableRepl
         primaryKeyEqualityComparison = predicateSet.popNodePKEqualityComparison(*nodeID);
     }
     if (primaryKeyEqualityComparison != nullptr) { // Try rewrite index scan
+        auto* table =
+            StorageManager::Get(*context)->getTable(tableIDs[0])->ptrCast<storage::NodeTable>();
         auto rhs = primaryKeyEqualityComparison->getChild(1);
-        if (isConstantExpression(rhs)) {
+        if (table->tryGetPrimaryKeyIndex() != nullptr && isConstantExpression(rhs)) {
             auto extraInfo = std::make_unique<PrimaryKeyScanInfo>(rhs);
             scan.setScanType(LogicalScanNodeTableType::PRIMARY_KEY_SCAN);
             scan.setExtraInfo(std::move(extraInfo));

--- a/src/optimizer/filter_push_down_optimizer.cpp
+++ b/src/optimizer/filter_push_down_optimizer.cpp
@@ -10,6 +10,9 @@
 #include "planner/operator/logical_hash_join.h"
 #include "planner/operator/logical_table_function_call.h"
 #include "planner/operator/scan/logical_scan_node_table.h"
+#include "storage/index/art_index.h"
+#include "storage/storage_manager.h"
+#include "storage/table/node_table.h"
 
 using namespace lbug::binder;
 using namespace lbug::common;
@@ -203,6 +206,22 @@ std::shared_ptr<LogicalOperator> FilterPushDownOptimizer::visitScanNodeTableRepl
             // Cannot rewrite and add predicate back.
             predicateSet.addPredicate(primaryKeyEqualityComparison);
         }
+    } else if (tableIDs.size() == 1) {
+        auto* table =
+            StorageManager::Get(*context)->getTable(tableIDs[0])->ptrCast<storage::NodeTable>();
+        auto* pkIndex = table->tryGetPrimaryKeyIndex();
+        if (pkIndex != nullptr && pkIndex->getIndexInfo().indexType ==
+                                      storage::ArtPrimaryKeyIndex::getIndexType().typeName) {
+            auto primaryKeyRangeComparison = predicateSet.popNodePKRangeComparison(*nodeID);
+            if (primaryKeyRangeComparison.hasBound()) {
+                auto extraInfo = std::make_unique<PrimaryKeyScanInfo>(
+                    primaryKeyRangeComparison.lowerBound, primaryKeyRangeComparison.lowerInclusive,
+                    primaryKeyRangeComparison.upperBound, primaryKeyRangeComparison.upperInclusive);
+                scan.setScanType(LogicalScanNodeTableType::PRIMARY_KEY_SCAN);
+                scan.setExtraInfo(std::move(extraInfo));
+                scan.computeFlatSchema();
+            }
+        }
     }
     return finishPushDown(op);
 }
@@ -319,6 +338,51 @@ std::shared_ptr<Expression> PredicateSet::popNodePKEqualityComparison(const Expr
         return result;
     }
     return nullptr;
+}
+
+PrimaryKeyRangePredicate PredicateSet::popNodePKRangeComparison(const Expression& nodeID) {
+    PrimaryKeyRangePredicate result;
+    for (auto i = 0u; i < nonEqualityPredicates.size(); ++i) {
+        auto predicate = nonEqualityPredicates[i];
+        if (!ExpressionTypeUtil::isComparison(predicate->expressionType) ||
+            predicate->expressionType == ExpressionType::NOT_EQUALS) {
+            continue;
+        }
+        auto comparisonType = predicate->expressionType;
+        std::shared_ptr<Expression> bound;
+        if (isNodePrimaryKey(*predicate->getChild(0), nodeID)) {
+            bound = predicate->getChild(1);
+        } else if (isNodePrimaryKey(*predicate->getChild(1), nodeID)) {
+            bound = predicate->getChild(0);
+            comparisonType = ExpressionTypeUtil::reverseComparisonDirection(comparisonType);
+        } else {
+            continue;
+        }
+        if (!isConstantExpression(bound)) {
+            continue;
+        }
+        switch (comparisonType) {
+        case ExpressionType::GREATER_THAN:
+            result.lowerBound = bound;
+            result.lowerInclusive = false;
+            break;
+        case ExpressionType::GREATER_THAN_EQUALS:
+            result.lowerBound = bound;
+            result.lowerInclusive = true;
+            break;
+        case ExpressionType::LESS_THAN:
+            result.upperBound = bound;
+            result.upperInclusive = false;
+            break;
+        case ExpressionType::LESS_THAN_EQUALS:
+            result.upperBound = bound;
+            result.upperInclusive = true;
+            break;
+        default:
+            break;
+        }
+    }
+    return result;
 }
 
 expression_vector PredicateSet::getAllPredicates() {

--- a/src/planner/join_order/cardinality_estimator.cpp
+++ b/src/planner/join_order/cardinality_estimator.cpp
@@ -73,8 +73,12 @@ cardinality_t CardinalityEstimator::getNodeIDDom(const std::string& nodeIDName) 
 uint64_t CardinalityEstimator::estimateScanNode(const LogicalOperator& op) const {
     const auto& scan = op.constCast<const LogicalScanNodeTable&>();
     switch (scan.getScanType()) {
-    case LogicalScanNodeTableType::PRIMARY_KEY_SCAN:
-        return 1;
+    case LogicalScanNodeTableType::PRIMARY_KEY_SCAN: {
+        auto& primaryKeyScanInfo = scan.getExtraInfo()->constCast<PrimaryKeyScanInfo>();
+        return primaryKeyScanInfo.isRange ?
+                   atLeastOne(getNodeIDDom(scan.getNodeID()->getUniqueName())) :
+                   1;
+    }
     default:
         return atLeastOne(getNodeIDDom(scan.getNodeID()->getUniqueName()));
     }

--- a/src/planner/operator/scan/logical_scan_node_table.cpp
+++ b/src/planner/operator/scan/logical_scan_node_table.cpp
@@ -23,7 +23,10 @@ void LogicalScanNodeTable::computeFactorizedSchema() {
     }
     switch (scanType) {
     case LogicalScanNodeTableType::PRIMARY_KEY_SCAN: {
-        schema->setGroupAsSingleState(groupPos);
+        auto& primaryKeyScanInfo = extraInfo->constCast<PrimaryKeyScanInfo>();
+        if (!primaryKeyScanInfo.isRange) {
+            schema->setGroupAsSingleState(groupPos);
+        }
     } break;
     default:
         break;

--- a/src/processor/map/map_scan_node_table.cpp
+++ b/src/processor/map/map_scan_node_table.cpp
@@ -100,8 +100,15 @@ std::unique_ptr<PhysicalOperator> PlanMapper::mapScanNodeTable(
             primaryKeyScanInfo.key != nullptr        ? primaryKeyScanInfo.key->toString() :
             primaryKeyScanInfo.lowerBound != nullptr ? primaryKeyScanInfo.lowerBound->toString() :
                                                        primaryKeyScanInfo.upperBound->toString();
-        auto printInfo =
-            std::make_unique<PrimaryKeyScanPrintInfo>(scan.getProperties(), keyString, alias);
+        std::string indexType = "NONE";
+        if (tableInfos.size() == 1) {
+            auto& nodeTable = tableInfos[0].table->cast<storage::NodeTable>();
+            if (auto* pkIndex = nodeTable.tryGetPrimaryKeyIndex()) {
+                indexType = pkIndex->getIndexInfo().indexType;
+            }
+        }
+        auto printInfo = std::make_unique<PrimaryKeyScanPrintInfo>(scan.getProperties(), keyString,
+            alias, indexType);
         return std::make_unique<PrimaryKeyScanNodeTable>(std::move(scanInfo), std::move(tableInfos),
             std::move(evaluator), std::move(upperBoundEvaluator), primaryKeyScanInfo.isRange,
             primaryKeyScanInfo.lowerInclusive, primaryKeyScanInfo.upperInclusive,

--- a/src/processor/map/map_scan_node_table.cpp
+++ b/src/processor/map/map_scan_node_table.cpp
@@ -87,12 +87,25 @@ std::unique_ptr<PhysicalOperator> PlanMapper::mapScanNodeTable(
     case LogicalScanNodeTableType::PRIMARY_KEY_SCAN: {
         auto& primaryKeyScanInfo = scan.getExtraInfo()->constCast<PrimaryKeyScanInfo>();
         auto exprMapper = ExpressionMapper(outSchema);
-        auto evaluator = exprMapper.getEvaluator(primaryKeyScanInfo.key);
+        auto evaluator =
+            primaryKeyScanInfo.isRange && primaryKeyScanInfo.lowerBound == nullptr ?
+                nullptr :
+                exprMapper.getEvaluator(primaryKeyScanInfo.isRange ? primaryKeyScanInfo.lowerBound :
+                                                                     primaryKeyScanInfo.key);
+        auto upperBoundEvaluator = primaryKeyScanInfo.upperBound == nullptr ?
+                                       nullptr :
+                                       exprMapper.getEvaluator(primaryKeyScanInfo.upperBound);
         auto sharedState = std::make_shared<PrimaryKeyScanSharedState>(tableInfos.size());
-        auto printInfo = std::make_unique<PrimaryKeyScanPrintInfo>(scan.getProperties(),
-            primaryKeyScanInfo.key->toString(), alias);
+        auto keyString =
+            primaryKeyScanInfo.key != nullptr        ? primaryKeyScanInfo.key->toString() :
+            primaryKeyScanInfo.lowerBound != nullptr ? primaryKeyScanInfo.lowerBound->toString() :
+                                                       primaryKeyScanInfo.upperBound->toString();
+        auto printInfo =
+            std::make_unique<PrimaryKeyScanPrintInfo>(scan.getProperties(), keyString, alias);
         return std::make_unique<PrimaryKeyScanNodeTable>(std::move(scanInfo), std::move(tableInfos),
-            std::move(evaluator), std::move(sharedState), getOperatorID(), std::move(printInfo));
+            std::move(evaluator), std::move(upperBoundEvaluator), primaryKeyScanInfo.isRange,
+            primaryKeyScanInfo.lowerInclusive, primaryKeyScanInfo.upperInclusive,
+            std::move(sharedState), getOperatorID(), std::move(printInfo));
     }
     default:
         UNREACHABLE_CODE;

--- a/src/processor/operator/ddl/create_index.cpp
+++ b/src/processor/operator/ddl/create_index.cpp
@@ -3,7 +3,9 @@
 #include "catalog/catalog.h"
 #include "catalog/catalog_entry/index_catalog_entry.h"
 #include "common/exception/binder.h"
+#include "common/string_utils.h"
 #include "processor/execution_context.h"
+#include "storage/index/art_index.h"
 #include "storage/index/hash_index.h"
 #include "storage/storage_manager.h"
 #include "storage/table/node_table.h"
@@ -53,17 +55,37 @@ void CreateIndex::executeInternal(ExecutionContext* context) {
     }
     auto* table = storageManager->getTable(info.tableID)->ptrCast<storage::NodeTable>();
     const auto storageIndexNameExists = table->getIndex(info.indexName).has_value();
-    auto storagePKIndexExists = table->tryGetPKIndex() != nullptr;
+    auto storagePKIndexExists = table->tryGetPrimaryKeyIndex() != nullptr;
     const auto canCreatePhysicalIndex = !storagePKIndexExists && !storageIndexNameExists;
-    auto indexType = storage::PrimaryKeyIndex::getIndexType();
+    auto indexTypeOptional = storageManager->getIndexType(info.indexType);
+    if (!indexTypeOptional.has_value()) {
+        throw BinderException(std::format("Index type {} does not exist.", info.indexType));
+    }
+    const auto& indexType = indexTypeOptional.value().get();
+    if (storagePKIndexExists &&
+        table->tryGetPrimaryKeyIndex()->getIndexInfo().indexType != indexType.typeName) {
+        throw BinderException(std::format(
+            "Cannot create {} index because the table already has a {} primary-key index.",
+            indexType.typeName, table->tryGetPrimaryKeyIndex()->getIndexInfo().indexType));
+    }
     if (canCreatePhysicalIndex) {
         storage::IndexInfo indexInfo{info.indexName, indexType.typeName, info.tableID,
             {info.columnID}, {info.keyDataType},
             indexType.constraintType == storage::IndexConstraintType::PRIMARY,
             indexType.definitionType == storage::IndexDefinitionType::BUILTIN};
-        auto index = storage::PrimaryKeyIndex::createNewIndex(std::move(indexInfo),
-            storageManager->isInMemory(), *memoryManager,
-            *storageManager->getDataFH()->getPageManager(), &storageManager->getShadowFile());
+        std::unique_ptr<storage::Index> index;
+        if (StringUtils::caseInsensitiveEquals(indexType.typeName,
+                storage::PrimaryKeyIndex::getIndexType().typeName)) {
+            index = storage::PrimaryKeyIndex::createNewIndex(std::move(indexInfo),
+                storageManager->isInMemory(), *memoryManager,
+                *storageManager->getDataFH()->getPageManager(), &storageManager->getShadowFile());
+        } else if (StringUtils::caseInsensitiveEquals(indexType.typeName,
+                       storage::ArtPrimaryKeyIndex::getIndexType().typeName)) {
+            index = storage::ArtPrimaryKeyIndex::createNewIndex(std::move(indexInfo));
+        } else {
+            throw BinderException(
+                std::format("Index type {} is not supported by CREATE INDEX.", indexType.typeName));
+        }
         table->buildIndexAndAdd(clientContext, std::move(index));
         storagePKIndexExists = true;
     }

--- a/src/processor/operator/ddl/drop.cpp
+++ b/src/processor/operator/ddl/drop.cpp
@@ -84,7 +84,8 @@ void Drop::dropTable(const main::ClientContext* context) {
     case CatalogEntryType::NODE_TABLE_ENTRY: {
         for (auto& indexEntry : catalog->getIndexEntries(transaction)) {
             if (indexEntry->getTableID() == entry->getTableID()) {
-                if (StringUtils::caseInsensitiveEquals(indexEntry->getIndexType(), "HASH")) {
+                if (StringUtils::caseInsensitiveEquals(indexEntry->getIndexType(), "HASH") ||
+                    StringUtils::caseInsensitiveEquals(indexEntry->getIndexType(), "ART")) {
                     continue;
                 }
                 throw BinderException(

--- a/src/processor/operator/index_lookup.cpp
+++ b/src/processor/operator/index_lookup.cpp
@@ -256,7 +256,7 @@ IndexLookup::IndexLookup(std::vector<IndexLookupInfo> infos,
       warningDataVectorPos{std::move(warningDataVectorPos)} {
     std::unordered_map<NodeTable*, std::shared_ptr<NoIndexLookupCache>> noIndexLookupCaches;
     for (auto& info : this->infos) {
-        if (!info.nodeTable->tryGetPKIndex()) {
+        if (!info.nodeTable->tryGetPrimaryKeyIndex()) {
             auto& cache = noIndexLookupCaches[info.nodeTable];
             if (!cache) {
                 cache = createNoIndexLookupCache(

--- a/src/processor/operator/persistent/node_batch_insert.cpp
+++ b/src/processor/operator/persistent/node_batch_insert.cpp
@@ -6,10 +6,12 @@
 #include "catalog/catalog.h"
 #include "catalog/catalog_entry/node_table_catalog_entry.h"
 #include "common/cast.h"
+#include "common/data_chunk/data_chunk_state.h"
 #include "common/exception/message.h"
 #include "common/exception/runtime.h"
 #include "common/finally_wrapper.h"
 #include "common/type_utils.h"
+#include "common/vector/value_vector.h"
 #include "processor/execution_context.h"
 #include "processor/operator/persistent/index_builder.h"
 #include "processor/result/factorized_table_util.h"
@@ -107,6 +109,12 @@ void NodeBatchInsertSharedState::initPKIndex(const ExecutionContext* context) {
     auto* nodeTable = dynamic_cast_checked<NodeTable*>(table);
     auto* pkIndex = nodeTable->tryGetPKIndex();
     if (!pkIndex) {
+        if (nodeTable->tryGetPrimaryKeyIndex() != nullptr) {
+            globalIndexBuilder.reset();
+            noIndexPKValidator.reset();
+            usePrimaryKeyIndexCommitInsert = true;
+            return;
+        }
         if (nodeTable->getNumTotalRows(Transaction::Get(*context->clientContext)) != 0) {
             throw RuntimeException(
                 "COPY into a non-empty primary-key node table without a hash index is not "
@@ -114,12 +122,14 @@ void NodeBatchInsertSharedState::initPKIndex(const ExecutionContext* context) {
         }
         globalIndexBuilder.reset();
         noIndexPKValidator = createNoIndexPKValidator(pkType);
+        usePrimaryKeyIndexCommitInsert = false;
         if (!noIndexPKValidator) {
             throw RuntimeException(ExceptionMessage::invalidPKType(pkType.toString()));
         }
         return;
     }
     noIndexPKValidator.reset();
+    usePrimaryKeyIndexCommitInsert = false;
     globalIndexBuilder = IndexBuilder(std::make_shared<IndexBuilderSharedState>(
         Transaction::Get(*context->clientContext), nodeTable));
 }
@@ -261,6 +271,27 @@ NodeBatchInsertErrorHandler NodeBatchInsert::createErrorHandler(ExecutionContext
         sharedState->numErroredRows, &sharedState->erroredRowMutex};
 }
 
+static void commitPrimaryKeyIndexInsertions(Transaction* transaction, NodeTable& nodeTable,
+    Index& index, const ColumnChunkData& pkChunk, offset_t nodeOffset, length_t numRows,
+    main::ClientContext* context) {
+    auto state = std::make_shared<DataChunkState>();
+    ValueVector nodeIDVector{LogicalType::INTERNAL_ID()};
+    ValueVector pkVector{pkChunk.getDataType().copy(), MemoryManager::Get(*context), state};
+    nodeIDVector.setState(state);
+    auto insertState = index.initInsertState(context, [&nodeTable, transaction](offset_t offset) {
+        return nodeTable.isVisible(transaction, offset);
+    });
+    for (auto start = 0u; start < numRows; start += DEFAULT_VECTOR_CAPACITY) {
+        const auto size = std::min<length_t>(DEFAULT_VECTOR_CAPACITY, numRows - start);
+        state->getSelVectorUnsafe().setToUnfiltered(size);
+        pkChunk.scan(pkVector, start, size);
+        for (auto i = 0u; i < size; ++i) {
+            nodeIDVector.setValue<nodeID_t>(i, {nodeOffset + start + i, nodeTable.getTableID()});
+        }
+        index.commitInsert(transaction, nodeIDVector, {&pkVector}, *insertState);
+    }
+}
+
 void NodeBatchInsert::clearToIndex(MemoryManager* mm,
     std::unique_ptr<InMemChunkedNodeGroup>& nodeGroup, offset_t startIndexInGroup) const {
     // Create a new chunked node group and move the unwritten values to it
@@ -312,6 +343,12 @@ void NodeBatchInsert::writeAndResetNodeGroup(transaction::Transaction* transacti
         }
         indexBuilder->insert(nodeGroup->getColumnChunk(nodeSharedState->pkColumnID),
             warningChunkData, nodeOffset, numRowsWritten, errorHandler);
+    } else if (nodeSharedState->usePrimaryKeyIndexCommitInsert) {
+        auto* index = nodeTable->tryGetPrimaryKeyIndex();
+        DASSERT(index != nullptr);
+        commitPrimaryKeyIndexInsertions(transaction, *nodeTable, *index,
+            nodeGroup->getColumnChunk(nodeSharedState->pkColumnID), nodeOffset, numRowsWritten,
+            transaction->getClientContext());
     } else if (nodeSharedState->noIndexPKValidator) {
         nodeSharedState->noIndexPKValidator->validate(
             nodeGroup->getColumnChunk(nodeSharedState->pkColumnID), 0, numRowsWritten);

--- a/src/processor/operator/scan/primary_key_scan_node_table.cpp
+++ b/src/processor/operator/scan/primary_key_scan_node_table.cpp
@@ -18,6 +18,10 @@ std::string PrimaryKeyScanPrintInfo::toString() const {
         result += ",Alias: ";
         result += alias;
     }
+    if (!indexType.empty()) {
+        result += ", Index: ";
+        result += indexType;
+    }
     result += ", Expressions: ";
     result += binder::ExpressionUtil::toString(expressions);
     return result;

--- a/src/processor/operator/scan/primary_key_scan_node_table.cpp
+++ b/src/processor/operator/scan/primary_key_scan_node_table.cpp
@@ -1,5 +1,7 @@
 #include "processor/operator/scan/primary_key_scan_node_table.h"
 
+#include <limits>
+
 #include "binder/expression/expression_util.h"
 #include "processor/execution_context.h"
 
@@ -35,10 +37,18 @@ void PrimaryKeyScanNodeTable::initLocalStateInternal(ResultSet* resultSet,
     auto nodeIDVector = resultSet->getValueVector(opInfo.nodeIDPos).get();
     scanState = std::make_unique<NodeTableScanState>(nodeIDVector, std::vector<ValueVector*>{},
         nodeIDVector->state);
-    indexEvaluator->init(*resultSet, context->clientContext);
+    if (indexEvaluator != nullptr) {
+        indexEvaluator->init(*resultSet, context->clientContext);
+    }
+    if (upperBoundEvaluator != nullptr) {
+        upperBoundEvaluator->init(*resultSet, context->clientContext);
+    }
 }
 
 bool PrimaryKeyScanNodeTable::getNextTuplesInternal(ExecutionContext* context) {
+    if (isRange) {
+        return lookupRange(context);
+    }
     auto transaction = transaction::Transaction::Get(*context->clientContext);
     auto tableIdx = sharedState->getTableIdx();
     if (tableIdx >= tableInfos.size()) {
@@ -69,6 +79,72 @@ bool PrimaryKeyScanNodeTable::getNextTuplesInternal(ExecutionContext* context) {
     tableInfo.castColumns();
     metrics->numOutputTuple.incrementByOne();
     return succeeded;
+}
+
+bool PrimaryKeyScanNodeTable::lookupRange(ExecutionContext* context) {
+    auto transaction = transaction::Transaction::Get(*context->clientContext);
+    while (currentRangeTableIdx < tableInfos.size()) {
+        auto& tableInfo = tableInfos[currentRangeTableIdx];
+        auto& table = tableInfo.table->cast<NodeTable>();
+        if (rangeOffsets.empty()) {
+            ValueVector* lowerBoundVector = nullptr;
+            uint64_t lowerPos = 0;
+            if (indexEvaluator != nullptr) {
+                indexEvaluator->evaluate();
+                lowerBoundVector = indexEvaluator->resultVector.get();
+                auto& lowerSelVector = lowerBoundVector->state->getSelVector();
+                DASSERT(lowerSelVector.getSelSize() == 1);
+                lowerPos = lowerSelVector.getSelectedPositions()[0];
+                if (lowerBoundVector->isNull(lowerPos)) {
+                    currentRangeTableIdx++;
+                    continue;
+                }
+            }
+
+            ValueVector* upperBoundVector = nullptr;
+            uint64_t upperPos = 0;
+            if (upperBoundEvaluator != nullptr) {
+                upperBoundEvaluator->evaluate();
+                upperBoundVector = upperBoundEvaluator->resultVector.get();
+                auto& upperSelVector = upperBoundVector->state->getSelVector();
+                DASSERT(upperSelVector.getSelSize() == 1);
+                upperPos = upperSelVector.getSelectedPositions()[0];
+                if (upperBoundVector->isNull(upperPos)) {
+                    currentRangeTableIdx++;
+                    continue;
+                }
+            }
+            static constexpr auto maxRangeResults = std::numeric_limits<common::idx_t>::max();
+            if (!table.lookupPKRange(transaction, lowerBoundVector, lowerPos, lowerInclusive,
+                    upperBoundVector, upperPos, upperInclusive, maxRangeResults, rangeOffsets)) {
+                currentRangeTableIdx++;
+                continue;
+            }
+        }
+
+        const auto remaining = rangeOffsets.size() - rangeOffsetCursor;
+        if (remaining == 0) {
+            rangeOffsets.clear();
+            rangeOffsetCursor = 0;
+            currentRangeTableIdx++;
+            continue;
+        }
+        const auto outputSize = std::min<uint64_t>(remaining, common::DEFAULT_VECTOR_CAPACITY);
+        auto& selVector = scanState->nodeIDVector->state->getSelVectorUnsafe();
+        selVector.setToUnfiltered(outputSize);
+        for (auto i = 0u; i < outputSize; ++i) {
+            const auto nodeOffset = rangeOffsets[rangeOffsetCursor + i];
+            scanState->nodeIDVector->setValue<nodeID_t>(i, {nodeOffset, table.getTableID()});
+        }
+        rangeOffsetCursor += outputSize;
+        tableInfo.initScanState(*scanState, outVectors, context->clientContext);
+        table.lookupMultiple(transaction, *scanState);
+        tableInfo.castColumns();
+        scanState->outState->setToUnflat();
+        metrics->numOutputTuple.increase(outputSize);
+        return true;
+    }
+    return false;
 }
 
 } // namespace processor

--- a/src/storage/index/CMakeLists.txt
+++ b/src/storage/index/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_library(lbug_storage_index
         OBJECT
+        art_index.cpp
         hash_index.cpp
         in_mem_hash_index.cpp
         index.cpp)

--- a/src/storage/index/art_index.cpp
+++ b/src/storage/index/art_index.cpp
@@ -73,7 +73,23 @@ void appendString(std::vector<uint8_t>& bytes, std::string_view value) {
 } // namespace
 
 ArtPrimaryKeyIndex::Node::Node() {
-    childIndex.fill(EMPTY_MARKER);
+    new (&small) SmallChildren();
+}
+
+ArtPrimaryKeyIndex::Node::~Node() = default;
+
+void ArtPrimaryKeyIndex::deleteTree(Node* root) {
+    if (root == nullptr) {
+        return;
+    }
+    std::vector<Node*> stack;
+    stack.push_back(root);
+    while (!stack.empty()) {
+        auto* node = stack.back();
+        stack.pop_back();
+        node->moveChildrenTo(stack);
+        delete node;
+    }
 }
 
 ArtPrimaryKeyIndex::Node* ArtPrimaryKeyIndex::Node::getChild(uint8_t byte) const {
@@ -81,18 +97,18 @@ ArtPrimaryKeyIndex::Node* ArtPrimaryKeyIndex::Node::getChild(uint8_t byte) const
     case Kind::NODE4:
     case Kind::NODE16: {
         for (auto i = 0u; i < count; ++i) {
-            if (keys[i] == byte) {
-                return smallChildren[i].get();
+            if (small.keys[i] == byte) {
+                return small.children[i];
             }
         }
         return nullptr;
     }
     case Kind::NODE48: {
-        const auto pos = childIndex[byte];
-        return pos == EMPTY_MARKER ? nullptr : node48Children[pos].get();
+        const auto pos = node48.childIndex[byte];
+        return pos == EMPTY_MARKER ? nullptr : node48.children[pos];
     }
     case Kind::NODE256:
-        return node256Children[byte].get();
+        return node256.children[byte];
     default:
         UNREACHABLE_CODE;
     }
@@ -110,22 +126,27 @@ ArtPrimaryKeyIndex::Node* ArtPrimaryKeyIndex::Node::getOrInsertChild(uint8_t byt
         break;
     case Kind::NODE16:
         if (count == 16) {
-            childIndex.fill(EMPTY_MARKER);
+            Node48Children children;
+            children.childIndex.fill(EMPTY_MARKER);
             for (auto i = 0u; i < count; ++i) {
-                childIndex[keys[i]] = i;
-                node48Children[i] = std::move(smallChildren[i]);
+                children.childIndex[small.keys[i]] = i;
+                children.children[i] = small.children[i];
             }
+            new (&node48) Node48Children(children);
             kind = Kind::NODE48;
         }
         break;
     case Kind::NODE48:
         if (count == 48) {
-            for (auto i = 0u; i < childIndex.size(); ++i) {
-                const auto pos = childIndex[i];
+            Node256Children children;
+            children.children.fill(nullptr);
+            for (auto i = 0u; i < node48.childIndex.size(); ++i) {
+                const auto pos = node48.childIndex[i];
                 if (pos != EMPTY_MARKER) {
-                    node256Children[i] = std::move(node48Children[pos]);
+                    children.children[i] = node48.children[pos];
                 }
             }
+            new (&node256) Node256Children(children);
             kind = Kind::NODE256;
         }
         break;
@@ -138,19 +159,19 @@ ArtPrimaryKeyIndex::Node* ArtPrimaryKeyIndex::Node::getOrInsertChild(uint8_t byt
     switch (kind) {
     case Kind::NODE4:
     case Kind::NODE16: {
-        keys[count] = byte;
-        smallChildren[count] = std::make_unique<Node>();
-        return smallChildren[count++].get();
+        small.keys[count] = byte;
+        small.children[count] = new Node();
+        return small.children[count++];
     }
     case Kind::NODE48: {
-        childIndex[byte] = static_cast<uint8_t>(count);
-        node48Children[count] = std::make_unique<Node>();
-        return node48Children[count++].get();
+        node48.childIndex[byte] = static_cast<uint8_t>(count);
+        node48.children[count] = new Node();
+        return node48.children[count++];
     }
     case Kind::NODE256:
-        node256Children[byte] = std::make_unique<Node>();
+        node256.children[byte] = new Node();
         ++count;
-        return node256Children[byte].get();
+        return node256.children[byte];
     default:
         UNREACHABLE_CODE;
     }
@@ -161,48 +182,80 @@ void ArtPrimaryKeyIndex::Node::removeChild(uint8_t byte) {
     case Kind::NODE4:
     case Kind::NODE16: {
         for (auto i = 0u; i < count; ++i) {
-            if (keys[i] != byte) {
+            if (small.keys[i] != byte) {
                 continue;
             }
+            ArtPrimaryKeyIndex::deleteTree(small.children[i]);
             for (auto j = i + 1; j < count; ++j) {
-                keys[j - 1] = keys[j];
-                smallChildren[j - 1] = std::move(smallChildren[j]);
+                small.keys[j - 1] = small.keys[j];
+                small.children[j - 1] = small.children[j];
             }
-            smallChildren[count - 1].reset();
+            small.children[count - 1] = nullptr;
             --count;
             return;
         }
         return;
     }
     case Kind::NODE48: {
-        const auto removedPos = childIndex[byte];
+        const auto removedPos = node48.childIndex[byte];
         if (removedPos == EMPTY_MARKER) {
             return;
         }
         const auto lastPos = count - 1;
-        childIndex[byte] = EMPTY_MARKER;
+        ArtPrimaryKeyIndex::deleteTree(node48.children[removedPos]);
+        node48.childIndex[byte] = EMPTY_MARKER;
         if (removedPos != lastPos) {
-            for (auto i = 0u; i < childIndex.size(); ++i) {
-                if (childIndex[i] == lastPos) {
-                    childIndex[i] = removedPos;
+            for (auto i = 0u; i < node48.childIndex.size(); ++i) {
+                if (node48.childIndex[i] == lastPos) {
+                    node48.childIndex[i] = removedPos;
                     break;
                 }
             }
-            node48Children[removedPos] = std::move(node48Children[lastPos]);
+            node48.children[removedPos] = node48.children[lastPos];
         }
-        node48Children[lastPos].reset();
+        node48.children[lastPos] = nullptr;
         --count;
         return;
     }
     case Kind::NODE256:
-        if (node256Children[byte]) {
-            node256Children[byte].reset();
+        if (node256.children[byte]) {
+            ArtPrimaryKeyIndex::deleteTree(node256.children[byte]);
+            node256.children[byte] = nullptr;
             --count;
         }
         return;
     default:
         UNREACHABLE_CODE;
     }
+}
+
+void ArtPrimaryKeyIndex::Node::moveChildrenTo(std::vector<Node*>& children) {
+    switch (kind) {
+    case Kind::NODE4:
+    case Kind::NODE16:
+        for (auto i = 0u; i < count; ++i) {
+            children.push_back(small.children[i]);
+            small.children[i] = nullptr;
+        }
+        break;
+    case Kind::NODE48:
+        for (auto i = 0u; i < count; ++i) {
+            children.push_back(node48.children[i]);
+            node48.children[i] = nullptr;
+        }
+        break;
+    case Kind::NODE256:
+        for (auto i = 0u; i < node256.children.size(); ++i) {
+            if (node256.children[i]) {
+                children.push_back(node256.children[i]);
+                node256.children[i] = nullptr;
+            }
+        }
+        break;
+    default:
+        UNREACHABLE_CODE;
+    }
+    count = 0;
 }
 
 ArtKey ArtKey::encode(ValueVector* vector, uint64_t vectorPos) {
@@ -273,7 +326,21 @@ ArtPrimaryKeyIndex::ArtPrimaryKeyIndex(IndexInfo indexInfo,
     loadEntries(this->storageInfo->constCast<ArtPrimaryKeyIndexStorageInfo>());
 }
 
-ArtPrimaryKeyIndex::~ArtPrimaryKeyIndex() = default;
+ArtPrimaryKeyIndex::~ArtPrimaryKeyIndex() {
+    clear();
+}
+
+void ArtPrimaryKeyIndex::clear() {
+    std::vector<Node*> children;
+    root.moveChildrenTo(children);
+    for (auto* child : children) {
+        deleteTree(child);
+    }
+    root.offset.reset();
+    root.kind = Node::Kind::NODE4;
+    root.count = 0;
+    new (&root.small) Node::SmallChildren();
+}
 
 std::unique_ptr<Index::InsertState> ArtPrimaryKeyIndex::initInsertState(main::ClientContext*,
     visible_func isVisible) {
@@ -457,10 +524,12 @@ void ArtPrimaryKeyIndex::collectRange(const Node& node, std::vector<uint8_t>& ke
             childOrder[i] = i;
         }
         std::sort(childOrder.begin(), childOrder.begin() + node.count,
-            [&node](auto left, auto right) { return node.keys[left] < node.keys[right]; });
+            [&node](auto left, auto right) {
+                return node.small.keys[left] < node.small.keys[right];
+            });
         for (auto i = 0u; i < node.count; ++i) {
             const auto pos = childOrder[i];
-            visitChild(node.keys[pos], *node.smallChildren[pos]);
+            visitChild(node.small.keys[pos], *node.small.children[pos]);
             if (results.size() >= maxResults) {
                 return;
             }
@@ -468,23 +537,23 @@ void ArtPrimaryKeyIndex::collectRange(const Node& node, std::vector<uint8_t>& ke
         break;
     }
     case Node::Kind::NODE48:
-        for (auto byte = 0u; byte < node.childIndex.size(); ++byte) {
-            const auto pos = node.childIndex[byte];
+        for (auto byte = 0u; byte < node.node48.childIndex.size(); ++byte) {
+            const auto pos = node.node48.childIndex[byte];
             if (pos == Node::EMPTY_MARKER) {
                 continue;
             }
-            visitChild(static_cast<uint8_t>(byte), *node.node48Children[pos]);
+            visitChild(static_cast<uint8_t>(byte), *node.node48.children[pos]);
             if (results.size() >= maxResults) {
                 return;
             }
         }
         break;
     case Node::Kind::NODE256:
-        for (auto byte = 0u; byte < node.node256Children.size(); ++byte) {
-            if (!node.node256Children[byte]) {
+        for (auto byte = 0u; byte < node.node256.children.size(); ++byte) {
+            if (!node.node256.children[byte]) {
                 continue;
             }
-            visitChild(static_cast<uint8_t>(byte), *node.node256Children[byte]);
+            visitChild(static_cast<uint8_t>(byte), *node.node256.children[byte]);
             if (results.size() >= maxResults) {
                 return;
             }
@@ -532,29 +601,29 @@ void ArtPrimaryKeyIndex::collectEntries(const Node& node, std::vector<uint8_t>& 
     case Node::Kind::NODE4:
     case Node::Kind::NODE16:
         for (auto i = 0u; i < node.count; ++i) {
-            key.push_back(node.keys[i]);
-            collectEntries(*node.smallChildren[i], key, entries);
+            key.push_back(node.small.keys[i]);
+            collectEntries(*node.small.children[i], key, entries);
             key.pop_back();
         }
         break;
     case Node::Kind::NODE48:
-        for (auto i = 0u; i < node.childIndex.size(); ++i) {
-            const auto pos = node.childIndex[i];
+        for (auto i = 0u; i < node.node48.childIndex.size(); ++i) {
+            const auto pos = node.node48.childIndex[i];
             if (pos == Node::EMPTY_MARKER) {
                 continue;
             }
             key.push_back(static_cast<uint8_t>(i));
-            collectEntries(*node.node48Children[pos], key, entries);
+            collectEntries(*node.node48.children[pos], key, entries);
             key.pop_back();
         }
         break;
     case Node::Kind::NODE256:
-        for (auto i = 0u; i < node.node256Children.size(); ++i) {
-            if (!node.node256Children[i]) {
+        for (auto i = 0u; i < node.node256.children.size(); ++i) {
+            if (!node.node256.children[i]) {
                 continue;
             }
             key.push_back(static_cast<uint8_t>(i));
-            collectEntries(*node.node256Children[i], key, entries);
+            collectEntries(*node.node256.children[i], key, entries);
             key.pop_back();
         }
         break;

--- a/src/storage/index/art_index.cpp
+++ b/src/storage/index/art_index.cpp
@@ -1,7 +1,11 @@
 #include "storage/index/art_index.h"
 
 #include <algorithm>
+#include <chrono>
+#include <cstdio>
+#include <cstdlib>
 #include <cstring>
+#include <new>
 #include <type_traits>
 
 #include "common/exception/message.h"
@@ -70,26 +74,40 @@ void appendString(std::vector<uint8_t>& bytes, std::string_view value) {
     bytes.push_back(0);
 }
 
+bool shouldPrintDestructorStats() {
+    const auto* value = std::getenv("LBUG_ART_INDEX_DESTRUCTOR_STATS");
+    return value != nullptr && value[0] != '\0' && std::strcmp(value, "0") != 0;
+}
+
 } // namespace
 
 ArtPrimaryKeyIndex::Node::Node() {
     new (&small) SmallChildren();
 }
 
-ArtPrimaryKeyIndex::Node::~Node() = default;
+ArtPrimaryKeyIndex::NodeBlock::NodeBlock()
+    : nodes{static_cast<Node*>(::operator new(sizeof(Node) * NODE_BLOCK_CAPACITY))} {}
 
-void ArtPrimaryKeyIndex::deleteTree(Node* root) {
-    if (root == nullptr) {
-        return;
+ArtPrimaryKeyIndex::NodeBlock::~NodeBlock() {
+    ::operator delete(nodes);
+}
+
+ArtPrimaryKeyIndex::NodeBlock::NodeBlock(NodeBlock&& other) noexcept
+    : nodes{other.nodes}, used{other.used} {
+    other.nodes = nullptr;
+    other.used = 0;
+}
+
+ArtPrimaryKeyIndex::NodeBlock& ArtPrimaryKeyIndex::NodeBlock::operator=(
+    NodeBlock&& other) noexcept {
+    if (this != &other) {
+        ::operator delete(nodes);
+        nodes = other.nodes;
+        used = other.used;
+        other.nodes = nullptr;
+        other.used = 0;
     }
-    std::vector<Node*> stack;
-    stack.push_back(root);
-    while (!stack.empty()) {
-        auto* node = stack.back();
-        stack.pop_back();
-        node->moveChildrenTo(stack);
-        delete node;
-    }
+    return *this;
 }
 
 ArtPrimaryKeyIndex::Node* ArtPrimaryKeyIndex::Node::getChild(uint8_t byte) const {
@@ -114,14 +132,15 @@ ArtPrimaryKeyIndex::Node* ArtPrimaryKeyIndex::Node::getChild(uint8_t byte) const
     }
 }
 
-ArtPrimaryKeyIndex::Node* ArtPrimaryKeyIndex::Node::getOrInsertChild(uint8_t byte) {
+ArtPrimaryKeyIndex::Node* ArtPrimaryKeyIndex::Node::getOrInsertChild(ArtPrimaryKeyIndex& index,
+    uint8_t byte) {
     if (auto* child = getChild(byte)) {
         return child;
     }
     switch (kind) {
     case Kind::NODE4:
         if (count == 4) {
-            kind = Kind::NODE16;
+            index.recordKindChange(*this, Kind::NODE16);
         }
         break;
     case Kind::NODE16:
@@ -133,7 +152,7 @@ ArtPrimaryKeyIndex::Node* ArtPrimaryKeyIndex::Node::getOrInsertChild(uint8_t byt
                 children.children[i] = small.children[i];
             }
             new (&node48) Node48Children(children);
-            kind = Kind::NODE48;
+            index.recordKindChange(*this, Kind::NODE48);
         }
         break;
     case Kind::NODE48:
@@ -147,7 +166,7 @@ ArtPrimaryKeyIndex::Node* ArtPrimaryKeyIndex::Node::getOrInsertChild(uint8_t byt
                 }
             }
             new (&node256) Node256Children(children);
-            kind = Kind::NODE256;
+            index.recordKindChange(*this, Kind::NODE256);
         }
         break;
     case Kind::NODE256:
@@ -160,16 +179,16 @@ ArtPrimaryKeyIndex::Node* ArtPrimaryKeyIndex::Node::getOrInsertChild(uint8_t byt
     case Kind::NODE4:
     case Kind::NODE16: {
         small.keys[count] = byte;
-        small.children[count] = new Node();
+        small.children[count] = index.allocateNode();
         return small.children[count++];
     }
     case Kind::NODE48: {
         node48.childIndex[byte] = static_cast<uint8_t>(count);
-        node48.children[count] = new Node();
+        node48.children[count] = index.allocateNode();
         return node48.children[count++];
     }
     case Kind::NODE256:
-        node256.children[byte] = new Node();
+        node256.children[byte] = index.allocateNode();
         ++count;
         return node256.children[byte];
     default:
@@ -185,7 +204,6 @@ void ArtPrimaryKeyIndex::Node::removeChild(uint8_t byte) {
             if (small.keys[i] != byte) {
                 continue;
             }
-            ArtPrimaryKeyIndex::deleteTree(small.children[i]);
             for (auto j = i + 1; j < count; ++j) {
                 small.keys[j - 1] = small.keys[j];
                 small.children[j - 1] = small.children[j];
@@ -202,7 +220,6 @@ void ArtPrimaryKeyIndex::Node::removeChild(uint8_t byte) {
             return;
         }
         const auto lastPos = count - 1;
-        ArtPrimaryKeyIndex::deleteTree(node48.children[removedPos]);
         node48.childIndex[byte] = EMPTY_MARKER;
         if (removedPos != lastPos) {
             for (auto i = 0u; i < node48.childIndex.size(); ++i) {
@@ -219,7 +236,6 @@ void ArtPrimaryKeyIndex::Node::removeChild(uint8_t byte) {
     }
     case Kind::NODE256:
         if (node256.children[byte]) {
-            ArtPrimaryKeyIndex::deleteTree(node256.children[byte]);
             node256.children[byte] = nullptr;
             --count;
         }
@@ -227,35 +243,6 @@ void ArtPrimaryKeyIndex::Node::removeChild(uint8_t byte) {
     default:
         UNREACHABLE_CODE;
     }
-}
-
-void ArtPrimaryKeyIndex::Node::moveChildrenTo(std::vector<Node*>& children) {
-    switch (kind) {
-    case Kind::NODE4:
-    case Kind::NODE16:
-        for (auto i = 0u; i < count; ++i) {
-            children.push_back(small.children[i]);
-            small.children[i] = nullptr;
-        }
-        break;
-    case Kind::NODE48:
-        for (auto i = 0u; i < count; ++i) {
-            children.push_back(node48.children[i]);
-            node48.children[i] = nullptr;
-        }
-        break;
-    case Kind::NODE256:
-        for (auto i = 0u; i < node256.children.size(); ++i) {
-            if (node256.children[i]) {
-                children.push_back(node256.children[i]);
-                node256.children[i] = nullptr;
-            }
-        }
-        break;
-    default:
-        UNREACHABLE_CODE;
-    }
-    count = 0;
 }
 
 ArtKey ArtKey::encode(ValueVector* vector, uint64_t vectorPos) {
@@ -327,19 +314,58 @@ ArtPrimaryKeyIndex::ArtPrimaryKeyIndex(IndexInfo indexInfo,
 }
 
 ArtPrimaryKeyIndex::~ArtPrimaryKeyIndex() {
+    if (!shouldPrintDestructorStats()) {
+        clear();
+        return;
+    }
+    const auto allocatedNodes = numAllocatedNodes;
+    const auto numBlocks = nodeBlocks.size();
+    const auto numNode4 = numNodesByKind[0];
+    const auto numNode16 = numNodesByKind[1];
+    const auto numNode48 = numNodesByKind[2];
+    const auto numNode256 = numNodesByKind[3];
+    const auto start = std::chrono::steady_clock::now();
     clear();
+    const auto end = std::chrono::steady_clock::now();
+    const auto elapsedMs =
+        std::chrono::duration_cast<std::chrono::milliseconds>(end - start).count();
+    std::fprintf(stderr,
+        "ART destructor index=%s table=%llu allocated_nodes=%llu arena_nodes=%llu blocks=%llu "
+        "node4=%llu node16=%llu node48=%llu node256=%llu elapsed_ms=%lld\n",
+        indexInfo.name.c_str(), static_cast<unsigned long long>(indexInfo.tableID),
+        static_cast<unsigned long long>(allocatedNodes),
+        static_cast<unsigned long long>(allocatedNodes - 1),
+        static_cast<unsigned long long>(numBlocks), static_cast<unsigned long long>(numNode4),
+        static_cast<unsigned long long>(numNode16), static_cast<unsigned long long>(numNode48),
+        static_cast<unsigned long long>(numNode256), static_cast<long long>(elapsedMs));
 }
 
 void ArtPrimaryKeyIndex::clear() {
-    std::vector<Node*> children;
-    root.moveChildrenTo(children);
-    for (auto* child : children) {
-        deleteTree(child);
-    }
+    nodeBlocks.clear();
     root.offset.reset();
     root.kind = Node::Kind::NODE4;
     root.count = 0;
     new (&root.small) Node::SmallChildren();
+    numAllocatedNodes = 1;
+    numNodesByKind = {1, 0, 0, 0};
+}
+
+ArtPrimaryKeyIndex::Node* ArtPrimaryKeyIndex::allocateNode() {
+    if (nodeBlocks.empty() || nodeBlocks.back().used == NODE_BLOCK_CAPACITY) {
+        nodeBlocks.emplace_back();
+    }
+    auto& block = nodeBlocks.back();
+    auto* node = block.nodes + block.used++;
+    new (node) Node();
+    ++numAllocatedNodes;
+    ++numNodesByKind[static_cast<uint8_t>(Node::Kind::NODE4)];
+    return node;
+}
+
+void ArtPrimaryKeyIndex::recordKindChange(Node& node, Node::Kind newKind) {
+    --numNodesByKind[static_cast<uint8_t>(node.kind)];
+    node.kind = newKind;
+    ++numNodesByKind[static_cast<uint8_t>(node.kind)];
 }
 
 std::unique_ptr<Index::InsertState> ArtPrimaryKeyIndex::initInsertState(main::ClientContext*,
@@ -385,7 +411,7 @@ bool ArtPrimaryKeyIndex::insertInternal(const ArtKey& key, offset_t offset,
     DASSERT(!key.empty());
     auto* node = &root;
     for (const auto byte : key.getBytes()) {
-        node = node->getOrInsertChild(byte);
+        node = node->getOrInsertChild(*this, byte);
     }
     if (node->offset.has_value() && isVisible(node->offset.value())) {
         return false;

--- a/src/storage/index/art_index.cpp
+++ b/src/storage/index/art_index.cpp
@@ -1,0 +1,341 @@
+#include "storage/index/art_index.h"
+
+#include "common/exception/message.h"
+#include "common/exception/runtime.h"
+#include "common/serializer/buffer_reader.h"
+#include "common/serializer/deserializer.h"
+#include "common/serializer/serializer.h"
+#include "common/types/value/value.h"
+#include "common/vector/value_vector.h"
+#include <concepts>
+
+using namespace lbug::common;
+
+namespace lbug {
+namespace storage {
+
+namespace {
+
+template<typename T>
+void appendRaw(std::vector<uint8_t>& bytes, const T& value) {
+    const auto* data = reinterpret_cast<const uint8_t*>(&value);
+    bytes.insert(bytes.end(), data, data + sizeof(T));
+}
+
+template<typename T>
+void appendFixed(std::vector<uint8_t>& bytes, T value) {
+    appendRaw(bytes, value);
+}
+
+void appendString(std::vector<uint8_t>& bytes, std::string_view value) {
+    for (const auto ch : value) {
+        const auto byte = static_cast<uint8_t>(ch);
+        if (byte <= 1) {
+            bytes.push_back(1);
+        }
+        bytes.push_back(byte);
+    }
+    bytes.push_back(0);
+}
+
+} // namespace
+
+ArtPrimaryKeyIndex::Node::Node() {
+    childIndex.fill(EMPTY_MARKER);
+}
+
+ArtPrimaryKeyIndex::Node* ArtPrimaryKeyIndex::Node::getChild(uint8_t byte) const {
+    switch (kind) {
+    case Kind::NODE4:
+    case Kind::NODE16: {
+        for (auto i = 0u; i < count; ++i) {
+            if (keys[i] == byte) {
+                return smallChildren[i].get();
+            }
+        }
+        return nullptr;
+    }
+    case Kind::NODE48: {
+        const auto pos = childIndex[byte];
+        return pos == EMPTY_MARKER ? nullptr : node48Children[pos].get();
+    }
+    case Kind::NODE256:
+        return node256Children[byte].get();
+    default:
+        UNREACHABLE_CODE;
+    }
+}
+
+ArtPrimaryKeyIndex::Node* ArtPrimaryKeyIndex::Node::getOrInsertChild(uint8_t byte) {
+    if (auto* child = getChild(byte)) {
+        return child;
+    }
+    switch (kind) {
+    case Kind::NODE4:
+        if (count == 4) {
+            kind = Kind::NODE16;
+        }
+        break;
+    case Kind::NODE16:
+        if (count == 16) {
+            childIndex.fill(EMPTY_MARKER);
+            for (auto i = 0u; i < count; ++i) {
+                childIndex[keys[i]] = i;
+                node48Children[i] = std::move(smallChildren[i]);
+            }
+            kind = Kind::NODE48;
+        }
+        break;
+    case Kind::NODE48:
+        if (count == 48) {
+            for (auto i = 0u; i < childIndex.size(); ++i) {
+                const auto pos = childIndex[i];
+                if (pos != EMPTY_MARKER) {
+                    node256Children[i] = std::move(node48Children[pos]);
+                }
+            }
+            kind = Kind::NODE256;
+        }
+        break;
+    case Kind::NODE256:
+        break;
+    default:
+        UNREACHABLE_CODE;
+    }
+
+    switch (kind) {
+    case Kind::NODE4:
+    case Kind::NODE16: {
+        keys[count] = byte;
+        smallChildren[count] = std::make_unique<Node>();
+        return smallChildren[count++].get();
+    }
+    case Kind::NODE48: {
+        childIndex[byte] = static_cast<uint8_t>(count);
+        node48Children[count] = std::make_unique<Node>();
+        return node48Children[count++].get();
+    }
+    case Kind::NODE256:
+        node256Children[byte] = std::make_unique<Node>();
+        ++count;
+        return node256Children[byte].get();
+    default:
+        UNREACHABLE_CODE;
+    }
+}
+
+ArtKey ArtKey::encode(ValueVector* vector, uint64_t vectorPos) {
+    if (vector->isNull(vectorPos)) {
+        return ArtKey{};
+    }
+    std::vector<uint8_t> bytes;
+    TypeUtils::visit(vector->dataType.getPhysicalType(), [&]<typename T>(T) {
+        if constexpr (std::same_as<T, string_t>) {
+            appendString(bytes, vector->getValue<string_t>(vectorPos).getAsStringView());
+        } else if constexpr (std::same_as<T, int128_t> || std::same_as<T, uint128_t>) {
+            const auto value = vector->getValue<T>(vectorPos);
+            appendRaw(bytes, value.low);
+            appendRaw(bytes, value.high);
+        } else if constexpr (std::integral<T> || std::floating_point<T>) {
+            appendFixed(bytes, vector->getValue<T>(vectorPos));
+        } else {
+            UNREACHABLE_CODE;
+        }
+    });
+    return ArtKey{std::move(bytes)};
+}
+
+std::shared_ptr<BufferWriter> ArtPrimaryKeyIndexStorageInfo::serialize() const {
+    auto bufferWriter = std::make_shared<BufferWriter>();
+    auto serializer = Serializer(bufferWriter);
+    serializer.write<uint64_t>(entries.size());
+    for (const auto& [key, offset] : entries) {
+        serializer.write<uint64_t>(key.size());
+        if (!key.empty()) {
+            serializer.write(key.data(), key.size());
+        }
+        serializer.write<offset_t>(offset);
+    }
+    return bufferWriter;
+}
+
+std::unique_ptr<IndexStorageInfo> ArtPrimaryKeyIndexStorageInfo::deserialize(
+    std::unique_ptr<BufferReader> reader) {
+    Deserializer deSer(std::move(reader));
+    uint64_t numEntries = 0;
+    deSer.deserializeValue(numEntries);
+    std::vector<std::pair<std::vector<uint8_t>, offset_t>> entries;
+    entries.reserve(numEntries);
+    for (auto i = 0u; i < numEntries; ++i) {
+        uint64_t keySize = 0;
+        deSer.deserializeValue(keySize);
+        std::vector<uint8_t> key(keySize);
+        if (keySize > 0) {
+            deSer.read(key.data(), keySize);
+        }
+        offset_t offset = INVALID_OFFSET;
+        deSer.deserializeValue(offset);
+        entries.emplace_back(std::move(key), offset);
+    }
+    return std::make_unique<ArtPrimaryKeyIndexStorageInfo>(std::move(entries));
+}
+
+ArtPrimaryKeyIndex::ArtPrimaryKeyIndex(IndexInfo indexInfo,
+    std::unique_ptr<IndexStorageInfo> storageInfo)
+    : Index{std::move(indexInfo), std::move(storageInfo)} {
+    loadEntries(this->storageInfo->constCast<ArtPrimaryKeyIndexStorageInfo>());
+}
+
+ArtPrimaryKeyIndex::~ArtPrimaryKeyIndex() = default;
+
+std::unique_ptr<ArtPrimaryKeyIndex> ArtPrimaryKeyIndex::createNewIndex(IndexInfo indexInfo) {
+    return std::make_unique<ArtPrimaryKeyIndex>(std::move(indexInfo),
+        std::make_unique<ArtPrimaryKeyIndexStorageInfo>());
+}
+
+bool ArtPrimaryKeyIndex::insertInternal(const ArtKey& key, offset_t offset,
+    visible_func isVisible) {
+    DASSERT(!key.empty());
+    auto* node = &root;
+    for (const auto byte : key.getBytes()) {
+        node = node->getOrInsertChild(byte);
+    }
+    if (node->offset.has_value() && isVisible(node->offset.value())) {
+        return false;
+    }
+    node->offset = offset;
+    return true;
+}
+
+bool ArtPrimaryKeyIndex::lookup(const ArtKey& key, offset_t& result, visible_func isVisible) const {
+    if (key.empty()) {
+        return false;
+    }
+    const auto* node = &root;
+    for (const auto byte : key.getBytes()) {
+        const auto* child = node->getChild(byte);
+        if (child == nullptr) {
+            return false;
+        }
+        node = child;
+    }
+    if (!node->offset.has_value() || !isVisible(node->offset.value())) {
+        return false;
+    }
+    result = node->offset.value();
+    return true;
+}
+
+void ArtPrimaryKeyIndex::erase(const ArtKey& key) {
+    if (key.empty()) {
+        return;
+    }
+    auto* node = &root;
+    for (const auto byte : key.getBytes()) {
+        auto* child = node->getChild(byte);
+        if (child == nullptr) {
+            return;
+        }
+        node = child;
+    }
+    node->offset.reset();
+}
+
+void ArtPrimaryKeyIndex::commitInsert(transaction::Transaction*, const ValueVector& nodeIDVector,
+    const std::vector<ValueVector*>& indexVectors, Index::InsertState& insertState) {
+    DASSERT(indexVectors.size() == 1);
+    auto& keyVector = *indexVectors[0];
+    const auto& artInsertState = insertState.cast<InsertState>();
+    for (auto i = 0u; i < nodeIDVector.state->getSelSize(); i++) {
+        const auto nodeIDPos = nodeIDVector.state->getSelVector()[i];
+        const auto offset = nodeIDVector.readNodeOffset(nodeIDPos);
+        const auto keyPos = keyVector.state->getSelVector()[i];
+        if (keyVector.isNull(keyPos)) {
+            throw RuntimeException(ExceptionMessage::nullPKException());
+        }
+        const auto key = ArtKey::encode(&keyVector, keyPos);
+        if (!insertInternal(key, offset, artInsertState.isVisible)) {
+            throw RuntimeException(
+                ExceptionMessage::duplicatePKException(keyVector.getAsValue(keyPos)->toString()));
+        }
+    }
+}
+
+bool ArtPrimaryKeyIndex::lookupPrimaryKey(const transaction::Transaction*, ValueVector* keyVector,
+    uint64_t vectorPos, offset_t& result, visible_func isVisible) {
+    const auto key = ArtKey::encode(keyVector, vectorPos);
+    return lookup(key, result, std::move(isVisible));
+}
+
+void ArtPrimaryKeyIndex::discardPrimaryKey(ValueVector* keyVector) {
+    for (auto i = 0u; i < keyVector->state->getSelSize(); ++i) {
+        const auto pos = keyVector->state->getSelVector()[i];
+        erase(ArtKey::encode(keyVector, pos));
+    }
+}
+
+void ArtPrimaryKeyIndex::collectEntries(const Node& node, std::vector<uint8_t>& key,
+    std::vector<std::pair<std::vector<uint8_t>, offset_t>>& entries) const {
+    if (node.offset.has_value()) {
+        entries.emplace_back(key, node.offset.value());
+    }
+    switch (node.kind) {
+    case Node::Kind::NODE4:
+    case Node::Kind::NODE16:
+        for (auto i = 0u; i < node.count; ++i) {
+            key.push_back(node.keys[i]);
+            collectEntries(*node.smallChildren[i], key, entries);
+            key.pop_back();
+        }
+        break;
+    case Node::Kind::NODE48:
+        for (auto i = 0u; i < node.childIndex.size(); ++i) {
+            const auto pos = node.childIndex[i];
+            if (pos == Node::EMPTY_MARKER) {
+                continue;
+            }
+            key.push_back(static_cast<uint8_t>(i));
+            collectEntries(*node.node48Children[pos], key, entries);
+            key.pop_back();
+        }
+        break;
+    case Node::Kind::NODE256:
+        for (auto i = 0u; i < node.node256Children.size(); ++i) {
+            if (!node.node256Children[i]) {
+                continue;
+            }
+            key.push_back(static_cast<uint8_t>(i));
+            collectEntries(*node.node256Children[i], key, entries);
+            key.pop_back();
+        }
+        break;
+    default:
+        UNREACHABLE_CODE;
+    }
+}
+
+void ArtPrimaryKeyIndex::checkpoint(main::ClientContext*, PageAllocator&) {
+    std::vector<std::pair<std::vector<uint8_t>, offset_t>> entries;
+    std::vector<uint8_t> key;
+    collectEntries(root, key, entries);
+    storageInfo = std::make_unique<ArtPrimaryKeyIndexStorageInfo>(std::move(entries));
+}
+
+void ArtPrimaryKeyIndex::loadEntries(const ArtPrimaryKeyIndexStorageInfo& storageInfo) {
+    static constexpr auto alwaysVisible = [](offset_t) { return true; };
+    for (const auto& [keyBytes, offset] : storageInfo.entries) {
+        insertInternal(ArtKey{keyBytes}, offset, alwaysVisible);
+    }
+}
+
+std::unique_ptr<Index> ArtPrimaryKeyIndex::load(main::ClientContext*, StorageManager*,
+    IndexInfo indexInfo, std::span<uint8_t> storageInfoBuffer) {
+    auto storageInfoBufferReader =
+        std::make_unique<BufferReader>(storageInfoBuffer.data(), storageInfoBuffer.size());
+    auto storageInfo =
+        ArtPrimaryKeyIndexStorageInfo::deserialize(std::move(storageInfoBufferReader));
+    return std::make_unique<ArtPrimaryKeyIndex>(std::move(indexInfo), std::move(storageInfo));
+}
+
+} // namespace storage
+} // namespace lbug

--- a/src/storage/index/art_index.cpp
+++ b/src/storage/index/art_index.cpp
@@ -2,7 +2,6 @@
 
 #include <algorithm>
 #include <cstring>
-#include <limits>
 #include <type_traits>
 
 #include "common/exception/message.h"
@@ -157,6 +156,55 @@ ArtPrimaryKeyIndex::Node* ArtPrimaryKeyIndex::Node::getOrInsertChild(uint8_t byt
     }
 }
 
+void ArtPrimaryKeyIndex::Node::removeChild(uint8_t byte) {
+    switch (kind) {
+    case Kind::NODE4:
+    case Kind::NODE16: {
+        for (auto i = 0u; i < count; ++i) {
+            if (keys[i] != byte) {
+                continue;
+            }
+            for (auto j = i + 1; j < count; ++j) {
+                keys[j - 1] = keys[j];
+                smallChildren[j - 1] = std::move(smallChildren[j]);
+            }
+            smallChildren[count - 1].reset();
+            --count;
+            return;
+        }
+        return;
+    }
+    case Kind::NODE48: {
+        const auto removedPos = childIndex[byte];
+        if (removedPos == EMPTY_MARKER) {
+            return;
+        }
+        const auto lastPos = count - 1;
+        childIndex[byte] = EMPTY_MARKER;
+        if (removedPos != lastPos) {
+            for (auto i = 0u; i < childIndex.size(); ++i) {
+                if (childIndex[i] == lastPos) {
+                    childIndex[i] = removedPos;
+                    break;
+                }
+            }
+            node48Children[removedPos] = std::move(node48Children[lastPos]);
+        }
+        node48Children[lastPos].reset();
+        --count;
+        return;
+    }
+    case Kind::NODE256:
+        if (node256Children[byte]) {
+            node256Children[byte].reset();
+            --count;
+        }
+        return;
+    default:
+        UNREACHABLE_CODE;
+    }
+}
+
 ArtKey ArtKey::encode(ValueVector* vector, uint64_t vectorPos) {
     if (vector->isNull(vectorPos)) {
         return ArtKey{};
@@ -227,7 +275,40 @@ ArtPrimaryKeyIndex::ArtPrimaryKeyIndex(IndexInfo indexInfo,
 
 ArtPrimaryKeyIndex::~ArtPrimaryKeyIndex() = default;
 
+std::unique_ptr<Index::InsertState> ArtPrimaryKeyIndex::initInsertState(main::ClientContext*,
+    visible_func isVisible) {
+    return std::make_unique<InsertState>(std::move(isVisible));
+}
+
+static void validateIndexInfo(const IndexInfo& indexInfo) {
+    if (!indexInfo.isPrimary || !indexInfo.isBuiltin) {
+        throw RuntimeException("ART indexes currently support only built-in primary-key indexes.");
+    }
+    if (indexInfo.columnIDs.size() != 1 || indexInfo.keyDataTypes.size() != 1) {
+        throw RuntimeException("ART indexes currently support exactly one primary-key property.");
+    }
+    switch (indexInfo.keyDataTypes[0]) {
+    case PhysicalTypeID::UINT8:
+    case PhysicalTypeID::UINT16:
+    case PhysicalTypeID::UINT32:
+    case PhysicalTypeID::UINT64:
+    case PhysicalTypeID::INT8:
+    case PhysicalTypeID::INT16:
+    case PhysicalTypeID::INT32:
+    case PhysicalTypeID::INT64:
+    case PhysicalTypeID::INT128:
+    case PhysicalTypeID::UINT128:
+    case PhysicalTypeID::STRING:
+    case PhysicalTypeID::FLOAT:
+    case PhysicalTypeID::DOUBLE:
+        return;
+    default:
+        throw RuntimeException("ART indexes do not support this primary-key type.");
+    }
+}
+
 std::unique_ptr<ArtPrimaryKeyIndex> ArtPrimaryKeyIndex::createNewIndex(IndexInfo indexInfo) {
+    validateIndexInfo(indexInfo);
     return std::make_unique<ArtPrimaryKeyIndex>(std::move(indexInfo),
         std::make_unique<ArtPrimaryKeyIndexStorageInfo>());
 }
@@ -265,24 +346,33 @@ bool ArtPrimaryKeyIndex::lookup(const ArtKey& key, offset_t& result, visible_fun
     return true;
 }
 
+bool ArtPrimaryKeyIndex::eraseInternal(Node& node, const std::vector<uint8_t>& key,
+    uint64_t depth) {
+    if (depth == key.size()) {
+        node.offset.reset();
+        return node.empty();
+    }
+    const auto byte = key[depth];
+    auto* child = node.getChild(byte);
+    if (child == nullptr) {
+        return false;
+    }
+    if (eraseInternal(*child, key, depth + 1)) {
+        node.removeChild(byte);
+    }
+    return node.empty();
+}
+
 void ArtPrimaryKeyIndex::erase(const ArtKey& key) {
-    if (key.empty()) {
-        return;
+    if (!key.empty()) {
+        eraseInternal(root, key.getBytes(), 0);
     }
-    auto* node = &root;
-    for (const auto byte : key.getBytes()) {
-        auto* child = node->getChild(byte);
-        if (child == nullptr) {
-            return;
-        }
-        node = child;
-    }
-    node->offset.reset();
 }
 
 void ArtPrimaryKeyIndex::commitInsert(transaction::Transaction*, const ValueVector& nodeIDVector,
     const std::vector<ValueVector*>& indexVectors, Index::InsertState& insertState) {
     DASSERT(indexVectors.size() == 1);
+    std::lock_guard lck{mutex};
     auto& keyVector = *indexVectors[0];
     const auto& artInsertState = insertState.cast<InsertState>();
     for (auto i = 0u; i < nodeIDVector.state->getSelSize(); i++) {
@@ -302,6 +392,7 @@ void ArtPrimaryKeyIndex::commitInsert(transaction::Transaction*, const ValueVect
 
 bool ArtPrimaryKeyIndex::lookupPrimaryKey(const transaction::Transaction*, ValueVector* keyVector,
     uint64_t vectorPos, offset_t& result, visible_func isVisible) {
+    std::lock_guard lck{mutex};
     const auto key = ArtKey::encode(keyVector, vectorPos);
     return lookup(key, result, std::move(isVisible));
 }
@@ -350,26 +441,64 @@ void ArtPrimaryKeyIndex::collectRange(const Node& node, std::vector<uint8_t>& ke
         satisfiesUpperBound(key, upperBound, upperInclusive) && isVisible(node.offset.value())) {
         results.push_back(node.offset.value());
     }
-    for (auto byte = 0u; byte <= std::numeric_limits<uint8_t>::max(); ++byte) {
-        auto* child = node.getChild(static_cast<uint8_t>(byte));
-        if (child == nullptr) {
-            continue;
-        }
-        key.push_back(static_cast<uint8_t>(byte));
+    auto visitChild = [&](uint8_t byte, const Node& child) {
+        key.push_back(byte);
         if (satisfiesUpperBound(key, upperBound, true)) {
-            collectRange(*child, key, lowerBound, lowerInclusive, upperBound, upperInclusive,
+            collectRange(child, key, lowerBound, lowerInclusive, upperBound, upperInclusive,
                 maxResults, results, isVisible);
         }
         key.pop_back();
-        if (results.size() >= maxResults) {
-            return;
+    };
+    switch (node.kind) {
+    case Node::Kind::NODE4:
+    case Node::Kind::NODE16: {
+        std::array<uint16_t, 16> childOrder{};
+        for (auto i = 0u; i < node.count; ++i) {
+            childOrder[i] = i;
         }
+        std::sort(childOrder.begin(), childOrder.begin() + node.count,
+            [&node](auto left, auto right) { return node.keys[left] < node.keys[right]; });
+        for (auto i = 0u; i < node.count; ++i) {
+            const auto pos = childOrder[i];
+            visitChild(node.keys[pos], *node.smallChildren[pos]);
+            if (results.size() >= maxResults) {
+                return;
+            }
+        }
+        break;
+    }
+    case Node::Kind::NODE48:
+        for (auto byte = 0u; byte < node.childIndex.size(); ++byte) {
+            const auto pos = node.childIndex[byte];
+            if (pos == Node::EMPTY_MARKER) {
+                continue;
+            }
+            visitChild(static_cast<uint8_t>(byte), *node.node48Children[pos]);
+            if (results.size() >= maxResults) {
+                return;
+            }
+        }
+        break;
+    case Node::Kind::NODE256:
+        for (auto byte = 0u; byte < node.node256Children.size(); ++byte) {
+            if (!node.node256Children[byte]) {
+                continue;
+            }
+            visitChild(static_cast<uint8_t>(byte), *node.node256Children[byte]);
+            if (results.size() >= maxResults) {
+                return;
+            }
+        }
+        break;
+    default:
+        UNREACHABLE_CODE;
     }
 }
 
 bool ArtPrimaryKeyIndex::scanPrimaryKeyRange(ValueVector* lowerBoundVector, uint64_t lowerBoundPos,
     bool lowerInclusive, ValueVector* upperBoundVector, uint64_t upperBoundPos, bool upperInclusive,
     idx_t maxResults, std::vector<offset_t>& results, visible_func isVisible) {
+    std::lock_guard lck{mutex};
     auto lowerBound =
         lowerBoundVector == nullptr ? ArtKey{} : ArtKey::encode(lowerBoundVector, lowerBoundPos);
     auto upperBound =
@@ -387,6 +516,7 @@ bool ArtPrimaryKeyIndex::scanPrimaryKeyRange(ValueVector* lowerBoundVector, uint
 }
 
 void ArtPrimaryKeyIndex::discardPrimaryKey(ValueVector* keyVector) {
+    std::lock_guard lck{mutex};
     for (auto i = 0u; i < keyVector->state->getSelSize(); ++i) {
         const auto pos = keyVector->state->getSelVector()[i];
         erase(ArtKey::encode(keyVector, pos));
@@ -434,6 +564,7 @@ void ArtPrimaryKeyIndex::collectEntries(const Node& node, std::vector<uint8_t>& 
 }
 
 void ArtPrimaryKeyIndex::checkpoint(main::ClientContext*, PageAllocator&) {
+    std::lock_guard lck{mutex};
     std::vector<std::pair<std::vector<uint8_t>, offset_t>> entries;
     std::vector<uint8_t> key;
     collectEntries(root, key, entries);
@@ -449,6 +580,7 @@ void ArtPrimaryKeyIndex::loadEntries(const ArtPrimaryKeyIndexStorageInfo& storag
 
 std::unique_ptr<Index> ArtPrimaryKeyIndex::load(main::ClientContext*, StorageManager*,
     IndexInfo indexInfo, std::span<uint8_t> storageInfoBuffer) {
+    validateIndexInfo(indexInfo);
     auto storageInfoBufferReader =
         std::make_unique<BufferReader>(storageInfoBuffer.data(), storageInfoBuffer.size());
     auto storageInfo =

--- a/src/storage/index/art_index.cpp
+++ b/src/storage/index/art_index.cpp
@@ -1,5 +1,10 @@
 #include "storage/index/art_index.h"
 
+#include <algorithm>
+#include <cstring>
+#include <limits>
+#include <type_traits>
+
 #include "common/exception/message.h"
 #include "common/exception/runtime.h"
 #include "common/serializer/buffer_reader.h"
@@ -17,14 +22,42 @@ namespace storage {
 namespace {
 
 template<typename T>
-void appendRaw(std::vector<uint8_t>& bytes, const T& value) {
-    const auto* data = reinterpret_cast<const uint8_t*>(&value);
-    bytes.insert(bytes.end(), data, data + sizeof(T));
+void appendBigEndian(std::vector<uint8_t>& bytes, T value) {
+    using U = std::make_unsigned_t<T>;
+    auto unsignedValue = static_cast<U>(value);
+    for (auto i = 0u; i < sizeof(T); ++i) {
+        const auto shift = (sizeof(T) - i - 1) * 8;
+        bytes.push_back(static_cast<uint8_t>(unsignedValue >> shift));
+    }
 }
 
 template<typename T>
-void appendFixed(std::vector<uint8_t>& bytes, T value) {
-    appendRaw(bytes, value);
+void appendIntegral(std::vector<uint8_t>& bytes, T value) {
+    using U = std::make_unsigned_t<T>;
+    auto encoded = static_cast<U>(value);
+    if constexpr (std::is_signed_v<T>) {
+        encoded ^= (U{1} << (sizeof(T) * 8 - 1));
+    }
+    appendBigEndian(bytes, encoded);
+}
+
+template<typename T>
+void appendFloat(std::vector<uint8_t>& bytes, T value) {
+    using U = std::conditional_t<sizeof(T) == sizeof(uint32_t), uint32_t, uint64_t>;
+    U encoded = 0;
+    std::memcpy(&encoded, &value, sizeof(T));
+    const auto signBit = U{1} << (sizeof(T) * 8 - 1);
+    encoded = (encoded & signBit) != 0 ? ~encoded : encoded ^ signBit;
+    appendBigEndian(bytes, encoded);
+}
+
+void appendUInt128(std::vector<uint8_t>& bytes, uint64_t high, uint64_t low) {
+    appendBigEndian(bytes, high);
+    appendBigEndian(bytes, low);
+}
+
+void appendInt128(std::vector<uint8_t>& bytes, int64_t high, uint64_t low) {
+    appendUInt128(bytes, static_cast<uint64_t>(high) ^ (uint64_t{1} << 63), low);
 }
 
 void appendString(std::vector<uint8_t>& bytes, std::string_view value) {
@@ -132,12 +165,18 @@ ArtKey ArtKey::encode(ValueVector* vector, uint64_t vectorPos) {
     TypeUtils::visit(vector->dataType.getPhysicalType(), [&]<typename T>(T) {
         if constexpr (std::same_as<T, string_t>) {
             appendString(bytes, vector->getValue<string_t>(vectorPos).getAsStringView());
-        } else if constexpr (std::same_as<T, int128_t> || std::same_as<T, uint128_t>) {
+        } else if constexpr (std::same_as<T, int128_t>) {
             const auto value = vector->getValue<T>(vectorPos);
-            appendRaw(bytes, value.low);
-            appendRaw(bytes, value.high);
-        } else if constexpr (std::integral<T> || std::floating_point<T>) {
-            appendFixed(bytes, vector->getValue<T>(vectorPos));
+            appendInt128(bytes, value.high, value.low);
+        } else if constexpr (std::same_as<T, uint128_t>) {
+            const auto value = vector->getValue<T>(vectorPos);
+            appendUInt128(bytes, value.high, value.low);
+        } else if constexpr (std::same_as<T, bool>) {
+            bytes.push_back(vector->getValue<T>(vectorPos) ? 1 : 0);
+        } else if constexpr (std::integral<T>) {
+            appendIntegral(bytes, vector->getValue<T>(vectorPos));
+        } else if constexpr (std::floating_point<T>) {
+            appendFloat(bytes, vector->getValue<T>(vectorPos));
         } else {
             UNREACHABLE_CODE;
         }
@@ -265,6 +304,86 @@ bool ArtPrimaryKeyIndex::lookupPrimaryKey(const transaction::Transaction*, Value
     uint64_t vectorPos, offset_t& result, visible_func isVisible) {
     const auto key = ArtKey::encode(keyVector, vectorPos);
     return lookup(key, result, std::move(isVisible));
+}
+
+static int compareKeys(const std::vector<uint8_t>& left, const std::vector<uint8_t>& right) {
+    const auto cmpSize = std::min(left.size(), right.size());
+    for (auto i = 0u; i < cmpSize; ++i) {
+        if (left[i] < right[i]) {
+            return -1;
+        }
+        if (left[i] > right[i]) {
+            return 1;
+        }
+    }
+    if (left.size() == right.size()) {
+        return 0;
+    }
+    return left.size() < right.size() ? -1 : 1;
+}
+
+static bool satisfiesLowerBound(const std::vector<uint8_t>& key, const ArtKey* lowerBound,
+    bool lowerInclusive) {
+    if (lowerBound == nullptr) {
+        return true;
+    }
+    const auto cmp = compareKeys(key, lowerBound->getBytes());
+    return lowerInclusive ? cmp >= 0 : cmp > 0;
+}
+
+static bool satisfiesUpperBound(const std::vector<uint8_t>& key, const ArtKey* upperBound,
+    bool upperInclusive) {
+    if (upperBound == nullptr) {
+        return true;
+    }
+    const auto cmp = compareKeys(key, upperBound->getBytes());
+    return upperInclusive ? cmp <= 0 : cmp < 0;
+}
+
+void ArtPrimaryKeyIndex::collectRange(const Node& node, std::vector<uint8_t>& key,
+    const ArtKey* lowerBound, bool lowerInclusive, const ArtKey* upperBound, bool upperInclusive,
+    idx_t maxResults, std::vector<offset_t>& results, visible_func isVisible) const {
+    if (results.size() >= maxResults) {
+        return;
+    }
+    if (node.offset.has_value() && satisfiesLowerBound(key, lowerBound, lowerInclusive) &&
+        satisfiesUpperBound(key, upperBound, upperInclusive) && isVisible(node.offset.value())) {
+        results.push_back(node.offset.value());
+    }
+    for (auto byte = 0u; byte <= std::numeric_limits<uint8_t>::max(); ++byte) {
+        auto* child = node.getChild(static_cast<uint8_t>(byte));
+        if (child == nullptr) {
+            continue;
+        }
+        key.push_back(static_cast<uint8_t>(byte));
+        if (satisfiesUpperBound(key, upperBound, true)) {
+            collectRange(*child, key, lowerBound, lowerInclusive, upperBound, upperInclusive,
+                maxResults, results, isVisible);
+        }
+        key.pop_back();
+        if (results.size() >= maxResults) {
+            return;
+        }
+    }
+}
+
+bool ArtPrimaryKeyIndex::scanPrimaryKeyRange(ValueVector* lowerBoundVector, uint64_t lowerBoundPos,
+    bool lowerInclusive, ValueVector* upperBoundVector, uint64_t upperBoundPos, bool upperInclusive,
+    idx_t maxResults, std::vector<offset_t>& results, visible_func isVisible) {
+    auto lowerBound =
+        lowerBoundVector == nullptr ? ArtKey{} : ArtKey::encode(lowerBoundVector, lowerBoundPos);
+    auto upperBound =
+        upperBoundVector == nullptr ? ArtKey{} : ArtKey::encode(upperBoundVector, upperBoundPos);
+    const auto* lowerBoundPtr = lowerBoundVector == nullptr ? nullptr : &lowerBound;
+    const auto* upperBoundPtr = upperBoundVector == nullptr ? nullptr : &upperBound;
+    if ((lowerBoundVector != nullptr && lowerBound.empty()) ||
+        (upperBoundVector != nullptr && upperBound.empty())) {
+        return true;
+    }
+    std::vector<uint8_t> key;
+    collectRange(root, key, lowerBoundPtr, lowerInclusive, upperBoundPtr, upperInclusive,
+        maxResults, results, std::move(isVisible));
+    return true;
 }
 
 void ArtPrimaryKeyIndex::discardPrimaryKey(ValueVector* keyVector) {

--- a/src/storage/storage_manager.cpp
+++ b/src/storage/storage_manager.cpp
@@ -16,6 +16,7 @@
 #include "storage/buffer_manager/buffer_manager.h"
 #include "storage/buffer_manager/memory_manager.h"
 #include "storage/checkpointer.h"
+#include "storage/index/art_index.h"
 #include "storage/table/arrow_node_table.h"
 #include "storage/table/arrow_rel_table.h"
 #include "storage/table/arrow_table_support.h"
@@ -46,6 +47,7 @@ StorageManager::StorageManager(const std::string& databasePath, bool readOnly, b
         std::make_unique<ShadowFile>(*memoryManager.getBufferManager(), vfs, this->databasePath);
     inMemory = main::DBConfig::isDBPathInMemory(databasePath);
     registerIndexType(PrimaryKeyIndex::getIndexType());
+    registerIndexType(ArtPrimaryKeyIndex::getIndexType());
 }
 
 StorageManager::~StorageManager() = default;

--- a/src/storage/table/node_table.cpp
+++ b/src/storage/table/node_table.cpp
@@ -108,7 +108,7 @@ struct UncommittedIndexInserter final : IndexScanHelper {
 
 struct RollbackPKDeleter final : IndexScanHelper {
     RollbackPKDeleter(row_idx_t startNodeOffset, row_idx_t numRows, NodeTable* table,
-        PrimaryKeyIndex* pkIndex)
+        Index* pkIndex)
         : IndexScanHelper(table, pkIndex),
           semiMask(SemiMaskUtil::createMask(startNodeOffset + numRows)) {
         semiMask->maskRange(startNodeOffset, startNodeOffset + numRows);
@@ -199,9 +199,6 @@ std::unique_ptr<NodeTableScanState> RollbackPKDeleter::initScanState(const Trans
     return scanState;
 }
 
-template<typename T>
-concept notIndexHashable = !IndexHashable<T>;
-
 bool RollbackPKDeleter::processScanOutput(main::ClientContext* context,
     NodeGroupScanResult scanResult, const std::vector<ValueVector*>& scannedVectors) {
     if (scanResult == NODE_GROUP_SCAN_EMPTY_RESULT) {
@@ -209,22 +206,7 @@ bool RollbackPKDeleter::processScanOutput(main::ClientContext* context,
     }
     DASSERT(scannedVectors.size() == 1);
     auto& scannedVector = *scannedVectors[0];
-    auto& pkIndex = index->cast<PrimaryKeyIndex>();
-    const auto rollbackFunc = [&]<IndexHashable T>(T) {
-        for (idx_t i = 0; i < scannedVector.state->getSelSize(); ++i) {
-            const auto pos = scannedVector.state->getSelVector()[i];
-            T key = scannedVector.getValue<T>(pos);
-            static constexpr auto isVisible = [](offset_t) { return true; };
-            if (offset_t lookupOffset = 0; pkIndex.lookup(transaction::Transaction::Get(*context),
-                    key, lookupOffset, isVisible)) {
-                // If we delete the key then it will not be visible to future transactions within
-                // this process
-                pkIndex.discardLocal(key);
-            }
-        }
-    };
-    TypeUtils::visit(scannedVector.dataType.getPhysicalType(), std::cref(rollbackFunc),
-        []<notIndexHashable T>(T) { UNREACHABLE_CODE; });
+    index->discardPrimaryKey(&scannedVector);
     return true;
 }
 } // namespace
@@ -744,7 +726,7 @@ bool NodeTable::checkpoint(main::ClientContext* context, TableCatalogEntry* tabl
 
 void NodeTable::rollbackPKIndexInsert(main::ClientContext* context, row_idx_t startRow,
     row_idx_t numRows_, node_group_idx_t nodeGroupIdx_) {
-    auto* pkIndex = tryGetPKIndex();
+    auto* pkIndex = tryGetPrimaryKeyIndex();
     if (!pkIndex) {
         return;
     }
@@ -825,7 +807,26 @@ PrimaryKeyIndex* NodeTable::tryGetPKIndex() const {
         }
         return nullptr;
     }
+    if (index.value()->getIndexInfo().indexType != PrimaryKeyIndex::getIndexType().typeName) {
+        return nullptr;
+    }
     return &index.value()->cast<PrimaryKeyIndex>();
+}
+
+Index* NodeTable::tryGetPrimaryKeyIndex() const {
+    if (auto* pkIndex = tryGetPKIndex()) {
+        return pkIndex;
+    }
+    for (auto& indexHolder : indexes) {
+        if (!indexHolder.isLoaded()) {
+            continue;
+        }
+        auto* loadedIndex = indexHolder.getIndex();
+        if (loadedIndex->isPrimary()) {
+            return loadedIndex;
+        }
+    }
+    return nullptr;
 }
 
 bool NodeTable::lookupPK(const Transaction* transaction, ValueVector* keyVector, uint64_t vectorPos,
@@ -837,8 +838,8 @@ bool NodeTable::lookupPK(const Transaction* transaction, ValueVector* keyVector,
             return true;
         }
     }
-    if (auto* pkIndex = tryGetPKIndex()) {
-        return pkIndex->lookup(transaction, keyVector, vectorPos, result,
+    if (auto* pkIndex = tryGetPrimaryKeyIndex()) {
+        return pkIndex->lookupPrimaryKey(transaction, keyVector, vectorPos, result,
             [&](offset_t offset) { return isVisibleNoLock(transaction, offset); });
     }
     auto keyToLookup = keyVector->getAsValue(vectorPos);

--- a/src/storage/table/node_table.cpp
+++ b/src/storage/table/node_table.cpp
@@ -201,6 +201,7 @@ std::unique_ptr<NodeTableScanState> RollbackPKDeleter::initScanState(const Trans
 
 bool RollbackPKDeleter::processScanOutput(main::ClientContext* context,
     NodeGroupScanResult scanResult, const std::vector<ValueVector*>& scannedVectors) {
+    (void)context;
     if (scanResult == NODE_GROUP_SCAN_EMPTY_RESULT) {
         return false;
     }
@@ -849,6 +850,19 @@ bool NodeTable::lookupPK(const Transaction* transaction, ValueVector* keyVector,
     std::vector<ColumnPredicateSet> predicateSets;
     predicateSets.push_back(std::move(predicateSet));
     return scanPKColumn(transaction, *keyToLookup, std::move(predicateSets), result);
+}
+
+bool NodeTable::lookupPKRange(const Transaction* transaction, ValueVector* lowerBoundVector,
+    uint64_t lowerBoundPos, bool lowerInclusive, ValueVector* upperBoundVector,
+    uint64_t upperBoundPos, bool upperInclusive, idx_t maxResults,
+    std::vector<offset_t>& results) const {
+    auto* pkIndex = tryGetPrimaryKeyIndex();
+    if (pkIndex == nullptr) {
+        return false;
+    }
+    return pkIndex->scanPrimaryKeyRange(lowerBoundVector, lowerBoundPos, lowerInclusive,
+        upperBoundVector, upperBoundPos, upperInclusive, maxResults, results,
+        [&](offset_t offset) { return isVisibleNoLock(transaction, offset); });
 }
 
 bool NodeTable::scanPKColumn(const Transaction* transaction, const Value& keyToLookup,

--- a/test/api/api_test.cpp
+++ b/test/api/api_test.cpp
@@ -113,6 +113,38 @@ TEST_F(ApiTest, Explain) {
     ASSERT_TRUE(result->isSuccess());
 }
 
+TEST_F(ApiTest, ExplainPrimaryKeyIndexChoice) {
+    ASSERT_TRUE(conn->query("CALL enable_default_hash_index=false")->isSuccess());
+    ASSERT_TRUE(conn->query("CREATE NODE TABLE ExplainNoIndex(id INT64, PRIMARY KEY(id));"
+                            "CREATE (:ExplainNoIndex {id: 1});")
+                    ->isSuccess());
+    auto noIndexPlan =
+        conn->query("EXPLAIN MATCH (n:ExplainNoIndex) WHERE n.id = 1 RETURN n.id")->toString();
+    EXPECT_NE(noIndexPlan.find("FILTER"), std::string::npos);
+    EXPECT_NE(noIndexPlan.find("SCAN_NODE_TABLE"), std::string::npos);
+    EXPECT_EQ(noIndexPlan.find("PRIMARY_KEY_SCAN_NODE_TABLE"), std::string::npos);
+
+    ASSERT_TRUE(conn->query("CREATE NODE TABLE ExplainHashIndex(id INT64, PRIMARY KEY(id));"
+                            "CREATE (:ExplainHashIndex {id: 1});"
+                            "CREATE HASH INDEX explain_hash_pk FOR (n:ExplainHashIndex) ON "
+                            "(n.id);")
+                    ->isSuccess());
+    auto hashPlan =
+        conn->query("EXPLAIN MATCH (n:ExplainHashIndex) WHERE n.id = 1 RETURN n.id")->toString();
+    EXPECT_NE(hashPlan.find("PRIMARY_KEY_SCAN_NODE_TABLE"), std::string::npos);
+    EXPECT_NE(hashPlan.find("Index: HASH"), std::string::npos);
+
+    ASSERT_TRUE(conn->query("CREATE NODE TABLE ExplainArtIndex(id INT64, PRIMARY KEY(id));"
+                            "CREATE (:ExplainArtIndex {id: 1});"
+                            "CREATE ART INDEX explain_art_pk FOR (n:ExplainArtIndex) ON "
+                            "(n.id);")
+                    ->isSuccess());
+    auto artPlan =
+        conn->query("EXPLAIN MATCH (n:ExplainArtIndex) WHERE n.id = 1 RETURN n.id")->toString();
+    EXPECT_NE(artPlan.find("PRIMARY_KEY_SCAN_NODE_TABLE"), std::string::npos);
+    EXPECT_NE(artPlan.find("Index: ART"), std::string::npos);
+}
+
 TEST_F(ApiTest, Profile) {
     auto result =
         conn->query("EXPLAIN MATCH (a:person) WHERE EXISTS { MATCH (a)-[:knows]->(b:person) WHERE "

--- a/test/test_files/ddl/art_index_person.csv
+++ b/test/test_files/ddl/art_index_person.csv
@@ -1,0 +1,5 @@
+ID,name
+1,Ada
+2,Grace
+-1,Edsger
+10,Barbara

--- a/test/test_files/ddl/ddl_empty.test
+++ b/test/test_files/ddl/ddl_empty.test
@@ -108,6 +108,33 @@ Runtime exception: Found duplicated primary key value 1, which violates the uniq
 -STATEMENT CALL enable_default_hash_index=true;
 ---- ok
 
+-CASE ArtIndexCopyFrom
+-STATEMENT CALL enable_default_hash_index=false;
+---- ok
+-STATEMENT CREATE NODE TABLE art_copy_person (ID INT64, name STRING, PRIMARY KEY(ID));
+---- 1
+Table art_copy_person has been created.
+-STATEMENT CREATE ART INDEX art_copy_person_pk FOR (p:art_copy_person) ON (p.ID);
+---- 1
+Index art_copy_person_pk has been created.
+-STATEMENT COPY art_copy_person FROM "${LBUG_ROOT_DIRECTORY}/test/test_files/ddl/art_index_person.csv";
+---- 1
+4 tuples have been copied to the art_copy_person table.
+-STATEMENT MATCH (p:art_copy_person) WHERE p.ID = 2 RETURN p.name;
+---- 1
+Grace
+-STATEMENT MATCH (p:art_copy_person) WHERE p.ID >= 1 AND p.ID <= 10 RETURN p.ID, p.name ORDER BY p.ID;
+---- 3
+1|Ada
+2|Grace
+10|Barbara
+-STATEMENT MATCH (p:art_copy_person) WHERE p.ID < 2 RETURN p.ID, p.name ORDER BY p.ID;
+---- 2
+-1|Edsger
+1|Ada
+-STATEMENT CALL enable_default_hash_index=true;
+---- ok
+
 # Check to see if Count() correctly handles full vectors that are all null
 -CASE AddInt64PropertyWithoutDefault
 -STATEMENT create node table Comment (id int64, creationDate INT64, locationIP STRING, browserUsed STRING, content STRING, length INT32, PRIMARY KEY (id));

--- a/test/test_files/ddl/ddl_empty.test
+++ b/test/test_files/ddl/ddl_empty.test
@@ -88,6 +88,14 @@ Grace
 ---- 2
 -1|Edsger
 1|Ada
+-STATEMENT MATCH (p:art_person) WHERE p.ID > 1 AND p.ID >= -1 RETURN p.ID, p.name ORDER BY p.ID;
+---- 2
+2|Grace
+10|Barbara
+-STATEMENT MATCH (p:art_person) WHERE p.ID > 1 + 0 RETURN p.ID, p.name ORDER BY p.ID;
+---- 2
+2|Grace
+10|Barbara
 -STATEMENT CREATE (:art_person {ID: 2, name: 'Duplicate'});
 ---- error
 Runtime exception: Found duplicated primary key value 2, which violates the uniqueness constraint of the primary key column.

--- a/test/test_files/ddl/ddl_empty.test
+++ b/test/test_files/ddl/ddl_empty.test
@@ -57,6 +57,40 @@ Bob
 -STATEMENT CALL enable_default_hash_index=true;
 ---- ok
 
+-CASE CreateArtIndex
+-STATEMENT CALL enable_default_hash_index=false;
+---- ok
+-STATEMENT CREATE NODE TABLE art_person (ID INT64, name STRING, PRIMARY KEY(ID));
+---- 1
+Table art_person has been created.
+-STATEMENT CREATE (:art_person {ID: 1, name: 'Ada'});
+---- ok
+-STATEMENT CREATE (:art_person {ID: 2, name: 'Grace'});
+---- ok
+-STATEMENT CREATE ART INDEX art_person_pk FOR (p:art_person) ON (p.ID);
+---- 1
+Index art_person_pk has been created.
+-STATEMENT CALL SHOW_INDEXES() RETURN table_name, index_name, index_type, property_names;
+---- 1
+art_person|art_person_pk|ART|[ID]
+-STATEMENT MATCH (p:art_person) WHERE p.ID = 2 RETURN p.name;
+---- 1
+Grace
+-STATEMENT CREATE (:art_person {ID: 2, name: 'Duplicate'});
+---- error
+Runtime exception: Found duplicated primary key value 2, which violates the uniqueness constraint of the primary key column.
+-STATEMENT CHECKPOINT;
+---- ok
+-RELOADDB
+-STATEMENT MATCH (p:art_person) WHERE p.ID = 1 RETURN p.name;
+---- 1
+Ada
+-STATEMENT CREATE (:art_person {ID: 1, name: 'DuplicateAfterReload'});
+---- error
+Runtime exception: Found duplicated primary key value 1, which violates the uniqueness constraint of the primary key column.
+-STATEMENT CALL enable_default_hash_index=true;
+---- ok
+
 # Check to see if Count() correctly handles full vectors that are all null
 -CASE AddInt64PropertyWithoutDefault
 -STATEMENT create node table Comment (id int64, creationDate INT64, locationIP STRING, browserUsed STRING, content STRING, length INT32, PRIMARY KEY (id));

--- a/test/test_files/ddl/ddl_empty.test
+++ b/test/test_files/ddl/ddl_empty.test
@@ -143,6 +143,21 @@ Grace
 -STATEMENT CALL enable_default_hash_index=true;
 ---- ok
 
+-CASE ArtIndexUnsupportedCreate
+-STATEMENT CALL enable_default_hash_index=false;
+---- ok
+-STATEMENT CREATE NODE TABLE art_bad_person (ID INT64, name STRING, PRIMARY KEY(ID));
+---- 1
+Table art_bad_person has been created.
+-STATEMENT CREATE ART INDEX art_bad_person_name FOR (p:art_bad_person) ON (p.name);
+---- error
+Binder exception: ART indexes are currently supported only on node primary keys.
+-STATEMENT CREATE ART INDEX art_bad_person_pk FOR (p:art_bad_person) ON (p.ID) OPTIONS {foo=true};
+---- error
+Binder exception: CREATE ART INDEX does not support OPTIONS.
+-STATEMENT CALL enable_default_hash_index=true;
+---- ok
+
 # Check to see if Count() correctly handles full vectors that are all null
 -CASE AddInt64PropertyWithoutDefault
 -STATEMENT create node table Comment (id int64, creationDate INT64, locationIP STRING, browserUsed STRING, content STRING, length INT32, PRIMARY KEY (id));

--- a/test/test_files/ddl/ddl_empty.test
+++ b/test/test_files/ddl/ddl_empty.test
@@ -67,6 +67,10 @@ Table art_person has been created.
 ---- ok
 -STATEMENT CREATE (:art_person {ID: 2, name: 'Grace'});
 ---- ok
+-STATEMENT CREATE (:art_person {ID: -1, name: 'Edsger'});
+---- ok
+-STATEMENT CREATE (:art_person {ID: 10, name: 'Barbara'});
+---- ok
 -STATEMENT CREATE ART INDEX art_person_pk FOR (p:art_person) ON (p.ID);
 ---- 1
 Index art_person_pk has been created.
@@ -76,6 +80,14 @@ art_person|art_person_pk|ART|[ID]
 -STATEMENT MATCH (p:art_person) WHERE p.ID = 2 RETURN p.name;
 ---- 1
 Grace
+-STATEMENT MATCH (p:art_person) WHERE p.ID >= 1 AND p.ID < 10 RETURN p.ID, p.name ORDER BY p.ID;
+---- 2
+1|Ada
+2|Grace
+-STATEMENT MATCH (p:art_person) WHERE p.ID < 2 RETURN p.ID, p.name ORDER BY p.ID;
+---- 2
+-1|Edsger
+1|Ada
 -STATEMENT CREATE (:art_person {ID: 2, name: 'Duplicate'});
 ---- error
 Runtime exception: Found duplicated primary key value 2, which violates the uniqueness constraint of the primary key column.
@@ -85,6 +97,11 @@ Runtime exception: Found duplicated primary key value 2, which violates the uniq
 -STATEMENT MATCH (p:art_person) WHERE p.ID = 1 RETURN p.name;
 ---- 1
 Ada
+-STATEMENT MATCH (p:art_person) WHERE p.ID > -1 AND p.ID <= 10 RETURN p.ID, p.name ORDER BY p.ID;
+---- 3
+1|Ada
+2|Grace
+10|Barbara
 -STATEMENT CREATE (:art_person {ID: 1, name: 'DuplicateAfterReload'});
 ---- error
 Runtime exception: Found duplicated primary key value 1, which violates the uniqueness constraint of the primary key column.

--- a/test/test_runner/fsm_leak_checker.cpp
+++ b/test/test_runner/fsm_leak_checker.cpp
@@ -64,7 +64,7 @@ void FSMLeakChecker::checkForLeakedPages(main::Connection* conn) {
             dropQuery = std::format("CALL DROP_FTS_INDEX('{}', '{}');", tableName, indexName);
         } else if (indexType == "HNSW") {
             dropQuery = std::format("CALL DROP_VECTOR_INDEX('{}', '{}');", tableName, indexName);
-        } else if (indexType == "HASH") {
+        } else if (indexType == "HASH" || indexType == "ART") {
             continue;
         } else {
             EXPECT_TRUE(false) << "Unknown index type: " << indexType << " (table=" << tableName


### PR DESCRIPTION
Details in the included docs.

```
du -sh /tmp/test1*.db
634M    /tmp/test1-hash.db
512M    /tmp/test1-noindex.db
604M    /tmp/test1-art.db
```

```
➜  ladybug git:(art_index) ✗ ./build/release/tools/shell/lbug -r /tmp/test1-hash.db
Opening the database at path: /tmp/test1-hash.db in read-only mode.
Enter ":help" for usage hints.
lbug> CALL show_indexes() return *;
┌────────────┬──────────────┬────────────┬────────────────┬──────────────────┬──────────────────────────────────────────────────────────────┐
│ table_name │ index_name   │ index_type │ property_names │ extension_loaded │ index_definition                                             │
│ STRING     │ STRING       │ STRING     │ STRING[]       │ BOOL             │ STRING                                                       │
├────────────┼──────────────┼────────────┼────────────────┼──────────────────┼──────────────────────────────────────────────────────────────┤
│ User       │ user_hash_pk │ HASH       │ [id]           │ True             │ CREATE HASH INDEX `user_hash_pk` FOR (n:`User`) ON (n.`id`); │
└────────────┴──────────────┴────────────┴────────────────┴──────────────────┴──────────────────────────────────────────────────────────────┘
(1 tuple)
(6 columns)
Time: 5.56ms (compiling), 1.69ms (executing)
lbug>
➜  ladybug git:(art_index) ✗ ./build/release/tools/shell/lbug -r /tmp/test1-art.db
Opening the database at path: /tmp/test1.db in read-only mode.
Enter ":help" for usage hints.
lbug> CALL show_indexes() return *;
┌────────────┬───────────────┬────────────┬────────────────┬──────────────────┬──────────────────────────────────────────────────────────────┐
│ table_name │ index_name    │ index_type │ property_names │ extension_loaded │ index_definition                                             │
│ STRING     │ STRING        │ STRING     │ STRING[]       │ BOOL             │ STRING                                                       │
├────────────┼───────────────┼────────────┼────────────────┼──────────────────┼──────────────────────────────────────────────────────────────┤
│ User       │ idx_person_pk │ ART        │ [id]           │ True             │ CREATE ART INDEX `idx_person_pk` FOR (n:`User`) ON (n.`id`); │
└────────────┴───────────────┴────────────┴────────────────┴──────────────────┴──────────────────────────────────────────────────────────────┘
(1 tuple)
(6 columns)
Time: 2.08ms (compiling), 0.21ms (executing)
lbug>
➜  ladybug git:(art_index) ✗ ./build/release/tools/shell/lbug -r /tmp/test1-noindex.db
Opening the database at path: /tmp/test1-save.db in read-only mode.
Enter ":help" for usage hints.
lbug> CALL show_indexes() return *;
┌────────────┬────────────┬────────────┬────────────────┬──────────────────┬──────────────────┐
│ table_name │ index_name │ index_type │ property_names │ extension_loaded │ index_definition │
│ STRING     │ STRING     │ STRING     │ STRING[]       │ BOOL             │ STRING           │
├────────────┼────────────┼────────────┼────────────────┼──────────────────┼──────────────────┤
└────────────┴────────────┴────────────┴────────────────┴──────────────────┴──────────────────┘
(0 tuples)
(6 columns)
Time: 1.50ms (compiling), 0.16ms (executing)
```