### PR TITLE
Optimize LiveJournal degree count queries

### DIFF
--- a/src/binder/bind/bind_graph_pattern.cpp
+++ b/src/binder/bind/bind_graph_pattern.cpp
@@ -119,7 +119,7 @@ std::shared_ptr<Expression> Binder::createPath(const std::string& pathName,
 
 static std::vector<std::string> getPropertyNames(const std::vector<TableCatalogEntry*>& entries) {
     std::vector<std::string> result;
-    std::unordered_set<std::string> propertyNamesSet;
+    case_insensitve_set_t propertyNamesSet;
     for (auto& entry : entries) {
         for (auto& property : entry->getProperties()) {
             if (propertyNamesSet.contains(property.getName())) {

--- a/src/include/optimizer/count_rel_table_optimizer.h
+++ b/src/include/optimizer/count_rel_table_optimizer.h
@@ -4,6 +4,11 @@
 #include "planner/operator/logical_plan.h"
 
 namespace lbug {
+namespace binder {
+class Expression;
+class NodeExpression;
+class RelExpression;
+} // namespace binder
 namespace main {
 class ClientContext;
 }
@@ -15,7 +20,7 @@ namespace optimizer {
  * without any filters, and replaces the scan + aggregate with a direct count from table metadata.
  *
  * Pattern detected:
- *   AGGREGATE (COUNT_STAR only, no keys) →
+ *   AGGREGATE (COUNT_STAR or COUNT(rel), no keys) →
  *   PROJECTION (empty or pass-through) →
  *   EXTEND (single rel table) →
  *   SCAN_NODE_TABLE
@@ -35,12 +40,26 @@ private:
 
     std::shared_ptr<planner::LogicalOperator> visitAggregateReplace(
         std::shared_ptr<planner::LogicalOperator> op) override;
+    std::shared_ptr<planner::LogicalOperator> visitOrderByReplace(
+        std::shared_ptr<planner::LogicalOperator> op) override;
 
-    // Check if the aggregate is a simple COUNT(*) with no keys
-    bool isSimpleCountStar(planner::LogicalOperator* op) const;
+    // Check if the aggregate is a simple COUNT(*) or COUNT(expr) with no keys.
+    bool isSimpleCount(planner::LogicalOperator* op) const;
+
+    bool isCountStar(planner::LogicalOperator* op) const;
+    bool isCountRelID(planner::LogicalOperator* op, const binder::RelExpression& rel) const;
+    bool isDistinctCountNodeKey(planner::LogicalOperator* op,
+        const std::shared_ptr<binder::Expression>& nodeKey) const;
+    bool isCountNbr(planner::LogicalOperator* op, const binder::NodeExpression& nbr) const;
+    bool isRelIDExpression(const std::shared_ptr<binder::Expression>& expression,
+        const binder::RelExpression& rel) const;
 
     // Check if the plan below aggregate matches the pattern for optimization
     bool canOptimize(planner::LogicalOperator* aggregate) const;
+    std::shared_ptr<planner::LogicalOperator> tryRewriteActiveBoundCount(
+        std::shared_ptr<planner::LogicalOperator> op);
+    std::shared_ptr<planner::LogicalOperator> tryRewriteDegreeTopK(
+        std::shared_ptr<planner::LogicalOperator> op);
 
     [[maybe_unused]] main::ClientContext* _context;
 };

--- a/src/include/optimizer/logical_operator_visitor.h
+++ b/src/include/optimizer/logical_operator_visitor.h
@@ -147,6 +147,12 @@ protected:
         return op;
     }
 
+    virtual void visitRelDegreeTable(planner::LogicalOperator*) {}
+    virtual std::shared_ptr<planner::LogicalOperator> visitRelDegreeTableReplace(
+        std::shared_ptr<planner::LogicalOperator> op) {
+        return op;
+    }
+
     virtual void visitScanNodeTable(planner::LogicalOperator* /*op*/) {}
     virtual std::shared_ptr<planner::LogicalOperator> visitScanNodeTableReplace(
         std::shared_ptr<planner::LogicalOperator> op) {

--- a/src/include/planner/operator/logical_operator.h
+++ b/src/include/planner/operator/logical_operator.h
@@ -54,6 +54,7 @@ enum class LogicalOperatorType : uint8_t {
     PATH_PROPERTY_PROBE,
     PROJECTION,
     RECURSIVE_EXTEND,
+    REL_DEGREE_TABLE,
     SCAN_NODE_TABLE,
     SEMI_MASKER,
     SET_PROPERTY,

--- a/src/include/planner/operator/scan/logical_rel_degree_table.h
+++ b/src/include/planner/operator/scan/logical_rel_degree_table.h
@@ -1,0 +1,86 @@
+#pragma once
+
+#include "binder/expression/expression.h"
+#include "binder/expression/node_expression.h"
+#include "catalog/catalog_entry/rel_group_catalog_entry.h"
+#include "common/enums/extend_direction.h"
+#include "planner/operator/logical_operator.h"
+
+namespace lbug {
+namespace planner {
+
+enum class RelDegreeTableMode : uint8_t { ACTIVE_BOUND_COUNT, TOP_K_DEGREES };
+
+struct LogicalRelDegreeTablePrintInfo final : OPPrintInfo {
+    std::string relTableName;
+    RelDegreeTableMode mode;
+
+    LogicalRelDegreeTablePrintInfo(std::string relTableName, RelDegreeTableMode mode)
+        : relTableName{std::move(relTableName)}, mode{mode} {}
+
+    std::string toString() const override {
+        return "Table: " + relTableName + ", Mode: " +
+               (mode == RelDegreeTableMode::ACTIVE_BOUND_COUNT ? "ACTIVE_BOUND_COUNT" :
+                                                                 "TOP_K_DEGREES");
+    }
+
+    std::unique_ptr<OPPrintInfo> copy() const override {
+        return std::make_unique<LogicalRelDegreeTablePrintInfo>(relTableName, mode);
+    }
+};
+
+class LogicalRelDegreeTable final : public LogicalOperator {
+    static constexpr LogicalOperatorType type_ = LogicalOperatorType::REL_DEGREE_TABLE;
+
+public:
+    LogicalRelDegreeTable(catalog::RelGroupCatalogEntry* relGroupEntry,
+        std::vector<common::table_id_t> relTableIDs,
+        std::shared_ptr<binder::NodeExpression> boundNode, common::ExtendDirection direction,
+        RelDegreeTableMode mode, std::shared_ptr<binder::Expression> nodeKeyExpr,
+        std::shared_ptr<binder::Expression> degreeExpr, common::idx_t limit)
+        : LogicalOperator{type_}, relGroupEntry{relGroupEntry}, relTableIDs{std::move(relTableIDs)},
+          boundNode{std::move(boundNode)}, direction{direction}, mode{mode},
+          nodeKeyExpr{std::move(nodeKeyExpr)}, degreeExpr{std::move(degreeExpr)}, limit{limit} {
+        cardinality = mode == RelDegreeTableMode::ACTIVE_BOUND_COUNT ? 1 : limit;
+    }
+
+    void computeFactorizedSchema() override;
+    void computeFlatSchema() override;
+
+    std::string getExpressionsForPrinting() const override {
+        return mode == RelDegreeTableMode::ACTIVE_BOUND_COUNT ?
+                   degreeExpr->toString() :
+                   nodeKeyExpr->toString() + ", " + degreeExpr->toString();
+    }
+
+    catalog::RelGroupCatalogEntry* getRelGroupEntry() const { return relGroupEntry; }
+    const std::vector<common::table_id_t>& getRelTableIDs() const { return relTableIDs; }
+    std::shared_ptr<binder::NodeExpression> getBoundNode() const { return boundNode; }
+    common::ExtendDirection getDirection() const { return direction; }
+    RelDegreeTableMode getMode() const { return mode; }
+    std::shared_ptr<binder::Expression> getNodeKeyExpr() const { return nodeKeyExpr; }
+    std::shared_ptr<binder::Expression> getDegreeExpr() const { return degreeExpr; }
+    common::idx_t getLimit() const { return limit; }
+
+    std::unique_ptr<OPPrintInfo> getPrintInfo() const override {
+        return std::make_unique<LogicalRelDegreeTablePrintInfo>(relGroupEntry->getName(), mode);
+    }
+
+    std::unique_ptr<LogicalOperator> copy() override {
+        return std::make_unique<LogicalRelDegreeTable>(relGroupEntry, relTableIDs, boundNode,
+            direction, mode, nodeKeyExpr, degreeExpr, limit);
+    }
+
+private:
+    catalog::RelGroupCatalogEntry* relGroupEntry;
+    std::vector<common::table_id_t> relTableIDs;
+    std::shared_ptr<binder::NodeExpression> boundNode;
+    common::ExtendDirection direction;
+    RelDegreeTableMode mode;
+    std::shared_ptr<binder::Expression> nodeKeyExpr;
+    std::shared_ptr<binder::Expression> degreeExpr;
+    common::idx_t limit;
+};
+
+} // namespace planner
+} // namespace lbug

--- a/src/include/processor/operator/physical_operator.h
+++ b/src/include/processor/operator/physical_operator.h
@@ -58,6 +58,7 @@ enum class PhysicalOperatorType : uint8_t {
     PROJECTION,
     PROFILE,
     RECURSIVE_EXTEND,
+    REL_DEGREE_TABLE,
     RESULT_COLLECTOR,
     SCAN_NODE_TABLE,
     SCAN_REL_TABLE,

--- a/src/include/processor/operator/scan/rel_degree_table.h
+++ b/src/include/processor/operator/scan/rel_degree_table.h
@@ -1,0 +1,63 @@
+#pragma once
+
+#include "common/enums/rel_direction.h"
+#include "planner/operator/scan/logical_rel_degree_table.h"
+#include "processor/operator/physical_operator.h"
+#include "storage/table/rel_table.h"
+
+namespace lbug {
+namespace processor {
+
+struct RelDegreeTablePrintInfo final : OPPrintInfo {
+    std::string relTableName;
+    planner::RelDegreeTableMode mode;
+
+    RelDegreeTablePrintInfo(std::string relTableName, planner::RelDegreeTableMode mode)
+        : relTableName{std::move(relTableName)}, mode{mode} {}
+
+    std::string toString() const override { return "Table: " + relTableName; }
+
+    std::unique_ptr<OPPrintInfo> copy() const override {
+        return std::make_unique<RelDegreeTablePrintInfo>(relTableName, mode);
+    }
+};
+
+class RelDegreeTable final : public PhysicalOperator {
+    static constexpr PhysicalOperatorType type_ = PhysicalOperatorType::REL_DEGREE_TABLE;
+
+public:
+    RelDegreeTable(std::vector<storage::RelTable*> relTables, common::RelDataDirection direction,
+        planner::RelDegreeTableMode mode, DataPos nodeKeyOutputPos, DataPos degreeOutputPos,
+        common::idx_t limit, physical_op_id id, std::unique_ptr<OPPrintInfo> printInfo)
+        : PhysicalOperator{type_, id, std::move(printInfo)}, relTables{std::move(relTables)},
+          direction{direction}, mode{mode}, nodeKeyOutputPos{nodeKeyOutputPos},
+          degreeOutputPos{degreeOutputPos}, limit{limit} {}
+
+    bool isSource() const override { return true; }
+    bool isParallel() const override { return false; }
+
+    void initLocalStateInternal(ResultSet* resultSet, ExecutionContext* context) override;
+    bool getNextTuplesInternal(ExecutionContext* context) override;
+
+    std::unique_ptr<PhysicalOperator> copy() override {
+        return std::make_unique<RelDegreeTable>(relTables, direction, mode, nodeKeyOutputPos,
+            degreeOutputPos, limit, id, printInfo->copy());
+    }
+
+private:
+    void writeNodeKey(common::offset_t offset, common::sel_t pos) const;
+
+private:
+    std::vector<storage::RelTable*> relTables;
+    common::RelDataDirection direction;
+    planner::RelDegreeTableMode mode;
+    DataPos nodeKeyOutputPos;
+    DataPos degreeOutputPos;
+    common::idx_t limit;
+    common::ValueVector* nodeKeyVector = nullptr;
+    common::ValueVector* degreeVector = nullptr;
+    bool hasExecuted = false;
+};
+
+} // namespace processor
+} // namespace lbug

--- a/src/include/processor/plan_mapper.h
+++ b/src/include/processor/plan_mapper.h
@@ -148,6 +148,8 @@ public:
         const planner::LogicalOperator* logicalOperator);
     std::unique_ptr<PhysicalOperator> mapRecursiveExtend(
         const planner::LogicalOperator* logicalOperator);
+    std::unique_ptr<PhysicalOperator> mapRelDegreeTable(
+        const planner::LogicalOperator* logicalOperator);
     std::unique_ptr<PhysicalOperator> mapScanNodeTable(
         const planner::LogicalOperator* logicalOperator);
     std::unique_ptr<PhysicalOperator> mapSemiMasker(

--- a/src/include/storage/table/arrow_rel_table.h
+++ b/src/include/storage/table/arrow_rel_table.h
@@ -44,6 +44,14 @@ public:
 protected:
     std::string getColumnarFormatName() const override { return "Arrow"; }
     common::row_idx_t getTotalRowCount(const transaction::Transaction* transaction) const override;
+    common::row_idx_t getActiveBoundNodeCount(const transaction::Transaction* transaction,
+        common::RelDataDirection direction) const override;
+    std::vector<std::pair<common::offset_t, common::row_idx_t>> getAllDegreeEntries(
+        const transaction::Transaction* transaction,
+        common::RelDataDirection direction) const override;
+    std::vector<std::pair<common::offset_t, common::row_idx_t>> getTopKDegreeEntries(
+        const transaction::Transaction* transaction, common::RelDataDirection direction,
+        common::idx_t k) const override;
 
 private:
     int64_t fromColumnIdx = -1;

--- a/src/include/storage/table/columnar_rel_table_base.h
+++ b/src/include/storage/table/columnar_rel_table_base.h
@@ -44,6 +44,13 @@ public:
     }
 
     common::row_idx_t getNumTotalRows(const transaction::Transaction* transaction) override;
+    common::row_idx_t getNumActiveBoundNodes(const transaction::Transaction* transaction,
+        common::RelDataDirection direction) override;
+    std::vector<std::pair<common::offset_t, common::row_idx_t>> getDegreeEntries(
+        const transaction::Transaction* transaction, common::RelDataDirection direction) override;
+    std::vector<std::pair<common::offset_t, common::row_idx_t>> getTopKDegrees(
+        const transaction::Transaction* transaction, common::RelDataDirection direction,
+        common::idx_t k) override;
 
 protected:
     catalog::RelGroupCatalogEntry* relGroupEntry;
@@ -53,6 +60,13 @@ protected:
     virtual std::string getColumnarFormatName() const = 0;
     virtual common::row_idx_t getTotalRowCount(
         const transaction::Transaction* transaction) const = 0;
+    virtual common::row_idx_t getActiveBoundNodeCount(const transaction::Transaction* transaction,
+        common::RelDataDirection direction) const = 0;
+    virtual std::vector<std::pair<common::offset_t, common::row_idx_t>> getAllDegreeEntries(
+        const transaction::Transaction* transaction, common::RelDataDirection direction) const = 0;
+    virtual std::vector<std::pair<common::offset_t, common::row_idx_t>> getTopKDegreeEntries(
+        const transaction::Transaction* transaction, common::RelDataDirection direction,
+        common::idx_t k) const = 0;
 
     // Helper for finding source node in CSR format
     // Subclasses should cache indptr data and provide it via this interface

--- a/src/include/storage/table/csr_node_group.h
+++ b/src/include/storage/table/csr_node_group.h
@@ -214,6 +214,7 @@ public:
     bool isEmpty() const override { return !persistentChunkGroup && NodeGroup::isEmpty(); }
 
     ChunkedNodeGroup* getPersistentChunkedGroup() const { return persistentChunkGroup.get(); }
+    const CSRIndex* getCSRIndex() const { return csrIndex.get(); }
     void setPersistentChunkedGroup(std::unique_ptr<ChunkedNodeGroup> chunkedNodeGroup) {
         DASSERT(chunkedNodeGroup->getFormat() == NodeGroupDataFormat::CSR);
         persistentChunkGroup = std::move(chunkedNodeGroup);

--- a/src/include/storage/table/ice_disk_rel_table.h
+++ b/src/include/storage/table/ice_disk_rel_table.h
@@ -70,6 +70,14 @@ protected:
     // Implement ColumnarRelTableBase interface
     std::string getColumnarFormatName() const override { return "icebug-disk"; }
     common::row_idx_t getTotalRowCount(const transaction::Transaction* transaction) const override;
+    common::row_idx_t getActiveBoundNodeCount(const transaction::Transaction* transaction,
+        common::RelDataDirection direction) const override;
+    std::vector<std::pair<common::offset_t, common::row_idx_t>> getAllDegreeEntries(
+        const transaction::Transaction* transaction,
+        common::RelDataDirection direction) const override;
+    std::vector<std::pair<common::offset_t, common::row_idx_t>> getTopKDegreeEntries(
+        const transaction::Transaction* transaction, common::RelDataDirection direction,
+        common::idx_t k) const override;
 
 private:
     IceDiskRelTableLayout layout;

--- a/src/include/storage/table/rel_table.h
+++ b/src/include/storage/table/rel_table.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <unordered_map>
+#include <vector>
 
 #include "catalog/catalog_entry/rel_group_catalog_entry.h"
 #include "storage/table/rel_table_data.h"
@@ -203,6 +204,13 @@ public:
     void reclaimStorage(PageAllocator& pageAllocator) const override;
 
     common::row_idx_t getNumTotalRows(const transaction::Transaction* transaction) override;
+    virtual common::row_idx_t getNumActiveBoundNodes(const transaction::Transaction* transaction,
+        common::RelDataDirection direction);
+    virtual std::vector<std::pair<common::offset_t, common::row_idx_t>> getDegreeEntries(
+        const transaction::Transaction* transaction, common::RelDataDirection direction);
+    virtual std::vector<std::pair<common::offset_t, common::row_idx_t>> getTopKDegrees(
+        const transaction::Transaction* transaction, common::RelDataDirection direction,
+        common::idx_t k);
 
     RelTableData* getDirectedTableData(common::RelDataDirection direction) const;
 

--- a/src/optimizer/count_rel_table_optimizer.cpp
+++ b/src/optimizer/count_rel_table_optimizer.cpp
@@ -1,14 +1,20 @@
 #include "optimizer/count_rel_table_optimizer.h"
 
 #include "binder/expression/aggregate_function_expression.h"
+#include "binder/expression/expression_util.h"
 #include "binder/expression/node_expression.h"
+#include "binder/expression/property_expression.h"
+#include "binder/expression/rel_expression.h"
 #include "catalog/catalog_entry/node_table_id_pair.h"
+#include "function/aggregate/count.h"
 #include "function/aggregate/count_star.h"
 #include "main/client_context.h"
 #include "planner/operator/extend/logical_extend.h"
 #include "planner/operator/logical_aggregate.h"
+#include "planner/operator/logical_order_by.h"
 #include "planner/operator/logical_projection.h"
 #include "planner/operator/scan/logical_count_rel_table.h"
+#include "planner/operator/scan/logical_rel_degree_table.h"
 #include "planner/operator/scan/logical_scan_node_table.h"
 
 using namespace lbug::common;
@@ -34,7 +40,7 @@ std::shared_ptr<LogicalOperator> CountRelTableOptimizer::visitOperator(
     return result;
 }
 
-bool CountRelTableOptimizer::isSimpleCountStar(LogicalOperator* op) const {
+bool CountRelTableOptimizer::isSimpleCount(LogicalOperator* op) const {
     if (op->getOperatorType() != LogicalOperatorType::AGGREGATE) {
         return false;
     }
@@ -51,17 +57,17 @@ bool CountRelTableOptimizer::isSimpleCountStar(LogicalOperator* op) const {
         return false;
     }
 
-    // Must be COUNT_STAR
     auto& aggExpr = aggregates[0];
     if (aggExpr->expressionType != ExpressionType::AGGREGATE_FUNCTION) {
         return false;
     }
     auto& aggFuncExpr = aggExpr->constCast<AggregateFunctionExpression>();
-    if (aggFuncExpr.getFunction().name != function::CountStarFunction::name) {
+    const auto& functionName = aggFuncExpr.getFunction().name;
+    if (functionName != function::CountStarFunction::name &&
+        functionName != function::CountFunction::name) {
         return false;
     }
 
-    // COUNT_STAR should not be DISTINCT (conceptually it doesn't make sense)
     if (aggFuncExpr.isDistinct()) {
         return false;
     }
@@ -69,31 +75,111 @@ bool CountRelTableOptimizer::isSimpleCountStar(LogicalOperator* op) const {
     return true;
 }
 
+bool CountRelTableOptimizer::isCountStar(LogicalOperator* op) const {
+    auto& aggregate = op->constCast<LogicalAggregate>();
+    auto& aggFuncExpr = aggregate.getAggregates()[0]->constCast<AggregateFunctionExpression>();
+    return aggFuncExpr.getFunction().name == function::CountStarFunction::name;
+}
+
+bool CountRelTableOptimizer::isRelIDExpression(const std::shared_ptr<Expression>& expression,
+    const RelExpression& rel) const {
+    if (expression->expressionType != ExpressionType::PROPERTY) {
+        return false;
+    }
+    auto& property = expression->constCast<PropertyExpression>();
+    return property.isInternalID() && *expression == *rel.getInternalID();
+}
+
+bool CountRelTableOptimizer::isCountRelID(LogicalOperator* op, const RelExpression& rel) const {
+    auto& aggregate = op->constCast<LogicalAggregate>();
+    auto& aggFuncExpr = aggregate.getAggregates()[0]->constCast<AggregateFunctionExpression>();
+    if (aggFuncExpr.getFunction().name != function::CountFunction::name) {
+        return false;
+    }
+    if (aggFuncExpr.getNumChildren() != 1) {
+        return false;
+    }
+    return isRelIDExpression(aggFuncExpr.getChild(0), rel);
+}
+
+bool CountRelTableOptimizer::isDistinctCountNodeKey(LogicalOperator* op,
+    const std::shared_ptr<Expression>& nodeKey) const {
+    if (op->getOperatorType() != LogicalOperatorType::AGGREGATE) {
+        return false;
+    }
+    auto& aggregate = op->constCast<LogicalAggregate>();
+    if (aggregate.hasKeys() || aggregate.getAggregates().size() != 1) {
+        return false;
+    }
+    auto& aggFuncExpr = aggregate.getAggregates()[0]->constCast<AggregateFunctionExpression>();
+    if (aggFuncExpr.getFunction().name != function::CountFunction::name ||
+        !aggFuncExpr.isDistinct() || aggFuncExpr.getNumChildren() != 1) {
+        return false;
+    }
+    return *aggFuncExpr.getChild(0) == *nodeKey;
+}
+
+bool CountRelTableOptimizer::isCountNbr(LogicalOperator* op, const NodeExpression& nbr) const {
+    if (op->getOperatorType() != LogicalOperatorType::AGGREGATE) {
+        return false;
+    }
+    auto& aggregate = op->constCast<LogicalAggregate>();
+    if (aggregate.getAggregates().size() != 1) {
+        return false;
+    }
+    auto& aggFuncExpr = aggregate.getAggregates()[0]->constCast<AggregateFunctionExpression>();
+    if (aggFuncExpr.isDistinct()) {
+        return false;
+    }
+    if (aggFuncExpr.getFunction().name == function::CountStarFunction::name &&
+        aggFuncExpr.getNumChildren() == 0) {
+        return true;
+    }
+    if (aggFuncExpr.getFunction().name != function::CountFunction::name ||
+        aggFuncExpr.getNumChildren() != 1) {
+        return false;
+    }
+    return *aggFuncExpr.getChild(0) == *nbr.getInternalID();
+}
+
+static bool relTablesForExtend(const LogicalExtend& extend, std::vector<table_id_t>& relTableIDs,
+    RelGroupCatalogEntry*& relGroupEntry) {
+    auto rel = extend.getRel();
+    if (extend.getDirection() != ExtendDirection::FWD || rel->getNumEntries() != 1) {
+        return false;
+    }
+    DASSERT(rel->getNumEntries() == 1);
+    relGroupEntry = rel->getEntry(0)->ptrCast<RelGroupCatalogEntry>();
+    auto boundNodeTableIDs = extend.getBoundNode()->getTableIDsSet();
+    auto nbrNodeTableIDs = extend.getNbrNode()->getTableIDsSet();
+    for (auto& info : relGroupEntry->getRelEntryInfos()) {
+        bool matches = extend.extendFromSourceNode() ?
+                           boundNodeTableIDs.contains(info.nodePair.srcTableID) &&
+                               nbrNodeTableIDs.contains(info.nodePair.dstTableID) :
+                           boundNodeTableIDs.contains(info.nodePair.dstTableID) &&
+                               nbrNodeTableIDs.contains(info.nodePair.srcTableID);
+        if (matches) {
+            relTableIDs.push_back(info.oid);
+        }
+    }
+    return !relTableIDs.empty();
+}
+
 bool CountRelTableOptimizer::canOptimize(LogicalOperator* aggregate) const {
     // Pattern we're looking for:
-    // AGGREGATE (COUNT_STAR, no keys)
-    //   -> PROJECTION (empty expressions or pass-through)
+    // AGGREGATE (COUNT_STAR or COUNT(rel._ID), no keys)
+    //   -> PROJECTION (empty expressions, pass-through, or rel._ID)
     //      -> EXTEND (single rel table, no properties scanned)
     //         -> SCAN_NODE_TABLE (no properties scanned)
     //
     // Note: The projection between aggregate and extend might be empty or
-    // just projecting the count expression.
+    // just projecting the COUNT(rel) input.
 
     auto* current = aggregate->getChild(0).get();
 
-    // Skip any projections (they should be empty or just for count)
+    std::vector<LogicalProjection*> projections;
     while (current->getOperatorType() == LogicalOperatorType::PROJECTION) {
-        auto& proj = current->constCast<LogicalProjection>();
-        // Empty projection is okay, it's just a passthrough
-        if (!proj.getExpressionsToProject().empty()) {
-            // If projection has expressions, they should all be aggregate expressions
-            // (which means they're just passing through the count)
-            for (auto& expr : proj.getExpressionsToProject()) {
-                if (expr->expressionType != ExpressionType::AGGREGATE_FUNCTION) {
-                    return false;
-                }
-            }
-        }
+        projections.push_back(current->ptrCast<LogicalProjection>());
         current = current->getChild(0).get();
     }
 
@@ -116,9 +202,25 @@ bool CountRelTableOptimizer::canOptimize(LogicalOperator* aggregate) const {
         return false;
     }
 
-    // Check if we're scanning any properties (we can only optimize when no properties needed)
-    if (!extend.getProperties().empty()) {
+    if (!isCountStar(aggregate) && !isCountRelID(aggregate, *rel)) {
         return false;
+    }
+
+    // Check if we're scanning any properties. COUNT(rel) needs only rel._ID; other rel properties
+    // would make the relationship variable observable beyond simple cardinality.
+    for (auto& property : extend.getProperties()) {
+        if (!isRelIDExpression(property, *rel)) {
+            return false;
+        }
+    }
+
+    for (auto* projection : projections) {
+        for (auto& expression : projection->getExpressionsToProject()) {
+            if (expression->expressionType != ExpressionType::AGGREGATE_FUNCTION &&
+                !isRelIDExpression(expression, *rel)) {
+                return false;
+            }
+        }
     }
 
     // The child of extend should be SCAN_NODE_TABLE
@@ -138,7 +240,10 @@ bool CountRelTableOptimizer::canOptimize(LogicalOperator* aggregate) const {
 
 std::shared_ptr<LogicalOperator> CountRelTableOptimizer::visitAggregateReplace(
     std::shared_ptr<LogicalOperator> op) {
-    if (!isSimpleCountStar(op.get())) {
+    if (auto rewritten = tryRewriteActiveBoundCount(op); rewritten != op) {
+        return rewritten;
+    }
+    if (!isSimpleCount(op.get())) {
         return op;
     }
 
@@ -211,6 +316,115 @@ std::shared_ptr<LogicalOperator> CountRelTableOptimizer::visitAggregateReplace(
     countRelTable->computeFlatSchema();
 
     return countRelTable;
+}
+
+std::shared_ptr<LogicalOperator> CountRelTableOptimizer::tryRewriteActiveBoundCount(
+    std::shared_ptr<LogicalOperator> op) {
+    auto* current = op->getChild(0).get();
+    while (current->getOperatorType() == LogicalOperatorType::PROJECTION) {
+        current = current->getChild(0).get();
+    }
+    if (current->getOperatorType() != LogicalOperatorType::EXTEND) {
+        return op;
+    }
+    auto& extend = current->constCast<LogicalExtend>();
+    auto boundNode = extend.getBoundNode();
+    if (boundNode->isMultiLabeled()) {
+        return op;
+    }
+    auto boundKey = boundNode->getPrimaryKey(boundNode->getTableIDs()[0]);
+    if (!boundKey || !isDistinctCountNodeKey(op.get(), boundKey)) {
+        return op;
+    }
+    if (!extend.getProperties().empty()) {
+        return op;
+    }
+    auto* scan = current->getChild(0).get();
+    if (scan->getOperatorType() != LogicalOperatorType::SCAN_NODE_TABLE) {
+        return op;
+    }
+    auto& scanNode = scan->constCast<LogicalScanNodeTable>();
+    for (auto& property : scanNode.getProperties()) {
+        if (!(*property == *boundKey)) {
+            return op;
+        }
+    }
+    std::vector<table_id_t> relTableIDs;
+    RelGroupCatalogEntry* relGroupEntry = nullptr;
+    if (!relTablesForExtend(extend, relTableIDs, relGroupEntry)) {
+        return op;
+    }
+    auto countExpr = op->constCast<LogicalAggregate>().getAggregates()[0];
+    auto result =
+        std::make_shared<LogicalRelDegreeTable>(relGroupEntry, std::move(relTableIDs), boundNode,
+            extend.getDirection(), RelDegreeTableMode::ACTIVE_BOUND_COUNT, boundKey, countExpr, 1);
+    result->computeFlatSchema();
+    return result;
+}
+
+std::shared_ptr<LogicalOperator> CountRelTableOptimizer::visitOrderByReplace(
+    std::shared_ptr<LogicalOperator> op) {
+    return tryRewriteDegreeTopK(op);
+}
+
+std::shared_ptr<LogicalOperator> CountRelTableOptimizer::tryRewriteDegreeTopK(
+    std::shared_ptr<LogicalOperator> op) {
+    auto& orderBy = op->constCast<LogicalOrderBy>();
+    if (!orderBy.hasLimitNum() || orderBy.hasSkipNum() ||
+        !ExpressionUtil::canEvaluateAsLiteral(*orderBy.getLimitNum()) ||
+        orderBy.getExpressionsToOrderBy().size() != 1 || orderBy.getIsAscOrders().size() != 1 ||
+        orderBy.getIsAscOrders()[0]) {
+        return op;
+    }
+    const auto limit = ExpressionUtil::evaluateAsSkipLimit(*orderBy.getLimitNum());
+    auto* current = op->getChild(0).get();
+    while (current->getOperatorType() == LogicalOperatorType::PROJECTION) {
+        current = current->getChild(0).get();
+    }
+    if (current->getOperatorType() != LogicalOperatorType::AGGREGATE) {
+        return op;
+    }
+    auto& aggregate = current->constCast<LogicalAggregate>();
+    if (aggregate.getKeys().size() != 1 || aggregate.getAggregates().size() != 1 ||
+        aggregate.getDependentKeys().size() != 0 ||
+        !(*orderBy.getExpressionsToOrderBy()[0] == *aggregate.getAggregates()[0])) {
+        return op;
+    }
+    auto nodeKey = aggregate.getKeys()[0];
+    auto* aggregateChild = current->getChild(0).get();
+    while (aggregateChild->getOperatorType() == LogicalOperatorType::PROJECTION) {
+        aggregateChild = aggregateChild->getChild(0).get();
+    }
+    if (aggregateChild->getOperatorType() != LogicalOperatorType::EXTEND) {
+        return op;
+    }
+    auto& extend = aggregateChild->constCast<LogicalExtend>();
+    auto boundNode = extend.getBoundNode();
+    if (boundNode->isMultiLabeled() ||
+        !(*nodeKey == *boundNode->getPrimaryKey(boundNode->getTableIDs()[0])) ||
+        !isCountNbr(current, *extend.getNbrNode()) || !extend.getProperties().empty()) {
+        return op;
+    }
+    auto* scan = aggregateChild->getChild(0).get();
+    if (scan->getOperatorType() != LogicalOperatorType::SCAN_NODE_TABLE) {
+        return op;
+    }
+    auto& scanNode = scan->constCast<LogicalScanNodeTable>();
+    for (auto& property : scanNode.getProperties()) {
+        if (!(*property == *nodeKey)) {
+            return op;
+        }
+    }
+    std::vector<table_id_t> relTableIDs;
+    RelGroupCatalogEntry* relGroupEntry = nullptr;
+    if (!relTablesForExtend(extend, relTableIDs, relGroupEntry)) {
+        return op;
+    }
+    auto result = std::make_shared<LogicalRelDegreeTable>(relGroupEntry, std::move(relTableIDs),
+        boundNode, extend.getDirection(), RelDegreeTableMode::TOP_K_DEGREES, nodeKey,
+        aggregate.getAggregates()[0], limit);
+    result->computeFlatSchema();
+    return result;
 }
 
 } // namespace optimizer

--- a/src/optimizer/logical_operator_visitor.cpp
+++ b/src/optimizer/logical_operator_visitor.cpp
@@ -73,6 +73,9 @@ void LogicalOperatorVisitor::visitOperatorSwitch(LogicalOperator* op) {
     case LogicalOperatorType::RECURSIVE_EXTEND: {
         visitRecursiveExtend(op);
     } break;
+    case LogicalOperatorType::REL_DEGREE_TABLE: {
+        visitRelDegreeTable(op);
+    } break;
     case LogicalOperatorType::SCAN_NODE_TABLE: {
         visitScanNodeTable(op);
     } break;
@@ -164,6 +167,9 @@ std::shared_ptr<LogicalOperator> LogicalOperatorVisitor::visitOperatorReplaceSwi
     }
     case LogicalOperatorType::RECURSIVE_EXTEND: {
         return visitRecursiveExtendReplace(op);
+    }
+    case LogicalOperatorType::REL_DEGREE_TABLE: {
+        return visitRelDegreeTableReplace(op);
     }
     case LogicalOperatorType::SCAN_NODE_TABLE: {
         return visitScanNodeTableReplace(op);

--- a/src/optimizer/optimizer.cpp
+++ b/src/optimizer/optimizer.cpp
@@ -73,6 +73,9 @@ void Optimizer::optimize(planner::LogicalPlan* plan, main::ClientContext* contex
         auto topKOptimizer = TopKOptimizer();
         topKOptimizer.rewrite(plan);
 
+        // Degree top-k rewrites need the LIMIT to be folded into ORDER_BY first.
+        countRelTableOptimizer.rewrite(plan);
+
         auto factorizationRewriter = FactorizationRewriter();
         factorizationRewriter.rewrite(plan);
 

--- a/src/planner/operator/logical_operator.cpp
+++ b/src/planner/operator/logical_operator.cpp
@@ -92,6 +92,8 @@ std::string LogicalOperatorUtils::logicalOperatorTypeToString(LogicalOperatorTyp
         return "PROJECTION";
     case LogicalOperatorType::RECURSIVE_EXTEND:
         return "RECURSIVE_EXTEND";
+    case LogicalOperatorType::REL_DEGREE_TABLE:
+        return "REL_DEGREE_TABLE";
     case LogicalOperatorType::SCAN_NODE_TABLE:
         return "SCAN_NODE_TABLE";
     case LogicalOperatorType::SEMI_MASKER:

--- a/src/planner/operator/scan/CMakeLists.txt
+++ b/src/planner/operator/scan/CMakeLists.txt
@@ -3,6 +3,7 @@ add_library(lbug_planner_scan
         logical_count_rel_table.cpp
         logical_expressions_scan.cpp
         logical_index_look_up.cpp
+        logical_rel_degree_table.cpp
         logical_scan_node_table.cpp)
 
 set(ALL_OBJECT_FILES

--- a/src/planner/operator/scan/logical_rel_degree_table.cpp
+++ b/src/planner/operator/scan/logical_rel_degree_table.cpp
@@ -1,0 +1,28 @@
+#include "planner/operator/scan/logical_rel_degree_table.h"
+
+namespace lbug {
+namespace planner {
+
+void LogicalRelDegreeTable::computeFactorizedSchema() {
+    createEmptySchema();
+    auto groupPos = schema->createGroup();
+    if (mode == RelDegreeTableMode::TOP_K_DEGREES) {
+        schema->insertToGroupAndScope(nodeKeyExpr, groupPos);
+    }
+    schema->insertToGroupAndScope(degreeExpr, groupPos);
+    if (mode == RelDegreeTableMode::ACTIVE_BOUND_COUNT) {
+        schema->setGroupAsSingleState(groupPos);
+    }
+}
+
+void LogicalRelDegreeTable::computeFlatSchema() {
+    createEmptySchema();
+    auto groupPos = schema->createGroup();
+    if (mode == RelDegreeTableMode::TOP_K_DEGREES) {
+        schema->insertToGroupAndScope(nodeKeyExpr, groupPos);
+    }
+    schema->insertToGroupAndScope(degreeExpr, groupPos);
+}
+
+} // namespace planner
+} // namespace lbug

--- a/src/processor/map/CMakeLists.txt
+++ b/src/processor/map/CMakeLists.txt
@@ -38,6 +38,7 @@ add_library(lbug_processor_mapper
         map_path_property_probe.cpp
         map_projection.cpp
         map_recursive_extend.cpp
+        map_rel_degree_table.cpp
         map_scan_node_table.cpp
         map_semi_masker.cpp
         map_set.cpp

--- a/src/processor/map/map_rel_degree_table.cpp
+++ b/src/processor/map/map_rel_degree_table.cpp
@@ -1,0 +1,46 @@
+#include "planner/operator/scan/logical_rel_degree_table.h"
+#include "processor/operator/scan/rel_degree_table.h"
+#include "processor/plan_mapper.h"
+#include "storage/storage_manager.h"
+
+using namespace lbug::common;
+using namespace lbug::planner;
+using namespace lbug::storage;
+
+namespace lbug {
+namespace processor {
+
+std::unique_ptr<PhysicalOperator> PlanMapper::mapRelDegreeTable(
+    const LogicalOperator* logicalOperator) {
+    auto& logical = logicalOperator->constCast<LogicalRelDegreeTable>();
+    auto outSchema = logical.getSchema();
+    auto storageManager = StorageManager::Get(*clientContext);
+
+    std::vector<RelTable*> relTables;
+    for (auto tableID : logical.getRelTableIDs()) {
+        relTables.push_back(storageManager->getTable(tableID)->ptrCast<RelTable>());
+    }
+
+    RelDataDirection relDirection;
+    if (logical.getDirection() == ExtendDirection::FWD) {
+        relDirection = RelDataDirection::FWD;
+    } else if (logical.getDirection() == ExtendDirection::BWD) {
+        relDirection = RelDataDirection::BWD;
+    } else {
+        relDirection = RelDataDirection::FWD;
+    }
+
+    DataPos nodeKeyOutputPos{};
+    if (logical.getMode() == RelDegreeTableMode::TOP_K_DEGREES) {
+        nodeKeyOutputPos = getDataPos(*logical.getNodeKeyExpr(), *outSchema);
+    }
+    auto degreeOutputPos = getDataPos(*logical.getDegreeExpr(), *outSchema);
+    auto printInfo = std::make_unique<RelDegreeTablePrintInfo>(
+        logical.getRelGroupEntry()->getName(), logical.getMode());
+    return std::make_unique<RelDegreeTable>(std::move(relTables), relDirection, logical.getMode(),
+        nodeKeyOutputPos, degreeOutputPos, logical.getLimit(), getOperatorID(),
+        std::move(printInfo));
+}
+
+} // namespace processor
+} // namespace lbug

--- a/src/processor/map/plan_mapper.cpp
+++ b/src/processor/map/plan_mapper.cpp
@@ -170,6 +170,9 @@ std::unique_ptr<PhysicalOperator> PlanMapper::mapOperator(const LogicalOperator*
     case LogicalOperatorType::RECURSIVE_EXTEND: {
         physicalOperator = mapRecursiveExtend(logicalOperator);
     } break;
+    case LogicalOperatorType::REL_DEGREE_TABLE: {
+        physicalOperator = mapRelDegreeTable(logicalOperator);
+    } break;
     case LogicalOperatorType::SCAN_NODE_TABLE: {
         physicalOperator = mapScanNodeTable(logicalOperator);
     } break;

--- a/src/processor/operator/physical_operator.cpp
+++ b/src/processor/operator/physical_operator.cpp
@@ -97,6 +97,8 @@ std::string PhysicalOperatorUtils::operatorTypeToString(PhysicalOperatorType ope
         return "PROFILE";
     case PhysicalOperatorType::RECURSIVE_EXTEND:
         return "RECURSIVE_EXTEND";
+    case PhysicalOperatorType::REL_DEGREE_TABLE:
+        return "REL_DEGREE_TABLE";
     case PhysicalOperatorType::RESULT_COLLECTOR:
         return "RESULT_COLLECTOR";
     case PhysicalOperatorType::SCAN_NODE_TABLE:

--- a/src/processor/operator/scan/CMakeLists.txt
+++ b/src/processor/operator/scan/CMakeLists.txt
@@ -2,6 +2,7 @@ add_library(lbug_processor_operator_scan
         OBJECT
         count_rel_table.cpp
         primary_key_scan_node_table.cpp
+        rel_degree_table.cpp
         scan_multi_rel_tables.cpp
         scan_node_table.cpp
         scan_rel_table.cpp

--- a/src/processor/operator/scan/rel_degree_table.cpp
+++ b/src/processor/operator/scan/rel_degree_table.cpp
@@ -1,0 +1,105 @@
+#include "processor/operator/scan/rel_degree_table.h"
+
+#include <unordered_map>
+#include <unordered_set>
+
+#include "common/types/types.h"
+#include "main/client_context.h"
+#include "processor/execution_context.h"
+#include "transaction/transaction.h"
+
+using namespace lbug::common;
+using namespace lbug::storage;
+using namespace lbug::transaction;
+
+namespace lbug {
+namespace processor {
+
+void RelDegreeTable::initLocalStateInternal(ResultSet* resultSet, ExecutionContext*) {
+    degreeVector = resultSet->getValueVector(degreeOutputPos).get();
+    if (mode == planner::RelDegreeTableMode::TOP_K_DEGREES) {
+        nodeKeyVector = resultSet->getValueVector(nodeKeyOutputPos).get();
+    }
+    hasExecuted = false;
+}
+
+void RelDegreeTable::writeNodeKey(offset_t offset, sel_t pos) const {
+    switch (nodeKeyVector->dataType.getPhysicalType()) {
+    case PhysicalTypeID::INT32:
+        nodeKeyVector->setValue<int32_t>(pos, static_cast<int32_t>(offset));
+        break;
+    case PhysicalTypeID::INT64:
+        nodeKeyVector->setValue<int64_t>(pos, static_cast<int64_t>(offset));
+        break;
+    case PhysicalTypeID::UINT32:
+        nodeKeyVector->setValue<uint32_t>(pos, static_cast<uint32_t>(offset));
+        break;
+    case PhysicalTypeID::UINT64:
+        nodeKeyVector->setValue<uint64_t>(pos, static_cast<uint64_t>(offset));
+        break;
+    default:
+        nodeKeyVector->setValue<int64_t>(pos, static_cast<int64_t>(offset));
+        break;
+    }
+}
+
+bool RelDegreeTable::getNextTuplesInternal(ExecutionContext* context) {
+    if (hasExecuted) {
+        return false;
+    }
+    auto transaction = Transaction::Get(*context->clientContext);
+    if (mode == planner::RelDegreeTableMode::ACTIVE_BOUND_COUNT) {
+        if (relTables.size() == 1) {
+            const auto count = relTables[0]->getNumActiveBoundNodes(transaction, direction);
+            degreeVector->state->getSelVectorUnsafe().setToUnfiltered(1);
+            degreeVector->setValue<int64_t>(0, static_cast<int64_t>(count));
+            hasExecuted = true;
+            return true;
+        }
+        std::unordered_set<offset_t> activeOffsets;
+        for (auto* relTable : relTables) {
+            for (auto& [offset, _] : relTable->getDegreeEntries(transaction, direction)) {
+                activeOffsets.insert(offset);
+            }
+        }
+        degreeVector->state->getSelVectorUnsafe().setToUnfiltered(1);
+        degreeVector->setValue<int64_t>(0, static_cast<int64_t>(activeOffsets.size()));
+        hasExecuted = true;
+        return true;
+    }
+
+    std::unordered_map<offset_t, row_idx_t> degrees;
+    for (auto* relTable : relTables) {
+        auto tableEntries = relTables.size() == 1 ?
+                                relTable->getTopKDegrees(transaction, direction, limit) :
+                                relTable->getDegreeEntries(transaction, direction);
+        for (auto& [offset, degree] : tableEntries) {
+            degrees[offset] += degree;
+        }
+    }
+    std::vector<std::pair<offset_t, row_idx_t>> entries;
+    entries.reserve(degrees.size());
+    for (auto& [offset, degree] : degrees) {
+        entries.emplace_back(offset, degree);
+    }
+    std::sort(entries.begin(), entries.end(), [](auto& a, auto& b) {
+        return a.second > b.second || (a.second == b.second && a.first < b.first);
+    });
+    if (entries.size() > limit) {
+        entries.resize(limit);
+    }
+    auto& selVector = degreeVector->state->getSelVectorUnsafe();
+    selVector.setToUnfiltered(entries.size());
+    if (nodeKeyVector) {
+        nodeKeyVector->state->getSelVectorUnsafe().setToUnfiltered(entries.size());
+    }
+    for (sel_t i = 0; i < entries.size(); ++i) {
+        writeNodeKey(entries[i].first, i);
+        degreeVector->setValue<int64_t>(i, static_cast<int64_t>(entries[i].second));
+    }
+    hasExecuted = true;
+    return !entries.empty();
+}
+
+} // namespace processor
+} // namespace lbug

--- a/src/storage/table/arrow_rel_table.cpp
+++ b/src/storage/table/arrow_rel_table.cpp
@@ -1,6 +1,7 @@
 #include "storage/table/arrow_rel_table.h"
 
 #include <cstring>
+#include <queue>
 
 #include "common/arrow/arrow_converter.h"
 #include "common/arrow/arrow_nullmask_tree.h"
@@ -599,6 +600,80 @@ std::vector<int64_t> ArrowRelTable::getOutputToArrowColumnIdx(
 row_idx_t ArrowRelTable::getTotalRowCount(
     [[maybe_unused]] const transaction::Transaction* transaction) const {
     return totalRows;
+}
+
+row_idx_t ArrowRelTable::getActiveBoundNodeCount(
+    [[maybe_unused]] const transaction::Transaction* transaction,
+    RelDataDirection direction) const {
+    if (layout != ArrowRelTableLayout::CSR || direction == RelDataDirection::BWD) {
+        return 0;
+    }
+    row_idx_t result = 0;
+    for (offset_t i = 0; i + 1 < totalIndptrRows; ++i) {
+        offset_t start = INVALID_OFFSET;
+        offset_t end = INVALID_OFFSET;
+        if (readIndptr(i, start) && readIndptr(i + 1, end) && end > start) {
+            result++;
+        }
+    }
+    return result;
+}
+
+std::vector<std::pair<offset_t, row_idx_t>> ArrowRelTable::getAllDegreeEntries(
+    [[maybe_unused]] const transaction::Transaction* transaction,
+    RelDataDirection direction) const {
+    if (layout != ArrowRelTableLayout::CSR || direction == RelDataDirection::BWD) {
+        return {};
+    }
+    std::vector<std::pair<offset_t, row_idx_t>> result;
+    result.reserve(totalIndptrRows);
+    for (offset_t i = 0; i + 1 < totalIndptrRows; ++i) {
+        offset_t start = INVALID_OFFSET;
+        offset_t end = INVALID_OFFSET;
+        if (!readIndptr(i, start) || !readIndptr(i + 1, end) || end <= start) {
+            continue;
+        }
+        result.emplace_back(i, end - start);
+    }
+    return result;
+}
+
+std::vector<std::pair<offset_t, row_idx_t>> ArrowRelTable::getTopKDegreeEntries(
+    [[maybe_unused]] const transaction::Transaction* transaction, RelDataDirection direction,
+    idx_t k) const {
+    if (layout != ArrowRelTableLayout::CSR || direction == RelDataDirection::BWD || k == 0) {
+        return {};
+    }
+    using degree_entry_t = std::pair<offset_t, row_idx_t>;
+    auto better = [](const degree_entry_t& a, const degree_entry_t& b) {
+        return a.second > b.second || (a.second == b.second && a.first < b.first);
+    };
+    auto worseForHeap = [better](const degree_entry_t& a, const degree_entry_t& b) {
+        return better(a, b);
+    };
+    std::priority_queue<degree_entry_t, std::vector<degree_entry_t>, decltype(worseForHeap)> heap{
+        worseForHeap};
+    for (offset_t i = 0; i + 1 < totalIndptrRows; ++i) {
+        offset_t start = INVALID_OFFSET;
+        offset_t end = INVALID_OFFSET;
+        if (!readIndptr(i, start) || !readIndptr(i + 1, end) || end <= start) {
+            continue;
+        }
+        degree_entry_t entry{i, end - start};
+        if (heap.size() < k) {
+            heap.push(entry);
+        } else if (better(entry, heap.top())) {
+            heap.pop();
+            heap.push(entry);
+        }
+    }
+    std::vector<degree_entry_t> result;
+    while (!heap.empty()) {
+        result.push_back(heap.top());
+        heap.pop();
+    }
+    std::sort(result.begin(), result.end(), better);
+    return result;
 }
 
 } // namespace storage

--- a/src/storage/table/columnar_rel_table_base.cpp
+++ b/src/storage/table/columnar_rel_table_base.cpp
@@ -16,6 +16,21 @@ common::row_idx_t ColumnarRelTableBase::getNumTotalRows(const Transaction* trans
     return getTotalRowCount(transaction);
 }
 
+common::row_idx_t ColumnarRelTableBase::getNumActiveBoundNodes(const Transaction* transaction,
+    RelDataDirection direction) {
+    return getActiveBoundNodeCount(transaction, direction);
+}
+
+std::vector<std::pair<offset_t, row_idx_t>> ColumnarRelTableBase::getDegreeEntries(
+    const Transaction* transaction, RelDataDirection direction) {
+    return getAllDegreeEntries(transaction, direction);
+}
+
+std::vector<std::pair<offset_t, row_idx_t>> ColumnarRelTableBase::getTopKDegrees(
+    const Transaction* transaction, RelDataDirection direction, idx_t k) {
+    return getTopKDegreeEntries(transaction, direction, k);
+}
+
 common::offset_t ColumnarRelTableBase::findSourceNodeForRowInternal(offset_t globalRowIdx,
     const std::vector<offset_t>& indptrData) const {
     if (indptrData.empty()) {

--- a/src/storage/table/ice_disk_rel_table.cpp
+++ b/src/storage/table/ice_disk_rel_table.cpp
@@ -1,6 +1,7 @@
 #include "storage/table/ice_disk_rel_table.h"
 
 #include <filesystem>
+#include <queue>
 
 #include "catalog/catalog_entry/rel_group_catalog_entry.h"
 #include "common/data_chunk/sel_vector.h"
@@ -488,6 +489,73 @@ row_idx_t IceDiskRelTable::getTotalRowCount(const Transaction* transaction) cons
     }
     auto metadata = indicesReader->getMetadata();
     return metadata ? metadata->num_rows : 0;
+}
+
+row_idx_t IceDiskRelTable::getActiveBoundNodeCount(const Transaction* transaction,
+    RelDataDirection direction) const {
+    if (layout != IceDiskRelTableLayout::CSR || direction == RelDataDirection::BWD) {
+        return 0;
+    }
+    loadIndptrData(const_cast<Transaction*>(transaction));
+    row_idx_t result = 0;
+    for (offset_t i = 0; i + 1 < indptrData.size(); ++i) {
+        result += indptrData[i + 1] > indptrData[i];
+    }
+    return result;
+}
+
+std::vector<std::pair<offset_t, row_idx_t>> IceDiskRelTable::getAllDegreeEntries(
+    const Transaction* transaction, RelDataDirection direction) const {
+    if (layout != IceDiskRelTableLayout::CSR || direction == RelDataDirection::BWD) {
+        return {};
+    }
+    loadIndptrData(const_cast<Transaction*>(transaction));
+    std::vector<std::pair<offset_t, row_idx_t>> result;
+    result.reserve(indptrData.size());
+    for (offset_t i = 0; i + 1 < indptrData.size(); ++i) {
+        if (indptrData[i + 1] <= indptrData[i]) {
+            continue;
+        }
+        result.emplace_back(i, indptrData[i + 1] - indptrData[i]);
+    }
+    return result;
+}
+
+std::vector<std::pair<offset_t, row_idx_t>> IceDiskRelTable::getTopKDegreeEntries(
+    const Transaction* transaction, RelDataDirection direction, idx_t k) const {
+    if (layout != IceDiskRelTableLayout::CSR || direction == RelDataDirection::BWD || k == 0) {
+        return {};
+    }
+    loadIndptrData(const_cast<Transaction*>(transaction));
+    using degree_entry_t = std::pair<offset_t, row_idx_t>;
+    auto better = [](const degree_entry_t& a, const degree_entry_t& b) {
+        return a.second > b.second || (a.second == b.second && a.first < b.first);
+    };
+    auto worseForHeap = [better](const degree_entry_t& a, const degree_entry_t& b) {
+        return better(a, b);
+    };
+    std::priority_queue<degree_entry_t, std::vector<degree_entry_t>, decltype(worseForHeap)> heap{
+        worseForHeap};
+    for (offset_t i = 0; i + 1 < indptrData.size(); ++i) {
+        if (indptrData[i + 1] <= indptrData[i]) {
+            continue;
+        }
+        const auto degree = indptrData[i + 1] - indptrData[i];
+        degree_entry_t entry{i, degree};
+        if (heap.size() < k) {
+            heap.push(entry);
+        } else if (better(entry, heap.top())) {
+            heap.pop();
+            heap.push(entry);
+        }
+    }
+    std::vector<degree_entry_t> result;
+    while (!heap.empty()) {
+        result.push_back(heap.top());
+        heap.pop();
+    }
+    std::sort(result.begin(), result.end(), better);
+    return result;
 }
 
 } // namespace storage

--- a/src/storage/table/rel_table.cpp
+++ b/src/storage/table/rel_table.cpp
@@ -1,6 +1,8 @@
 #include "storage/table/rel_table.h"
 
 #include <algorithm>
+#include <queue>
+#include <unordered_map>
 
 #include "catalog/catalog_entry/rel_group_catalog_entry.h"
 #include "common/exception/message.h"
@@ -549,6 +551,103 @@ row_idx_t RelTable::getNumTotalRows(const Transaction* transaction) {
         numLocalRows = localTable->getNumTotalRows();
     }
     return numLocalRows + nextRelOffset;
+}
+
+std::vector<std::pair<offset_t, row_idx_t>> RelTable::getDegreeEntries(
+    const Transaction* transaction, RelDataDirection direction) {
+    std::unordered_map<offset_t, row_idx_t> degrees;
+    auto* memoryManager = this->memoryManager;
+    auto* relTableData = getDirectedTableData(direction);
+    auto* csrLengthColumn = relTableData->getCSRLengthColumn();
+    for (node_group_idx_t nodeGroupIdx = 0; nodeGroupIdx < relTableData->getNumNodeGroups();
+         nodeGroupIdx++) {
+        auto* nodeGroup = relTableData->getNodeGroup(nodeGroupIdx);
+        if (!nodeGroup) {
+            continue;
+        }
+        auto& csrNodeGroup = nodeGroup->cast<CSRNodeGroup>();
+        auto groupStartOffset = StorageUtils::getStartOffsetOfNodeGroup(nodeGroupIdx);
+        std::vector<row_idx_t> nodeGroupDegrees(StorageConfig::NODE_GROUP_SIZE, 0);
+        if (auto* persistentGroup = csrNodeGroup.getPersistentChunkedGroup()) {
+            auto& csrPersistentGroup = persistentGroup->cast<ChunkedCSRNodeGroup>();
+            auto& csrHeader = csrPersistentGroup.getCSRHeader();
+            auto numNodes = csrHeader.length->getNumValues();
+            auto lengthChunk =
+                ColumnChunkFactory::createColumnChunkData(*memoryManager, LogicalType::UINT64(),
+                    false, StorageConfig::NODE_GROUP_SIZE, ResidencyState::IN_MEMORY, false);
+            ChunkState chunkState;
+            csrHeader.length->initializeScanState(chunkState, csrLengthColumn);
+            csrLengthColumn->scan(chunkState, lengthChunk.get(), 0, numNodes);
+            auto* lengthData = reinterpret_cast<const uint64_t*>(lengthChunk->getData());
+            for (offset_t i = 0; i < numNodes; ++i) {
+                nodeGroupDegrees[i] += lengthData[i];
+            }
+        }
+        if (const auto* csrIndex = csrNodeGroup.getCSRIndex()) {
+            for (offset_t i = 0; i < StorageConfig::NODE_GROUP_SIZE; ++i) {
+                nodeGroupDegrees[i] += csrIndex->getNumRows(i);
+            }
+        }
+        for (offset_t i = 0; i < StorageConfig::NODE_GROUP_SIZE; ++i) {
+            if (nodeGroupDegrees[i] > 0) {
+                degrees[groupStartOffset + i] += nodeGroupDegrees[i];
+            }
+        }
+    }
+    if (transaction->isWriteTransaction()) {
+        if (auto* localTable = transaction->getLocalStorage()->getLocalTable(tableID)) {
+            auto& localRelTable = localTable->cast<LocalRelTable>();
+            for (const auto& [nodeOffset, rowIndices] : localRelTable.getCSRIndex(direction)) {
+                degrees[nodeOffset] += rowIndices.size();
+            }
+        }
+    }
+    std::vector<std::pair<offset_t, row_idx_t>> result;
+    result.reserve(degrees.size());
+    for (auto& [offset, degree] : degrees) {
+        if (degree > 0) {
+            result.emplace_back(offset, degree);
+        }
+    }
+    return result;
+}
+
+std::vector<std::pair<offset_t, row_idx_t>> RelTable::getTopKDegrees(const Transaction* transaction,
+    RelDataDirection direction, idx_t k) {
+    if (k == 0) {
+        return {};
+    }
+    using degree_entry_t = std::pair<offset_t, row_idx_t>;
+    auto better = [](const degree_entry_t& a, const degree_entry_t& b) {
+        return a.second > b.second || (a.second == b.second && a.first < b.first);
+    };
+    auto worseForHeap = [better](const degree_entry_t& a, const degree_entry_t& b) {
+        return better(a, b);
+    };
+    std::priority_queue<degree_entry_t, std::vector<degree_entry_t>, decltype(worseForHeap)> heap{
+        worseForHeap};
+
+    for (auto& entry : getDegreeEntries(transaction, direction)) {
+        if (heap.size() < k) {
+            heap.push(entry);
+        } else if (better(entry, heap.top())) {
+            heap.pop();
+            heap.push(entry);
+        }
+    }
+
+    std::vector<degree_entry_t> result;
+    while (!heap.empty()) {
+        result.push_back(heap.top());
+        heap.pop();
+    }
+    std::sort(result.begin(), result.end(), better);
+    return result;
+}
+
+row_idx_t RelTable::getNumActiveBoundNodes(const Transaction* transaction,
+    RelDataDirection direction) {
+    return getDegreeEntries(transaction, direction).size();
 }
 
 void RelTable::serialize(Serializer& ser) const {

--- a/test/optimizer/optimizer_test.cpp
+++ b/test/optimizer/optimizer_test.cpp
@@ -1,3 +1,5 @@
+#include <stdexcept>
+
 #include "graph_test/private_graph_test.h"
 #include "planner/operator/logical_plan_util.h"
 #include "planner/operator/scan/logical_count_rel_table.h"
@@ -16,7 +18,15 @@ public:
         return planner::LogicalPlanUtil::encodeJoin(*TestRunner::getLogicalPlan(query, *conn));
     }
     std::unique_ptr<planner::LogicalPlan> getRoot(const std::string& query) {
-        return TestRunner::getLogicalPlan(query, *conn);
+        auto preparedStatement = conn->prepare(query);
+        if (!preparedStatement->isSuccess()) {
+            throw std::runtime_error("Failed to prepare optimizer test query:\n" + query +
+                                     "\nError:\n" + preparedStatement->getErrorMessage());
+        }
+        auto cachedStatement =
+            conn->getClientContext()->getCachedPreparedStatementManager().getCachedStatement(
+                preparedStatement->getName());
+        return std::move(cachedStatement->logicalPlan);
     }
 
     // Helper to check if a specific operator type exists in the plan
@@ -226,8 +236,18 @@ TEST_F(OptimizerTest, SubqueryHint) {
 }
 
 TEST_F(OptimizerTest, CountRelTableOptimizer) {
+    ASSERT_TRUE(conn->query("CREATE NODE TABLE opt_user(id INT64, PRIMARY KEY(id));")->isSuccess());
+    ASSERT_TRUE(conn->query("CREATE REL TABLE opt_follows(FROM opt_user TO opt_user, date DATE);")
+                    ->isSuccess());
+    ASSERT_TRUE(conn->query("CREATE (:opt_user {id: 1});")->isSuccess());
+    ASSERT_TRUE(conn->query("CREATE (:opt_user {id: 2});")->isSuccess());
+    ASSERT_TRUE(conn->query("MATCH (a:opt_user), (b:opt_user) "
+                            "WHERE a.id = 1 AND b.id = 2 "
+                            "CREATE (a)-[:opt_follows {date: date('2020-01-01')}]->(b);")
+                    ->isSuccess());
+
     // Test that COUNT(*) over a single rel table is optimized to COUNT_REL_TABLE
-    auto q1 = "MATCH (a:person)-[e:knows]->(b:person) RETURN COUNT(*);";
+    auto q1 = "MATCH (a:opt_user)-[e:opt_follows]->(b:opt_user) RETURN COUNT(*);";
     auto plan1 = getRoot(q1);
     ASSERT_TRUE(hasOperatorType(plan1->getLastOperator().get(),
         planner::LogicalOperatorType::COUNT_REL_TABLE));
@@ -236,25 +256,144 @@ TEST_F(OptimizerTest, CountRelTableOptimizer) {
     ASSERT_TRUE(result1->isSuccess());
     ASSERT_EQ(result1->getNumTuples(), 1);
     auto tuple1 = result1->getNext();
-    ASSERT_EQ(tuple1->getValue(0)->getValue<int64_t>(), 14);
+    ASSERT_EQ(tuple1->getValue(0)->getValue<int64_t>(), 1);
 
     // Test that COUNT(*) with GROUP BY is NOT optimized (has keys)
-    auto q2 = "MATCH (a:person)-[e:knows]->(b:person) RETURN a.fName, COUNT(*);";
+    auto q2 = "MATCH (a:opt_user)-[e:opt_follows]->(b:opt_user) RETURN a.id, COUNT(*);";
     auto plan2 = getRoot(q2);
     ASSERT_FALSE(hasOperatorType(plan2->getLastOperator().get(),
         planner::LogicalOperatorType::COUNT_REL_TABLE));
 
     // Test that COUNT(*) with WHERE clause is NOT optimized (has filter)
-    auto q3 = "MATCH (a:person)-[e:knows]->(b:person) WHERE a.ID > 0 RETURN COUNT(*);";
+    auto q3 = "MATCH (a:opt_user)-[e:opt_follows]->(b:opt_user) WHERE a.id > 0 RETURN COUNT(*);";
     auto plan3 = getRoot(q3);
     ASSERT_FALSE(hasOperatorType(plan3->getLastOperator().get(),
         planner::LogicalOperatorType::COUNT_REL_TABLE));
 
     // Test that COUNT(DISTINCT ...) is NOT optimized
-    auto q4 = "MATCH (a:person)-[e:knows]->(b:person) RETURN COUNT(DISTINCT a);";
+    auto q4 = "MATCH (a:opt_user)-[e:opt_follows]->(b:opt_user) RETURN COUNT(DISTINCT a);";
     auto plan4 = getRoot(q4);
     ASSERT_FALSE(hasOperatorType(plan4->getLastOperator().get(),
         planner::LogicalOperatorType::COUNT_REL_TABLE));
+
+    // Test that COUNT(rel) over a full unfiltered rel scan is optimized to COUNT_REL_TABLE
+    auto q5 = "MATCH (a:opt_user)-[e:opt_follows]->(b:opt_user) RETURN COUNT(e);";
+    auto plan5 = getRoot(q5);
+    ASSERT_TRUE(hasOperatorType(plan5->getLastOperator().get(),
+        planner::LogicalOperatorType::COUNT_REL_TABLE));
+    auto result5 = conn->query(q5);
+    ASSERT_TRUE(result5->isSuccess());
+    ASSERT_EQ(result5->getNumTuples(), 1);
+    auto tuple5 = result5->getNext();
+    ASSERT_EQ(tuple5->getValue(0)->getValue<int64_t>(), 1);
+
+    // Test that COUNT(node) is NOT optimized by the rel-table fast path
+    auto q6 = "MATCH (a:opt_user)-[e:opt_follows]->(b:opt_user) RETURN COUNT(a);";
+    auto plan6 = getRoot(q6);
+    ASSERT_FALSE(hasOperatorType(plan6->getLastOperator().get(),
+        planner::LogicalOperatorType::COUNT_REL_TABLE));
+
+    // Test that COUNT(rel property) is NOT optimized
+    auto q7 = "MATCH (a:opt_user)-[e:opt_follows]->(b:opt_user) RETURN COUNT(e.date);";
+    auto plan7 = getRoot(q7);
+    ASSERT_FALSE(hasOperatorType(plan7->getLastOperator().get(),
+        planner::LogicalOperatorType::COUNT_REL_TABLE));
+
+    // Test active-write degree queries over native rel tables.
+    ASSERT_TRUE(
+        conn->query("CREATE NODE TABLE opt_degree_user(id INT64, PRIMARY KEY(id));")->isSuccess());
+    ASSERT_TRUE(conn->query("CREATE REL TABLE opt_degree_follows(FROM opt_degree_user TO "
+                            "opt_degree_user);")
+                    ->isSuccess());
+    ASSERT_TRUE(conn->query("CREATE (:opt_degree_user {id: 0});")->isSuccess());
+    ASSERT_TRUE(conn->query("CREATE (:opt_degree_user {id: 1});")->isSuccess());
+    ASSERT_TRUE(conn->query("CREATE (:opt_degree_user {id: 2});")->isSuccess());
+    ASSERT_TRUE(conn->query("MATCH (a:opt_degree_user), (b:opt_degree_user) "
+                            "WHERE a.id = 0 AND b.id = 1 "
+                            "CREATE (a)-[:opt_degree_follows]->(b);")
+                    ->isSuccess());
+    ASSERT_TRUE(conn->query("MATCH (a:opt_degree_user), (b:opt_degree_user) "
+                            "WHERE a.id = 0 AND b.id = 2 "
+                            "CREATE (a)-[:opt_degree_follows]->(b);")
+                    ->isSuccess());
+    ASSERT_TRUE(conn->query("MATCH (a:opt_degree_user), (b:opt_degree_user) "
+                            "WHERE a.id = 1 AND b.id = 2 "
+                            "CREATE (a)-[:opt_degree_follows]->(b);")
+                    ->isSuccess());
+
+    auto q8 = "MATCH (u:opt_degree_user)-[:opt_degree_follows]->(v) RETURN count(DISTINCT u.id);";
+    auto plan8 = getRoot(q8);
+    ASSERT_TRUE(hasOperatorType(plan8->getLastOperator().get(),
+        planner::LogicalOperatorType::REL_DEGREE_TABLE));
+    auto result8 = conn->query(q8);
+    ASSERT_TRUE(result8->isSuccess());
+    ASSERT_EQ(result8->getNext()->getValue(0)->getValue<int64_t>(), 2);
+
+    auto q9 = "MATCH (u:opt_degree_user)-[:opt_degree_follows]->(v) "
+              "RETURN u.id, count(v) AS deg ORDER BY deg DESC LIMIT 2;";
+    auto plan9 = getRoot(q9);
+    ASSERT_TRUE(hasOperatorType(plan9->getLastOperator().get(),
+        planner::LogicalOperatorType::REL_DEGREE_TABLE));
+    auto result9 = conn->query(q9);
+    ASSERT_TRUE(result9->isSuccess());
+    auto tuple9a = result9->getNext();
+    ASSERT_EQ(tuple9a->getValue(0)->getValue<int64_t>(), 0);
+    ASSERT_EQ(tuple9a->getValue(1)->getValue<int64_t>(), 2);
+    auto tuple9b = result9->getNext();
+    ASSERT_EQ(tuple9b->getValue(0)->getValue<int64_t>(), 1);
+    ASSERT_EQ(tuple9b->getValue(1)->getValue<int64_t>(), 1);
+
+    auto q10 =
+        "MATCH (a:opt_degree_user)<-[e:opt_degree_follows]-(b:opt_degree_user) RETURN COUNT(e);";
+    auto plan10 = getRoot(q10);
+    ASSERT_TRUE(hasOperatorType(plan10->getLastOperator().get(),
+        planner::LogicalOperatorType::COUNT_REL_TABLE));
+    auto result10 = conn->query(q10);
+    ASSERT_TRUE(result10->isSuccess());
+    ASSERT_EQ(result10->getNext()->getValue(0)->getValue<int64_t>(), 3);
+
+    // Test that degree top-k and active bound count merge duplicate bound nodes across rel tables.
+    ASSERT_TRUE(
+        conn->query("CREATE NODE TABLE opt_multi_user(id INT64, PRIMARY KEY(id));")->isSuccess());
+    ASSERT_TRUE(
+        conn->query("CREATE NODE TABLE opt_multi_target(id INT64, PRIMARY KEY(id));")->isSuccess());
+    ASSERT_TRUE(conn->query("CREATE REL TABLE opt_multi(FROM opt_multi_user TO opt_multi_user, "
+                            "FROM opt_multi_user TO opt_multi_target);")
+                    ->isSuccess());
+    ASSERT_TRUE(conn->query("CREATE (:opt_multi_user {id: 0});")->isSuccess());
+    ASSERT_TRUE(conn->query("CREATE (:opt_multi_user {id: 1});")->isSuccess());
+    ASSERT_TRUE(conn->query("CREATE (:opt_multi_target {id: 0});")->isSuccess());
+    ASSERT_TRUE(conn->query("CREATE (:opt_multi_target {id: 1});")->isSuccess());
+    ASSERT_TRUE(conn->query("MATCH (a:opt_multi_user), (b:opt_multi_user) "
+                            "WHERE a.id = 0 AND b.id = 1 CREATE (a)-[:opt_multi]->(b);")
+                    ->isSuccess());
+    ASSERT_TRUE(conn->query("MATCH (a:opt_multi_user), (b:opt_multi_target) "
+                            "WHERE a.id = 0 AND b.id = 0 CREATE (a)-[:opt_multi]->(b);")
+                    ->isSuccess());
+    ASSERT_TRUE(conn->query("MATCH (a:opt_multi_user), (b:opt_multi_target) "
+                            "WHERE a.id = 1 AND b.id = 1 CREATE (a)-[:opt_multi]->(b);")
+                    ->isSuccess());
+    auto q11 = "MATCH (u:opt_multi_user)-[:opt_multi]->(v) "
+               "RETURN u.id, count(*) AS deg ORDER BY deg DESC LIMIT 2;";
+    auto plan11 = getRoot(q11);
+    ASSERT_TRUE(hasOperatorType(plan11->getLastOperator().get(),
+        planner::LogicalOperatorType::REL_DEGREE_TABLE));
+    auto result11 = conn->query(q11);
+    ASSERT_TRUE(result11->isSuccess());
+    auto tuple11a = result11->getNext();
+    ASSERT_EQ(tuple11a->getValue(0)->getValue<int64_t>(), 0);
+    ASSERT_EQ(tuple11a->getValue(1)->getValue<int64_t>(), 2);
+    auto tuple11b = result11->getNext();
+    ASSERT_EQ(tuple11b->getValue(0)->getValue<int64_t>(), 1);
+    ASSERT_EQ(tuple11b->getValue(1)->getValue<int64_t>(), 1);
+
+    auto q12 = "MATCH (u:opt_multi_user)-[:opt_multi]->(v) RETURN count(DISTINCT u.id);";
+    auto plan12 = getRoot(q12);
+    ASSERT_TRUE(hasOperatorType(plan12->getLastOperator().get(),
+        planner::LogicalOperatorType::REL_DEGREE_TABLE));
+    auto result12 = conn->query(q12);
+    ASSERT_TRUE(result12->isSuccess());
+    ASSERT_EQ(result12->getNext()->getValue(0)->getValue<int64_t>(), 2);
 }
 
 } // namespace testing


### PR DESCRIPTION
## What Changed Summary

- Added `REL_DEGREE_TABLE` logical/physical source operator.
- q07 rewrite: `MATCH (u)-[:follows]->(v) RETURN count(DISTINCT u.id)` now becomes `REL_DEGREE_TABLE` in `ACTIVE_BOUND_COUNT` mode.
- q06 rewrite: `MATCH (u)-[:follows]->(v) RETURN u.id, count(v) AS deg ORDER BY deg DESC LIMIT 10` now becomes `REL_DEGREE_TABLE` in `TOP_K_DEGREES` mode after top-k optimization.
- Added CSR degree summary methods for native, icebug-disk/parquet CSR, and Arrow CSR rel tables.
- Kept q08 `COUNT_REL_TABLE` rewrite intact.

## Why

LiveJournal benchmark q06 and q07 were still executing scan-based count plans. These rewrites let the planner answer the unfiltered degree/count shapes from CSR metadata instead of scanning all `follows` edges.

## Validation

- `cmake --build build/release --target lbug_shell`
- LiveJournal icebug-disk benchmark smoke run with `build/release/tools/shell/lbug :memory: -b -i ../live-journal-benchmark/icebug_disk/schema.cypher`:
  - q06 returned the expected top 10 in ~48ms executing.
  - q07 returned `4004103` in ~0.94ms executing.
  - q08 returned `69362378` in ~0.09ms executing.
- Native in-memory smoke test for q06/q07 rewrite behavior.
