### PR TITLE
Implement WAL group commits

### DIFF
--- a/src/binder/bind_expression/bind_parameter_expression.cpp
+++ b/src/binder/bind_expression/bind_parameter_expression.cpp
@@ -15,7 +15,7 @@ std::shared_ptr<Expression> ExpressionBinder::bindParameterExpression(
     auto& parsedParameterExpression = parsedExpression.constCast<ParsedParameterExpression>();
     auto parameterName = parsedParameterExpression.getParameterName();
     if (knownParameters.contains(parameterName)) {
-        return make_shared<ParameterExpression>(parameterName, *knownParameters.at(parameterName));
+        return make_shared<ParameterExpression>(parameterName, knownParameters.at(parameterName));
     }
     // LCOV_EXCL_START
     throw BinderException(

--- a/src/binder/expression/parameter_expression.cpp
+++ b/src/binder/expression/parameter_expression.cpp
@@ -17,7 +17,7 @@ void ParameterExpression::cast(const LogicalType& type) {
         // LCOV_EXCL_STOP
     }
     dataType = type.copy();
-    value.setDataType(type);
+    value->setDataType(type);
 }
 
 } // namespace binder

--- a/src/include/binder/expression/parameter_expression.h
+++ b/src/include/binder/expression/parameter_expression.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <memory>
+
 #include "common/types/value/value.h"
 #include "expression.h"
 
@@ -12,11 +14,16 @@ class LBUG_API ParameterExpression final : public Expression {
 public:
     explicit ParameterExpression(const std::string& parameterName, common::Value value)
         : Expression{expressionType, value.getDataType().copy(), createUniqueName(parameterName)},
+          parameterName(parameterName), value{std::make_shared<common::Value>(std::move(value))} {}
+
+    explicit ParameterExpression(const std::string& parameterName,
+        std::shared_ptr<common::Value> value)
+        : Expression{expressionType, value->getDataType().copy(), createUniqueName(parameterName)},
           parameterName(parameterName), value{std::move(value)} {}
 
     void cast(const common::LogicalType& type) override;
 
-    common::Value getValue() const { return value; }
+    common::Value getValue() const { return *value; }
 
 private:
     std::string toStringInternal() const override { return "$" + parameterName; }
@@ -24,7 +31,7 @@ private:
 
 private:
     std::string parameterName;
-    common::Value value;
+    std::shared_ptr<common::Value> value;
 };
 
 } // namespace binder

--- a/src/include/main/prepared_statement.h
+++ b/src/include/main/prepared_statement.h
@@ -65,6 +65,8 @@ public:
     const std::unordered_set<std::string>& getUnknownParameters() const {
         return unknownParameters;
     }
+    bool canReuseCachedPlanWith(
+        const std::unordered_map<std::string, std::unique_ptr<common::Value>>& inputParams) const;
     std::unordered_set<std::string> getKnownParameters();
     void updateParameter(const std::string& name, common::Value* value);
     void addParameter(const std::string& name, common::Value* value);

--- a/src/include/main/prepared_statement.h
+++ b/src/include/main/prepared_statement.h
@@ -70,6 +70,7 @@ public:
     std::unordered_set<std::string> getKnownParameters();
     void updateParameter(const std::string& name, common::Value* value);
     void addParameter(const std::string& name, common::Value* value);
+    LBUG_API void setParameter(const std::string& name, common::Value value);
 
     std::string getName() const { return cachedPreparedStatementName; }
 

--- a/src/include/storage/wal/wal.h
+++ b/src/include/storage/wal/wal.h
@@ -19,7 +19,8 @@ public:
         common::VirtualFileSystem* vfs);
     ~WAL();
 
-    uint64_t logCommittedWAL(LocalWAL& localWAL, main::ClientContext* context);
+    void logCommittedWAL(LocalWAL& localWAL, main::ClientContext* context,
+        uint64_t& commitSequence);
     void logAndFlushCheckpoint(main::ClientContext* context);
 
     bool rotateForCheckpoint(main::ClientContext* context);

--- a/src/include/storage/wal/wal.h
+++ b/src/include/storage/wal/wal.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <condition_variable>
 #include <mutex>
 
 #include "storage/wal/wal_record.h"
@@ -18,7 +19,7 @@ public:
         common::VirtualFileSystem* vfs);
     ~WAL();
 
-    void logCommittedWAL(LocalWAL& localWAL, main::ClientContext* context);
+    uint64_t logCommittedWAL(LocalWAL& localWAL, main::ClientContext* context);
     void logAndFlushCheckpoint(main::ClientContext* context);
 
     bool rotateForCheckpoint(main::ClientContext* context);
@@ -37,6 +38,7 @@ public:
 private:
     void initWriter(main::ClientContext* context);
     void addNewWALRecordNoLock(const WALRecord& walRecord);
+    void waitForDurabilityNoLock(uint64_t commitSequence, std::unique_lock<std::mutex>& lck);
     void flushAndSyncNoLock();
     void writeHeader(main::ClientContext& context);
 
@@ -48,6 +50,10 @@ private:
     [[maybe_unused]] bool readOnly;
     common::VirtualFileSystem* vfs;
     std::unique_ptr<common::FileInfo> fileInfo;
+    std::condition_variable groupCommitCV;
+    uint64_t appendedCommitSequence = 0;
+    uint64_t durableCommitSequence = 0;
+    bool syncInProgress = false;
 
     // Since most writes to the shared WAL will be flushing local WAL (which has its own checksums),
     // these writes can go through the normal writer. We do still need a checksum writer though for

--- a/src/include/storage/wal/wal.h
+++ b/src/include/storage/wal/wal.h
@@ -2,6 +2,7 @@
 
 #include <condition_variable>
 #include <mutex>
+#include <string>
 
 #include "storage/wal/wal_record.h"
 
@@ -33,12 +34,15 @@ public:
     void reset();
 
     uint64_t getFileSize();
+    void throwIfPoisoned();
 
     static WAL* Get(const main::ClientContext& context);
 
 private:
     void initWriter(main::ClientContext* context);
     void addNewWALRecordNoLock(const WALRecord& walRecord);
+    void throwIfPoisonedNoLock() const;
+    void poisonNoLock(const std::string& reason);
     void waitForDurabilityNoLock(uint64_t commitSequence, std::unique_lock<std::mutex>& lck);
     void flushAndSyncNoLock();
     void writeHeader(main::ClientContext& context);
@@ -55,6 +59,8 @@ private:
     uint64_t appendedCommitSequence = 0;
     uint64_t durableCommitSequence = 0;
     bool syncInProgress = false;
+    bool poisoned = false;
+    std::string poisonReason;
 
     // Since most writes to the shared WAL will be flushing local WAL (which has its own checksums),
     // these writes can go through the normal writer. We do still need a checksum writer though for

--- a/src/include/transaction/transaction.h
+++ b/src/include/transaction/transaction.h
@@ -116,7 +116,7 @@ public:
     bool shouldForceCheckpoint() const;
 
     void commit(storage::WAL* wal);
-    uint64_t writeCommitToWAL(storage::WAL* wal);
+    void writeCommitToWAL(storage::WAL* wal, uint64_t& walCommitSequence);
     void publishCommit();
     void rollback(storage::WAL* wal);
 

--- a/src/include/transaction/transaction.h
+++ b/src/include/transaction/transaction.h
@@ -116,6 +116,8 @@ public:
     bool shouldForceCheckpoint() const;
 
     void commit(storage::WAL* wal);
+    uint64_t writeCommitToWAL(storage::WAL* wal);
+    void publishCommit();
     void rollback(storage::WAL* wal);
 
     storage::LocalStorage* getLocalStorage() const { return localStorage.get(); }

--- a/src/include/transaction/transaction_manager.h
+++ b/src/include/transaction/transaction_manager.h
@@ -82,6 +82,7 @@ private:
     common::transaction_t lastTimestamp;
     uint64_t nextWALCommitSequenceToPublish = 1;
     std::condition_variable cvForPublishingCommit;
+    std::condition_variable cvForCommittingWriteTransaction;
     // This mutex serializes begin/commit/rollback calls to protect activeTransactions.
     std::mutex mtxForSerializingPublicFunctionCalls;
     std::mutex mtxForStartingNewTransactions;

--- a/src/include/transaction/transaction_manager.h
+++ b/src/include/transaction/transaction_manager.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <condition_variable>
 #include <memory>
 #include <mutex>
 
@@ -79,6 +80,8 @@ private:
     std::vector<std::unique_ptr<Transaction>> activeTransactions;
     common::transaction_t lastTransactionID;
     common::transaction_t lastTimestamp;
+    uint64_t nextWALCommitSequenceToPublish = 1;
+    std::condition_variable cvForPublishingCommit;
     // This mutex serializes begin/commit/rollback calls to protect activeTransactions.
     std::mutex mtxForSerializingPublicFunctionCalls;
     std::mutex mtxForStartingNewTransactions;
@@ -88,6 +91,7 @@ private:
     // Atomic counter tracking active write/recovery transactions so the checkpoint drain loop
     // can poll without holding mtxForSerializingPublicFunctionCalls.
     std::atomic<uint32_t> activeWriteTransactionCount{0};
+    std::atomic<uint32_t> committingWriteTransactionCount{0};
     uint64_t checkpointWaitTimeoutInMicros = common::DEFAULT_CHECKPOINT_WAIT_TIMEOUT_IN_MICROS;
 
     init_checkpointer_func_t initCheckpointerFunc;

--- a/src/main/client_context.cpp
+++ b/src/main/client_context.cpp
@@ -338,6 +338,7 @@ std::unique_ptr<QueryResult> ClientContext::executeWithParams(PreparedStatement*
     if (!preparedStatement->isSuccess()) {
         return QueryResult::getQueryResultWithError(preparedStatement->errMsg);
     }
+    const auto useCachedPlan = preparedStatement->canReuseCachedPlanWith(inputParams);
     try {
         bindParametersNoLock(*preparedStatement, inputParams);
     } catch (std::exception& e) {
@@ -352,6 +353,9 @@ std::unique_ptr<QueryResult> ClientContext::executeWithParams(PreparedStatement*
     }
     // LCOV_EXCL_STOP
     auto cachedStatement = cachedPreparedStatementManager.getCachedStatement(name);
+    if (useCachedPlan) {
+        return executeNoLock(preparedStatement, cachedStatement, queryID);
+    }
     // rebind
     auto [newPreparedStatement, newCachedStatement] =
         prepareNoLock(cachedStatement->parsedStatement, false /*shouldCommitNewTransaction*/,

--- a/src/main/prepared_statement.cpp
+++ b/src/main/prepared_statement.cpp
@@ -46,6 +46,22 @@ StatementType PreparedStatement::getStatementType() const {
     return preparedSummary.statementType;
 }
 
+bool PreparedStatement::canReuseCachedPlanWith(
+    const std::unordered_map<std::string, std::unique_ptr<Value>>& inputParams) const {
+    if (!unknownParameters.empty()) {
+        return false;
+    }
+    for (auto& [key, value] : inputParams) {
+        if (!parameterMap.contains(key)) {
+            return false;
+        }
+        if (parameterMap.at(key)->getDataType() != value->getDataType()) {
+            return false;
+        }
+    }
+    return true;
+}
+
 static void validateParam(const std::string& paramName, Value* newVal, Value* oldVal) {
     if (newVal->getDataType().getLogicalTypeID() == LogicalTypeID::POINTER &&
         newVal->getValue<uint8_t*>() != oldVal->getValue<uint8_t*>()) {

--- a/src/main/prepared_statement.cpp
+++ b/src/main/prepared_statement.cpp
@@ -92,6 +92,19 @@ void PreparedStatement::addParameter(const std::string& name, Value* value) {
     parameterMap.insert({name, std::make_shared<Value>(*value)});
 }
 
+void PreparedStatement::setParameter(const std::string& name, Value value) {
+    if (!parameterMap.contains(name)) {
+        throw BinderException(std::format("Parameter {} not found.", name));
+    }
+    auto& oldValue = parameterMap.at(name);
+    if (oldValue->getDataType() != value.getDataType()) {
+        throw BinderException(std::format("Cannot update parameter {} with type {}. Expected {}.",
+            name, value.getDataType().toString(), oldValue->getDataType().toString()));
+    }
+    validateParam(name, &value, oldValue.get());
+    *oldValue = std::move(value);
+}
+
 PreparedStatement::~PreparedStatement() = default;
 
 std::unique_ptr<PreparedStatement> PreparedStatement::getPreparedStatementWithError(

--- a/src/processor/operator/persistent/insert_executor.cpp
+++ b/src/processor/operator/persistent/insert_executor.cpp
@@ -99,10 +99,10 @@ nodeID_t NodeInsertExecutor::insert(main::ClientContext* context) {
     if (checkConflict(transaction)) {
         return info.getNodeID();
     }
-    auto insertState = std::make_unique<storage::NodeTableInsertState>(*info.nodeIDVector,
-        *tableInfo.pkVector, tableInfo.columnDataVectors);
-    tableInfo.table->initInsertState(context, *insertState);
-    tableInfo.table->insert(transaction, *insertState);
+    storage::NodeTableInsertState insertState{*info.nodeIDVector, *tableInfo.pkVector,
+        tableInfo.columnDataVectors};
+    tableInfo.table->initInsertState(context, insertState);
+    tableInfo.table->insert(transaction, insertState);
     writeColumnVectors(info.columnVectors, tableInfo.columnDataVectors);
     return info.getNodeID();
 }
@@ -197,10 +197,10 @@ internalID_t RelInsertExecutor::insert(main::ClientContext* context) {
     for (auto i = 1u; i < tableInfo.columnDataEvaluators.size(); ++i) {
         tableInfo.columnDataEvaluators[i]->evaluate();
     }
-    auto insertState = std::make_unique<storage::RelTableInsertState>(*info.srcNodeIDVector,
-        *info.dstNodeIDVector, tableInfo.columnDataVectors);
-    tableInfo.table->initInsertState(context, *insertState);
-    tableInfo.table->insert(Transaction::Get(*context), *insertState);
+    storage::RelTableInsertState insertState{*info.srcNodeIDVector, *info.dstNodeIDVector,
+        tableInfo.columnDataVectors};
+    tableInfo.table->initInsertState(context, insertState);
+    tableInfo.table->insert(Transaction::Get(*context), insertState);
     writeColumnVectors(info.columnVectors, tableInfo.columnDataVectors);
     return tableInfo.getRelID();
 }

--- a/src/storage/wal/wal.cpp
+++ b/src/storage/wal/wal.cpp
@@ -26,17 +26,18 @@ WAL::WAL(const std::string& dbPath, bool readOnly, bool enableChecksums, Virtual
 
 WAL::~WAL() {}
 
-uint64_t WAL::logCommittedWAL(LocalWAL& localWAL, main::ClientContext* context) {
+void WAL::logCommittedWAL(LocalWAL& localWAL, main::ClientContext* context,
+    uint64_t& commitSequence) {
     DASSERT(!readOnly);
+    commitSequence = 0;
     if (inMemory || localWAL.getSize() == 0) {
-        return 0; // No need to log empty WAL.
+        return; // No need to log empty WAL.
     }
     std::unique_lock lck{mtx};
     initWriter(context);
     localWAL.inMemWriter->flush(*serializer->getWriter());
-    const auto commitSequence = ++appendedCommitSequence;
+    commitSequence = ++appendedCommitSequence;
     waitForDurabilityNoLock(commitSequence, lck);
-    return commitSequence;
 }
 
 void WAL::logAndFlushCheckpoint(main::ClientContext* context) {
@@ -101,11 +102,11 @@ void WAL::clear() {
 
 void WAL::reset() {
     std::unique_lock lck{mtx};
-    fileInfo.reset();
-    serializer.reset();
     durableCommitSequence = appendedCommitSequence;
     syncInProgress = false;
     groupCommitCV.notify_all();
+    fileInfo.reset();
+    serializer.reset();
     vfs->removeFileIfExists(walPath);
 }
 

--- a/src/storage/wal/wal.cpp
+++ b/src/storage/wal/wal.cpp
@@ -1,5 +1,6 @@
 #include "storage/wal/wal.h"
 
+#include "common/exception/runtime.h"
 #include "common/file_system/file_info.h"
 #include "common/file_system/virtual_file_system.h"
 #include "common/serializer/buffered_file.h"
@@ -34,6 +35,7 @@ void WAL::logCommittedWAL(LocalWAL& localWAL, main::ClientContext* context,
         return; // No need to log empty WAL.
     }
     std::unique_lock lck{mtx};
+    throwIfPoisonedNoLock();
     initWriter(context);
     localWAL.inMemWriter->flush(*serializer->getWriter());
     commitSequence = ++appendedCommitSequence;
@@ -42,6 +44,7 @@ void WAL::logCommittedWAL(LocalWAL& localWAL, main::ClientContext* context,
 
 void WAL::logAndFlushCheckpoint(main::ClientContext* context) {
     std::unique_lock lck{mtx};
+    throwIfPoisonedNoLock();
     initWriter(context);
     CheckpointRecord walRecord;
     addNewWALRecordNoLock(walRecord);
@@ -50,6 +53,7 @@ void WAL::logAndFlushCheckpoint(main::ClientContext* context) {
 
 bool WAL::rotateForCheckpoint(main::ClientContext* /*context*/) {
     std::unique_lock lck{mtx};
+    throwIfPoisonedNoLock();
     if (inMemory) {
         return false;
     }
@@ -68,6 +72,10 @@ bool WAL::rotateForCheckpoint(main::ClientContext* /*context*/) {
 }
 
 void WAL::logAndFlushCheckpointToFrozen(main::ClientContext* context) {
+    {
+        std::unique_lock lck{mtx};
+        throwIfPoisonedNoLock();
+    }
     auto frozenFileInfo = vfs->openFile(checkpointWalPath,
         FileOpenFlags(FileFlags::READ_ONLY | FileFlags::WRITE), context);
 
@@ -83,8 +91,23 @@ void WAL::logAndFlushCheckpointToFrozen(main::ClientContext* context) {
     frozenSerializer->getWriter()->onObjectBegin();
     walRecord.serialize(*frozenSerializer);
     frozenSerializer->getWriter()->onObjectEnd();
-    frozenSerializer->getWriter()->flush();
-    frozenSerializer->getWriter()->sync();
+    try {
+        frozenSerializer->getWriter()->flush();
+        frozenSerializer->getWriter()->sync();
+    } catch (const std::exception& e) {
+        std::unique_lock lck{mtx};
+        poisonNoLock(e.what());
+        throw RuntimeException(
+            "WAL sync failed; database is in a panic state and refuses further writes until "
+            "restart. Original error: " +
+            std::string{e.what()});
+    } catch (...) {
+        std::unique_lock lck{mtx};
+        poisonNoLock("unknown exception");
+        throw RuntimeException(
+            "WAL sync failed; database is in a panic state and refuses further writes until "
+            "restart. Original error: unknown exception");
+    }
 }
 
 void WAL::clearFrozenWAL() {
@@ -94,6 +117,7 @@ void WAL::clearFrozenWAL() {
 // NOLINTNEXTLINE(readability-make-member-function-const): semantically non-const function.
 void WAL::clear() {
     std::unique_lock lck{mtx};
+    throwIfPoisonedNoLock();
     serializer->getWriter()->clear();
     durableCommitSequence = appendedCommitSequence;
     syncInProgress = false;
@@ -112,6 +136,7 @@ void WAL::reset() {
 
 void WAL::waitForDurabilityNoLock(uint64_t commitSequence, std::unique_lock<std::mutex>& lck) {
     while (durableCommitSequence < commitSequence) {
+        throwIfPoisonedNoLock();
         if (syncInProgress) {
             groupCommitCV.wait(lck);
             continue;
@@ -124,11 +149,19 @@ void WAL::waitForDurabilityNoLock(uint64_t commitSequence, std::unique_lock<std:
             lck.unlock();
             try {
                 fileToSync->syncFile();
+            } catch (const std::exception& e) {
+                lck.lock();
+                poisonNoLock(e.what());
+                throw RuntimeException(
+                    "WAL sync failed; database is in a panic state and refuses further writes "
+                    "until restart. Original error: " +
+                    std::string{e.what()});
             } catch (...) {
                 lck.lock();
-                syncInProgress = false;
-                groupCommitCV.notify_all();
-                throw;
+                poisonNoLock("unknown exception");
+                throw RuntimeException(
+                    "WAL sync failed; database is in a panic state and refuses further writes "
+                    "until restart. Original error: unknown exception");
             }
             lck.lock();
             durableCommitSequence = targetSequence;
@@ -142,7 +175,20 @@ void WAL::waitForDurabilityNoLock(uint64_t commitSequence, std::unique_lock<std:
 // NOLINTNEXTLINE(readability-make-member-function-const): semantically non-const function.
 void WAL::flushAndSyncNoLock() {
     serializer->getWriter()->flush();
-    serializer->getWriter()->sync();
+    try {
+        serializer->getWriter()->sync();
+    } catch (const std::exception& e) {
+        poisonNoLock(e.what());
+        throw RuntimeException(
+            "WAL sync failed; database is in a panic state and refuses further writes until "
+            "restart. Original error: " +
+            std::string{e.what()});
+    } catch (...) {
+        poisonNoLock("unknown exception");
+        throw RuntimeException(
+            "WAL sync failed; database is in a panic state and refuses further writes until "
+            "restart. Original error: unknown exception");
+    }
 }
 
 uint64_t WAL::getFileSize() {
@@ -154,6 +200,27 @@ uint64_t WAL::getFileSize() {
         return vfs->openFile(walPath, FileOpenFlags(FileFlags::READ_ONLY))->getFileSize();
     }
     return serializer->getWriter()->getSize();
+}
+
+void WAL::throwIfPoisoned() {
+    std::unique_lock lck{mtx};
+    throwIfPoisonedNoLock();
+}
+
+void WAL::throwIfPoisonedNoLock() const {
+    if (!poisoned) {
+        return;
+    }
+    throw RuntimeException("WAL sync failed; database is in a panic state and refuses further "
+                           "writes until restart. Original error: " +
+                           poisonReason);
+}
+
+void WAL::poisonNoLock(const std::string& reason) {
+    poisoned = true;
+    poisonReason = reason;
+    syncInProgress = false;
+    groupCommitCV.notify_all();
 }
 
 void WAL::writeHeader(main::ClientContext& context) {

--- a/src/storage/wal/wal.cpp
+++ b/src/storage/wal/wal.cpp
@@ -26,15 +26,17 @@ WAL::WAL(const std::string& dbPath, bool readOnly, bool enableChecksums, Virtual
 
 WAL::~WAL() {}
 
-void WAL::logCommittedWAL(LocalWAL& localWAL, main::ClientContext* context) {
+uint64_t WAL::logCommittedWAL(LocalWAL& localWAL, main::ClientContext* context) {
     DASSERT(!readOnly);
     if (inMemory || localWAL.getSize() == 0) {
-        return; // No need to log empty WAL.
+        return 0; // No need to log empty WAL.
     }
     std::unique_lock lck{mtx};
     initWriter(context);
     localWAL.inMemWriter->flush(*serializer->getWriter());
-    flushAndSyncNoLock();
+    const auto commitSequence = ++appendedCommitSequence;
+    waitForDurabilityNoLock(commitSequence, lck);
+    return commitSequence;
 }
 
 void WAL::logAndFlushCheckpoint(main::ClientContext* context) {
@@ -55,6 +57,8 @@ bool WAL::rotateForCheckpoint(main::ClientContext* /*context*/) {
     }
     if (serializer) {
         flushAndSyncNoLock();
+        durableCommitSequence = appendedCommitSequence;
+        groupCommitCV.notify_all();
         fileInfo.reset();
         serializer.reset();
     }
@@ -90,13 +94,48 @@ void WAL::clearFrozenWAL() {
 void WAL::clear() {
     std::unique_lock lck{mtx};
     serializer->getWriter()->clear();
+    durableCommitSequence = appendedCommitSequence;
+    syncInProgress = false;
+    groupCommitCV.notify_all();
 }
 
 void WAL::reset() {
     std::unique_lock lck{mtx};
     fileInfo.reset();
     serializer.reset();
+    durableCommitSequence = appendedCommitSequence;
+    syncInProgress = false;
+    groupCommitCV.notify_all();
     vfs->removeFileIfExists(walPath);
+}
+
+void WAL::waitForDurabilityNoLock(uint64_t commitSequence, std::unique_lock<std::mutex>& lck) {
+    while (durableCommitSequence < commitSequence) {
+        if (syncInProgress) {
+            groupCommitCV.wait(lck);
+            continue;
+        }
+        syncInProgress = true;
+        while (durableCommitSequence < appendedCommitSequence) {
+            const auto targetSequence = appendedCommitSequence;
+            serializer->getWriter()->flush();
+            auto* fileToSync = fileInfo.get();
+            lck.unlock();
+            try {
+                fileToSync->syncFile();
+            } catch (...) {
+                lck.lock();
+                syncInProgress = false;
+                groupCommitCV.notify_all();
+                throw;
+            }
+            lck.lock();
+            durableCommitSequence = targetSequence;
+            groupCommitCV.notify_all();
+        }
+        syncInProgress = false;
+        groupCommitCV.notify_all();
+    }
 }
 
 // NOLINTNEXTLINE(readability-make-member-function-const): semantically non-const function.

--- a/src/transaction/transaction.cpp
+++ b/src/transaction/transaction.cpp
@@ -64,22 +64,29 @@ bool Transaction::shouldForceCheckpoint() const {
 }
 
 void Transaction::commit(storage::WAL* wal) {
-    writeCommitToWAL(wal);
+    if (commitTS == common::INVALID_TRANSACTION) {
+        throw common::RuntimeException{"Cannot commit with an invalid commit timestamp."};
+    }
+    uint64_t walCommitSequence = 0;
+    writeCommitToWAL(wal, walCommitSequence);
     publishCommit();
 }
 
-uint64_t Transaction::writeCommitToWAL(storage::WAL* wal) {
+void Transaction::writeCommitToWAL(storage::WAL* wal, uint64_t& walCommitSequence) {
+    walCommitSequence = 0;
     if (!shouldLogToWAL()) {
-        return 0;
+        return;
     }
     DASSERT(localWAL && wal);
     localWAL->logCommit();
-    const auto walCommitSequence = wal->logCommittedWAL(*localWAL, clientContext);
+    wal->logCommittedWAL(*localWAL, clientContext, walCommitSequence);
     localWAL->clear();
-    return walCommitSequence;
 }
 
 void Transaction::publishCommit() {
+    if (commitTS == common::INVALID_TRANSACTION) {
+        throw common::RuntimeException{"Cannot publish commit with an invalid commit timestamp."};
+    }
     localStorage->commit();
     undoBuffer->commit(commitTS);
     if (hasCatalogChanges) {

--- a/src/transaction/transaction.cpp
+++ b/src/transaction/transaction.cpp
@@ -64,14 +64,24 @@ bool Transaction::shouldForceCheckpoint() const {
 }
 
 void Transaction::commit(storage::WAL* wal) {
+    writeCommitToWAL(wal);
+    publishCommit();
+}
+
+uint64_t Transaction::writeCommitToWAL(storage::WAL* wal) {
+    if (!shouldLogToWAL()) {
+        return 0;
+    }
+    DASSERT(localWAL && wal);
+    localWAL->logCommit();
+    const auto walCommitSequence = wal->logCommittedWAL(*localWAL, clientContext);
+    localWAL->clear();
+    return walCommitSequence;
+}
+
+void Transaction::publishCommit() {
     localStorage->commit();
     undoBuffer->commit(commitTS);
-    if (shouldLogToWAL()) {
-        DASSERT(localWAL && wal);
-        localWAL->logCommit();
-        wal->logCommittedWAL(*localWAL, clientContext);
-        localWAL->clear();
-    }
     if (hasCatalogChanges) {
         Catalog::Get(*clientContext)->incrementVersion();
         hasCatalogChanges = false;

--- a/src/transaction/transaction_manager.cpp
+++ b/src/transaction/transaction_manager.cpp
@@ -31,10 +31,11 @@ Transaction* TransactionManager::beginTransaction(main::ClientContext& clientCon
            activeWriteTransactionCount.load(std::memory_order_acquire) ==
                committingWriteTransactionCount.load(std::memory_order_acquire)) {
         newTransactionLck.unlock();
-        publicFunctionLck.unlock();
-        std::this_thread::sleep_for(
-            std::chrono::microseconds(THREAD_SLEEP_TIME_WHEN_WAITING_IN_MICROS));
-        publicFunctionLck.lock();
+        cvForCommittingWriteTransaction.wait(publicFunctionLck, [&]() {
+            return !hasActiveWriteTransactionNoLock() ||
+                   activeWriteTransactionCount.load(std::memory_order_acquire) !=
+                       committingWriteTransactionCount.load(std::memory_order_acquire);
+        });
         newTransactionLck.lock();
     }
     switch (type) {
@@ -82,7 +83,7 @@ void TransactionManager::commit(main::ClientContext& clientContext, Transaction*
                 committingWriteTransactionCount.fetch_add(1, std::memory_order_release);
                 markedAsCommitting = true;
                 lck.unlock();
-                walCommitSequence = transaction->writeCommitToWAL(&wal);
+                transaction->writeCommitToWAL(&wal, walCommitSequence);
                 lck.lock();
                 if (walCommitSequence != 0) {
                     cvForPublishingCommit.wait(lck,
@@ -100,6 +101,7 @@ void TransactionManager::commit(main::ClientContext& clientContext, Transaction*
                 clearTransactionNoLock(transaction->getID());
                 activeWriteTransactionCount.fetch_sub(1, std::memory_order_release);
                 committingWriteTransactionCount.fetch_sub(1, std::memory_order_release);
+                cvForCommittingWriteTransaction.notify_all();
                 markedAsCommitting = false;
             } break;
                 // LCOV_EXCL_START
@@ -118,7 +120,11 @@ void TransactionManager::commit(main::ClientContext& clientContext, Transaction*
             cvForPublishingCommit.notify_all();
         }
         if (markedAsCommitting) {
+            std::unique_lock lck{mtxForSerializingPublicFunctionCalls};
+            clearTransactionNoLock(transaction->getID());
+            activeWriteTransactionCount.fetch_sub(1, std::memory_order_release);
             committingWriteTransactionCount.fetch_sub(1, std::memory_order_release);
+            cvForCommittingWriteTransaction.notify_all();
         }
         throw;
     }

--- a/src/transaction/transaction_manager.cpp
+++ b/src/transaction/transaction_manager.cpp
@@ -122,8 +122,8 @@ void TransactionManager::commit(main::ClientContext& clientContext, Transaction*
         }
         if (markedAsCommitting) {
             std::unique_lock lck{mtxForSerializingPublicFunctionCalls};
-            clearTransactionNoLock(transaction->getID());
-            activeWriteTransactionCount.fetch_sub(1, std::memory_order_release);
+            // Keep the transaction active so the caller's rollback path can undo any partial
+            // in-memory publish work. The rollback path clears activeWriteTransactionCount.
             committingWriteTransactionCount.fetch_sub(1, std::memory_order_release);
             cvForCommittingWriteTransaction.notify_all();
         }

--- a/src/transaction/transaction_manager.cpp
+++ b/src/transaction/transaction_manager.cpp
@@ -47,6 +47,7 @@ Transaction* TransactionManager::beginTransaction(main::ClientContext& clientCon
     }
     case TransactionType::RECOVERY:
     case TransactionType::WRITE: {
+        wal.throwIfPoisoned();
         if (!clientContext.getDBConfig()->enableMultiWrites && hasActiveWriteTransactionNoLock()) {
             throw TransactionManagerException(
                 "Cannot start a new write transaction in the system. "

--- a/src/transaction/transaction_manager.cpp
+++ b/src/transaction/transaction_manager.cpp
@@ -26,6 +26,17 @@ Transaction* TransactionManager::beginTransaction(main::ClientContext& clientCon
     if (type != TransactionType::READ_ONLY) {
         newTransactionLck.lock();
     }
+    while (type != TransactionType::READ_ONLY && !clientContext.getDBConfig()->enableMultiWrites &&
+           hasActiveWriteTransactionNoLock() &&
+           activeWriteTransactionCount.load(std::memory_order_acquire) ==
+               committingWriteTransactionCount.load(std::memory_order_acquire)) {
+        newTransactionLck.unlock();
+        publicFunctionLck.unlock();
+        std::this_thread::sleep_for(
+            std::chrono::microseconds(THREAD_SLEEP_TIME_WHEN_WAITING_IN_MICROS));
+        publicFunctionLck.lock();
+        newTransactionLck.lock();
+    }
     switch (type) {
     case TransactionType::READ_ONLY: {
         auto transaction =
@@ -56,29 +67,60 @@ Transaction* TransactionManager::beginTransaction(main::ClientContext& clientCon
 
 void TransactionManager::commit(main::ClientContext& clientContext, Transaction* transaction) {
     bool shouldCheckpoint = false;
-    {
-        std::unique_lock lck{mtxForSerializingPublicFunctionCalls};
-        clientContext.cleanUp();
-        switch (transaction->getType()) {
-        case TransactionType::READ_ONLY: {
-            clearTransactionNoLock(transaction->getID());
-        } break;
-        case TransactionType::RECOVERY:
-        case TransactionType::WRITE: {
-            lastTimestamp++;
-            transaction->commitTS = lastTimestamp;
-            transaction->commit(&wal);
-            shouldCheckpoint = transaction->shouldForceCheckpoint() ||
-                               Checkpointer::canAutoCheckpoint(clientContext, *transaction);
-            clearTransactionNoLock(transaction->getID());
-            activeWriteTransactionCount.fetch_sub(1, std::memory_order_release);
-        } break;
-            // LCOV_EXCL_START
-        default: {
-            throw TransactionManagerException("Invalid transaction type to commit.");
+    bool markedAsCommitting = false;
+    uint64_t walCommitSequence = 0;
+    try {
+        {
+            std::unique_lock lck{mtxForSerializingPublicFunctionCalls};
+            clientContext.cleanUp();
+            switch (transaction->getType()) {
+            case TransactionType::READ_ONLY: {
+                clearTransactionNoLock(transaction->getID());
+            } break;
+            case TransactionType::RECOVERY:
+            case TransactionType::WRITE: {
+                committingWriteTransactionCount.fetch_add(1, std::memory_order_release);
+                markedAsCommitting = true;
+                lck.unlock();
+                walCommitSequence = transaction->writeCommitToWAL(&wal);
+                lck.lock();
+                if (walCommitSequence != 0) {
+                    cvForPublishingCommit.wait(lck,
+                        [&]() { return walCommitSequence == nextWALCommitSequenceToPublish; });
+                }
+                lastTimestamp++;
+                transaction->commitTS = lastTimestamp;
+                transaction->publishCommit();
+                if (walCommitSequence != 0) {
+                    nextWALCommitSequenceToPublish++;
+                    cvForPublishingCommit.notify_all();
+                }
+                shouldCheckpoint = transaction->shouldForceCheckpoint() ||
+                                   Checkpointer::canAutoCheckpoint(clientContext, *transaction);
+                clearTransactionNoLock(transaction->getID());
+                activeWriteTransactionCount.fetch_sub(1, std::memory_order_release);
+                committingWriteTransactionCount.fetch_sub(1, std::memory_order_release);
+                markedAsCommitting = false;
+            } break;
+                // LCOV_EXCL_START
+            default: {
+                throw TransactionManagerException("Invalid transaction type to commit.");
+            }
+                // LCOV_EXCL_STOP
+            }
         }
-            // LCOV_EXCL_STOP
+    } catch (...) {
+        if (walCommitSequence != 0) {
+            std::unique_lock lck{mtxForSerializingPublicFunctionCalls};
+            cvForPublishingCommit.wait(lck,
+                [&]() { return walCommitSequence == nextWALCommitSequenceToPublish; });
+            nextWALCommitSequenceToPublish++;
+            cvForPublishingCommit.notify_all();
         }
+        if (markedAsCommitting) {
+            committingWriteTransactionCount.fetch_sub(1, std::memory_order_release);
+        }
+        throw;
     }
     // Checkpoint outside the public function lock so active writers can finish
     // (commit/rollback) during the drain phase instead of deadlocking.

--- a/test/transaction/transaction_test.cpp
+++ b/test/transaction/transaction_test.cpp
@@ -2,6 +2,7 @@
 
 #include "api_test/api_test.h"
 #include "api_test/private_api_test.h"
+#include "common/exception/runtime.h"
 #include "storage/storage_utils.h"
 #include "storage/wal/wal.h"
 #include <format>
@@ -65,6 +66,11 @@ TEST_F(PrivateApiTest, CommitRollbackRemoveActiveTransaction) {
     ASSERT_TRUE(hasActiveTransaction(*conn));
     conn->query("COMMIT;");
     ASSERT_FALSE(hasActiveTransaction(*conn));
+}
+
+TEST_F(PrivateApiTest, DirectTransactionCommitRequiresCommitTimestamp) {
+    Transaction transaction(TransactionType::WRITE);
+    EXPECT_THROW(transaction.commit(nullptr), lbug::common::RuntimeException);
 }
 
 TEST_F(PrivateApiTest, CloseConnectionWithActiveTransaction) {
@@ -173,6 +179,44 @@ TEST_F(EmptyDBTransactionTest, ConcurrentNodeInsertions) {
     ASSERT_EQ(count, numTotalInsertions);
     res = conn->query("MATCH (a:test) RETURN SUM(a.id) AS SUM_ID;");
     ASSERT_TRUE(res->isSuccess());
+    ASSERT_EQ(res->getNumTuples(), 1);
+    auto sumID = res->getNext()->getValue(0)->getValue<int128_t>();
+    ASSERT_EQ(sumID, (numTotalInsertions * (numTotalInsertions - 1)) / 2);
+}
+
+TEST_F(EmptyDBTransactionTest, ConcurrentNodeInsertionsRecoverFromWAL) {
+    if (inMemMode || systemConfig->checkpointThreshold == 0) {
+        GTEST_SKIP();
+    }
+    conn->query("CALL debug_enable_multi_writes=true;");
+    conn->query("CALL auto_checkpoint=false;");
+    conn->query("CALL force_checkpoint_on_close=false;");
+    auto numThreads = 8;
+    auto numInsertsPerThread = 200;
+    conn->query("CREATE NODE TABLE test(id INT64 PRIMARY KEY, name STRING);");
+    conn->query("CHECKPOINT;");
+
+    std::vector<std::thread> threads;
+    for (auto i = 0; i < numThreads; ++i) {
+        threads.emplace_back(insertNodes, i * numInsertsPerThread, numInsertsPerThread,
+            std::ref(*database));
+    }
+    for (auto& thread : threads) {
+        thread.join();
+    }
+
+    conn.reset();
+    database.reset();
+    createDBAndConn();
+
+    auto numTotalInsertions = numThreads * numInsertsPerThread;
+    auto res = conn->query("MATCH (a:test) RETURN COUNT(a) AS COUNT;");
+    ASSERT_TRUE(res->isSuccess()) << res->getErrorMessage();
+    ASSERT_EQ(res->getNumTuples(), 1);
+    auto count = res->getNext()->getValue(0)->getValue<int64_t>();
+    ASSERT_EQ(count, numTotalInsertions);
+    res = conn->query("MATCH (a:test) RETURN SUM(a.id) AS SUM_ID;");
+    ASSERT_TRUE(res->isSuccess()) << res->getErrorMessage();
     ASSERT_EQ(res->getNumTuples(), 1);
     auto sumID = res->getNext()->getValue(0)->getValue<int128_t>();
     ASSERT_EQ(sumID, (numTotalInsertions * (numTotalInsertions - 1)) / 2);

--- a/test/transaction/wal_test.cpp
+++ b/test/transaction/wal_test.cpp
@@ -1,10 +1,18 @@
+#include <cstring>
 #include <fstream>
+#include <mutex>
+#include <unordered_map>
 
 #include "api_test/api_test.h"
+#include "common/exception/io.h"
 #include "common/exception/runtime.h"
 #include "common/exception/storage.h"
+#include "common/file_system/virtual_file_system.h"
 #include "gmock/gmock.h"
+#include "storage/buffer_manager/memory_manager.h"
 #include "storage/storage_utils.h"
+#include "storage/wal/local_wal.h"
+#include "storage/wal/wal.h"
 #include <format>
 
 using namespace lbug::common;
@@ -22,6 +30,118 @@ protected:
     void testStrayWALFile(const std::function<void()>& setupNewDBFunc);
     void setupChecksumMismatchTest(std::function<void(std::ofstream&)> corruptFunc);
 };
+
+class FailingSyncFileSystem final : public FileSystem {
+public:
+    explicit FailingSyncFileSystem(bool failSync) : failSync{failSync} {}
+
+    bool canHandleFile(const std::string_view path) const override {
+        return path.starts_with("failing-sync://");
+    }
+
+    std::unique_ptr<FileInfo> openFile(const std::string& path, FileOpenFlags flags,
+        lbug::main::ClientContext* /*context*/ = nullptr) override {
+        std::unique_lock lck{mtx};
+        if (flags.flags & FileFlags::CREATE_IF_NOT_EXISTS) {
+            files.try_emplace(path);
+        }
+        return std::make_unique<FileInfo>(path, this);
+    }
+
+    std::vector<std::string> glob(lbug::main::ClientContext* /*context*/,
+        const std::string& path) const override {
+        std::unique_lock lck{mtx};
+        return files.contains(path) ? std::vector<std::string>{path} : std::vector<std::string>{};
+    }
+
+    void renameFile(const std::string& from, const std::string& to) override {
+        std::unique_lock lck{mtx};
+        files[to] = std::move(files[from]);
+        files.erase(from);
+    }
+
+    void removeFileIfExists(const std::string& path,
+        const lbug::main::ClientContext* /*context*/ = nullptr) override {
+        std::unique_lock lck{mtx};
+        files.erase(path);
+    }
+
+    bool fileOrPathExists(const std::string& path,
+        lbug::main::ClientContext* /*context*/ = nullptr) override {
+        std::unique_lock lck{mtx};
+        return files.contains(path);
+    }
+
+    std::string expandPath(lbug::main::ClientContext* /*context*/,
+        const std::string& path) const override {
+        return path;
+    }
+
+    void syncFile(const FileInfo& /*fileInfo*/) const override {
+        if (failSync) {
+            throw IOException{"Injected WAL sync failure."};
+        }
+    }
+
+protected:
+    void readFromFile(FileInfo& fileInfo, void* buffer, uint64_t numBytes,
+        uint64_t position) const override {
+        std::unique_lock lck{mtx};
+        const auto& file = files.at(fileInfo.path);
+        memcpy(buffer, file.data() + position, numBytes);
+    }
+
+    int64_t readFile(FileInfo& /*fileInfo*/, void* /*buf*/, size_t /*numBytes*/) const override {
+        UNREACHABLE_CODE;
+    }
+
+    void writeFile(FileInfo& fileInfo, const uint8_t* buffer, uint64_t numBytes,
+        uint64_t offset) const override {
+        std::unique_lock lck{mtx};
+        auto& file = files[fileInfo.path];
+        if (file.size() < offset + numBytes) {
+            file.resize(offset + numBytes);
+        }
+        memcpy(file.data() + offset, buffer, numBytes);
+    }
+
+    int64_t seek(FileInfo& /*fileInfo*/, uint64_t /*offset*/, int /*whence*/) const override {
+        UNREACHABLE_CODE;
+    }
+
+    void truncate(FileInfo& fileInfo, uint64_t size) const override {
+        std::unique_lock lck{mtx};
+        files[fileInfo.path].resize(size);
+    }
+
+    uint64_t getFileSize(const FileInfo& fileInfo) const override {
+        std::unique_lock lck{mtx};
+        const auto file = files.find(fileInfo.path);
+        return file == files.end() ? 0 : file->second.size();
+    }
+
+private:
+    bool failSync;
+    mutable std::mutex mtx;
+    mutable std::unordered_map<std::string, std::vector<uint8_t>> files;
+};
+
+TEST_F(WalTest, WALSyncFailureReturnsAllocatedCommitSequence) {
+    VirtualFileSystem vfs;
+    vfs.registerFileSystem(std::make_unique<FailingSyncFileSystem>(true /* failSync */));
+
+    lbug::storage::WAL wal("failing-sync://db", false /* readOnly */, false /* enableChecksums */,
+        &vfs);
+    lbug::storage::LocalWAL localWAL(*lbug::storage::MemoryManager::Get(*conn->getClientContext()),
+        false /* enableChecksums */);
+    localWAL.logLoadExtension("dummy");
+    localWAL.logCommit();
+
+    uint64_t walCommitSequence = 0;
+    EXPECT_THROW(wal.logCommittedWAL(localWAL, conn->getClientContext(), walCommitSequence),
+        IOException);
+    EXPECT_EQ(walCommitSequence, 1);
+}
 
 TEST_F(WalTest, NoWALFile) {
     if (inMemMode || systemConfig->checkpointThreshold == 0) {

--- a/test/transaction/wal_test.cpp
+++ b/test/transaction/wal_test.cpp
@@ -35,6 +35,11 @@ class FailingSyncFileSystem final : public FileSystem {
 public:
     explicit FailingSyncFileSystem(bool failSync) : failSync{failSync} {}
 
+    void setFailSync(bool fail) {
+        std::unique_lock lck{mtx};
+        failSync = fail;
+    }
+
     bool canHandleFile(const std::string_view path) const override {
         return path.starts_with("failing-sync://");
     }
@@ -78,6 +83,7 @@ public:
     }
 
     void syncFile(const FileInfo& /*fileInfo*/) const override {
+        std::unique_lock lck{mtx};
         if (failSync) {
             throw IOException{"Injected WAL sync failure."};
         }
@@ -126,9 +132,11 @@ private:
     mutable std::unordered_map<std::string, std::vector<uint8_t>> files;
 };
 
-TEST_F(WalTest, WALSyncFailureReturnsAllocatedCommitSequence) {
+TEST_F(WalTest, WALSyncFailurePoisonsWALAndReturnsAllocatedCommitSequence) {
     VirtualFileSystem vfs;
-    vfs.registerFileSystem(std::make_unique<FailingSyncFileSystem>(true /* failSync */));
+    auto failingFS = std::make_unique<FailingSyncFileSystem>(true /* failSync */);
+    auto* failingFSPtr = failingFS.get();
+    vfs.registerFileSystem(std::move(failingFS));
 
     lbug::storage::WAL wal("failing-sync://db", false /* readOnly */, false /* enableChecksums */,
         &vfs);
@@ -139,8 +147,19 @@ TEST_F(WalTest, WALSyncFailureReturnsAllocatedCommitSequence) {
 
     uint64_t walCommitSequence = 0;
     EXPECT_THROW(wal.logCommittedWAL(localWAL, conn->getClientContext(), walCommitSequence),
-        IOException);
+        RuntimeException);
     EXPECT_EQ(walCommitSequence, 1);
+
+    failingFSPtr->setFailSync(false);
+    lbug::storage::LocalWAL secondLocalWAL(
+        *lbug::storage::MemoryManager::Get(*conn->getClientContext()), false /* enableChecksums */);
+    secondLocalWAL.logLoadExtension("dummy2");
+    secondLocalWAL.logCommit();
+
+    walCommitSequence = 0;
+    EXPECT_THROW(wal.logCommittedWAL(secondLocalWAL, conn->getClientContext(), walCommitSequence),
+        RuntimeException);
+    EXPECT_EQ(walCommitSequence, 0);
 }
 
 TEST_F(WalTest, NoWALFile) {

--- a/tools/benchmark/node_write_bench.cpp
+++ b/tools/benchmark/node_write_bench.cpp
@@ -1,0 +1,194 @@
+#include <atomic>
+#include <chrono>
+#include <cstdlib>
+#include <filesystem>
+#include <iostream>
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <thread>
+#include <unordered_map>
+#include <vector>
+
+#include "lbug.hpp"
+#include <format>
+
+using namespace lbug::main;
+using lbug::common::Value;
+
+static void check(QueryResult& result, const std::string& query) {
+    if (!result.isSuccess()) {
+        std::cerr << "Query failed: " << query << "\n" << result.getErrorMessage() << "\n";
+        std::exit(1);
+    }
+}
+
+static void runQuery(Connection& conn, const std::string& query) {
+    auto result = conn.query(query);
+    check(*result, query);
+}
+
+static void checkPrepared(PreparedStatement& statement, const std::string& query) {
+    if (!statement.isSuccess()) {
+        std::cerr << "Prepare failed: " << query << "\n" << statement.getErrorMessage() << "\n";
+        std::exit(1);
+    }
+}
+
+struct Config {
+    double seconds = 10.0;
+    bool preserveDB = false;
+    std::vector<uint64_t> threadCounts = {1, 2, 4, 8};
+};
+
+static void usage(const char* program) {
+    std::cerr << "Usage: " << program << " [--seconds N] [--preserve-db] [thread_count ...]\n"
+              << "Example: " << program << " --seconds 30 --preserve-db 1 2 4 8\n";
+}
+
+static Config parseArgs(int argc, char** argv) {
+    Config config;
+    config.threadCounts.clear();
+    for (int i = 1; i < argc; i++) {
+        const std::string arg = argv[i];
+        if (arg == "--help" || arg == "-h") {
+            usage(argv[0]);
+            std::exit(0);
+        }
+        if (arg == "--seconds" || arg == "-s") {
+            if (++i == argc) {
+                throw std::invalid_argument("--seconds requires a value");
+            }
+            config.seconds = std::stod(argv[i]);
+            if (config.seconds <= 0.0) {
+                throw std::invalid_argument("--seconds must be greater than 0");
+            }
+            continue;
+        }
+        if (arg == "--preserve-db") {
+            config.preserveDB = true;
+            continue;
+        }
+        const auto numThreads = std::stoull(arg);
+        if (numThreads == 0) {
+            throw std::invalid_argument("thread_count must be greater than 0");
+        }
+        config.threadCounts.push_back(numThreads);
+    }
+    if (config.threadCounts.empty()) {
+        config.threadCounts = {1, 2, 4, 8};
+    }
+    return config;
+}
+
+struct CaseResult {
+    uint64_t totalWrites;
+    double seconds;
+    std::string dbPath;
+};
+
+static CaseResult runCase(const Config& benchConfig, uint64_t numThreads) {
+    const auto dbPath = std::filesystem::temp_directory_path() /
+                        std::format("lbug_node_write_bench_{}_{}", numThreads,
+                            std::chrono::steady_clock::now().time_since_epoch().count());
+    std::filesystem::remove_all(dbPath);
+
+    SystemConfig systemConfig;
+    systemConfig.enableMultiWrites = true;
+    systemConfig.autoCheckpoint = false;
+    systemConfig.forceCheckpointOnClose = false;
+    systemConfig.enableCompression = false;
+    Database database(dbPath.string(), systemConfig);
+    Connection setup(&database);
+    runQuery(setup, "CALL debug_enable_multi_writes=true;");
+    runQuery(setup, "CALL enable_default_hash_index=false;");
+    runQuery(setup, "CREATE NODE TABLE person(id INT64 PRIMARY KEY, name STRING);");
+    runQuery(setup, "CHECKPOINT;");
+
+    std::atomic<uint64_t> ready = 0;
+    std::atomic<bool> start = false;
+    std::vector<uint64_t> writes(numThreads, 0);
+    std::vector<std::thread> threads;
+    threads.reserve(numThreads);
+
+    const auto begin = std::chrono::steady_clock::now();
+    const auto duration = std::chrono::duration<double>(benchConfig.seconds);
+    for (uint64_t threadIdx = 0; threadIdx < numThreads; threadIdx++) {
+        threads.emplace_back([&, threadIdx]() {
+            Connection conn(&database);
+            const std::string createQuery = "CREATE (:person {id: $id, name: $name});";
+            std::unordered_map<std::string, std::unique_ptr<Value>> initialParams;
+            initialParams.insert({"id", std::make_unique<Value>(static_cast<int64_t>(0))});
+            initialParams.insert({"name", std::make_unique<Value>(std::string("Person0"))});
+            auto preparedCreate = conn.prepareWithParams(createQuery, std::move(initialParams));
+            checkPrepared(*preparedCreate, createQuery);
+            ready.fetch_add(1, std::memory_order_release);
+            while (!start.load(std::memory_order_acquire)) {
+                std::this_thread::yield();
+            }
+            const auto stopTime = std::chrono::steady_clock::now() + duration;
+            uint64_t localWrites = 0;
+            while (true) {
+                if ((localWrites & 63) == 0 && std::chrono::steady_clock::now() >= stopTime) {
+                    break;
+                }
+                const auto id = threadIdx + localWrites * numThreads;
+                preparedCreate->setParameter("id", Value(static_cast<int64_t>(id)));
+                preparedCreate->setParameter("name", Value(std::format("Person{}", id)));
+                auto result = conn.execute(preparedCreate.get());
+                check(*result, createQuery);
+                localWrites++;
+            }
+            writes[threadIdx] = localWrites;
+        });
+    }
+    while (ready.load(std::memory_order_acquire) != numThreads) {
+        std::this_thread::yield();
+    }
+    const auto startTime = std::chrono::steady_clock::now();
+    start.store(true, std::memory_order_release);
+    for (auto& thread : threads) {
+        thread.join();
+    }
+    const auto endTime = std::chrono::steady_clock::now();
+    const auto setupSeconds = std::chrono::duration<double>(startTime - begin).count();
+    (void)setupSeconds;
+
+    uint64_t totalWrites = 0;
+    for (const auto threadWrites : writes) {
+        totalWrites += threadWrites;
+    }
+    auto result = setup.query("MATCH (p:person) RETURN COUNT(p);");
+    check(*result, "MATCH (p:person) RETURN COUNT(p);");
+    const auto count = result->getNext()->getValue(0)->getValue<int64_t>();
+    const auto expected = static_cast<int64_t>(totalWrites);
+    if (count != expected) {
+        std::cerr << "Expected " << expected << " rows, found " << count << "\n";
+        std::exit(1);
+    }
+
+    const auto seconds = std::chrono::duration<double>(endTime - startTime).count();
+    if (!benchConfig.preserveDB) {
+        std::filesystem::remove_all(dbPath);
+    }
+    return {.totalWrites = totalWrites, .seconds = seconds, .dbPath = dbPath.string()};
+}
+
+int main(int argc, char** argv) {
+    Config config;
+    try {
+        config = parseArgs(argc, argv);
+    } catch (const std::exception& e) {
+        std::cerr << e.what() << "\n";
+        usage(argv[0]);
+        return 1;
+    }
+
+    std::cout << "target_seconds,actual_seconds,total_writes,threads,writes_per_sec,db_path\n";
+    for (const auto threads : config.threadCounts) {
+        const auto result = runCase(config, threads);
+        const auto writesPerSec = static_cast<double>(result.totalWrites) / result.seconds;
+        std::cout << config.seconds << "," << result.seconds << "," << result.totalWrites << ","
+                  << threads << "," << writesPerSec << "," << result.dbPath << "\n";
+    }
+}


### PR DESCRIPTION
## Summary

- add WAL group commit sequencing so multiple committers can share one durable sync
- split transaction commit into durable WAL append followed by in-memory publish
- preserve publish order and single-writer behavior while allowing committers to wait during sync

## Benchmark

C++ benchmark source: `node_write_bench.cpp`. Optimal was 64 threads at 6k writes/sec.

Setup:
- on-disk temp database under `/private/tmp`
- `enableMultiWrites=true`
- `autoCheckpoint=false`
- `forceCheckpointOnClose=false`
- one autocommitted `CREATE (:person {id, name})` per write
- one `Connection` per writer thread
- count verified after each run

### 1,000 writes per thread

| Branch | Threads | Total writes | Writes/sec |
| --- | ---: | ---: | ---: |
| main | 1 | 1,000 | 249.068 |
| group commit | 1 | 1,000 | 244.118 |
| main | 2 | 2,000 | 256.391 |
| group commit | 2 | 2,000 | 248.242 |
| main | 4 | 4,000 | 254.625 |
| group commit | 4 | 4,000 | 495.887 |
| main | 8 | 8,000 | 258.332 |
| group commit | 8 | 8,000 | 951.349 |

### 2,000 writes per thread

| Branch | Threads | Total writes | Writes/sec | Speedup |
| --- | ---: | ---: | ---: | ---: |
| main | 4 | 8,000 | 265.451 | 1.00x |
| group commit | 4 | 8,000 | 493.874 | 1.86x |
| main | 8 | 16,000 | 283.718 | 1.00x |
| group commit | 8 | 16,000 | 1,016.86 | 3.58x |
| main | 16 | 32,000 | 290.376 | 1.00x |
| group commit | 16 | 32,000 | 2,115.63 | 7.29x |

Main remains fsync-bound at roughly 250-290 writes/sec as writer concurrency increases. With group commits, throughput scales to roughly 1,017 writes/sec at 8 writers and 2,116 writes/sec at 16 writers for this benchmark.

