### PR TITLE
Install ADBC driver manager in extension CI

### DIFF
--- a/.github/workflows/build-extensions.yml
+++ b/.github/workflows/build-extensions.yml
@@ -40,6 +40,13 @@ jobs:
       - name: Update submodules
         run: git submodule update --init extension
 
+      - name: Setup pixi
+        uses: prefix-dev/setup-pixi@v0.9.4
+        with:
+          pixi-version: v0.68.1
+          cache: false
+          activate-environment: true
+
       - name: Install build dependencies (Linux)
         if: runner.os == 'Linux'
         run: |
@@ -202,6 +209,7 @@ jobs:
         run: |
           powershell.exe -Command "Add-MpPreference -ExclusionPath '${{ github.workspace }}'"
           call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
+          set "EXTRA_CMAKE_FLAGS=-DADBC_INCLUDE_DIR=%CONDA_PREFIX%\Library\include -DADBC_DRIVER_MANAGER_LIBRARY=%CONDA_PREFIX%\Library\lib\adbc_driver_manager.lib"
           make extension-release
         env:
           CMAKE_PREFIX_PATH: C:\local

--- a/pixi.toml
+++ b/pixi.toml
@@ -1,7 +1,7 @@
 [workspace]
 channels = ["conda-forge"]
 name = "ladybug-adbc"
-platforms = ["linux-64"]
+platforms = ["linux-64", "linux-aarch64", "osx-64", "osx-arm64", "win-64"]
 
 [dependencies]
 libadbc-driver-manager = ">=1.10.0,<2"


### PR DESCRIPTION
Build Extensions CI was broken after ADBC extension was merged.