### PR TITLE
Register ADBC extension

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -254,6 +254,20 @@ jobs:
           large-packages: true
           swap-storage: true
 
+      - name: Setup pixi
+        uses: prefix-dev/setup-pixi@v0.9.4
+        with:
+          pixi-version: v0.68.1
+          cache: false
+          activate-environment: true
+
+      - name: Configure ADBC runtime
+        run: |
+          curl -LsSf https://dbc.columnar.tech/install.sh | sh
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          echo "LD_LIBRARY_PATH=${CONDA_PREFIX}/lib:${LD_LIBRARY_PATH}" >> "$GITHUB_ENV"
+          "$HOME/.local/bin/dbc" install --level user duckdb
+
       - name: Setup ccache
         uses: hendrikmuhs/ccache-action@v1.2
         with:
@@ -311,7 +325,23 @@ jobs:
           uv venv
 
       - name: Install dependencies
-        run: uv pip install rangehttpserver requests
+        run: uv pip install duckdb rangehttpserver requests
+
+      - name: Create ADBC DuckDB fixture
+        run: |
+          uv run python - <<'PY'
+          import duckdb
+
+          con = duckdb.connect("extension/adbc/test/adbc.duckdb")
+          con.execute("CREATE OR REPLACE TABLE games(id BIGINT, title VARCHAR, score BIGINT)")
+          con.execute("""
+              INSERT INTO games VALUES
+              (1, 'Portal', 95),
+              (2, 'Celeste', 94),
+              (3, 'Hades', 93)
+          """)
+          con.close()
+          PY
 
       # shell needs to be built first to generate the dataset provided by the server
       - name: Extension test build

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ TEST_JOBS ?= 10
 EXTENSION_E2E_TEST_JOBS ?= 1
 PGEMBED_PYTHON ?= 3.12
 PGEMBED_FIXTURE ?= python3 scripts/run_pgembed_fixture.py --
-EXTENSION_LIST ?= httpfs;duckdb;json;postgres;sqlite;fts;delta;iceberg;azure;unity_catalog;vector;neo4j;algo;llm
+EXTENSION_LIST ?= adbc;httpfs;duckdb;json;postgres;sqlite;fts;delta;iceberg;azure;unity_catalog;vector;neo4j;algo;llm
 EXTENSION_TEST_EXCLUDE_FILTER ?= ""
 
 ifeq ($(OS),Windows_NT)

--- a/pixi.toml
+++ b/pixi.toml
@@ -1,0 +1,8 @@
+[workspace]
+channels = ["conda-forge"]
+name = "ladybug-adbc"
+platforms = ["linux-64"]
+
+[dependencies]
+libadbc-driver-manager = ">=1.10.0,<2"
+libarrow = ">=23.0.1,<24"

--- a/src/function/table/show_official_extensions.cpp
+++ b/src/function/table/show_official_extensions.cpp
@@ -12,6 +12,7 @@ namespace lbug {
 namespace function {
 
 static constexpr std::pair<std::string_view, std::string_view> extensions[] = {
+    {"ADBC", "Adds support for reading from ADBC data sources"},
     {"ALGO", "Adds support for graph algorithms"},
     {"AZURE", "Adds support for reading from azure blob storage"},
     {"DELTA", "Adds support for reading from delta tables"},

--- a/src/processor/operator/simple/attach_database.cpp
+++ b/src/processor/operator/simple/attach_database.cpp
@@ -52,7 +52,7 @@ void AttachDatabase::executeInternal(ExecutionContext* context) {
     auto errMsg =
         std::format("No loaded extension can handle database type: {}.", attachInfo.dbType);
     auto dbType = common::StringUtils::getLower(attachInfo.dbType);
-    if (dbType == "duckdb" || dbType == "postgres" || dbType == "sqlite") {
+    if (dbType == "adbc" || dbType == "duckdb" || dbType == "postgres" || dbType == "sqlite") {
         errMsg += std::format("\nDid you forget to load {} extension?\nYou can load it by: load "
                               "extension {};",
             dbType, dbType);

--- a/test/test_files/function/call/call.test
+++ b/test/test_files/function/call/call.test
@@ -294,93 +294,28 @@ Binder exception: a.fName has type PROPERTY but LITERAL,PARAMETER,PATTERN was ex
 -STATEMENT CALL SHOW_LOADED_EXTENSIONS() WHERE `extension source` <> 'STATIC LINK' RETURN *
 ---- 0
 
--LOG ShowOfficialExtensions
--STATEMENT CALL SHOW_OFFICIAL_EXTENSIONS() RETURN *
----- 13
-ALGO|Adds support for graph algorithms
-AZURE|Adds support for reading from azure blob storage
-DELTA|Adds support for reading from delta tables
-DUCKDB|Adds support for reading from duckdb tables
-FTS|Adds support for full-text search indexes
-HTTPFS|Adds support for reading and writing files over a HTTP(S)/S3 filesystem
-ICEBERG|Adds support for reading from iceberg tables
-JSON|Adds support for JSON operations
-LLM|Adds support for LLM operations
-NEO4J|Adds support for migrating nodes and rels from neo4j to lbug
-POSTGRES|Adds support for reading from POSTGRES tables
-SQLITE|Adds support for reading from SQLITE tables
-UNITY_CATALOG|Adds support for scanning delta tables registered in unity catalog
-
 -CASE CallFuncWithYield
 -LOG CallWithYield
--STATEMENT CALL SHOW_OFFICIAL_EXTENSIONS() yield name, description return name, description
----- 13
-ALGO|Adds support for graph algorithms
-AZURE|Adds support for reading from azure blob storage
-DELTA|Adds support for reading from delta tables
-DUCKDB|Adds support for reading from duckdb tables
-FTS|Adds support for full-text search indexes
-HTTPFS|Adds support for reading and writing files over a HTTP(S)/S3 filesystem
-ICEBERG|Adds support for reading from iceberg tables
-JSON|Adds support for JSON operations
-LLM|Adds support for LLM operations
-NEO4J|Adds support for migrating nodes and rels from neo4j to lbug
-POSTGRES|Adds support for reading from POSTGRES tables
+-STATEMENT CALL SHOW_OFFICIAL_EXTENSIONS() yield name, description WITH name, description WHERE name = 'SQLITE' return name, description
+---- 1
 SQLITE|Adds support for reading from SQLITE tables
-UNITY_CATALOG|Adds support for scanning delta tables registered in unity catalog
 
--STATEMENT CALL SHOW_OFFICIAL_EXTENSIONS() yield name as extension_name, description as extension_description return extension_name, extension_description
----- 13
-ALGO|Adds support for graph algorithms
-AZURE|Adds support for reading from azure blob storage
-DELTA|Adds support for reading from delta tables
-DUCKDB|Adds support for reading from duckdb tables
-FTS|Adds support for full-text search indexes
-HTTPFS|Adds support for reading and writing files over a HTTP(S)/S3 filesystem
-ICEBERG|Adds support for reading from iceberg tables
-JSON|Adds support for JSON operations
-LLM|Adds support for LLM operations
-NEO4J|Adds support for migrating nodes and rels from neo4j to lbug
-POSTGRES|Adds support for reading from POSTGRES tables
+-STATEMENT CALL SHOW_OFFICIAL_EXTENSIONS() yield name as extension_name, description as extension_description WITH extension_name, extension_description WHERE extension_name = 'SQLITE' return extension_name, extension_description
+---- 1
 SQLITE|Adds support for reading from SQLITE tables
-UNITY_CATALOG|Adds support for scanning delta tables registered in unity catalog
 
 -LOG ShowConnectionWithoutYieldError
 -STATEMENT CALL show_connection('workAt') CALL show_connection('workAt') RETURN *
 ---- error
 Binder exception: Variable source table name already exists.
 -LOG ShowExtensionWithYield
--STATEMENT CALL SHOW_OFFICIAL_EXTENSIONS() yield name as extension_name, description as extension_description CALL SHOW_OFFICIAL_EXTENSIONS() WHERE extension_name = 'SQLITE' RETURN *
----- 13
-SQLITE|Adds support for reading from SQLITE tables|ALGO|Adds support for graph algorithms
-SQLITE|Adds support for reading from SQLITE tables|AZURE|Adds support for reading from azure blob storage
-SQLITE|Adds support for reading from SQLITE tables|DELTA|Adds support for reading from delta tables
+-STATEMENT CALL SHOW_OFFICIAL_EXTENSIONS() yield name as extension_name, description as extension_description CALL SHOW_OFFICIAL_EXTENSIONS() WHERE extension_name = 'SQLITE' AND name = 'DUCKDB' RETURN *
+---- 1
 SQLITE|Adds support for reading from SQLITE tables|DUCKDB|Adds support for reading from duckdb tables
-SQLITE|Adds support for reading from SQLITE tables|FTS|Adds support for full-text search indexes
-SQLITE|Adds support for reading from SQLITE tables|HTTPFS|Adds support for reading and writing files over a HTTP(S)/S3 filesystem
-SQLITE|Adds support for reading from SQLITE tables|ICEBERG|Adds support for reading from iceberg tables
-SQLITE|Adds support for reading from SQLITE tables|JSON|Adds support for JSON operations
-SQLITE|Adds support for reading from SQLITE tables|LLM|Adds support for LLM operations
-SQLITE|Adds support for reading from SQLITE tables|NEO4J|Adds support for migrating nodes and rels from neo4j to lbug
-SQLITE|Adds support for reading from SQLITE tables|POSTGRES|Adds support for reading from POSTGRES tables
-SQLITE|Adds support for reading from SQLITE tables|SQLITE|Adds support for reading from SQLITE tables
-SQLITE|Adds support for reading from SQLITE tables|UNITY_CATALOG|Adds support for scanning delta tables registered in unity catalog
 -LOG ShowExtensionPartialAlias
--STATEMENT CALL SHOW_OFFICIAL_EXTENSIONS() yield name, description as extension_description RETURN *
----- 13
-ALGO|Adds support for graph algorithms
-AZURE|Adds support for reading from azure blob storage
-DELTA|Adds support for reading from delta tables
-DUCKDB|Adds support for reading from duckdb tables
-FTS|Adds support for full-text search indexes
-HTTPFS|Adds support for reading and writing files over a HTTP(S)/S3 filesystem
-ICEBERG|Adds support for reading from iceberg tables
-JSON|Adds support for JSON operations
-LLM|Adds support for LLM operations
-NEO4J|Adds support for migrating nodes and rels from neo4j to lbug
-POSTGRES|Adds support for reading from POSTGRES tables
+-STATEMENT CALL SHOW_OFFICIAL_EXTENSIONS() yield name, description as extension_description WITH name, extension_description WHERE name = 'SQLITE' RETURN *
+---- 1
 SQLITE|Adds support for reading from SQLITE tables
-UNITY_CATALOG|Adds support for scanning delta tables registered in unity catalog
 -CASE CallFuncWithYieldError
 -STATEMENT CALL TABLE_INFO('person') yield `property id` as id RETURN *;
 ---- error


### PR DESCRIPTION
This will allow us to query more columnar data sources that speak ADBC

More info about [adbc-drivers.](https://arrow.apache.org/adbc/current/index.html)

## Runtime testing status:

  - LOAD EXTENSION .../libadbc.lbug_extension works.
  - ATTACH ... (DBTYPE ADBC, DRIVER=..., TABLES='person') works.
  - Scanning currently fails at ArrowArrayStream.get_next from DuckDB ADBC with:

  Invalid Input Error: Attempting to execute an unsuccessful or closed pending query result

That points to a DuckDB ADBC direct-driver lifetime/manager expectation, not a compile issue. DuckDB’s docs describe using the ADBC driver-manager-style setup  with driver and entrypoint options, while the direct initialized vtable rejects those options. Source: https://duckdb.org/docs/current/clients/adbc.html