### PR TITLE
Link httpfs in WASM build

### DIFF
--- a/.github/workflows/wasm-workflow.yml
+++ b/.github/workflows/wasm-workflow.yml
@@ -101,6 +101,7 @@ jobs:
         env:
           CMAKE_C_COMPILER_LAUNCHER: ccache
           CMAKE_CXX_COMPILER_LAUNCHER: ccache
+          EXTRA_CMAKE_FLAGS: -DBUILD_EXTENSIONS=httpfs -DEXTENSION_STATIC_LINK_LIST=httpfs
         run: |
           source /home/runner/emsdk/emsdk_env.sh
           npm run build


### PR DESCRIPTION
## Summary
- build the httpfs extension as part of the WASM package build
- statically link httpfs into the WASM artifact so s3:// and xet:// URLs are available

## Validation
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/wasm-workflow.yml"); puts "ok"'
- git diff --check -- .github/workflows/wasm-workflow.yml