### PR TITLE
Batch IceDisk relationship source scans

### DIFF
--- a/src/include/processor/operator/scan/scan_rel_table.h
+++ b/src/include/processor/operator/scan/scan_rel_table.h
@@ -2,6 +2,7 @@
 
 #include "binder/expression/rel_expression.h"
 #include "common/enums/extend_direction.h"
+#include "processor/operator/scan/scan_node_table.h"
 #include "processor/operator/scan/scan_table.h"
 #include "storage/predicate/column_predicate.h"
 #include "storage/table/rel_table.h"
@@ -68,14 +69,26 @@ public:
         std::unique_ptr<PhysicalOperator> child, physical_op_id id,
         std::unique_ptr<OPPrintInfo> printInfo)
         : ScanTable{type_, std::move(info), std::move(child), id, std::move(printInfo)},
-          tableInfo{std::move(tableInfo)} {}
+          tableInfo{std::move(tableInfo)}, sourceNodeScanInfo{DataPos::getInvalidPos(), {}} {}
 
     ScanRelTable(ScanOpInfo info, ScanRelTableInfo tableInfo,
         std::vector<storage::NodeTable*> sourceNodeTables, physical_op_id id,
         std::unique_ptr<OPPrintInfo> printInfo)
         : ScanTable{type_, std::move(info), id, std::move(printInfo)},
           tableInfo{std::move(tableInfo)}, sourceNodeTables{std::move(sourceNodeTables)},
-          sourceMode{true} {}
+          sourceNodeScanInfo{DataPos::getInvalidPos(), {}}, sourceMode{true} {}
+
+    ScanRelTable(ScanOpInfo info, ScanRelTableInfo tableInfo,
+        std::vector<ScanNodeTableInfo> sourceNodeTableInfos,
+        std::vector<std::shared_ptr<ScanNodeTableSharedState>> sourceNodeSharedStates,
+        std::shared_ptr<ScanNodeTableProgressSharedState> sourceNodeProgressSharedState,
+        ScanOpInfo sourceNodeScanInfo, physical_op_id id, std::unique_ptr<OPPrintInfo> printInfo)
+        : ScanTable{type_, std::move(info), id, std::move(printInfo)},
+          tableInfo{std::move(tableInfo)}, sourceNodeTableInfos{std::move(sourceNodeTableInfos)},
+          sourceNodeSharedStates{std::move(sourceNodeSharedStates)},
+          sourceNodeProgressSharedState{std::move(sourceNodeProgressSharedState)},
+          sourceNodeScanInfo{std::move(sourceNodeScanInfo)}, sourceMode{true},
+          sourceNodeScanMode{true} {}
 
     bool isSource() const override { return sourceMode; }
     bool isParallel() const override { return !sourceMode; }
@@ -86,6 +99,12 @@ public:
 
     std::unique_ptr<PhysicalOperator> copy() override {
         if (sourceMode) {
+            if (sourceNodeScanMode) {
+                return std::make_unique<ScanRelTable>(opInfo.copy(), tableInfo.copy(),
+                    copyVector(sourceNodeTableInfos), sourceNodeSharedStates,
+                    sourceNodeProgressSharedState, sourceNodeScanInfo.copy(), id,
+                    printInfo->copy());
+            }
             return std::make_unique<ScanRelTable>(opInfo.copy(), tableInfo.copy(), sourceNodeTables,
                 id, printInfo->copy());
         }
@@ -94,13 +113,21 @@ public:
     }
 
 protected:
+    void initGlobalStateInternal(ExecutionContext* context) override;
     bool fetchNextBoundNodeBatch(transaction::Transaction* transaction);
 
 protected:
     ScanRelTableInfo tableInfo;
     std::unique_ptr<storage::RelTableScanState> scanState;
     std::vector<storage::NodeTable*> sourceNodeTables;
+    std::vector<ScanNodeTableInfo> sourceNodeTableInfos;
+    std::vector<std::shared_ptr<ScanNodeTableSharedState>> sourceNodeSharedStates;
+    std::shared_ptr<ScanNodeTableProgressSharedState> sourceNodeProgressSharedState;
+    ScanOpInfo sourceNodeScanInfo;
+    std::unique_ptr<storage::TableScanState> sourceNodeScanState;
+    std::vector<common::ValueVector*> sourceNodeOutVectors;
     bool sourceMode = false;
+    bool sourceNodeScanMode = false;
     common::idx_t currentSourceTableIdx = 0;
     common::offset_t nextSourceOffset = 0;
     common::row_idx_t currentSourceTableNumRows = 0;

--- a/src/processor/map/map_extend.cpp
+++ b/src/processor/map/map_extend.cpp
@@ -1,6 +1,7 @@
 #include "binder/binder.h"
 #include "binder/expression/property_expression.h"
 #include "binder/expression_binder.h"
+#include "catalog/catalog.h"
 #include "common/enums/extend_direction_util.h"
 #include "main/client_context.h"
 #include "planner/operator/extend/logical_extend.h"
@@ -9,6 +10,7 @@
 #include "processor/operator/scan/scan_rel_table.h"
 #include "processor/plan_mapper.h"
 #include "storage/storage_manager.h"
+#include "storage/table/ice_disk_rel_table.h"
 #include "storage/table/node_table.h"
 
 using namespace lbug::binder;
@@ -126,6 +128,39 @@ static bool scanSingleRelTable(const RelExpression& rel, const NodeExpression& b
            extendDirection != ExtendDirection::BOTH;
 }
 
+static ScanNodeTableInfo getNodeTableScanInfo(const LogicalScanNodeTable& scan,
+    storage::NodeTable* table, const catalog::TableCatalogEntry* tableEntry,
+    main::ClientContext* clientContext) {
+    auto tableInfo = ScanNodeTableInfo(table, copyVector(scan.getPropertyPredicates()));
+    auto binder = Binder(clientContext);
+    auto expressionBinder = ExpressionBinder(&binder, clientContext);
+    for (auto& expr : scan.getProperties()) {
+        auto& property = expr->constCast<PropertyExpression>();
+        if (property.hasProperty(tableEntry->getTableID())) {
+            auto propertyName = property.getPropertyName();
+            if (!tableEntry->containsProperty(propertyName) &&
+                tableEntry->containsProperty("data")) {
+                auto columnCaster = ColumnCaster(LogicalType::JSON());
+                columnCaster.setJSONExtract(propertyName);
+                tableInfo.addColumnInfo(tableEntry->getColumnID("data"), std::move(columnCaster));
+                continue;
+            }
+            auto& columnType = tableEntry->getProperty(propertyName).getType();
+            auto columnCaster = ColumnCaster(columnType.copy());
+            if (property.getDataType() != columnType) {
+                auto columnExpr = std::make_shared<PropertyExpression>(property);
+                columnExpr->dataType = columnType.copy();
+                columnCaster.setCastExpr(
+                    expressionBinder.forceCast(columnExpr, property.getDataType()));
+            }
+            tableInfo.addColumnInfo(tableEntry->getColumnID(propertyName), std::move(columnCaster));
+        } else {
+            tableInfo.addColumnInfo(INVALID_COLUMN_ID, ColumnCaster(LogicalType::ANY()));
+        }
+    }
+    return tableInfo;
+}
+
 std::unique_ptr<PhysicalOperator> PlanMapper::mapExtend(const LogicalOperator* logicalOperator) {
     auto extend = logicalOperator->constPtrCast<LogicalExtend>();
     auto outFSchema = extend->getSchema();
@@ -162,22 +197,51 @@ std::unique_ptr<PhysicalOperator> PlanMapper::mapExtend(const LogicalOperator* l
         if (logicalOperator->getChild(0)->getOperatorType() ==
             LogicalOperatorType::SCAN_NODE_TABLE) {
             auto* scanNode = logicalOperator->getChild(0)->ptrCast<LogicalScanNodeTable>();
-            if (scanNode->getScanType() == LogicalScanNodeTableType::SCAN &&
-                scanNode->getProperties().empty()) {
+            if (scanNode->getScanType() == LogicalScanNodeTableType::SCAN) {
                 std::vector<NodeTable*> sourceNodeTables;
+                std::vector<ScanNodeTableInfo> sourceNodeTableInfos;
+                std::vector<std::shared_ptr<ScanNodeTableSharedState>> sourceNodeSharedStates;
                 auto expectedBoundTableID = relDataDirection == RelDataDirection::FWD ?
                                                 relTable->getFromNodeTableID() :
                                                 relTable->getToNodeTableID();
+                auto catalog = catalog::Catalog::Get(*clientContext);
+                auto transaction = transaction::Transaction::Get(*clientContext);
                 for (auto tableID : scanNode->getTableIDs()) {
                     if (tableID == expectedBoundTableID) {
-                        sourceNodeTables.push_back(
-                            storageManager->getTable(tableID)->ptrCast<NodeTable>());
+                        auto table = storageManager->getTable(tableID)->ptrCast<NodeTable>();
+                        sourceNodeTables.push_back(table);
+                        auto tableEntry = catalog->getTableCatalogEntry(transaction, tableID);
+                        sourceNodeTableInfos.push_back(
+                            getNodeTableScanInfo(*scanNode, table, tableEntry, clientContext));
+                        auto semiMask =
+                            SemiMaskUtil::createMask(table->getNumTotalRows(transaction));
+                        sourceNodeSharedStates.push_back(
+                            std::make_shared<ScanNodeTableSharedState>(std::move(semiMask)));
                     }
                 }
-                // Only apply optimization if scan node is not already mapped (e.g., by a
-                // semi-masker)
+                if (!sourceNodeTables.empty() && !scanNode->getProperties().empty() &&
+                    dynamic_cast<IceDiskRelTable*>(relTable) != nullptr) {
+                    std::vector<DataPos> sourceOutVectorsPos;
+                    for (auto& expression : scanNode->getProperties()) {
+                        sourceOutVectorsPos.emplace_back(getDataPos(*expression, *inFSchema));
+                    }
+                    auto sourceNodeScanInfo =
+                        ScanOpInfo(inNodeIDPos, std::move(sourceOutVectorsPos));
+                    auto progressSharedState = std::make_shared<ScanNodeTableProgressSharedState>();
+                    return std::make_unique<ScanRelTable>(std::move(scanInfo),
+                        std::move(scanRelInfo), std::move(sourceNodeTableInfos),
+                        std::move(sourceNodeSharedStates), std::move(progressSharedState),
+                        std::move(sourceNodeScanInfo), getOperatorID(), printInfo->copy());
+                }
+                // Only apply the existing no-property optimization if scan node is not already
+                // mapped (e.g., by a semi-masker).
                 if (!sourceNodeTables.empty() &&
                     !logicalOpToPhysicalOpMap.contains(logicalOperator->getChild(0).get())) {
+                    if (!scanNode->getProperties().empty()) {
+                        return std::make_unique<ScanRelTable>(std::move(scanInfo),
+                            std::move(scanRelInfo), std::move(prevOperator), getOperatorID(),
+                            printInfo->copy());
+                    }
                     return std::make_unique<ScanRelTable>(std::move(scanInfo),
                         std::move(scanRelInfo), std::move(sourceNodeTables), getOperatorID(),
                         printInfo->copy());

--- a/src/processor/operator/scan/scan_rel_table.cpp
+++ b/src/processor/operator/scan/scan_rel_table.cpp
@@ -7,8 +7,10 @@
 #include "processor/execution_context.h"
 #include "storage/buffer_manager/memory_manager.h"
 #include "storage/local_storage/local_rel_table.h"
+#include "storage/table/arrow_node_table.h"
 #include "storage/table/arrow_rel_table.h"
 #include "storage/table/foreign_rel_table.h"
+#include "storage/table/ice_disk_node_table.h"
 #include "storage/table/ice_disk_rel_table.h"
 #include "storage/table/node_table.h"
 
@@ -17,6 +19,20 @@ using namespace lbug::storage;
 
 namespace lbug {
 namespace processor {
+
+static std::unique_ptr<TableScanState> createSourceNodeTableScanState(NodeTable* table,
+    ValueVector* nodeIDVector, const std::vector<ValueVector*>& outVectors,
+    MemoryManager* memoryManager) {
+    if (dynamic_cast<IceDiskNodeTable*>(table) != nullptr) {
+        return std::make_unique<IceDiskNodeTableScanState>(*memoryManager, nodeIDVector, outVectors,
+            nodeIDVector->state);
+    }
+    if (dynamic_cast<ArrowNodeTable*>(table) != nullptr) {
+        return std::make_unique<ArrowNodeTableScanState>(*memoryManager, nodeIDVector, outVectors,
+            nodeIDVector->state);
+    }
+    return std::make_unique<NodeTableScanState>(nodeIDVector, outVectors, nodeIDVector->state);
+}
 
 std::string ScanRelTablePrintInfo::toString() const {
     std::string result = "Tables: ";
@@ -95,6 +111,12 @@ void ScanRelTable::initLocalStateInternal(ResultSet* resultSet, ExecutionContext
             boundNodeIDVector, outVectors, nbrNodeIDVector->state);
     }
     tableInfo.initScanState(*scanState, outVectors, clientContext);
+    if (sourceNodeScanMode) {
+        sourceNodeOutVectors.clear();
+        for (auto& pos : sourceNodeScanInfo.outVectorsPos) {
+            sourceNodeOutVectors.push_back(resultSet->getValueVector(pos).get());
+        }
+    }
     if (sourceMode) {
         currentSourceTableIdx = 0;
         nextSourceOffset = 0;
@@ -102,7 +124,61 @@ void ScanRelTable::initLocalStateInternal(ResultSet* resultSet, ExecutionContext
     }
 }
 
+void ScanRelTable::initGlobalStateInternal(ExecutionContext* context) {
+    if (!sourceNodeScanMode) {
+        return;
+    }
+    DASSERT(sourceNodeTableInfos.size() == sourceNodeSharedStates.size());
+    for (auto i = 0u; i < sourceNodeTableInfos.size(); ++i) {
+        sourceNodeSharedStates[i]->initialize(
+            transaction::Transaction::Get(*context->clientContext),
+            sourceNodeTableInfos[i].table->ptrCast<NodeTable>(), *sourceNodeProgressSharedState);
+    }
+}
+
+static void initSourceNodeScanState(ScanNodeTableInfo& sourceInfo,
+    std::unique_ptr<TableScanState>& sourceScanState, ValueVector* boundNodeIDVector,
+    const std::vector<ValueVector*>& sourceNodeOutVectors, main::ClientContext* context) {
+    sourceScanState = createSourceNodeTableScanState(sourceInfo.table->ptrCast<NodeTable>(),
+        boundNodeIDVector, sourceNodeOutVectors, MemoryManager::Get(*context));
+    sourceInfo.initScanState(*sourceScanState, sourceNodeOutVectors, context);
+    if (dynamic_cast<IceDiskNodeTable*>(sourceInfo.table) ||
+        dynamic_cast<ArrowNodeTable*>(sourceInfo.table)) {
+        sourceInfo.table->initScanState(transaction::Transaction::Get(*context), *sourceScanState);
+    }
+}
+
 bool ScanRelTable::fetchNextBoundNodeBatch(transaction::Transaction* transaction) {
+    if (sourceNodeScanMode) {
+        auto* boundNodeIDVector = scanState->nodeIDVector;
+        auto context = transaction->getClientContext();
+        while (currentSourceTableIdx < sourceNodeTableInfos.size()) {
+            auto& sourceInfo = sourceNodeTableInfos[currentSourceTableIdx];
+            if (!sourceNodeScanState) {
+                initSourceNodeScanState(sourceInfo, sourceNodeScanState, boundNodeIDVector,
+                    sourceNodeOutVectors, context);
+            }
+            while (sourceInfo.table->scan(transaction, *sourceNodeScanState)) {
+                const auto outputSize = sourceNodeScanState->outState->getSelVector().getSelSize();
+                if (outputSize > 0) {
+                    sourceInfo.castColumns();
+                    sourceNodeScanState->outState->setToUnflat();
+                    tableInfo.table->initScanState(transaction, *scanState);
+                    return true;
+                }
+            }
+            sourceNodeSharedStates[currentSourceTableIdx]->nextMorsel(*sourceNodeScanState,
+                *sourceNodeProgressSharedState);
+            if (sourceNodeScanState->source == TableScanSource::NONE) {
+                currentSourceTableIdx++;
+                sourceNodeScanState = nullptr;
+            } else {
+                sourceInfo.table->initScanState(transaction, *sourceNodeScanState);
+            }
+        }
+        return false;
+    }
+
     auto* boundNodeIDVector = scanState->nodeIDVector;
     while (currentSourceTableIdx < sourceNodeTables.size()) {
         auto* nodeTable = sourceNodeTables[currentSourceTableIdx];

--- a/src/storage/table/ice_disk_node_table.cpp
+++ b/src/storage/table/ice_disk_node_table.cpp
@@ -266,45 +266,9 @@ bool IceDiskNodeTable::scanInternal(Transaction* transaction, TableScanState& sc
         iceDiskScanState.dataRead = true;
     }
 
-    // Now distribute one row to this scan state
     if (iceDiskScanState.nextRowToDistribute >= iceDiskScanState.totalRows) {
         iceDiskScanState.scanCompleted = true;
-        return false; // No more rows to distribute
-    }
-
-    size_t rowIndex = iceDiskScanState.nextRowToDistribute++;
-
-    // Copy one row to output vectors
-    // Defensive checks: ensure valid row index and handle empty data gracefully
-    if (rowIndex >= iceDiskScanState.allData.size()) {
-        iceDiskScanState.scanCompleted = true;
         return false;
-    }
-
-    auto numColumns =
-        std::min(scanState.outputVectors.size(), iceDiskScanState.allData[rowIndex].size());
-    for (size_t col = 0; col < numColumns; ++col) {
-        // Defensive check: ensure output vector exists
-        if (col >= scanState.outputVectors.size() || !scanState.outputVectors[col]) {
-            continue;
-        }
-
-        auto& dstVector = *scanState.outputVectors[col];
-
-        // Defensive check: ensure value exists for this column
-        if (col >= iceDiskScanState.allData[rowIndex].size() ||
-            !iceDiskScanState.allData[rowIndex][col]) {
-            dstVector.setNull(0, true);
-            continue;
-        }
-
-        auto& value = *iceDiskScanState.allData[rowIndex][col];
-
-        if (value.isNull()) {
-            dstVector.setNull(0, true);
-        } else {
-            dstVector.copyFromValue(0, value);
-        }
     }
 
     // calc current global row index based on assigned row group and local row index within that
@@ -319,11 +283,47 @@ bool IceDiskNodeTable::scanInternal(Transaction* transaction, TableScanState& sc
 
     // Set node ID for this row
     auto tableID = this->getTableID();
-    auto& nodeID = scanState.nodeIDVector->getValue<nodeID_t>(0);
-    nodeID.tableID = tableID;
-    nodeID.offset = startOffset + rowIndex; // Use the actual row index from parquet
+    auto rowsToDistribute = std::min<uint64_t>(DEFAULT_VECTOR_CAPACITY,
+        iceDiskScanState.totalRows - iceDiskScanState.nextRowToDistribute);
+    uint64_t rowsDistributed = 0;
+    for (; rowsDistributed < rowsToDistribute; ++rowsDistributed) {
+        const auto rowIndex = iceDiskScanState.nextRowToDistribute++;
+        if (rowIndex >= iceDiskScanState.allData.size()) {
+            iceDiskScanState.scanCompleted = true;
+            break;
+        }
 
-    scanState.outState->getSelVectorUnsafe().setSelSize(1); // Return exactly one row
+        auto numColumns =
+            std::min(scanState.outputVectors.size(), iceDiskScanState.allData[rowIndex].size());
+        for (size_t col = 0; col < numColumns; ++col) {
+            if (col >= scanState.outputVectors.size() || !scanState.outputVectors[col]) {
+                continue;
+            }
+
+            auto& dstVector = *scanState.outputVectors[col];
+            if (col >= iceDiskScanState.allData[rowIndex].size() ||
+                !iceDiskScanState.allData[rowIndex][col]) {
+                dstVector.setNull(rowsDistributed, true);
+                continue;
+            }
+
+            auto& value = *iceDiskScanState.allData[rowIndex][col];
+            if (value.isNull()) {
+                dstVector.setNull(rowsDistributed, true);
+            } else {
+                dstVector.copyFromValue(rowsDistributed, value);
+            }
+        }
+
+        auto& nodeID = scanState.nodeIDVector->getValue<nodeID_t>(rowsDistributed);
+        nodeID.tableID = tableID;
+        nodeID.offset = startOffset + rowIndex;
+    }
+
+    if (rowsDistributed == 0) {
+        return false;
+    }
+    scanState.outState->getSelVectorUnsafe().setToUnfiltered(rowsDistributed);
     return true;
 }
 


### PR DESCRIPTION
## Summary
```
lbug -i xet://datasets/ladybugdb/small-kgs/main/kg_history/icebug-disk/schema.cypher
lbug> MATCH (a:person)-[b:proposed]->(c:concept) RETURN *; 
<takes 17 secs because of many network roundtrips>
```

- batch IceDisk relationship source scans when the bound node scan has projected properties
- return IceDisk node scan rows in vector batches instead of one row per scan call

## Why
Remote relationship scans were slow when the bound node had projected properties: the planner could not use source-mode batching, and IceDisk node scans emitted one row per call, so the relationship parquet was rescanned once per bound node. IceDisk relationship extends can now scan the source node properties inside the source-mode rel operator, and IceDisk node scans emit vector batches.

## Validation
- profile MATCH (a:person)-[b:proposed]->(c:concept) RETURN *; via xet://datasets/ladybugdb/small-kgs/main/kg_history/icebug-disk/schema.cypher
  - before: SCAN_REL_TABLE ~9.8s, wall ~17s
  - after: SCAN_REL_TABLE ~3.7s, wall ~10s