### PR TITLE
Fix hash PK rollback after failed COPY

### DIFF
--- a/src/include/storage/index/hash_index.h
+++ b/src/include/storage/index/hash_index.h
@@ -458,7 +458,7 @@ public:
     }
 
     void delete_(common::ValueVector* keyVector);
-    void discardPrimaryKey(common::ValueVector* keyVector) override { delete_(keyVector); }
+    void discardPrimaryKey(common::ValueVector* keyVector) override;
 
     void checkpointInMemory() override;
     void checkpoint(main::ClientContext*, storage::PageAllocator& pageAllocator) override;

--- a/src/storage/index/hash_index.cpp
+++ b/src/storage/index/hash_index.cpp
@@ -603,6 +603,23 @@ void PrimaryKeyIndex::delete_(ValueVector* keyVector) {
         [](auto) { UNREACHABLE_CODE; });
 }
 
+void PrimaryKeyIndex::discardPrimaryKey(ValueVector* keyVector) {
+    DASSERT(indexInfo.keyDataTypes.size() == 1);
+    TypeUtils::visit(
+        indexInfo.keyDataTypes[0],
+        [&]<IndexHashable T>(T) {
+            for (auto i = 0u; i < keyVector->state->getSelVector().getSelSize(); i++) {
+                auto pos = keyVector->state->getSelVector()[i];
+                if (keyVector->isNull(pos)) {
+                    continue;
+                }
+                auto key = keyVector->getValue<T>(pos);
+                discardLocal(key);
+            }
+        },
+        [](auto) { UNREACHABLE_CODE; });
+}
+
 void PrimaryKeyIndex::checkpointInMemory() {
     bool indexChanged = false;
     for (auto i = 0u; i < NUM_HASH_INDEXES; i++) {


### PR DESCRIPTION
## Summary

Fix failed COPY rollback for hash primary-key indexes by making `discardPrimaryKey()` discard only uncommitted local insertions instead of recording a local deletion.

## Root Cause

The regression was introduced by `b2055a915` (`Add ART primary key index`). That commit added a generic `discardPrimaryKey()` rollback hook and wired the hash primary-key index implementation to `delete_()`.

For hash indexes, `delete_()` can create local deletion markers. During the failed duplicate-PK COPY rollback, those markers could mask rows from the subsequent successful COPY. This showed up in the WASM in-memory kernel test as `transaction~copy~copy_node.CopyNodeAfterPKErrorRollbackFlushedGroups` returning no row for `Comment.ID = 962073046352`.

The first scheduled main failure after the May 16 successful run was May 17 at `7d6335a7b`, with the same failing test; the relevant regression range starts at `b2055a915`.

## Change

`PrimaryKeyIndex::discardPrimaryKey()` now removes matching keys only from local uncommitted hash-index insertions via `discardLocal()`. It no longer calls `delete_()` and therefore does not add local deletion entries during COPY rollback.

## Validation

- `make test-build-release`
- `IN_MEM_MODE=true E2E_TEST_FILES_DIRECTORY=test/test_files build/release/test/runner/e2e_test --gtest_filter='transaction~copy~copy_node.CopyNodeAfterPKErrorRollbackFlushedGroups'`
- `E2E_TEST_FILES_DIRECTORY=test/test_files build/release/test/runner/e2e_test --gtest_filter='transaction~copy~copy_node.CopyNodeAfterPKErrorRollbackFlushedGroups'`
