### PR TITLE
Handle join enumeration limits

### DIFF
--- a/src/include/planner/subplans_table.h
+++ b/src/include/planner/subplans_table.h
@@ -27,7 +27,7 @@ public:
 
     uint64_t getMaxCost() const { return maxCost; }
 
-    void addPlan(LogicalPlan plan);
+    bool addPlan(LogicalPlan plan);
 
     const std::vector<LogicalPlan>& getPlans() const { return plans; }
 
@@ -37,7 +37,7 @@ private:
     std::bitset<binder::MAX_NUM_QUERY_VARIABLES> encodePlan(const LogicalPlan& plan);
 
 private:
-    constexpr static uint32_t MAX_NUM_PLANS = 10;
+    constexpr static uint32_t MAX_NUM_PLANS = 16;
 
 private:
     uint64_t maxCost = UINT64_MAX;
@@ -61,12 +61,12 @@ public:
 
     std::vector<binder::SubqueryGraph> getSubqueryGraphs();
 
-    void addPlan(const binder::SubqueryGraph& subqueryGraph, LogicalPlan plan);
+    bool addPlan(const binder::SubqueryGraph& subqueryGraph, LogicalPlan plan);
 
     void clear() { subgraph2Plans.clear(); }
 
 private:
-    constexpr static uint32_t MAX_NUM_SUBGRAPH = 50;
+    constexpr static uint32_t MAX_NUM_SUBGRAPH = 128;
 
 private:
     binder::subquery_graph_V_map_t<SubgraphPlans> subgraph2Plans;
@@ -86,6 +86,7 @@ public:
     std::vector<binder::SubqueryGraph> getSubqueryGraphs(uint32_t level);
 
     void addPlan(const binder::SubqueryGraph& subqueryGraph, LogicalPlan plan);
+    bool hasExceededPlanLimit() const { return exceededPlanLimit; }
 
     void clear();
 
@@ -99,6 +100,7 @@ private:
 
 private:
     std::vector<DPLevel> dpLevels;
+    bool exceededPlanLimit = false;
 };
 
 } // namespace planner

--- a/src/planner/plan/plan_join_order.cpp
+++ b/src/planner/plan/plan_join_order.cpp
@@ -6,6 +6,7 @@
 #include "common/enums/join_type.h"
 #include "common/enums/rel_direction.h"
 #include "common/enums/table_type.h"
+#include "common/exception/runtime.h"
 #include "common/utils.h"
 #include "planner/join_order/cost_model.h"
 #include "planner/join_order/join_plan_solver.h"
@@ -143,7 +144,16 @@ LogicalPlan Planner::planQueryGraph(const QueryGraph& queryGraph,
         planLevel(context.currentLevel++);
     }
 
-    auto& plans = context.getPlans(context.getFullyMatchedSubqueryGraph());
+    auto fullyMatchedSubqueryGraph = context.getFullyMatchedSubqueryGraph();
+    if (!context.containPlans(fullyMatchedSubqueryGraph)) {
+        if (context.subPlansTable->hasExceededPlanLimit()) {
+            throw RuntimeException(
+                "Query planning exceeded the join enumeration limits. Try simplifying the MATCH "
+                "pattern, splitting it into multiple query parts, or using a join hint.");
+        }
+        throw RuntimeException("Unable to construct a complete plan for the query graph.");
+    }
+    auto& plans = context.getPlans(fullyMatchedSubqueryGraph);
     auto bestIdx = 0;
     for (auto i = 1u; i < plans.size(); ++i) {
         if (plans[i].getCost() < plans[bestIdx].getCost()) {

--- a/src/planner/subplans_table.cpp
+++ b/src/planner/subplans_table.cpp
@@ -14,9 +14,9 @@ SubgraphPlans::SubgraphPlans(const SubqueryGraph& subqueryGraph) {
     maxCost = UINT64_MAX;
 }
 
-void SubgraphPlans::addPlan(LogicalPlan plan) {
+bool SubgraphPlans::addPlan(LogicalPlan plan) {
     if (plans.size() > MAX_NUM_PLANS) {
-        return;
+        return false;
     }
     auto planCode = encodePlan(plan);
     if (!encodedPlan2PlanIdx.contains(planCode)) {
@@ -39,6 +39,7 @@ void SubgraphPlans::addPlan(LogicalPlan plan) {
             plans[planIdx] = std::move(plan);
         }
     }
+    return true;
 }
 
 std::bitset<MAX_NUM_QUERY_VARIABLES> SubgraphPlans::encodePlan(const LogicalPlan& plan) {
@@ -59,14 +60,14 @@ std::vector<SubqueryGraph> DPLevel::getSubqueryGraphs() {
     return result;
 }
 
-void DPLevel::addPlan(const SubqueryGraph& subqueryGraph, LogicalPlan plan) {
+bool DPLevel::addPlan(const SubqueryGraph& subqueryGraph, LogicalPlan plan) {
     if (subgraph2Plans.size() > MAX_NUM_SUBGRAPH) {
-        return;
+        return false;
     }
     if (!contains(subqueryGraph)) {
         subgraph2Plans.insert({subqueryGraph, SubgraphPlans(subqueryGraph)});
     }
-    subgraph2Plans.at(subqueryGraph).addPlan(std::move(plan));
+    return subgraph2Plans.at(subqueryGraph).addPlan(std::move(plan));
 }
 
 void SubPlansTable::resize(uint32_t newSize) {
@@ -100,10 +101,11 @@ std::vector<SubqueryGraph> SubPlansTable::getSubqueryGraphs(uint32_t level) {
 
 void SubPlansTable::addPlan(const SubqueryGraph& subqueryGraph, LogicalPlan plan) {
     auto& dpLevel = getDPLevelUnsafe(subqueryGraph);
-    dpLevel.addPlan(subqueryGraph, std::move(plan));
+    exceededPlanLimit = !dpLevel.addPlan(subqueryGraph, std::move(plan)) || exceededPlanLimit;
 }
 
 void SubPlansTable::clear() {
+    exceededPlanLimit = false;
     for (auto& dpLevel : dpLevels) {
         dpLevel.clear();
     }

--- a/test/test_files/issue/issue.test
+++ b/test/test_files/issue/issue.test
@@ -652,6 +652,59 @@ alice
 {_ID: 0:0, _LABEL: Node, id: 0, cities: [Old York,Los Angeles]}
 {_ID: 0:1, _LABEL: Node, id: 1, cities: [Tokyo,Osaka]}
 
+-CASE 556
+-STATEMENT CREATE NODE TABLE Issue556Node(
+    id STRING,
+    kind STRING,
+    reference STRING,
+    name STRING,
+    value STRING,
+    type STRING,
+    PRIMARY KEY (id)
+);
+---- ok
+-STATEMENT CREATE REL TABLE Issue556Child(
+    FROM Issue556Node TO Issue556Node
+);
+---- ok
+-STATEMENT MATCH (MODULE:Issue556Node { kind: 'Module' }),
+    (MODULE:Issue556Node)-[:Issue556Child*1..5]->(FUNCOP:Issue556Node),
+        (FUNCOP:Issue556Node { kind: 'Operation', type: 'llvm.func' }),
+        (FUNCOP:Issue556Node)-[:Issue556Child*1..5]->(BASE:Issue556Node),
+        (FUNCOP:Issue556Node)-[:Issue556Child*1..5]->(BASE_ALIGNED:Issue556Node),
+        (FUNCOP:Issue556Node)-[:Issue556Child*1..5]->(BASE_OFFSET:Issue556Node),
+        (FUNCOP:Issue556Node)-[:Issue556Child*1..5]->(BASE_STRIDE0:Issue556Node),
+        (FUNCOP:Issue556Node)-[:Issue556Child*1..5]->(BASE_STRIDE1:Issue556Node),
+        (FUNCOP:Issue556Node)-[:Issue556Child*1..5]->(BASE_SIZE0:Issue556Node),
+        (FUNCOP:Issue556Node)-[:Issue556Child*1..5]->(BASE_SIZE1:Issue556Node),
+        (FUNCOP:Issue556Node)-[:Issue556Child*1..5]->(ARG0:Issue556Node),
+        (FUNCOP:Issue556Node)-[:Issue556Child*1..5]->(ARG1:Issue556Node),
+        (FUNCOP:Issue556Node)-[:Issue556Child*1..5]->(ARG2:Issue556Node),
+        (FUNCOP:Issue556Node)-[:Issue556Child*1..5]->(STRIDE0:Issue556Node),
+            (STRIDE0:Issue556Node { kind: 'Operation', type: 'llvm.mlir.constant' }),
+            (STRIDE0:Issue556Node)-[:Issue556Child*1..5]->(STRIDE0_VALUE:Issue556Node),
+        (FUNCOP:Issue556Node)-[:Issue556Child*1..5]->(DESCSTRIDE0:Issue556Node),
+            (DESCSTRIDE0:Issue556Node { kind: 'Operation', type: 'llvm.mul' }),
+            (DESCSTRIDE0:Issue556Node)-[:Issue556Child*1..5]->(ARG0_OP:Issue556Node),
+            (DESCSTRIDE0:Issue556Node)-[:Issue556Child*1..5]->(STRIDE0_OP:Issue556Node),
+            (DESCSTRIDE0:Issue556Node)-[:Issue556Child*1..5]->(DESCSTRIDE0_VALUE:Issue556Node),
+            (DESCSTRIDE0_VALUE:Issue556Node { kind: 'Value' }),
+        (FUNCOP:Issue556Node)-[:Issue556Child*1..5]->(OFF2:Issue556Node),
+            (OFF2:Issue556Node { kind: 'Operation', type: 'llvm.add' }),
+            (OFF2:Issue556Node)-[:Issue556Child*1..5]->(DESCSTRIDE0_OP:Issue556Node),
+            (OFF2:Issue556Node)-[:Issue556Child*1..5]->(ARG1_OP:Issue556Node),
+            (OFF2:Issue556Node)-[:Issue556Child*1..5]->(OFF2_VALUE:Issue556Node),
+        (FUNCOP:Issue556Node)-[:Issue556Child*1..5]->(DESCPOISON:Issue556Node),
+            (DESCPOISON:Issue556Node { kind: 'Operation', type: 'llvm.mlir.poison' }),
+            (DESCPOISON:Issue556Node)-[:Issue556Child*1..5]->(DESCPOISON_VALUE:Issue556Node),
+        (FUNCOP:Issue556Node)-[:Issue556Child*1..5]->(DESC0:Issue556Node),
+            (DESC0:Issue556Node { kind: 'Operation', type: 'llvm.insertvalue' }),
+            (DESC0:Issue556Node)-[:Issue556Child*1..5]->(BASE_INSERT_OP:Issue556Node),
+            (DESC0:Issue556Node)-[:Issue556Child*1..5]->(POISON_INSERT_OP:Issue556Node)
+RETURN COUNT(*);
+---- 1
+0
+
 -CASE unwind_merge_with_projection_dedup
 -STATEMENT CREATE NODE TABLE Person(id STRING PRIMARY KEY, name STRING, age INT64, department STRING);
 ---- ok


### PR DESCRIPTION
Fixes: #556 

## Summary
- increase bounded join enumeration capacity so the issue-556 recursive MATCH pattern can be planned
- track when DP subplan pruning hits planner limits
- return a clear Runtime exception instead of falling through to an unchecked map access
- add an issue regression for the large recursive pattern

## Validation
- cmake --build build/release --target lbug_shell --config Release
- verified the original shell repro returns COUNT(*) = 0 with the raised limits
- temporarily lowered the limits while developing to verify the new Runtime exception path replaces unordered_map::at