### PR TITLE
Support proxy env for extension downloads

### DIFF
--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -34,6 +34,20 @@ make extension-debug
 make extension-release
 ```
 
+## Installing Through a Proxy
+
+Extension downloads use proxy settings from environment variables. Ladybug-specific variables take
+priority over standard proxy variables:
+
+- `LADYBUG_HTTP_PROXY` for `http://` extension repositories
+- `LADYBUG_HTTPS_PROXY` for `https://` extension repositories
+- `LADYBUG_ALL_PROXY` as a fallback
+- `LADYBUG_NO_PROXY` to bypass the proxy for matching hosts
+
+Standard `http_proxy`, `https_proxy`, `all_proxy`, and `no_proxy` variables are also supported, along
+with their uppercase variants. Proxy values may include basic auth, for example
+`http://user:pass@proxy.example.com:8080`.
+
 ## Testing Extensions
 
 ```bash

--- a/src/extension/extension.cpp
+++ b/src/extension/extension.cpp
@@ -1,12 +1,13 @@
 #include "extension/extension.h"
 
+#include <cstdlib>
+
 #include "common/exception/io.h"
 #include "common/string_utils.h"
 #include "common/system_message.h"
 #include "main/client_context.h"
 #include "main/database.h"
 #include "storage/storage_manager.h"
-
 #ifdef _WIN32
 
 #include "windows.h"
@@ -21,6 +22,104 @@
 
 namespace lbug {
 namespace extension {
+
+namespace {
+
+struct ParsedURL {
+    std::string scheme;
+    std::string host;
+    int port = -1;
+};
+
+std::string getEnv(const char* name) {
+    const auto value = std::getenv(name); // NOLINT(*-mt-unsafe)
+    return value == nullptr ? "" : value;
+}
+
+std::string getProxyEnv(std::initializer_list<const char*> names) {
+    for (auto name : names) {
+        auto value = getEnv(name);
+        if (!value.empty()) {
+            return value;
+        }
+    }
+    return "";
+}
+
+int parsePort(const std::string& port) {
+    try {
+        auto parsedPort = std::stoi(port);
+        return parsedPort > 0 && parsedPort <= 65535 ? parsedPort : -1;
+    } catch (...) {
+        return -1;
+    }
+}
+
+ParsedURL parseURL(std::string url) {
+    ParsedURL result;
+    auto schemeEnd = url.find("://");
+    if (schemeEnd != std::string::npos) {
+        result.scheme = common::StringUtils::getLower(url.substr(0, schemeEnd));
+        url = url.substr(schemeEnd + 3);
+    }
+    auto pathStart = url.find_first_of("/?#");
+    if (pathStart != std::string::npos) {
+        url = url.substr(0, pathStart);
+    }
+    auto atPos = url.rfind('@');
+    if (atPos != std::string::npos) {
+        url = url.substr(atPos + 1);
+    }
+    if (url.starts_with('[')) {
+        auto bracketEnd = url.find(']');
+        if (bracketEnd != std::string::npos) {
+            result.host = url.substr(1, bracketEnd - 1);
+            if (bracketEnd + 1 < url.size() && url[bracketEnd + 1] == ':') {
+                result.port = parsePort(url.substr(bracketEnd + 2));
+            }
+        }
+        return result;
+    }
+    auto portPos = url.rfind(':');
+    if (portPos != std::string::npos && url.find(':') == portPos) {
+        result.host = url.substr(0, portPos);
+        result.port = parsePort(url.substr(portPos + 1));
+    } else {
+        result.host = url;
+    }
+    return result;
+}
+
+bool noProxyMatches(std::string noProxy, const ParsedURL& target) {
+    auto targetHost = common::StringUtils::getLower(target.host);
+    while (!noProxy.empty()) {
+        auto commaPos = noProxy.find(',');
+        auto entry = commaPos == std::string::npos ? noProxy : noProxy.substr(0, commaPos);
+        entry = common::StringUtils::ltrim(common::StringUtils::rtrim(entry));
+        entry = common::StringUtils::getLower(entry);
+        if (entry == "*") {
+            return true;
+        }
+        if (entry.starts_with('.')) {
+            if (targetHost.ends_with(entry)) {
+                return true;
+            }
+        } else {
+            auto entryHost = parseURL(entry).host;
+            entryHost = common::StringUtils::getLower(entryHost);
+            if (targetHost == entryHost || targetHost.ends_with("." + entryHost)) {
+                return true;
+            }
+        }
+        if (commaPos == std::string::npos) {
+            break;
+        }
+        noProxy = noProxy.substr(commaPos + 1);
+    }
+    return false;
+}
+
+} // namespace
 
 std::string getOS() {
     std::string os = "linux";
@@ -102,6 +201,56 @@ ExtensionRepoInfo ExtensionUtils::getSharedLibRepoInfo(const std::string& fileNa
     auto extensionURL = std::format(SHARED_LIB_REPO, extensionRepo, LBUG_EXTENSION_VERSION,
         getPlatform(), fileName);
     return getExtensionRepoInfo(extensionURL);
+}
+
+std::optional<ExtensionProxyConfig> ExtensionUtils::parseProxyConfig(const std::string& proxyURL) {
+    auto parsedURL = parseURL(proxyURL);
+    if (parsedURL.host.empty()) {
+        return std::nullopt;
+    }
+    ExtensionProxyConfig config{parsedURL.host, parsedURL.port == -1 ? 80 : parsedURL.port, "", ""};
+    auto authority = proxyURL;
+    auto schemeEnd = authority.find("://");
+    if (schemeEnd != std::string::npos) {
+        authority = authority.substr(schemeEnd + 3);
+    }
+    auto pathStart = authority.find_first_of("/?#");
+    if (pathStart != std::string::npos) {
+        authority = authority.substr(0, pathStart);
+    }
+    auto atPos = authority.rfind('@');
+    if (atPos != std::string::npos) {
+        auto userInfo = authority.substr(0, atPos);
+        auto passwordPos = userInfo.find(':');
+        if (passwordPos == std::string::npos) {
+            config.username = userInfo;
+        } else {
+            config.username = userInfo.substr(0, passwordPos);
+            config.password = userInfo.substr(passwordPos + 1);
+        }
+    }
+    return config;
+}
+
+std::optional<ExtensionProxyConfig> ExtensionUtils::getProxyConfigForURL(const std::string& url) {
+    auto targetURL = parseURL(url);
+    if (targetURL.host.empty()) {
+        return std::nullopt;
+    }
+    auto noProxy = getProxyEnv({"LADYBUG_NO_PROXY", "no_proxy", "NO_PROXY"});
+    if (!noProxy.empty() && noProxyMatches(noProxy, targetURL)) {
+        return std::nullopt;
+    }
+    std::string proxyURL;
+    if (targetURL.scheme == "https") {
+        proxyURL = getProxyEnv({"LADYBUG_HTTPS_PROXY", "https_proxy", "HTTPS_PROXY"});
+    } else {
+        proxyURL = getProxyEnv({"LADYBUG_HTTP_PROXY", "http_proxy", "HTTP_PROXY"});
+    }
+    if (proxyURL.empty()) {
+        proxyURL = getProxyEnv({"LADYBUG_ALL_PROXY", "all_proxy", "ALL_PROXY"});
+    }
+    return proxyURL.empty() ? std::nullopt : parseProxyConfig(proxyURL);
 }
 
 std::string ExtensionUtils::getExtensionFileName(const std::string& name) {

--- a/src/extension/extension_installer.cpp
+++ b/src/extension/extension_installer.cpp
@@ -9,9 +9,30 @@
 namespace lbug {
 namespace extension {
 
+namespace {
+
+void applyProxyConfig(httplib::Client& client, const ExtensionRepoInfo& repoInfo) {
+    auto proxyConfig = ExtensionUtils::getProxyConfigForURL(repoInfo.hostURL);
+    if (!proxyConfig) {
+        return;
+    }
+    client.set_proxy(proxyConfig->host, proxyConfig->port);
+    if (!proxyConfig->username.empty()) {
+        client.set_proxy_basic_auth(proxyConfig->username, proxyConfig->password);
+    }
+}
+
+httplib::Client createExtensionDownloadClient(const ExtensionRepoInfo& repoInfo) {
+    httplib::Client client(repoInfo.hostURL.c_str());
+    applyProxyConfig(client, repoInfo);
+    return client;
+}
+
+} // namespace
+
 void ExtensionInstaller::tryDownloadExtensionFile(const ExtensionRepoInfo& repoInfo,
     const std::string& localFilePath) {
-    httplib::Client cli(repoInfo.hostURL.c_str());
+    auto cli = createExtensionDownloadClient(repoInfo);
     httplib::Headers headers = {{"User-Agent", std::format("lbug/v{}", LBUG_EXTENSION_VERSION)}};
     auto res = cli.Get(repoInfo.hostPath.c_str(), headers);
     if (!res || res->status != 200) {
@@ -74,7 +95,7 @@ bool ExtensionInstaller::installExtension() {
 
 void ExtensionInstaller::installDependencies() {
     auto extensionRepoInfo = ExtensionUtils::getExtensionInstallerRepoInfo(info.name, info.repo);
-    httplib::Client cli(extensionRepoInfo.hostURL.c_str());
+    auto cli = createExtensionDownloadClient(extensionRepoInfo);
     httplib::Headers headers = {{"User-Agent", std::format("lbug/v{}", LBUG_EXTENSION_VERSION)}};
     auto res = cli.Get(extensionRepoInfo.hostPath.c_str(), headers);
     if (!res || res->status != 200) {

--- a/src/include/extension/extension.h
+++ b/src/include/extension/extension.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <optional>
+
 #include "catalog/catalog.h"
 #include "catalog/catalog_entry/catalog_entry_type.h"
 #include "common/api.h"
@@ -38,6 +40,13 @@ struct ExtensionRepoInfo {
     std::string hostPath;
     std::string hostURL;
     std::string repoURL;
+};
+
+struct ExtensionProxyConfig {
+    std::string host;
+    int port;
+    std::string username;
+    std::string password;
 };
 
 enum class ExtensionSource : uint8_t { OFFICIAL, USER, STATIC_LINKED };
@@ -86,6 +95,10 @@ struct LBUG_API ExtensionUtils {
 
     static ExtensionRepoInfo getSharedLibRepoInfo(const std::string& fileName,
         const std::string& extensionRepo);
+
+    static std::optional<ExtensionProxyConfig> getProxyConfigForURL(const std::string& url);
+
+    static std::optional<ExtensionProxyConfig> parseProxyConfig(const std::string& proxyURL);
 
     static std::string getExtensionFileName(const std::string& name);
 

--- a/test/common/CMakeLists.txt
+++ b/test/common/CMakeLists.txt
@@ -2,6 +2,7 @@ add_lbug_test(types_test
         int128_test.cpp
         uint128_test.cpp
         date_test.cpp
+        extension_proxy_test.cpp
         interval_test.cpp
         null_mask_test.cpp
         string_test.cpp

--- a/test/common/extension_proxy_test.cpp
+++ b/test/common/extension_proxy_test.cpp
@@ -1,0 +1,112 @@
+#include <cstdlib>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "extension/extension.h"
+#include "gtest/gtest.h"
+
+#ifdef _WIN32
+#include <stdlib.h>
+#endif
+
+using namespace lbug::extension;
+
+namespace {
+
+const std::vector<std::string> PROXY_ENV_VARS = {"LADYBUG_HTTP_PROXY", "LADYBUG_HTTPS_PROXY",
+    "LADYBUG_ALL_PROXY", "LADYBUG_NO_PROXY", "http_proxy", "HTTP_PROXY", "https_proxy",
+    "HTTPS_PROXY", "all_proxy", "ALL_PROXY", "no_proxy", "NO_PROXY"};
+
+void setEnv(const std::string& key, const std::string& value) {
+#ifdef _WIN32
+    _putenv_s(key.c_str(), value.c_str());
+#else
+    setenv(key.c_str(), value.c_str(), 1);
+#endif
+}
+
+void unsetEnv(const std::string& key) {
+#ifdef _WIN32
+    _putenv_s(key.c_str(), "");
+#else
+    unsetenv(key.c_str());
+#endif
+}
+
+class ScopedProxyEnv {
+public:
+    ScopedProxyEnv() {
+        for (auto& key : PROXY_ENV_VARS) {
+            const auto value = std::getenv(key.c_str()); // NOLINT(*-mt-unsafe)
+            savedEnv.push_back(value == nullptr ? std::nullopt : std::optional<std::string>{value});
+            unsetEnv(key);
+        }
+    }
+
+    ~ScopedProxyEnv() {
+        for (auto i = 0u; i < PROXY_ENV_VARS.size(); ++i) {
+            if (savedEnv[i]) {
+                setEnv(PROXY_ENV_VARS[i], *savedEnv[i]);
+            } else {
+                unsetEnv(PROXY_ENV_VARS[i]);
+            }
+        }
+    }
+
+private:
+    std::vector<std::optional<std::string>> savedEnv;
+};
+
+} // namespace
+
+TEST(ExtensionProxyTest, ParseProxyURLWithAuth) {
+    auto config = ExtensionUtils::parseProxyConfig("http://user:pass@proxy.example.com:8080");
+    ASSERT_TRUE(config.has_value());
+    EXPECT_EQ(config->host, "proxy.example.com");
+    EXPECT_EQ(config->port, 8080);
+    EXPECT_EQ(config->username, "user");
+    EXPECT_EQ(config->password, "pass");
+}
+
+TEST(ExtensionProxyTest, ParseProxyURLWithoutSchemeUsesDefaultPort) {
+    auto config = ExtensionUtils::parseProxyConfig("proxy.example.com");
+    ASSERT_TRUE(config.has_value());
+    EXPECT_EQ(config->host, "proxy.example.com");
+    EXPECT_EQ(config->port, 80);
+    EXPECT_TRUE(config->username.empty());
+    EXPECT_TRUE(config->password.empty());
+}
+
+TEST(ExtensionProxyTest, UsesLadybugHTTPProxyForHTTPURLs) {
+    ScopedProxyEnv env;
+    setEnv("LADYBUG_HTTP_PROXY", "http://proxy.example.com:8080");
+
+    auto config = ExtensionUtils::getProxyConfigForURL("http://extension.ladybugdb.com");
+
+    ASSERT_TRUE(config.has_value());
+    EXPECT_EQ(config->host, "proxy.example.com");
+    EXPECT_EQ(config->port, 8080);
+}
+
+TEST(ExtensionProxyTest, UsesLadybugHTTPSProxyForHTTPSURLs) {
+    ScopedProxyEnv env;
+    setEnv("LADYBUG_HTTPS_PROXY", "https-proxy.example.com:8443");
+    setEnv("LADYBUG_HTTP_PROXY", "http-proxy.example.com:8080");
+
+    auto config = ExtensionUtils::getProxyConfigForURL("https://extension.ladybugdb.com");
+
+    ASSERT_TRUE(config.has_value());
+    EXPECT_EQ(config->host, "https-proxy.example.com");
+    EXPECT_EQ(config->port, 8443);
+}
+
+TEST(ExtensionProxyTest, NoProxyBypassesProxy) {
+    ScopedProxyEnv env;
+    setEnv("LADYBUG_HTTP_PROXY", "proxy.example.com:8080");
+    setEnv("LADYBUG_NO_PROXY", ".ladybugdb.com");
+
+    auto config = ExtensionUtils::getProxyConfigForURL("http://extension.ladybugdb.com");
+
+    EXPECT_FALSE(config.has_value());
+}


### PR DESCRIPTION
Fixes: #415 

## Summary
- read Ladybug-specific and standard proxy environment variables for extension downloads
- apply the resolved proxy settings to httplib clients used for extension libraries and installers
- document the supported variables and add focused proxy parsing/env selection tests

## Root Cause
Ladybug used httplib directly for extension downloads, but did not pass proxy settings into the client. httplib supports proxies through set_proxy, but it does not automatically consume process proxy environment variables.

## Validation
- cmake --build build/release --target types_test
- build/release/test/common/types_test '--gtest_filter=ExtensionProxyTest.*'
- git diff --check