### PR TITLE
Add vector to official extensions listing

### DIFF
--- a/src/function/table/show_official_extensions.cpp
+++ b/src/function/table/show_official_extensions.cpp
@@ -24,7 +24,8 @@ static constexpr std::pair<std::string_view, std::string_view> extensions[] = {
     {"NEO4J", "Adds support for migrating nodes and rels from neo4j to lbug"},
     {"POSTGRES", "Adds support for reading from POSTGRES tables"},
     {"SQLITE", "Adds support for reading from SQLITE tables"},
-    {"UNITY_CATALOG", "Adds support for scanning delta tables registered in unity catalog"}};
+    {"UNITY_CATALOG", "Adds support for scanning delta tables registered in unity catalog"},
+    {"VECTOR", "Adds support for vector indexes"}};
 static constexpr auto officialExtensions = std::to_array(extensions);
 
 static offset_t internalTableFunc(const TableFuncMorsel& morsel, const TableFuncInput& /*input*/,

--- a/test/test_files/function/call/call.test
+++ b/test/test_files/function/call/call.test
@@ -300,6 +300,10 @@ Binder exception: a.fName has type PROPERTY but LITERAL,PARAMETER,PATTERN was ex
 ---- 1
 SQLITE|Adds support for reading from SQLITE tables
 
+-STATEMENT CALL SHOW_OFFICIAL_EXTENSIONS() yield name, description WITH name, description WHERE name = 'VECTOR' return name, description
+---- 1
+VECTOR|Adds support for vector indexes
+
 -STATEMENT CALL SHOW_OFFICIAL_EXTENSIONS() yield name as extension_name, description as extension_description WITH extension_name, extension_description WHERE extension_name = 'SQLITE' return extension_name, extension_description
 ---- 1
 SQLITE|Adds support for reading from SQLITE tables


### PR DESCRIPTION
## Summary
- add VECTOR to SHOW_OFFICIAL_EXTENSIONS() output
- add regression coverage for querying VECTOR from the official extension list

## Root cause
SHOW_OFFICIAL_EXTENSIONS() maintains a separate hardcoded metadata list that was missing vector, even though vector is present in the official extension allowlist and on the extension server.

## Validation
- git diff --cached --check
- local e2e_test rebuild was started, but interrupted before completion; CI will run the full test suite

Fixes: #549