### PR TITLE
Add Xet VFS support

### DIFF
--- a/src/common/file_system/local_file_system.cpp
+++ b/src/common/file_system/local_file_system.cpp
@@ -414,7 +414,7 @@ bool LocalFileSystem::isLocalPath(const std::string& path) {
     return path.rfind("s3://", 0) != 0 && path.rfind("gs://", 0) != 0 &&
            path.rfind("gcs://", 0) != 0 && path.rfind("http://", 0) != 0 &&
            path.rfind("https://", 0) != 0 && path.rfind("az://", 0) != 0 &&
-           path.rfind("abfss://", 0) != 0;
+           path.rfind("abfss://", 0) != 0 && path.rfind("xet://", 0) != 0;
 }
 
 void LocalFileSystem::readFromFile(FileInfo& fileInfo, void* buffer, uint64_t numBytes,


### PR DESCRIPTION
## Summary
- mark xet:// as a non-local VFS path in the parent repo
- advance the extension submodule to include HTTPFS Xet support
- support xet:// Hugging Face model, dataset, and space URLs without requiring Xet client libraries

Extension PR: https://github.com/LadybugDB/extensions/pull/3

## Validation
- build/release/extension/httpfs/test/httpfs_xetfs_test --gtest_filter='XetFileSystemTest.*' passed 4/4
- live validation against ladybugdb/small-kgs: LOAD FROM 'xet://datasets/ladybugdb/small-kgs/main/kg_history/icebug-disk/csr_graph_nodes_person.parquet' RETURN count(*); returned 20

Build note: lbug_httpfs_extension builds successfully. The local build emits existing Homebrew OpenSSL macOS deployment-target linker warnings, but they are warnings only.