### PR TITLE
add db path to VFS search paths

### DIFF
--- a/src/include/main/client_context.h
+++ b/src/include/main/client_context.h
@@ -131,6 +131,8 @@ public:
 
     bool isInMemory() const;
 
+    void addDBDirToFileSearchPath(const std::string& dbPath);
+
     static std::string getEnvVariable(const std::string& name);
     static std::string getUserHomeDir();
 

--- a/src/main/client_context.cpp
+++ b/src/main/client_context.cpp
@@ -60,6 +60,7 @@ ClientContext::ClientContext(Database* database) : localDatabase{database} {
     graphEntrySet = std::make_unique<graph::GraphEntrySet>();
     clientConfig.homeDirectory = getUserHomeDir();
     clientConfig.fileSearchPath = "";
+    addDBDirToFileSearchPath(database->databasePath);
     clientConfig.enableSemiMask = ClientConfigDefault::ENABLE_SEMI_MASK;
     clientConfig.enableZoneMap = ClientConfigDefault::ENABLE_ZONE_MAP;
     clientConfig.numThreads = database->dbConfig->maxNumThreads;
@@ -207,6 +208,39 @@ bool ClientContext::isInMemory() const {
         return false;
     }
     return localDatabase->storageManager->isInMemory();
+}
+
+void ClientContext::addDBDirToFileSearchPath(const std::string& dbPath) {
+    // Skip remote paths (e.g. s3://, https://)
+    if (dbPath.find("://") != std::string::npos) {
+        return;
+    }
+    // Expand ~ using the home directory from config
+    std::string expandedPath = dbPath;
+    if (dbPath.starts_with('~')) {
+        expandedPath = clientConfig.homeDirectory + dbPath.substr(1);
+    }
+    const auto slashPos = expandedPath.find_last_of("/\\");
+    if (slashPos == std::string::npos) {
+        return;
+    }
+    std::string dirPath = expandedPath.substr(0, slashPos);
+    if (dirPath.empty()) {
+        dirPath = expandedPath[slashPos] == '\\' ? "\\" : "/";
+    } else {
+        dirPath = std::filesystem::absolute(dirPath).lexically_normal().string();
+    }
+    // Prepend to fileSearchPath if not already present
+    auto& fileSearchPath = clientConfig.fileSearchPath;
+    if (!fileSearchPath.empty()) {
+        const auto searchPaths = StringUtils::split(fileSearchPath, ",");
+        if (std::find(searchPaths.begin(), searchPaths.end(), dirPath) != searchPaths.end()) {
+            return;
+        }
+        fileSearchPath = std::format("{},{}", dirPath, fileSearchPath);
+    } else {
+        fileSearchPath = dirPath;
+    }
 }
 
 std::string ClientContext::getEnvVariable(const std::string& name) {

--- a/src/main/client_context.cpp
+++ b/src/main/client_context.cpp
@@ -27,6 +27,7 @@
 #include "storage/buffer_manager/buffer_manager.h"
 #include "storage/buffer_manager/spiller.h"
 #include "storage/storage_manager.h"
+#include "storage/storage_utils.h"
 #include "transaction/transaction_context.h"
 #include <format>
 #include <processor/warning_context.h>
@@ -215,11 +216,10 @@ void ClientContext::addDBDirToFileSearchPath(const std::string& dbPath) {
     if (dbPath.find("://") != std::string::npos) {
         return;
     }
-    // Expand ~ using the home directory from config
-    std::string expandedPath = dbPath;
-    if (dbPath.starts_with('~')) {
-        expandedPath = clientConfig.homeDirectory + dbPath.substr(1);
+    if (dbPath.find_first_of("/\\") == std::string::npos) {
+        return;
     }
+    const auto expandedPath = storage::StorageUtils::expandPath(this, dbPath);
     const auto slashPos = expandedPath.find_last_of("/\\");
     if (slashPos == std::string::npos) {
         return;

--- a/src/main/database.cpp
+++ b/src/main/database.cpp
@@ -106,6 +106,7 @@ void Database::initMembers(std::string_view dbPath, construct_bm_func_t initBmFu
     const auto dbPathStr = std::string(dbPath);
     auto clientContext = ClientContext(this);
     databasePath = StorageUtils::expandPath(&clientContext, dbPathStr);
+    clientContext.addDBDirToFileSearchPath(databasePath);
 
     if (std::filesystem::is_directory(databasePath)) {
         throw RuntimeException("Database path cannot be a directory: " + databasePath);

--- a/src/processor/operator/simple/attach_database.cpp
+++ b/src/processor/operator/simple/attach_database.cpp
@@ -33,6 +33,7 @@ void AttachDatabase::executeInternal(ExecutionContext* context) {
     auto databaseManager = main::DatabaseManager::Get(*client);
     auto memoryManager = storage::MemoryManager::Get(*client);
     if (common::StringUtils::getUpper(attachInfo.dbType) == common::ATTACHED_LBUG_DB_TYPE) {
+        client->addDBDirToFileSearchPath(attachInfo.dbPath);
         auto db = std::make_unique<main::AttachedLbugDatabase>(attachInfo.dbPath,
             attachInfo.dbAlias, common::ATTACHED_LBUG_DB_TYPE, client);
         client->setDefaultDatabase(db.get());
@@ -42,6 +43,7 @@ void AttachDatabase::executeInternal(ExecutionContext* context) {
     }
     for (auto& storageExtension : client->getDatabase()->getStorageExtensions()) {
         if (storageExtension->canHandleDB(attachInfo.dbType)) {
+            client->addDBDirToFileSearchPath(attachInfo.dbPath);
             auto db = storageExtension->attach(attachInfo.dbAlias, attachInfo.dbPath, client,
                 attachInfo.options);
             databaseManager->registerAttachedDatabase(std::move(db));

--- a/src/processor/operator/simple/attach_database.cpp
+++ b/src/processor/operator/simple/attach_database.cpp
@@ -33,20 +33,20 @@ void AttachDatabase::executeInternal(ExecutionContext* context) {
     auto databaseManager = main::DatabaseManager::Get(*client);
     auto memoryManager = storage::MemoryManager::Get(*client);
     if (common::StringUtils::getUpper(attachInfo.dbType) == common::ATTACHED_LBUG_DB_TYPE) {
-        client->addDBDirToFileSearchPath(attachInfo.dbPath);
         auto db = std::make_unique<main::AttachedLbugDatabase>(attachInfo.dbPath,
             attachInfo.dbAlias, common::ATTACHED_LBUG_DB_TYPE, client);
         client->setDefaultDatabase(db.get());
         databaseManager->registerAttachedDatabase(std::move(db));
+        client->addDBDirToFileSearchPath(attachInfo.dbPath);
         appendMessage(attachMessage(), memoryManager);
         return;
     }
     for (auto& storageExtension : client->getDatabase()->getStorageExtensions()) {
         if (storageExtension->canHandleDB(attachInfo.dbType)) {
-            client->addDBDirToFileSearchPath(attachInfo.dbPath);
             auto db = storageExtension->attach(attachInfo.dbAlias, attachInfo.dbPath, client,
                 attachInfo.options);
             databaseManager->registerAttachedDatabase(std::move(db));
+            client->addDBDirToFileSearchPath(attachInfo.dbPath);
             appendMessage(attachMessage(), memoryManager);
             return;
         }

--- a/test/api/CMakeLists.txt
+++ b/test/api/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_lbug_api_test(api_test
         api_test.cpp
+        file_search_path_test.cpp
         system_config_test.cpp
         arrow_test.cpp
         arrow_node_table_test.cpp

--- a/test/api/file_search_path_test.cpp
+++ b/test/api/file_search_path_test.cpp
@@ -1,0 +1,163 @@
+#include <filesystem>
+#include <memory>
+#include <string>
+
+#include "gtest/gtest.h"
+#include "main/connection.h"
+#include "main/database.h"
+#include "test_helper/test_helper.h"
+#include <format>
+
+using namespace lbug::main;
+namespace fs = std::filesystem;
+
+namespace lbug {
+namespace testing {
+
+// Verifies that creating a Connection to an on-disk database automatically adds
+// the database directory to the VFS file search path.
+TEST(FileSearchPathTest, DBInitAddsDBDirToSearchPath) {
+    auto dbPath = TestHelper::getTempDBPathStr("FileSearchPath.DBInit");
+    auto database = std::make_unique<Database>(dbPath, SystemConfig());
+    auto conn = std::make_unique<Connection>(database.get());
+
+    auto expectedDir = fs::path(dbPath).parent_path().lexically_normal().string();
+    const auto& searchPath = conn->getClientContext()->getClientConfigUnsafe()->fileSearchPath;
+    EXPECT_EQ(searchPath, expectedDir);
+}
+
+// Verifies that an in-memory database does not add any entry to the file search path.
+TEST(FileSearchPathTest, InMemoryDBHasEmptySearchPath) {
+    auto database = std::make_unique<Database>(":memory:", SystemConfig());
+    auto conn = std::make_unique<Connection>(database.get());
+
+    const auto& searchPath = conn->getClientContext()->getClientConfigUnsafe()->fileSearchPath;
+    EXPECT_EQ(searchPath, "");
+}
+
+// Verifies that each new Connection independently receives the db directory in its search path.
+TEST(FileSearchPathTest, NewConnectionGetsDBDirSearchPath) {
+    auto dbPath = TestHelper::getTempDBPathStr("FileSearchPath.MultiConn");
+    auto database = std::make_unique<Database>(dbPath, SystemConfig());
+    auto conn1 = std::make_unique<Connection>(database.get());
+    auto conn2 = std::make_unique<Connection>(database.get());
+
+    auto expectedDir = fs::path(dbPath).parent_path().lexically_normal().string();
+    EXPECT_EQ(conn1->getClientContext()->getClientConfigUnsafe()->fileSearchPath, expectedDir);
+    EXPECT_EQ(conn2->getClientContext()->getClientConfigUnsafe()->fileSearchPath, expectedDir);
+}
+
+// Verifies that ATTACHing a Lbug database adds the attached database's directory
+// to the executing connection's file search path.
+TEST(FileSearchPathTest, AttachAddsAttachedDBDirToSearchPath) {
+    auto srcDbPath = TestHelper::getTempDBPathStr("FileSearchPath.AttachSrc");
+    auto dstDbPath = TestHelper::getTempDBPathStr("FileSearchPath.AttachDst");
+
+    // Create source database on disk
+    { auto srcDb = std::make_unique<Database>(srcDbPath, SystemConfig()); }
+
+    auto dstDb = std::make_unique<Database>(dstDbPath, SystemConfig());
+    auto conn = std::make_unique<Connection>(dstDb.get());
+
+    auto result = conn->query(std::format("ATTACH '{}' AS srcdb (DBTYPE lbug)", srcDbPath));
+    ASSERT_TRUE(result->isSuccess()) << result->toString();
+
+    const auto& searchPath = conn->getClientContext()->getClientConfigUnsafe()->fileSearchPath;
+    auto expectedSrcDir = fs::path(srcDbPath).parent_path().lexically_normal().string();
+    auto expectedDstDir = fs::path(dstDbPath).parent_path().lexically_normal().string();
+
+    EXPECT_NE(searchPath.find(expectedSrcDir), std::string::npos)
+        << "Attached db directory should be in fileSearchPath. Got: " << searchPath;
+    EXPECT_NE(searchPath.find(expectedDstDir), std::string::npos)
+        << "Main db directory should still be in fileSearchPath. Got: " << searchPath;
+}
+
+// Verifies that the attached db directory is prepended (highest priority) in the search path.
+TEST(FileSearchPathTest, AttachPrependsSearchPath) {
+    auto srcDbPath = TestHelper::getTempDBPathStr("FileSearchPath.Prepend");
+    auto dstDbPath = TestHelper::getTempDBPathStr("FileSearchPath.PrependDst");
+
+    { auto srcDb = std::make_unique<Database>(srcDbPath, SystemConfig()); }
+
+    auto dstDb = std::make_unique<Database>(dstDbPath, SystemConfig());
+    auto conn = std::make_unique<Connection>(dstDb.get());
+
+    auto result = conn->query(std::format("ATTACH '{}' AS srcdb (DBTYPE lbug)", srcDbPath));
+    ASSERT_TRUE(result->isSuccess()) << result->toString();
+
+    const auto& searchPath = conn->getClientContext()->getClientConfigUnsafe()->fileSearchPath;
+    auto expectedSrcDir = fs::path(srcDbPath).parent_path().lexically_normal().string();
+
+    // Attached db directory should appear before (or at the start of) the search path
+    EXPECT_EQ(searchPath.substr(0, expectedSrcDir.size()), expectedSrcDir)
+        << "Attached db directory should be prepended. Got: " << searchPath;
+}
+
+// ── Windows-path tests ────────────────────────────────────────────────────────
+// These tests call addDBDirToFileSearchPath() directly with Windows-style paths
+// (backslash separators) to verify the separator-agnostic logic. They run on
+// all platforms because the extraction logic is purely string-based before the
+// std::filesystem::absolute() call.
+
+// A Windows absolute path with backslashes should extract the parent directory.
+TEST(FileSearchPathTest, WindowsAbsolutePathExtractsDir) {
+    auto database = std::make_unique<Database>(":memory:", SystemConfig());
+    auto conn = std::make_unique<Connection>(database.get());
+    auto* ctx = conn->getClientContext();
+    ctx->getClientConfigUnsafe()->fileSearchPath = "";
+
+    ctx->addDBDirToFileSearchPath("C:\\Users\\foo\\bar.lbug");
+
+    const auto& searchPath = ctx->getClientConfigUnsafe()->fileSearchPath;
+    // The backslash separator must be recognised: the call must not be a no-op.
+    EXPECT_FALSE(searchPath.empty()) << "Windows-style path should add a directory";
+    // The filename itself must not appear in the directory entry.
+    EXPECT_EQ(searchPath.find("bar.lbug"), std::string::npos)
+        << "Filename should be stripped from the directory entry. Got: " << searchPath;
+}
+
+// A path with only a backslash separator (root-level) should produce a non-empty entry.
+TEST(FileSearchPathTest, WindowsRootBackslashPath) {
+    auto database = std::make_unique<Database>(":memory:", SystemConfig());
+    auto conn = std::make_unique<Connection>(database.get());
+    auto* ctx = conn->getClientContext();
+    ctx->getClientConfigUnsafe()->fileSearchPath = "";
+
+    ctx->addDBDirToFileSearchPath("\\file.lbug");
+
+    // slashPos == 0, dirPath becomes "\\" (root), so searchPath must be non-empty
+    const auto& searchPath = ctx->getClientConfigUnsafe()->fileSearchPath;
+    EXPECT_FALSE(searchPath.empty()) << "Root backslash path should add an entry";
+}
+
+// A path with no separator at all (bare filename) must be a no-op on any platform.
+TEST(FileSearchPathTest, BareFilenameIsNoOp) {
+    auto database = std::make_unique<Database>(":memory:", SystemConfig());
+    auto conn = std::make_unique<Connection>(database.get());
+    auto* ctx = conn->getClientContext();
+    ctx->getClientConfigUnsafe()->fileSearchPath = "";
+
+    ctx->addDBDirToFileSearchPath("bare.lbug");
+
+    EXPECT_EQ(ctx->getClientConfigUnsafe()->fileSearchPath, "")
+        << "Bare filename (no separator) should not modify fileSearchPath";
+}
+
+// Duplicate Windows-style paths should not be added twice.
+TEST(FileSearchPathTest, WindowsPathNotAddedTwice) {
+    auto database = std::make_unique<Database>(":memory:", SystemConfig());
+    auto conn = std::make_unique<Connection>(database.get());
+    auto* ctx = conn->getClientContext();
+    ctx->getClientConfigUnsafe()->fileSearchPath = "";
+
+    ctx->addDBDirToFileSearchPath("C:\\Users\\foo\\bar.lbug");
+    const auto firstPath = ctx->getClientConfigUnsafe()->fileSearchPath;
+
+    ctx->addDBDirToFileSearchPath("C:\\Users\\foo\\other.lbug");
+    const auto secondPath = ctx->getClientConfigUnsafe()->fileSearchPath;
+
+    EXPECT_EQ(firstPath, secondPath) << "Same directory should not be added twice";
+}
+
+} // namespace testing
+} // namespace lbug


### PR DESCRIPTION
### Caveats
- remote dirs are ignored to avoid security and permission issues

### Testing
- `./build/relwithdebinfo/tools/shell/lbug -i ../benchmarks/OptimusKG-lady-mem/icebug_disk/optimuskg_csr/schema.cypher`
- `./build/relwithdebinfo/tools/shell/lbug -i ../benchmarks/OptimusKG-lady-mem/icebug_disk/optimuskg_csr/schema.cypher ../benchmarks/OptimusKG-lady-mem/icebug_disk/optimuskg_csr/optimuskg.lbdb`
- `./build/relwithdebinfo/tools/shell/lbug ../benchmarks/OptimusKG-lady-mem/icebug_disk/optimuskg_csr/optimuskg.lbdb`
- `ATTACH "../benchmarks/OptimusKG-lady-mem/icebug_disk/optimuskg_csr/optimuskg.lbdb" AS op (dbtype lbug);`

Closes https://github.com/LadybugDB/ladybug/issues/539