### PR TITLE
Use trusted publishing for Node.js deploy

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -356,8 +356,9 @@ jobs:
     if: ${{ github.event_name == 'schedule' || github.event.inputs.skipNodejs != 'true' }}
     needs: [build-nodejs]
     runs-on: ubuntu-latest
-    env:
-      NODE_AUTH_TOKEN: ${{ secrets.NPM_JS_TOKEN }}
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@v4
 
@@ -407,6 +408,9 @@ jobs:
         with:
           node-version: "22"
           registry-url: "https://registry.npmjs.org"
+
+      - name: Upgrade npm
+        run: npm install -g npm@latest
 
       - name: Package Node.js API (main + per-platform sub-packages)
         run: node package
@@ -464,12 +468,10 @@ jobs:
             PACKAGE_REF="${PACKAGE_NAME}@${PACKAGE_VERSION}"
             echo "Nightly tag: ${NIGHTLY_TAG}, Package: ${PACKAGE_REF}"
             if npm view "${PACKAGE_REF}" version >/dev/null 2>&1; then
-              echo "Already published; updating dist-tags only."
+              echo "Already published; trusted publishing only supports publish, so skipping dist-tag update."
             else
-              npm publish "$tarball" --access public --tag "${NIGHTLY_TAG}"
+              npm publish "$tarball" --provenance --access public --tag "${NIGHTLY_TAG}"
             fi
-            npm dist-tag add "${PACKAGE_REF}" "${NIGHTLY_TAG}"
-            npm dist-tag add "${PACKAGE_REF}" next
           done
         working-directory: tools/nodejs_api
 
@@ -478,7 +480,7 @@ jobs:
         run: |
           for tarball in lbug-linux-x64.tar.gz lbug-linux-arm64.tar.gz lbug-darwin-arm64.tar.gz lbug-darwin-x64.tar.gz lbug-win32-x64.tar.gz lbug-source.tar.gz; do
             [ -f "$tarball" ] || continue
-            npm publish "$tarball" --access public --tag latest
+            npm publish "$tarball" --provenance --access public --tag latest
           done
         working-directory: tools/nodejs_api
   


### PR DESCRIPTION
Our tokens had expired and we were not uploading nightlies for sometime.

Now uses trusted publishing:

https://github.com/LadybugDB/ladybug/actions/runs/26471416621