### PR TITLE
fix unwind merge relation issue

### DIFF
--- a/src/include/optimizer/unwind_dedup_optimizer.h
+++ b/src/include/optimizer/unwind_dedup_optimizer.h
@@ -8,11 +8,11 @@ namespace optimizer {
 
 /* When UNWIND is followed by MERGE, duplicate values in the UNWIND list can cause
  * issues because the MERGE's HASH_JOIN doesn't see newly created nodes within the same batch.
- * This optimizer inserts a UNWIND_DEDUP operator to deduplicate UNWIND output before MERGE.
+ * This optimizer inserts a UNWIND_DEDUP operator to deduplicate MERGE input rows.
  *
  * E.g., UNWIND [1, 1, 2] AS x MERGE (a:A {val: x})
  * Before: UNWIND -> HASH_JOIN (for optional match) -> MERGE
- * After:  UNWIND -> UNWIND_DEDUP -> HASH_JOIN -> MERGE
+ * After:  UNWIND -> HASH_JOIN (for optional match) -> UNWIND_DEDUP -> MERGE
  */
 class UnwindDedupOptimizer : public LogicalOperatorVisitor {
 public:
@@ -20,10 +20,12 @@ public:
 
 private:
     std::shared_ptr<planner::LogicalOperator> visitOperator(
-        const std::shared_ptr<planner::LogicalOperator>& op);
+        const std::shared_ptr<planner::LogicalOperator>& op, bool isRoot = false);
 
     std::shared_ptr<planner::LogicalOperator> visitMergeReplace(
         std::shared_ptr<planner::LogicalOperator> op) override;
+
+    bool canRewriteCurrentMerge = false;
 };
 
 } // namespace optimizer

--- a/src/include/planner/operator/logical_unwind_deduplicate.h
+++ b/src/include/planner/operator/logical_unwind_deduplicate.h
@@ -10,22 +10,22 @@ class LogicalUnwindDeduplicate final : public LogicalOperator {
 
 public:
     LogicalUnwindDeduplicate(std::shared_ptr<LogicalOperator> child,
-        std::shared_ptr<binder::Expression> keyExpression)
-        : LogicalOperator{type_, std::move(child)}, keyExpression{std::move(keyExpression)} {}
+        binder::expression_vector keyExpressions)
+        : LogicalOperator{type_, std::move(child)}, keyExpressions{std::move(keyExpressions)} {}
 
     void computeFactorizedSchema() override;
     void computeFlatSchema() override { copyChildSchema(0); }
 
     std::string getExpressionsForPrinting() const override { return {}; }
 
-    std::shared_ptr<binder::Expression> getKeyExpression() const { return keyExpression; }
+    const binder::expression_vector& getKeyExpressions() const { return keyExpressions; }
 
     std::unique_ptr<LogicalOperator> copy() override {
-        return make_unique<LogicalUnwindDeduplicate>(children[0]->copy(), keyExpression);
+        return std::make_unique<LogicalUnwindDeduplicate>(children[0]->copy(), keyExpressions);
     }
 
 private:
-    std::shared_ptr<binder::Expression> keyExpression;
+    binder::expression_vector keyExpressions;
 };
 
 } // namespace planner

--- a/src/include/processor/operator/unwind_dedup.h
+++ b/src/include/processor/operator/unwind_dedup.h
@@ -19,22 +19,24 @@ class UnwindDedup final : public PhysicalOperator {
     static constexpr PhysicalOperatorType type_ = PhysicalOperatorType::UNWIND_DEDUP;
 
 public:
-    UnwindDedup(DataPos keyDataPos, std::unique_ptr<PhysicalOperator> child, uint32_t id,
+        UnwindDedup(std::vector<DataPos> keyDataPositions, std::unique_ptr<PhysicalOperator> child,
+                uint32_t id,
         std::unique_ptr<OPPrintInfo> printInfo)
         : PhysicalOperator{type_, std::move(child), id, std::move(printInfo)},
-          keyDataPos{keyDataPos} {}
+                    keyDataPositions{std::move(keyDataPositions)} {}
 
     bool getNextTuplesInternal(ExecutionContext* context) override;
 
     void initLocalStateInternal(ResultSet* resultSet, ExecutionContext* context) override;
 
     std::unique_ptr<PhysicalOperator> copy() override {
-        return make_unique<UnwindDedup>(keyDataPos, children[0]->copy(), id, printInfo->copy());
+        return make_unique<UnwindDedup>(keyDataPositions, children[0]->copy(), id,
+            printInfo->copy());
     }
 
 private:
-    DataPos keyDataPos;
-    common::ValueVector* keyVector = nullptr;
+    std::vector<DataPos> keyDataPositions;
+    std::vector<common::ValueVector*> keyVectors;
     std::unordered_set<common::hash_t> seenHashes;
 };
 

--- a/src/include/processor/operator/unwind_dedup.h
+++ b/src/include/processor/operator/unwind_dedup.h
@@ -19,11 +19,10 @@ class UnwindDedup final : public PhysicalOperator {
     static constexpr PhysicalOperatorType type_ = PhysicalOperatorType::UNWIND_DEDUP;
 
 public:
-        UnwindDedup(std::vector<DataPos> keyDataPositions, std::unique_ptr<PhysicalOperator> child,
-                uint32_t id,
-        std::unique_ptr<OPPrintInfo> printInfo)
+    UnwindDedup(std::vector<DataPos> keyDataPositions, std::unique_ptr<PhysicalOperator> child,
+        uint32_t id, std::unique_ptr<OPPrintInfo> printInfo)
         : PhysicalOperator{type_, std::move(child), id, std::move(printInfo)},
-                    keyDataPositions{std::move(keyDataPositions)} {}
+          keyDataPositions{std::move(keyDataPositions)} {}
 
     bool getNextTuplesInternal(ExecutionContext* context) override;
 

--- a/src/optimizer/unwind_dedup_optimizer.cpp
+++ b/src/optimizer/unwind_dedup_optimizer.cpp
@@ -1,6 +1,5 @@
 #include "optimizer/unwind_dedup_optimizer.h"
 
-#include "binder/expression_visitor.h"
 #include "planner/operator/logical_hash_join.h"
 #include "planner/operator/logical_unwind.h"
 #include "planner/operator/logical_unwind_deduplicate.h"
@@ -42,20 +41,15 @@ static std::shared_ptr<LogicalUnwind> findUnwind(std::shared_ptr<LogicalOperator
     return nullptr;
 }
 
-static binder::expression_vector getDedupKeyExpressions(const LogicalOperator& probeChild,
-    const std::shared_ptr<binder::Expression>& unwindExpr) {
+static binder::expression_vector getDedupKeyExpressions(const LogicalMerge& merge,
+    const LogicalOperator& probeChild) {
     auto schema = probeChild.getSchema();
-    if (schema->isExpressionInScope(*unwindExpr)) {
-        return {unwindExpr};
-    }
     binder::expression_vector result;
-    auto unwindName = unwindExpr->getUniqueName();
-    for (auto& expr : schema->getExpressionsInScope()) {
-        binder::DependentVarNameCollector collector;
-        collector.visit(expr);
-        if (collector.getVarNames().contains(unwindName)) {
-            result.push_back(expr);
+    for (auto& key : merge.getKeys()) {
+        if (!schema->isExpressionInScope(*key)) {
+            return {};
         }
+        result.push_back(key);
     }
     return result;
 }
@@ -96,7 +90,7 @@ std::shared_ptr<LogicalOperator> UnwindDedupOptimizer::visitMergeReplace(
     }
 
     if (unwind != nullptr) {
-        auto keyExpressions = getDedupKeyExpressions(*probeChild, unwind->getOutExpr());
+        auto keyExpressions = getDedupKeyExpressions(*merge, *probeChild);
         if (keyExpressions.empty()) {
             return op;
         }

--- a/src/optimizer/unwind_dedup_optimizer.cpp
+++ b/src/optimizer/unwind_dedup_optimizer.cpp
@@ -101,8 +101,8 @@ std::shared_ptr<LogicalOperator> UnwindDedupOptimizer::visitMergeReplace(
             return op;
         }
         // Wrap the probe child with UNWIND_DEDUP
-        auto dedup = std::make_shared<LogicalUnwindDeduplicate>(probeChild,
-            std::move(keyExpressions));
+        auto dedup =
+            std::make_shared<LogicalUnwindDeduplicate>(probeChild, std::move(keyExpressions));
         dedup->computeFlatSchema();
         hashJoin->setChild(0, dedup);
         return op;

--- a/src/optimizer/unwind_dedup_optimizer.cpp
+++ b/src/optimizer/unwind_dedup_optimizer.cpp
@@ -1,5 +1,8 @@
 #include "optimizer/unwind_dedup_optimizer.h"
 
+#include <unordered_set>
+
+#include "binder/expression/rel_expression.h"
 #include "planner/operator/logical_hash_join.h"
 #include "planner/operator/logical_unwind.h"
 #include "planner/operator/logical_unwind_deduplicate.h"
@@ -12,16 +15,19 @@ namespace lbug {
 namespace optimizer {
 
 void UnwindDedupOptimizer::rewrite(LogicalPlan* plan) {
-    visitOperator(plan->getLastOperator());
+    visitOperator(plan->getLastOperator(), true /* isRoot */);
 }
 
 std::shared_ptr<LogicalOperator> UnwindDedupOptimizer::visitOperator(
-    const std::shared_ptr<LogicalOperator>& op) {
+    const std::shared_ptr<LogicalOperator>& op, bool isRoot) {
     // bottom-up traversal
     for (auto i = 0u; i < op->getNumChildren(); ++i) {
-        op->setChild(i, visitOperator(op->getChild(i)));
+        op->setChild(i, visitOperator(op->getChild(i), false /* isRoot */));
     }
+    auto canRewriteParentMerge = canRewriteCurrentMerge;
+    canRewriteCurrentMerge = isRoot;
     auto result = visitOperatorReplaceSwitch(op);
+    canRewriteCurrentMerge = canRewriteParentMerge;
     result->computeFlatSchema();
     return result;
 }
@@ -41,15 +47,36 @@ static std::shared_ptr<LogicalUnwind> findUnwind(std::shared_ptr<LogicalOperator
     return nullptr;
 }
 
+static bool appendKeyIfInScope(binder::expression_vector& keys,
+    std::unordered_set<std::string>& names, const LogicalOperator& op,
+    const std::shared_ptr<binder::Expression>& key) {
+    auto schema = op.getSchema();
+    if (!schema->isExpressionInScope(*key)) {
+        return false;
+    }
+    if (names.insert(key->getUniqueName()).second) {
+        keys.push_back(key);
+    }
+    return true;
+}
+
 static binder::expression_vector getDedupKeyExpressions(const LogicalMerge& merge,
-    const LogicalOperator& probeChild) {
-    auto schema = probeChild.getSchema();
+    const LogicalOperator& op) {
     binder::expression_vector result;
+    std::unordered_set<std::string> keyNames;
     for (auto& key : merge.getKeys()) {
-        if (!schema->isExpressionInScope(*key)) {
+        if (!appendKeyIfInScope(result, keyNames, op, key)) {
             return {};
         }
-        result.push_back(key);
+    }
+    for (auto& info : merge.getInsertRelInfos()) {
+        auto rel = info.pattern->constPtrCast<binder::RelExpression>();
+        if (!appendKeyIfInScope(result, keyNames, op, rel->getSrcNode()->getInternalID())) {
+            return {};
+        }
+        if (!appendKeyIfInScope(result, keyNames, op, rel->getDstNode()->getInternalID())) {
+            return {};
+        }
     }
     return result;
 }
@@ -58,6 +85,9 @@ std::shared_ptr<LogicalOperator> UnwindDedupOptimizer::visitMergeReplace(
     std::shared_ptr<LogicalOperator> op) {
     auto merge = op->ptrCast<LogicalMerge>();
     if (merge == nullptr) {
+        return op;
+    }
+    if (!canRewriteCurrentMerge && !merge->getInsertRelInfos().empty()) {
         return op;
     }
 
@@ -90,15 +120,16 @@ std::shared_ptr<LogicalOperator> UnwindDedupOptimizer::visitMergeReplace(
     }
 
     if (unwind != nullptr) {
-        auto keyExpressions = getDedupKeyExpressions(*merge, *probeChild);
+        // Place UNWIND_DEDUP after the join so MERGE keys that depend on matched nodes are in
+        // scope.
+        auto keyExpressions = getDedupKeyExpressions(*merge, *mergeChild);
         if (keyExpressions.empty()) {
             return op;
         }
-        // Wrap the probe child with UNWIND_DEDUP
         auto dedup =
-            std::make_shared<LogicalUnwindDeduplicate>(probeChild, std::move(keyExpressions));
+            std::make_shared<LogicalUnwindDeduplicate>(mergeChild, std::move(keyExpressions));
         dedup->computeFlatSchema();
-        hashJoin->setChild(0, dedup);
+        merge->setChild(0, dedup);
         return op;
     }
 

--- a/src/optimizer/unwind_dedup_optimizer.cpp
+++ b/src/optimizer/unwind_dedup_optimizer.cpp
@@ -1,5 +1,6 @@
 #include "optimizer/unwind_dedup_optimizer.h"
 
+#include "binder/expression_visitor.h"
 #include "planner/operator/logical_hash_join.h"
 #include "planner/operator/logical_unwind.h"
 #include "planner/operator/logical_unwind_deduplicate.h"
@@ -41,6 +42,24 @@ static std::shared_ptr<LogicalUnwind> findUnwind(std::shared_ptr<LogicalOperator
     return nullptr;
 }
 
+static binder::expression_vector getDedupKeyExpressions(const LogicalOperator& probeChild,
+    const std::shared_ptr<binder::Expression>& unwindExpr) {
+    auto schema = probeChild.getSchema();
+    if (schema->isExpressionInScope(*unwindExpr)) {
+        return {unwindExpr};
+    }
+    binder::expression_vector result;
+    auto unwindName = unwindExpr->getUniqueName();
+    for (auto& expr : schema->getExpressionsInScope()) {
+        binder::DependentVarNameCollector collector;
+        collector.visit(expr);
+        if (collector.getVarNames().contains(unwindName)) {
+            result.push_back(expr);
+        }
+    }
+    return result;
+}
+
 std::shared_ptr<LogicalOperator> UnwindDedupOptimizer::visitMergeReplace(
     std::shared_ptr<LogicalOperator> op) {
     auto merge = op->ptrCast<LogicalMerge>();
@@ -77,8 +96,13 @@ std::shared_ptr<LogicalOperator> UnwindDedupOptimizer::visitMergeReplace(
     }
 
     if (unwind != nullptr) {
+        auto keyExpressions = getDedupKeyExpressions(*probeChild, unwind->getOutExpr());
+        if (keyExpressions.empty()) {
+            return op;
+        }
         // Wrap the probe child with UNWIND_DEDUP
-        auto dedup = std::make_shared<LogicalUnwindDeduplicate>(probeChild, unwind->getOutExpr());
+        auto dedup = std::make_shared<LogicalUnwindDeduplicate>(probeChild,
+            std::move(keyExpressions));
         dedup->computeFlatSchema();
         hashJoin->setChild(0, dedup);
         return op;

--- a/src/processor/map/map_unwind_dedup.cpp
+++ b/src/processor/map/map_unwind_dedup.cpp
@@ -20,8 +20,8 @@ std::unique_ptr<PhysicalOperator> PlanMapper::mapUnwindDedup(
         keyDataPositions.emplace_back(outSchema->getExpressionPos(*expr));
     }
     auto printInfo = std::make_unique<UnwindDedupPrintInfo>();
-    return std::make_unique<UnwindDedup>(std::move(keyDataPositions),
-        std::move(prevOperator), getOperatorID(), std::move(printInfo));
+    return std::make_unique<UnwindDedup>(std::move(keyDataPositions), std::move(prevOperator),
+        getOperatorID(), std::move(printInfo));
 }
 
 } // namespace processor

--- a/src/processor/map/map_unwind_dedup.cpp
+++ b/src/processor/map/map_unwind_dedup.cpp
@@ -14,10 +14,14 @@ std::unique_ptr<PhysicalOperator> PlanMapper::mapUnwindDedup(
     auto& unwindDedup = logicalOperator->constCast<LogicalUnwindDeduplicate>();
     auto outSchema = unwindDedup.getSchema();
     auto prevOperator = mapOperator(logicalOperator->getChild(0).get());
-    auto keyDataPos = DataPos(outSchema->getExpressionPos(*unwindDedup.getKeyExpression()));
+    std::vector<DataPos> keyDataPositions;
+    keyDataPositions.reserve(unwindDedup.getKeyExpressions().size());
+    for (auto& expr : unwindDedup.getKeyExpressions()) {
+        keyDataPositions.emplace_back(outSchema->getExpressionPos(*expr));
+    }
     auto printInfo = std::make_unique<UnwindDedupPrintInfo>();
-    return std::make_unique<UnwindDedup>(keyDataPos, std::move(prevOperator), getOperatorID(),
-        std::move(printInfo));
+    return std::make_unique<UnwindDedup>(std::move(keyDataPositions),
+        std::move(prevOperator), getOperatorID(), std::move(printInfo));
 }
 
 } // namespace processor

--- a/src/processor/operator/unwind_dedup.cpp
+++ b/src/processor/operator/unwind_dedup.cpp
@@ -13,7 +13,11 @@ namespace lbug {
 namespace processor {
 
 void UnwindDedup::initLocalStateInternal(ResultSet* resultSet, ExecutionContext* /*context*/) {
-    keyVector = resultSet->getValueVector(keyDataPos).get();
+    keyVectors.clear();
+    keyVectors.reserve(keyDataPositions.size());
+    for (auto& keyDataPos : keyDataPositions) {
+        keyVectors.push_back(resultSet->getValueVector(keyDataPos).get());
+    }
 }
 
 bool UnwindDedup::getNextTuplesInternal(ExecutionContext* context) {
@@ -23,15 +27,28 @@ bool UnwindDedup::getNextTuplesInternal(ExecutionContext* context) {
         }
 
         // Compute hash for the key vector
-        const auto& selVector = keyVector->state->getSelVector();
+        DASSERT(!keyVectors.empty());
+        const auto& selVector = keyVectors[0]->state->getSelVector();
         if (selVector.getSelSize() == 0) {
             continue;
         }
 
         auto hashVector = std::make_unique<ValueVector>(LogicalType::HASH(),
             MemoryManager::Get(*context->clientContext));
-        hashVector->state = keyVector->state;
-        VectorHashFunction::computeHash(*keyVector, selVector, *hashVector, selVector);
+        hashVector->state = keyVectors[0]->state;
+        VectorHashFunction::computeHash(*keyVectors[0], selVector, *hashVector, selVector);
+        if (keyVectors.size() > 1) {
+            auto tmpHashVector = std::make_unique<ValueVector>(LogicalType::HASH(),
+                MemoryManager::Get(*context->clientContext));
+            tmpHashVector->state = keyVectors[0]->state;
+            for (auto i = 1u; i < keyVectors.size(); ++i) {
+                DASSERT(keyVectors[i]->state == keyVectors[0]->state);
+                VectorHashFunction::computeHash(*keyVectors[i], selVector, *tmpHashVector,
+                    selVector);
+                VectorHashFunction::combineHash(*hashVector, selVector, *tmpHashVector, selVector,
+                    *hashVector, selVector);
+            }
+        }
 
         // Filter out duplicate values by modifying the selection vector
         auto hashData = reinterpret_cast<hash_t*>(hashVector->getData());
@@ -50,7 +67,7 @@ bool UnwindDedup::getNextTuplesInternal(ExecutionContext* context) {
 
         if (newSelSize > 0) {
             // Update the selection vector to only include non-duplicate values
-            auto& selVectorUnsafe = keyVector->state->getSelVectorUnsafe();
+            auto& selVectorUnsafe = keyVectors[0]->state->getSelVectorUnsafe();
             selVectorUnsafe.setToFiltered(newSelSize);
             auto buffer = selVectorUnsafe.getMutableBuffer();
             for (auto i = 0u; i < newSelSize; i++) {

--- a/test/test_files/issue/issue.test
+++ b/test/test_files/issue/issue.test
@@ -698,6 +698,35 @@ alice
 ---- 1
 2
 
+-CASE unwind_merge_rel_after_rel_match_dedup
+-STATEMENT CREATE NODE TABLE MergePerson(id INT64 PRIMARY KEY);
+---- ok
+-STATEMENT CREATE REL TABLE MergeSeed(FROM MergePerson TO MergePerson);
+---- ok
+-STATEMENT CREATE REL TABLE MergeKnows(FROM MergePerson TO MergePerson, comment STRING);
+---- ok
+-STATEMENT CREATE (:MergePerson {id:0}), (:MergePerson {id:1}), (:MergePerson {id:2}), (:MergePerson {id:3});
+---- ok
+-STATEMENT MATCH (a:MergePerson {id:0}), (b:MergePerson)
+        WHERE b.id > 0
+        CREATE (a)-[:MergeSeed]->(b);
+---- ok
+-STATEMENT MATCH (a:MergePerson)-[:MergeSeed]->(b:MergePerson)
+        WHERE a.id = 0
+        UNWIND [1,2] AS x
+        MERGE (a)-[e:MergeKnows {comment:'h'}]->(b)
+        RETURN e.comment;
+---- 6
+h
+h
+h
+h
+h
+h
+-STATEMENT MATCH (:MergePerson)-[:MergeKnows]->(:MergePerson) RETURN COUNT(*);
+---- 1
+3
+
 -CASE 5817
 -STATEMENT CREATE NODE TABLE N(id SERIAL PRIMARY KEY);
 ---- ok

--- a/test/test_files/issue/issue.test
+++ b/test/test_files/issue/issue.test
@@ -676,6 +676,28 @@ alice
 ---- 1
 2
 
+-CASE unwind_merge_with_projection_preserves_match_expansion
+-STATEMENT CREATE NODE TABLE Person2(id STRING PRIMARY KEY, age INT64);
+---- ok
+-STATEMENT CREATE NODE TABLE Department2(id STRING PRIMARY KEY);
+---- ok
+-STATEMENT CREATE REL TABLE Person2_belongsTo_Department2(FROM Person2 TO Department2);
+---- ok
+-STATEMENT CREATE (:Person2 {id:'p1', age:42});
+---- ok
+-STATEMENT CREATE (:Person2 {id:'p2', age:42});
+---- ok
+-STATEMENT CREATE (:Department2 {id:'d1'});
+---- ok
+-STATEMENT UNWIND [{age:42,dept_id:'d1'}] AS row
+        WITH row.age AS age, row.dept_id AS dept_id
+        MATCH (p:Person2 {age: age}), (d:Department2 {id: dept_id})
+        MERGE (p)-[:Person2_belongsTo_Department2]->(d);
+---- ok
+-STATEMENT MATCH (:Person2)-[:Person2_belongsTo_Department2]->(:Department2) RETURN COUNT(*);
+---- 1
+2
+
 -CASE 5817
 -STATEMENT CREATE NODE TABLE N(id SERIAL PRIMARY KEY);
 ---- ok

--- a/test/test_files/issue/issue.test
+++ b/test/test_files/issue/issue.test
@@ -652,6 +652,30 @@ alice
 {_ID: 0:0, _LABEL: Node, id: 0, cities: [Old York,Los Angeles]}
 {_ID: 0:1, _LABEL: Node, id: 1, cities: [Tokyo,Osaka]}
 
+-CASE unwind_merge_with_projection_dedup
+-STATEMENT CREATE NODE TABLE Person(id STRING PRIMARY KEY, name STRING, age INT64, department STRING);
+---- ok
+-STATEMENT CREATE NODE TABLE Department(id STRING PRIMARY KEY, name STRING, headcount INT64);
+---- ok
+-STATEMENT CREATE REL TABLE Person_belongsTo_Department(FROM Person TO Department);
+---- ok
+-STATEMENT CREATE (:Person {id:'p008', name:'a', age:1, department:'x'});
+---- ok
+-STATEMENT CREATE (:Person {id:'p009', name:'b', age:1, department:'x'});
+---- ok
+-STATEMENT CREATE (:Department {id:'d002', name:'d2', headcount:1});
+---- ok
+-STATEMENT CREATE (:Department {id:'d003', name:'d3', headcount:1});
+---- ok
+-STATEMENT UNWIND [{person_id:'p008',dept_id:'d002'},{person_id:'p008',dept_id:'d002'},{person_id:'p009',dept_id:'d003'}] AS row
+        WITH row.person_id AS person_id, row.dept_id AS dept_id
+        MATCH (p:Person {id: person_id}), (d:Department {id: dept_id})
+        MERGE (p)-[:Person_belongsTo_Department]->(d);
+---- ok
+-STATEMENT MATCH (:Person)-[:Person_belongsTo_Department]->(:Department) RETURN COUNT(*);
+---- 1
+2
+
 -CASE 5817
 -STATEMENT CREATE NODE TABLE N(id SERIAL PRIMARY KEY);
 ---- ok


### PR DESCRIPTION
  src/optimizer/unwind_dedup_optimizer.cpp:45
  Blocking correctness concern: the dedup key is inferred as “all expressions in the probe schema that depend on the unwind variable”, not the actual `MERGE` identity. That can drop legitimate rows when one input row expands to multiple matched nodes.

  Example shape:

```
  UNWIND [{age: 1, dept_id: 'd'}] AS row
  WITH row.age AS age, row.dept_id AS dept_id
  MATCH (p:Person {age: age}), (d:Department {id: dept_id})
  MERGE (p)-[:R]->(d)
```

 If two Person nodes have `age = 1`, this should create two relationships.  The buggy UNWIND_DEDUP operator creates only one relationship because of the dedup key structure.
  
 Fixed by placing the dedup where the actual merge identity is available.