### PR TITLE
icebug-disk: relax metadata checks

### DIFF
--- a/src/include/storage/table/ice_disk_utils.h
+++ b/src/include/storage/table/ice_disk_utils.h
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <cctype>
 #include <filesystem>
+#include <iostream>
 #include <memory>
 #include <string>
 #include <vector>
@@ -91,8 +92,11 @@ public:
         }
 
         if (!found) {
-            throw common::RuntimeException(
-                path + ": parquet file is missing icebug_disk_version metadata");
+            std::cerr << "Warning: " << path
+                      << ": parquet file is missing icebug_disk_version metadata; continuing "
+                         "without version compatibility check"
+                      << std::endl;
+            return;
         }
 
         const auto& expected = IceDiskConstants::CURRENT_VERSION;

--- a/test/storage/ice_disk_utils_test.cpp
+++ b/test/storage/ice_disk_utils_test.cpp
@@ -133,12 +133,8 @@ TEST_F(IceDiskCheckVersionTest, NotAParquetFile) {
 }
 
 TEST_F(IceDiskCheckVersionTest, MissingVersionKey) {
-    try {
-        IceDiskUtils::checkVersionCompatibility(context, DATASET_DIR + "/nodes_noversion.parquet");
-        FAIL() << "Expected RuntimeException for missing version key";
-    } catch (const RuntimeException& e) {
-        EXPECT_TRUE(std::string(e.what()).find("missing icebug_disk_version") != std::string::npos);
-    }
+    EXPECT_NO_THROW(
+        IceDiskUtils::checkVersionCompatibility(context, DATASET_DIR + "/nodes_noversion.parquet"));
 }
 
 TEST_F(IceDiskCheckVersionTest, WrongVersionValue) {


### PR DESCRIPTION
```
# link httpfs statically into lbug
lbug -i xet://datasets/ladybugdb/small-kgs/main/kg_history/icebug-disk/schema.cypher
```

works now. But two problems remain:

- Many roundtrips opening all the files at startup. Perhaps some of it can be delayed
- queries are slow

```
lbug> match (a)-[b:followedby]->(c) return a.*, b.*, c.*;
...
(40 tuples, 20 shown)
(52 columns, 10 shown)
Time: 630.63ms (compiling), 16320.14ms (executing)
```