### PR TITLE
Fix Windows install without static lbug archive

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -76,7 +76,11 @@ elseif(NOT WIN32)
         set_target_properties(lbug_shared PROPERTIES OUTPUT_NAME lbug)
 endif()
 
-install(TARGETS lbug lbug_shared)
+if(MSVC)
+        install(TARGETS lbug_shared)
+else()
+        install(TARGETS lbug lbug_shared)
+endif()
 
 if(${BUILD_SINGLE_FILE_HEADER})
         # Create a command to generate lbug.hpp, and then create a target that is

--- a/test/api/arrow_complex_queries_test.cpp
+++ b/test/api/arrow_complex_queries_test.cpp
@@ -17,7 +17,6 @@ constexpr int32_t DATE_2020_01_01 = 18262;
 constexpr int32_t DATE_2021_01_01 = 18628;
 constexpr int32_t DATE_2022_01_01 = 18993;
 constexpr int32_t DATE_2023_01_01 = 19358;
-constexpr int32_t DATE_2024_01_01 = 19723;
 
 struct UserRow {
     int64_t id;


### PR DESCRIPTION
## Summary

- Fix the Windows install step after the MSVC static `lbug` archive was excluded from the default build.
- Remove an unused Arrow complex query test date constant that fails `-Werror,-Wunused-const-variable` on macOS.

## Root cause

Commit `595012848` marked the MSVC `lbug` static target `EXCLUDE_FROM_ALL` to avoid oversized COFF archives, but `install(TARGETS lbug lbug_shared)` still generated an install rule for `build/release/src/lbug.lib`. The nightly precompiled binary workflow builds the default target, then runs `cmake --install`, so the skipped static archive was missing during install.

## Change

- Install only `lbug_shared` on MSVC. Other platforms still install both `lbug` and `lbug_shared`.
- Drop the unused `DATE_2024_01_01` declaration from `arrow_complex_queries_test.cpp`.

## Validation

- `cmake -S . -B /private/tmp/lbug-cmake-install-check -G Ninja -DCMAKE_BUILD_TYPE=Release -DBUILD_SINGLE_FILE_HEADER=OFF`
- `git diff --check`
