### PR TITLE
Fix/windows storage version check

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -23,6 +23,12 @@ add_subdirectory(extension)
 add_library(lbug STATIC ${ALL_OBJECT_FILES})
 add_library(lbug_shared SHARED ${ALL_OBJECT_FILES})
 
+if(MSVC)
+    # MSVC COFF archives cannot exceed 4GB. The bundled static lbug.lib can cross that
+    # limit in RelWithDebInfo builds, while Windows CI and tests consume lbug_shared.
+    set_target_properties(lbug PROPERTIES EXCLUDE_FROM_ALL TRUE)
+endif()
+
 set_target_properties(lbug_shared PROPERTIES
     VERSION ${PROJECT_VERSION}
     SOVERSION ${PROJECT_VERSION_MAJOR}

--- a/test/graph_test/private_graph_test.cpp
+++ b/test/graph_test/private_graph_test.cpp
@@ -123,8 +123,13 @@ void DBTest::runTest(std::vector<TestStatement>& statements, uint64_t checkpoint
         }
         if (statement.expectedStorageVersion.has_value()) {
             if (!inMemMode) {
-                ASSERT_EQ(readStorageVersionFromHeader(databasePath),
-                    statement.expectedStorageVersion.value());
+                conn.reset();
+                connMap.clear();
+                database.reset();
+                const auto storageVersion = readStorageVersionFromHeader(databasePath);
+                createDB(checkpointWaitTimeout);
+                createConns(connNames);
+                ASSERT_EQ(storageVersion, statement.expectedStorageVersion.value());
             }
             continue;
         }

--- a/tools/shell/CMakeLists.txt
+++ b/tools/shell/CMakeLists.txt
@@ -13,8 +13,8 @@ add_executable(lbug_shell
         linenoise.cpp
         shell_runner.cpp)
 
-# Static link: avoid LNK4217 (locally defined symbol imported) when linking lbug.lib
-if(WIN32)
+# Static link: avoid LNK4217 (locally defined symbol imported) when linking lbug.lib.
+if(WIN32 AND NOT MSVC)
     target_compile_definitions(lbug_shell PRIVATE LBUG_STATIC_DEFINE)
 endif()
 
@@ -26,7 +26,11 @@ if (NOT MSVC)
 endif ()
 
 
-target_link_libraries(lbug_shell lbug)
+if(MSVC)
+    target_link_libraries(lbug_shell lbug_shared)
+else()
+    target_link_libraries(lbug_shell lbug)
+endif()
 if (ENABLE_BACKTRACES)
     target_link_libraries(lbug_shell register_backtrace_signal_handler)
 endif ()

--- a/tools/shell/printer/CMakeLists.txt
+++ b/tools/shell/printer/CMakeLists.txt
@@ -6,9 +6,11 @@ add_library(lbug_shell_printer
         OBJECT
         json_printer.cpp
         printer_factory.cpp
-        ${PROJECT_SOURCE_DIR}/src/common/types/json_type.cpp
 )
-if(WIN32)
+if(NOT MSVC)
+    target_sources(lbug_shell_printer PRIVATE ${PROJECT_SOURCE_DIR}/src/common/types/json_type.cpp)
+endif()
+if(WIN32 AND NOT MSVC)
     target_compile_definitions(lbug_shell_printer PUBLIC LBUG_STATIC_DEFINE)
 endif()
 


### PR DESCRIPTION
- Fix nightly test failures related to windows file locking
- Today's arrow updates triggered another windows symptom: lbug.lib > 4GB + 400kb in size. This triggers build errors.
- Fixed by switching to shared instead of static lbug library.