### PR TITLE
Add ADBC to official extensions

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -4,5 +4,5 @@ name = "ladybug-adbc"
 platforms = ["linux-64", "linux-aarch64", "osx-64", "osx-arm64", "win-64"]
 
 [dependencies]
-libadbc-driver-manager = ">=1.10.0,<2"
+libadbc-driver-manager = ">=1.11.0,<2"
 libarrow = ">=23.0.1,<24"

--- a/src/include/extension/extension.h
+++ b/src/include/extension/extension.h
@@ -76,9 +76,9 @@ struct LBUG_API ExtensionUtils {
 
     static constexpr const char* EXTENSION_FILE_NAME = "lib{}.{}";
 
-    static constexpr const char* OFFICIAL_EXTENSION[] = {"HTTPFS", "POSTGRES", "DUCKDB", "JSON",
-        "SQLITE", "FTS", "DELTA", "ICEBERG", "AZURE", "UNITY_CATALOG", "VECTOR", "NEO4J", "ALGO",
-        "LLM"};
+    static constexpr const char* OFFICIAL_EXTENSION[] = {"ADBC", "HTTPFS", "POSTGRES", "DUCKDB",
+        "JSON", "SQLITE", "FTS", "DELTA", "ICEBERG", "AZURE", "UNITY_CATALOG", "VECTOR", "NEO4J",
+        "ALGO", "LLM"};
 
     static constexpr const char* EXTENSION_LOADER_SUFFIX = "_loader";
 

--- a/test/common/extension_proxy_test.cpp
+++ b/test/common/extension_proxy_test.cpp
@@ -69,6 +69,12 @@ TEST(ExtensionProxyTest, ParseProxyURLWithAuth) {
     EXPECT_EQ(config->password, "pass");
 }
 
+TEST(ExtensionUtilsTest, IdentifiesOfficialExtensions) {
+    EXPECT_TRUE(ExtensionUtils::isOfficialExtension("adbc"));
+    EXPECT_TRUE(ExtensionUtils::isOfficialExtension("ADBC"));
+    EXPECT_FALSE(ExtensionUtils::isOfficialExtension("sqlitescanner"));
+}
+
 TEST(ExtensionProxyTest, ParseProxyURLWithoutSchemeUsesDefaultPort) {
     auto config = ExtensionUtils::parseProxyConfig("proxy.example.com");
     ASSERT_TRUE(config.has_value());


### PR DESCRIPTION
## Summary
- add ADBC to the runtime official extension allowlist
- add a regression check for case-insensitive official extension lookup

## Testing
```
$ pixi add libadbc-driver-manager
$ install_name_tool -rpath \
    /Users/runner/work/ladybug/ladybug/.pixi/envs/default/lib \
    /path/to/.pixi/envs/default/lib 
    
lbug> load adbc;
┌──────────────────────────────────┐
│ result                           │
│ STRING                           │
├──────────────────────────────────┤
│ Extension: adbc has been loaded. │
└──────────────────────────────────┘
(1 tuple)
(1 column)
```
