### PR TITLE
ci: disable wasm httpfs static link

### DIFF
--- a/.github/workflows/wasm-workflow.yml
+++ b/.github/workflows/wasm-workflow.yml
@@ -101,7 +101,6 @@ jobs:
         env:
           CMAKE_C_COMPILER_LAUNCHER: ccache
           CMAKE_CXX_COMPILER_LAUNCHER: ccache
-          EXTRA_CMAKE_FLAGS: -DBUILD_EXTENSIONS=httpfs -DEXTENSION_STATIC_LINK_LIST=httpfs
         run: |
           source /home/runner/emsdk/emsdk_env.sh
           npm run build


### PR DESCRIPTION
## Summary

Temporarily disables static linking of the `httpfs` extension in the wasm package build.

## Context

The wasm build started failing after `httpfs` was added to `EXTRA_CMAKE_FLAGS` because the extension needs OpenSSL support. Initial attempts to satisfy that dependency showed that the available prebuilt wasm OpenSSL package is not compatible with `cpp-httplib` socket BIO usage, so this rolls wasm back to the previously working extension set while we sort out the right OpenSSL/httpfs approach.

## Validation

- `git diff --check`
