### PR TITLE
Update extension submodule for Gremlin support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ TEST_JOBS ?= 10
 EXTENSION_E2E_TEST_JOBS ?= 1
 PGEMBED_PYTHON ?= 3.12
 PGEMBED_FIXTURE ?= python3 scripts/run_pgembed_fixture.py --
-EXTENSION_LIST ?= adbc;httpfs;duckdb;json;postgres;sqlite;fts;delta;iceberg;azure;unity_catalog;vector;neo4j;algo;llm
+EXTENSION_LIST ?= adbc;httpfs;duckdb;json;postgres;sqlite;fts;gremlin;delta;iceberg;azure;unity_catalog;vector;neo4j;algo;llm
 EXTENSION_TEST_EXCLUDE_FILTER ?= ""
 
 ifeq ($(OS),Windows_NT)


### PR DESCRIPTION
## Summary
- update the extension submodule to include the new Gremlin traversal extension
- depends on LadybugDB/extensions#9

## Validation
- E2E_TEST_FILES_DIRECTORY=extension build/gremlin-test/test/runner/e2e_test --gtest_filter=gremlin~test~basic.GremlinOutOutValues

Fixes: #563