### PR TITLE
Fix duplicate MERGE default projection

### DIFF
--- a/src/include/planner/operator/persistent/logical_merge.h
+++ b/src/include/planner/operator/persistent/logical_merge.h
@@ -60,9 +60,13 @@ public:
     }
     const binder::expression_vector& getKeys() const { return keys; }
 
+    bool suppressesDuplicateCreatedOutput() const { return suppressDuplicateCreatedOutput; }
+
     std::unique_ptr<LogicalOperator> copy() override;
 
 private:
+    void computeSuppressDuplicateCreatedOutput();
+
     std::shared_ptr<binder::Expression> existenceMark;
     // Create infos
     std::vector<LogicalInsertInfo> insertNodeInfos;
@@ -79,6 +83,7 @@ private:
     // Since we don't re-evaluate the existence of n for each x, we need to create n only for
     // distinct x, i.e. 1 & 3. So there is a notion of key in MERGE.
     binder::expression_vector keys;
+    bool suppressDuplicateCreatedOutput = false;
 };
 
 } // namespace planner

--- a/src/include/processor/operator/persistent/insert_executor.h
+++ b/src/include/processor/operator/persistent/insert_executor.h
@@ -42,6 +42,7 @@ struct NodeTableInsertInfo {
 
     common::ValueVector* pkVector;
     std::vector<common::ValueVector*> columnDataVectors;
+    std::vector<common::column_id_t> columnIDs;
 
     NodeTableInsertInfo(storage::NodeTable* table,
         evaluator::evaluator_vector_t columnDataEvaluators)
@@ -70,6 +71,7 @@ public:
     // For MERGE, we might need to skip the insert for duplicate input. But still, we need to write
     // the output vector for later usage.
     void skipInsert() const;
+    void skipInsert(common::nodeID_t nodeID, main::ClientContext* context) const;
 
 private:
     NodeInsertExecutor(const NodeInsertExecutor& other)

--- a/src/include/processor/operator/persistent/merge.h
+++ b/src/include/processor/operator/persistent/merge.h
@@ -12,19 +12,25 @@ struct MergeInfo {
     std::vector<std::unique_ptr<evaluator::ExpressionEvaluator>> keyEvaluators;
     FactorizedTableSchema tableSchema;
     common::executor_info executorInfo;
+    bool storeInsertedPatternIDs;
+    bool suppressDuplicateCreatedOutput;
     DataPos existenceMark;
 
     MergeInfo(std::vector<std::unique_ptr<evaluator::ExpressionEvaluator>> keyEvaluators,
         FactorizedTableSchema tableSchema, common::executor_info executorInfo,
-        DataPos existenceMark)
+        bool storeInsertedPatternIDs, bool suppressDuplicateCreatedOutput, DataPos existenceMark)
         : keyEvaluators{std::move(keyEvaluators)}, tableSchema{std::move(tableSchema)},
-          executorInfo{std::move(executorInfo)}, existenceMark{existenceMark} {}
+          executorInfo{std::move(executorInfo)}, storeInsertedPatternIDs{storeInsertedPatternIDs},
+          suppressDuplicateCreatedOutput{suppressDuplicateCreatedOutput},
+          existenceMark{existenceMark} {}
     EXPLICIT_COPY_DEFAULT_MOVE(MergeInfo);
 
 private:
     MergeInfo(const MergeInfo& other)
         : keyEvaluators{copyVector(other.keyEvaluators)}, tableSchema{other.tableSchema.copy()},
-          executorInfo{other.executorInfo}, existenceMark{other.existenceMark} {}
+          executorInfo{other.executorInfo}, storeInsertedPatternIDs{other.storeInsertedPatternIDs},
+          suppressDuplicateCreatedOutput{other.suppressDuplicateCreatedOutput},
+          existenceMark{other.existenceMark} {}
 };
 
 struct MergePrintInfo final : OPPrintInfo {
@@ -103,7 +109,7 @@ private:
 
     void executeOnNewPattern(PatternCreationInfo& info, ExecutionContext* context);
 
-    void executeNoMatch(ExecutionContext* context);
+    bool executeNoMatch(ExecutionContext* context);
 
 private:
     std::vector<NodeInsertExecutor> nodeInsertExecutors;

--- a/src/include/processor/result/pattern_creation_info_table.h
+++ b/src/include/processor/result/pattern_creation_info_table.h
@@ -15,7 +15,7 @@ struct PatternCreationInfo {
     }
 
     void updateID(common::executor_id_t executorID, common::executor_info executorInfo,
-        common::nodeID_t nodeID) const;
+        bool storeInsertedPatternIDs, common::nodeID_t nodeID) const;
 };
 
 class PatternCreationInfoTable : public AggregateHashTable {

--- a/src/planner/operator/persistent/logical_merge.cpp
+++ b/src/planner/operator/persistent/logical_merge.cpp
@@ -1,7 +1,10 @@
 #include "planner/operator/persistent/logical_merge.h"
 
+#include <unordered_set>
+
 #include "binder/expression/node_expression.h"
 #include "binder/expression/rel_expression.h"
+#include "binder/expression_visitor.h"
 #include "common/cast.h"
 #include "planner/operator/factorization/flatten_resolver.h"
 
@@ -11,7 +14,57 @@ using namespace lbug::common;
 namespace lbug {
 namespace planner {
 
+static bool hasNonKeyPayload(const Schema& schema, const expression_vector& keys,
+    const std::vector<LogicalInsertInfo>& insertNodeInfos,
+    const std::vector<LogicalInsertInfo>& insertRelInfos, const Expression& existenceMark) {
+    std::unordered_set<std::string> keyNames;
+    keyNames.insert(existenceMark.getUniqueName());
+    for (auto& key : keys) {
+        keyNames.insert(key->getUniqueName());
+        DependentVarNameCollector collector;
+        collector.visit(key);
+        for (auto& name : collector.getVarNames()) {
+            keyNames.insert(name);
+        }
+    }
+    for (auto& info : insertNodeInfos) {
+        keyNames.insert(info.pattern->getUniqueName());
+        for (auto& expression : info.columnExprs) {
+            keyNames.insert(expression->getUniqueName());
+        }
+    }
+    for (auto& info : insertRelInfos) {
+        for (auto& expression : info.columnExprs) {
+            keyNames.insert(expression->getUniqueName());
+        }
+    }
+    for (auto& expression : schema.getExpressionsInScope()) {
+        auto uniqueName = expression->getUniqueName();
+        auto isMergePatternExpression = false;
+        for (auto& info : insertNodeInfos) {
+            isMergePatternExpression |= uniqueName.starts_with(info.pattern->getUniqueName() + ".");
+        }
+        for (auto& info : insertRelInfos) {
+            isMergePatternExpression |= uniqueName.starts_with(info.pattern->getUniqueName() + ".");
+        }
+        if (!keyNames.contains(uniqueName) && !isMergePatternExpression) {
+            return true;
+        }
+    }
+    return false;
+}
+
+void LogicalMerge::computeSuppressDuplicateCreatedOutput() {
+    auto childSchema = children[0]->getSchema();
+    auto storesInsertedPatternIDs = onMatchSetNodeInfos.empty() && onMatchSetRelInfos.empty();
+    suppressDuplicateCreatedOutput =
+        storesInsertedPatternIDs && insertRelInfos.empty() && onCreateSetNodeInfos.empty() &&
+        onCreateSetRelInfos.empty() &&
+        !hasNonKeyPayload(*childSchema, keys, insertNodeInfos, insertRelInfos, *existenceMark);
+}
+
 void LogicalMerge::computeFactorizedSchema() {
+    computeSuppressDuplicateCreatedOutput();
     copyChildSchema(0);
     for (auto& info : insertNodeInfos) {
         // Predicate iri is not matched but needs to be inserted.
@@ -33,6 +86,7 @@ void LogicalMerge::computeFactorizedSchema() {
 }
 
 void LogicalMerge::computeFlatSchema() {
+    computeSuppressDuplicateCreatedOutput();
     copyChildSchema(0);
     for (auto& info : insertNodeInfos) {
         auto node = dynamic_cast_checked<NodeExpression*>(info.pattern.get());
@@ -57,6 +111,7 @@ std::unique_ptr<LogicalOperator> LogicalMerge::copy() {
     merge->onCreateSetRelInfos = copyVector(onCreateSetRelInfos);
     merge->onMatchSetNodeInfos = copyVector(onMatchSetNodeInfos);
     merge->onMatchSetRelInfos = copyVector(onMatchSetRelInfos);
+    merge->suppressDuplicateCreatedOutput = suppressDuplicateCreatedOutput;
     return merge;
 }
 

--- a/src/processor/map/map_merge.cpp
+++ b/src/processor/map/map_merge.cpp
@@ -102,11 +102,17 @@ std::unique_ptr<PhysicalOperator> PlanMapper::mapMerge(const LogicalOperator* lo
         keyEvaluators.push_back(expressionMapper.getEvaluator(key));
     }
 
+    auto storeInsertedPatternIDs = logicalMerge.getOnMatchSetNodeInfos().empty() &&
+                                   logicalMerge.getOnMatchSetRelInfos().empty();
+    auto suppressDuplicateCreatedOutput = logicalMerge.suppressesDuplicateCreatedOutput();
+    auto numNodeIDFields = storeInsertedPatternIDs ? logicalMerge.getInsertNodeInfos().size() :
+                                                     logicalMerge.getOnMatchSetNodeInfos().size();
+    auto numRelIDFields = storeInsertedPatternIDs ? logicalMerge.getInsertRelInfos().size() :
+                                                    logicalMerge.getOnMatchSetRelInfos().size();
     MergeInfo mergeInfo{std::move(keyEvaluators),
-        getFactorizedTableSchema(logicalMerge.getKeys(),
-            logicalMerge.getOnMatchSetNodeInfos().size(),
-            logicalMerge.getOnMatchSetRelInfos().size()),
-        std::move(executorInfo), existenceMarkPos};
+        getFactorizedTableSchema(logicalMerge.getKeys(), numNodeIDFields, numRelIDFields),
+        std::move(executorInfo), storeInsertedPatternIDs, suppressDuplicateCreatedOutput,
+        existenceMarkPos};
     return std::make_unique<Merge>(std::move(nodeInsertExecutors), std::move(relInsertExecutors),
         std::move(onCreateNodeSetExecutors), std::move(onCreateRelSetExecutors),
         std::move(onMatchNodeSetExecutors), std::move(onMatchRelSetExecutors), std::move(mergeInfo),

--- a/src/processor/operator/persistent/insert_executor.cpp
+++ b/src/processor/operator/persistent/insert_executor.cpp
@@ -39,6 +39,7 @@ void NodeTableInsertInfo::init(const ResultSet& resultSet, main::ClientContext* 
     for (auto& evaluator : columnDataEvaluators) {
         evaluator->init(resultSet, context);
         columnDataVectors.push_back(evaluator->resultVector.get());
+        columnIDs.push_back(columnIDs.size());
     }
     pkVector = columnDataVectors[table->getPKColumnID()];
 }
@@ -112,6 +113,28 @@ void NodeInsertExecutor::skipInsert() const {
     }
     info.nodeIDVector->setNull(info.nodeIDVector->state->getSelVector()[0], false);
     writeColumnVectors(info.columnVectors, tableInfo.columnDataVectors);
+}
+
+void NodeInsertExecutor::skipInsert(nodeID_t nodeID, main::ClientContext* context) const {
+    info.updateNodeID(nodeID);
+    std::vector<column_id_t> columnIDs;
+    std::vector<ValueVector*> outputVectors;
+    for (auto i = 0u; i < info.columnVectors.size(); ++i) {
+        if (info.columnVectors[i] == nullptr) {
+            continue;
+        }
+        columnIDs.push_back(tableInfo.columnIDs[i]);
+        outputVectors.push_back(info.columnVectors[i]);
+    }
+    if (outputVectors.empty()) {
+        return;
+    }
+    auto transaction = Transaction::Get(*context);
+    storage::NodeTableScanState scanState{info.nodeIDVector, std::move(outputVectors),
+        info.nodeIDVector->state};
+    scanState.setToTable(transaction, tableInfo.table, std::move(columnIDs), {});
+    tableInfo.table->initScanState(transaction, scanState, nodeID.tableID, nodeID.offset);
+    tableInfo.table->lookup(transaction, scanState);
 }
 
 bool NodeInsertExecutor::checkConflict(const Transaction* transaction) const {

--- a/src/processor/operator/persistent/merge.cpp
+++ b/src/processor/operator/persistent/merge.cpp
@@ -73,8 +73,13 @@ void Merge::executeOnMatch(ExecutionContext* context) {
 
 void Merge::executeOnCreatedPattern(PatternCreationInfo& patternCreationInfo,
     ExecutionContext* context) {
-    for (auto& executor : nodeInsertExecutors) {
-        executor.skipInsert();
+    for (auto i = 0u; i < nodeInsertExecutors.size(); ++i) {
+        auto& executor = nodeInsertExecutors[i];
+        if (info.storeInsertedPatternIDs) {
+            executor.skipInsert(patternCreationInfo.getPatternID(i), context->clientContext);
+        } else {
+            executor.skipInsert();
+        }
     }
     for (auto& executor : relInsertExecutors) {
         executor.skipInsert();
@@ -100,12 +105,13 @@ void Merge::executeOnNewPattern(PatternCreationInfo& patternCreationInfo,
         auto& executor = nodeInsertExecutors[i];
         executor.setNodeIDVectorToNonNull();
         auto nodeID = executor.insert(context->clientContext);
-        patternCreationInfo.updateID(i, info.executorInfo, nodeID);
+        patternCreationInfo.updateID(i, info.executorInfo, info.storeInsertedPatternIDs, nodeID);
     }
     for (auto i = 0u; i < relInsertExecutors.size(); i++) {
         auto& executor = relInsertExecutors[i];
         auto relID = executor.insert(context->clientContext);
-        patternCreationInfo.updateID(i + nodeInsertExecutors.size(), info.executorInfo, relID);
+        patternCreationInfo.updateID(i + nodeInsertExecutors.size(), info.executorInfo,
+            info.storeInsertedPatternIDs, relID);
     }
     for (auto& executor : onCreateNodeSetExecutors) {
         executor->set(context);
@@ -115,28 +121,33 @@ void Merge::executeOnNewPattern(PatternCreationInfo& patternCreationInfo,
     }
 }
 
-void Merge::executeNoMatch(ExecutionContext* context) {
+bool Merge::executeNoMatch(ExecutionContext* context) {
     for (auto& evaluator : info.keyEvaluators) {
         evaluator->evaluate();
     }
     auto patternCreationInfo = localState.getPatternCreationInfo();
     if (patternCreationInfo.hasCreated) {
+        if (info.suppressDuplicateCreatedOutput) {
+            return false;
+        }
         executeOnCreatedPattern(patternCreationInfo, context);
     } else {
         executeOnNewPattern(patternCreationInfo, context);
     }
+    return true;
 }
 
 bool Merge::getNextTuplesInternal(ExecutionContext* context) {
-    if (!children[0]->getNextTuple(context)) {
-        return false;
+    while (children[0]->getNextTuple(context)) {
+        if (localState.patternExists()) {
+            executeOnMatch(context);
+            return true;
+        }
+        if (executeNoMatch(context)) {
+            return true;
+        }
     }
-    if (localState.patternExists()) {
-        executeOnMatch(context);
-    } else {
-        executeNoMatch(context);
-    }
-    return true;
+    return false;
 }
 
 } // namespace processor

--- a/src/processor/result/pattern_creation_info_table.cpp
+++ b/src/processor/result/pattern_creation_info_table.cpp
@@ -4,7 +4,12 @@ namespace lbug {
 namespace processor {
 
 void PatternCreationInfo::updateID(common::executor_id_t executorID,
-    common::executor_info executorInfo, common::nodeID_t nodeID) const {
+    common::executor_info executorInfo, bool storeInsertedPatternIDs,
+    common::nodeID_t nodeID) const {
+    if (storeInsertedPatternIDs) {
+        *(common::nodeID_t*)(tuple + executorID * sizeof(common::nodeID_t)) = nodeID;
+        return;
+    }
     if (!executorInfo.contains(executorID)) {
         return;
     }

--- a/test/test_files/issue/issue.test
+++ b/test/test_files/issue/issue.test
@@ -765,3 +765,31 @@ h
 -STATEMENT UNWIND [gen_random_uuid(), gen_random_uuid()] AS i RETURN COUNT(DISTINCT i);
 ---- 1
 2
+-STATEMENT CREATE NODE TABLE A_uuid(id STRING DEFAULT gen_random_uuid(), stuff INT64, PRIMARY KEY(id));
+---- ok
+-STATEMENT UNWIND [1, 1] AS i
+           MERGE (a:A_uuid {stuff: i})
+           WITH collect(a.id) AS ids
+           RETURN size(ids), COUNT(DISTINCT ids[1]);
+---- 1
+1|1
+-STATEMENT UNWIND [1, 1] AS i
+           MERGE (a:A_uuid {stuff: i})
+           WITH a
+           RETURN COUNT(*), COUNT(DISTINCT a.id);
+---- 1
+1|1
+-STATEMENT MATCH (a:A_uuid) RETURN COUNT(*), COUNT(DISTINCT a.id);
+---- 1
+1|1
+-STATEMENT CREATE NODE TABLE A_uuid_count(id STRING DEFAULT gen_random_uuid(), stuff INT64, PRIMARY KEY(id));
+---- ok
+-STATEMENT UNWIND [1, 1] AS i
+           MERGE (a:A_uuid_count {stuff: i})
+           WITH a
+           RETURN COUNT(*), COUNT(DISTINCT a.id);
+---- 1
+1|1
+-STATEMENT MATCH (a:A_uuid_count) RETURN COUNT(*), COUNT(DISTINCT a.id);
+---- 1
+1|1

--- a/tools/shell/test/test_shell_basics.py
+++ b/tools/shell/test/test_shell_basics.py
@@ -1,4 +1,5 @@
 import os
+import re
 
 import pexpect
 import pytest
@@ -45,6 +46,33 @@ def test_invalid_cast(temp_db) -> None:
     result.check_stdout(
         'Error: Conversion exception: Cast failed. Could not convert "****" to INT8.',
     )
+
+
+def test_unwind_merge_uuid_default_returns_same_id(temp_db) -> None:
+    test = (
+        ShellTest()
+        .add_argument(temp_db)
+        .add_argument("-m")
+        .add_argument("csv")
+        .add_argument("-s")
+        .add_argument("-b")
+        .statement(
+            "CREATE NODE TABLE MergeUuidDefault("
+            "id STRING DEFAULT gen_random_uuid(), stuff INT64, PRIMARY KEY(id));"
+        )
+        .statement(
+            "UNWIND [1, 1] AS i "
+            "MERGE (a:MergeUuidDefault {stuff: i}) "
+            "RETURN a.id;"
+        )
+    )
+    result = test.run()
+    assert result.status_code == 0
+    ids = re.findall(
+        r"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}",
+        result.stdout,
+    )
+    assert len(ids) == 1
 
 
 def test_enter_in_between_input(temp_db) -> None:


### PR DESCRIPTION
Fixes: #170 

## Summary

This fix separates the responsibilities more cleanly:

  Planner / `LogicalMerge`:
  - Decides whether duplicate-created `MERGE` rows are user-visible.
  - Computes `suppressDuplicateCreatedOutput` from the logical child schema, merge keys, inserted pattern expressions, and ON CREATE / ON MATCH state.
  - Suppresses duplicate-created output only when the row has no non-key upstream payload and no ON CREATE side effects.

  Mapper / `map_merge`:
  - No longer classifies payload semantics.
  - Just reads `logicalMerge.suppressesDuplicateCreatedOutput()` and passes that decision into physical `MergeInfo`.
  - Still owns the mechanical translation from logical expressions to evaluators, executors, `DataPos`, and local table layout.

  Executor / persistent `Merge`:
  - Enforces the planner’s decision.
  - The pattern creation table still deduplicates physical creation by merge key.
  - If a later row hits an already-created key, the executor either suppresses the duplicate-created output row or rehydrates the already-created pattern for output, depending on the planner-provided flag.

  The important semantic invariant is:

  `MERGE` creates at most one physical pattern per merge key, but duplicate-created output rows are preserved only when they carry user-visible upstream payload.

  That gives the desired behavior for both cases:
  - `UNWIND [1, 1] AS i MERGE (a {stuff: i}) RETURN a.id` returns one row.
  - `MATCH ... WITH ..., age MERGE (...) RETURN u.ID, age` still returns one row per upstream payload row.

  The UUID/default part is fixed separately but consistently: when a duplicate-created row must still be output, we read the already-created node’s projected properties from storage instead of re-evaluating default expressions. That prevents volatile defaults like `gen_random_uuid()` from producing a fresh value for a row that was not actually inserted.

## Root Cause
The unwind dedup changes let duplicate no-match MERGE rows continue through the merge output path. The duplicate-created path skipped the physical insert but still evaluated insert defaults again, so projected defaults such as gen_random_uuid() differed from the row that was actually stored.

## Validation
- cmake --build build/release --target lbug_shell e2e_test --config Release
- manual release-shell repro for duplicate UUID MERGE
- E2E_TEST_FILES_DIRECTORY=test/test_files build/release/test/runner/e2e_test --gtest_filter='issue~issue.issue_170'
- E2E_TEST_FILES_DIRECTORY=test/test_files build/release/test/runner/e2e_test --gtest_filter='issue~issue.unwind_merge_rel_after_rel_match_dedup:issue~issue.unwind_merge_with_projection_dedup:issue~issue.unwind_merge_with_projection_preserves_match_expansion'