### PR TITLE
Batch detached node relationship deletes

### DIFF
--- a/src/include/processor/operator/persistent/delete.h
+++ b/src/include/processor/operator/persistent/delete.h
@@ -40,6 +40,8 @@ public:
 
     bool getNextTuplesInternal(ExecutionContext* context) override;
 
+    void finalizeInternal(ExecutionContext* context) override;
+
     std::unique_ptr<PhysicalOperator> copy() override {
         return std::make_unique<DeleteNode>(copyVector(executors), children[0]->copy(), id,
             printInfo->copy());

--- a/src/include/processor/operator/persistent/delete_executor.h
+++ b/src/include/processor/operator/persistent/delete_executor.h
@@ -69,11 +69,25 @@ public:
 
     virtual std::unique_ptr<NodeDeleteExecutor> copy() const = 0;
 
+    virtual void finalize(ExecutionContext* context) = 0;
+
 protected:
+    void appendToBatch(common::internalID_t nodeID);
+    void flushBatch(const std::vector<common::internalID_t>& nodeIDs,
+        common::ValueVector& srcNodeIDVector,
+        const std::unordered_set<storage::RelTable*>& fwdRelTables,
+        const std::unordered_set<storage::RelTable*>& bwdRelTables,
+        transaction::Transaction* transaction);
+
     NodeDeleteInfo info;
     std::unique_ptr<common::ValueVector> dstNodeIDVector;
     std::unique_ptr<common::ValueVector> relIDVector;
     std::unique_ptr<storage::RelTableDeleteState> detachDeleteState;
+    std::vector<common::internalID_t> batchNodeIDs;
+    std::unique_ptr<common::ValueVector> batchSrcNodeIDVector;
+    std::unique_ptr<common::ValueVector> batchDstNodeIDVector;
+    std::unique_ptr<common::ValueVector> batchRelIDVector;
+    static constexpr uint32_t BATCH_SIZE = 1024;
 };
 
 // Handle MATCH (n) (DETACH)? DELETE n
@@ -83,6 +97,8 @@ public:
     EmptyNodeDeleteExecutor(const EmptyNodeDeleteExecutor& other) : NodeDeleteExecutor{other} {}
 
     void delete_(ExecutionContext*) override {}
+
+    void finalize(ExecutionContext*) override {}
 
     std::unique_ptr<NodeDeleteExecutor> copy() const override {
         return std::make_unique<EmptyNodeDeleteExecutor>(*this);
@@ -98,6 +114,7 @@ public:
 
     void init(ResultSet* resultSet, ExecutionContext*) override;
     void delete_(ExecutionContext* context) override;
+    void finalize(ExecutionContext* context) override;
 
     std::unique_ptr<NodeDeleteExecutor> copy() const override {
         return std::make_unique<SingleLabelNodeDeleteExecutor>(*this);
@@ -117,6 +134,7 @@ public:
 
     void init(ResultSet* resultSet, ExecutionContext*) override;
     void delete_(ExecutionContext* context) override;
+    void finalize(ExecutionContext* context) override;
 
     std::unique_ptr<NodeDeleteExecutor> copy() const override {
         return std::make_unique<MultiLabelNodeDeleteExecutor>(*this);

--- a/src/include/storage/table/rel_table.h
+++ b/src/include/storage/table/rel_table.h
@@ -166,6 +166,9 @@ public:
     // Currently only supports deleting from a single src node
     // Note that since the rel table doesn't store nodes this doesn't delete the node itself
     void detachDelete(transaction::Transaction* transaction, RelTableDeleteState* deleteState);
+    void detachDeleteBatch(transaction::Transaction* transaction,
+        common::ValueVector& srcNodeIDVector, common::ValueVector& dstNodeIDVector,
+        common::ValueVector& relIDVector, common::RelDataDirection direction);
     bool checkIfNodeHasRels(transaction::Transaction* transaction,
         common::RelDataDirection direction, common::ValueVector* srcNodeIDVector) const;
     void throwIfNodeHasRels(transaction::Transaction* transaction,

--- a/src/processor/operator/persistent/delete.cpp
+++ b/src/processor/operator/persistent/delete.cpp
@@ -36,12 +36,21 @@ void DeleteNode::initLocalStateInternal(ResultSet* resultSet, ExecutionContext* 
 
 bool DeleteNode::getNextTuplesInternal(ExecutionContext* context) {
     if (!children[0]->getNextTuple(context)) {
+        for (auto& executor : executors) {
+            executor->finalize(context);
+        }
         return false;
     }
     for (auto& executor : executors) {
         executor->delete_(context);
     }
     return true;
+}
+
+void DeleteNode::finalizeInternal(ExecutionContext* context) {
+    for (auto& executor : executors) {
+        executor->finalize(context);
+    }
 }
 
 void DeleteRel::initLocalStateInternal(ResultSet* resultSet, ExecutionContext* context) {

--- a/src/processor/operator/persistent/delete_executor.cpp
+++ b/src/processor/operator/persistent/delete_executor.cpp
@@ -63,12 +63,51 @@ void NodeDeleteExecutor::init(ResultSet* resultSet, ExecutionContext*) {
         relIDVector->setState(tempSharedState);
         detachDeleteState = std::make_unique<RelTableDeleteState>(*info.nodeIDVector,
             *dstNodeIDVector, *relIDVector);
+        batchSrcNodeIDVector = std::make_unique<ValueVector>(LogicalType::INTERNAL_ID());
+        batchDstNodeIDVector = std::make_unique<ValueVector>(LogicalType::INTERNAL_ID());
+        batchRelIDVector = std::make_unique<ValueVector>(LogicalType::INTERNAL_ID());
+    }
+}
+
+void NodeDeleteExecutor::appendToBatch(internalID_t nodeID) {
+    batchNodeIDs.push_back(nodeID);
+}
+
+void NodeDeleteExecutor::flushBatch(const std::vector<internalID_t>& nodeIDs,
+    ValueVector& srcNodeIDVector, const std::unordered_set<RelTable*>& fwdRelTables,
+    const std::unordered_set<RelTable*>& bwdRelTables, Transaction* transaction) {
+    if (nodeIDs.empty()) {
+        return;
+    }
+    const auto srcState = std::make_shared<DataChunkState>();
+    const auto relState = std::make_shared<DataChunkState>();
+    srcNodeIDVector.setState(srcState);
+    batchDstNodeIDVector->setState(relState);
+    batchRelIDVector->setState(relState);
+    srcState->getSelVectorUnsafe().setSelSize(nodeIDs.size());
+    for (auto i = 0u; i < nodeIDs.size(); i++) {
+        srcNodeIDVector.setValue(i, nodeIDs[i]);
+    }
+    for (auto& relTable : fwdRelTables) {
+        relTable->detachDeleteBatch(transaction, srcNodeIDVector, *batchDstNodeIDVector,
+            *batchRelIDVector, RelDataDirection::FWD);
+    }
+    for (auto& relTable : bwdRelTables) {
+        relTable->detachDeleteBatch(transaction, srcNodeIDVector, *batchDstNodeIDVector,
+            *batchRelIDVector, RelDataDirection::BWD);
     }
 }
 
 void SingleLabelNodeDeleteExecutor::init(ResultSet* resultSet, ExecutionContext* context) {
     NodeDeleteExecutor::init(resultSet, context);
     tableInfo.init(*resultSet);
+}
+
+void SingleLabelNodeDeleteExecutor::finalize(ExecutionContext* context) {
+    auto transaction = Transaction::Get(*context->clientContext);
+    flushBatch(batchNodeIDs, *batchSrcNodeIDVector, tableInfo.fwdRelTables, tableInfo.bwdRelTables,
+        transaction);
+    batchNodeIDs.clear();
 }
 
 void SingleLabelNodeDeleteExecutor::delete_(ExecutionContext* context) {
@@ -84,7 +123,16 @@ void SingleLabelNodeDeleteExecutor::delete_(ExecutionContext* context) {
         tableInfo.deleteFromRelTable(transaction, info.nodeIDVector);
     } break;
     case DeleteNodeType::DETACH_DELETE: {
-        tableInfo.detachDeleteFromRelTable(transaction, detachDeleteState.get());
+        const auto& selVector = info.nodeIDVector->state->getSelVector();
+        const auto pos = selVector[0];
+        if (!info.nodeIDVector->isNull(pos)) {
+            appendToBatch(info.nodeIDVector->getValue<internalID_t>(pos));
+        }
+        if (batchNodeIDs.size() >= BATCH_SIZE) {
+            flushBatch(batchNodeIDs, *batchSrcNodeIDVector, tableInfo.fwdRelTables,
+                tableInfo.bwdRelTables, transaction);
+            batchNodeIDs.clear();
+        }
     } break;
     default:
         UNREACHABLE_CODE;
@@ -96,6 +144,20 @@ void MultiLabelNodeDeleteExecutor::init(ResultSet* resultSet, ExecutionContext* 
     for (auto& [_, tableInfo] : tableInfos) {
         tableInfo.init(*resultSet);
     }
+}
+
+void MultiLabelNodeDeleteExecutor::finalize(ExecutionContext* context) {
+    auto transaction = Transaction::Get(*context->clientContext);
+    table_id_map_t<std::vector<internalID_t>> tableIDToNodeIDs;
+    for (const auto nodeID : batchNodeIDs) {
+        tableIDToNodeIDs[nodeID.tableID].push_back(nodeID);
+    }
+    for (auto& [tableID, nodeIDs] : tableIDToNodeIDs) {
+        const auto& tableInfo = tableInfos.at(tableID);
+        flushBatch(nodeIDs, *batchSrcNodeIDVector, tableInfo.fwdRelTables, tableInfo.bwdRelTables,
+            transaction);
+    }
+    batchNodeIDs.clear();
 }
 
 void MultiLabelNodeDeleteExecutor::delete_(ExecutionContext* context) {
@@ -118,7 +180,10 @@ void MultiLabelNodeDeleteExecutor::delete_(ExecutionContext* context) {
         tableInfo.deleteFromRelTable(transaction, info.nodeIDVector);
     } break;
     case DeleteNodeType::DETACH_DELETE: {
-        tableInfo.detachDeleteFromRelTable(transaction, detachDeleteState.get());
+        appendToBatch(nodeID);
+        if (batchNodeIDs.size() >= BATCH_SIZE) {
+            finalize(context);
+        }
     } break;
     default:
         UNREACHABLE_CODE;

--- a/src/storage/table/rel_table.cpp
+++ b/src/storage/table/rel_table.cpp
@@ -325,6 +325,88 @@ void RelTable::detachDelete(Transaction* transaction, RelTableDeleteState* delet
     setHasChanges();
 }
 
+void RelTable::detachDeleteBatch(Transaction* transaction, ValueVector& srcNodeIDVector,
+    ValueVector& dstNodeIDVector, ValueVector& relIDVector, RelDataDirection direction) {
+    if (std::ranges::count(getStorageDirections(), direction) == 0) {
+        return;
+    }
+    const auto& srcSelVector = srcNodeIDVector.state->getSelVector();
+    const auto numNodes = srcSelVector.getSelSize();
+    if (numNodes == 0) {
+        return;
+    }
+
+    std::vector<nodeID_t> srcNodeIDs;
+    srcNodeIDs.reserve(numNodes);
+    for (auto i = 0u; i < numNodes; i++) {
+        const auto pos = srcSelVector[i];
+        if (!srcNodeIDVector.isNull(pos)) {
+            srcNodeIDs.push_back(srcNodeIDVector.getValue<nodeID_t>(pos));
+        }
+    }
+    if (srcNodeIDs.empty()) {
+        return;
+    }
+
+    const auto tableData = getDirectedTableData(direction);
+    const auto reverseTableData =
+        directedRelData.size() == NUM_REL_DIRECTIONS ?
+            getDirectedTableData(RelDirectionUtils::getOppositeDirection(direction)) :
+            nullptr;
+    const auto localTable = transaction->getLocalStorage()->getLocalTable(tableID);
+
+    for (const auto srcNodeID : srcNodeIDs) {
+        const auto srcState = std::make_shared<DataChunkState>();
+        ValueVector tempSrcNodeID(LogicalType::INTERNAL_ID());
+        tempSrcNodeID.setState(srcState);
+        srcState->getSelVectorUnsafe().setSelSize(1);
+        tempSrcNodeID.setValue(0, srcNodeID);
+
+        auto relReadState = std::make_unique<RelTableScanState>(*memoryManager, &tempSrcNodeID,
+            std::vector{&dstNodeIDVector, &relIDVector}, dstNodeIDVector.state,
+            true /*randomLookup*/);
+        relReadState->setToTable(transaction, this, {NBR_ID_COLUMN_ID, REL_ID_COLUMN_ID}, {},
+            direction);
+        initScanState(transaction, *relReadState);
+
+        const auto relState = dstNodeIDVector.state.get();
+        while (scan(transaction, *relReadState)) {
+            const auto numRelsScanned = relState->getSelVector().getSelSize();
+            if (relState->getSelVector().isUnfiltered()) {
+                relState->getSelVectorUnsafe().setRange(0, numRelsScanned);
+            }
+            relState->getSelVectorUnsafe().setToFiltered(1);
+
+            for (auto i = 0u; i < numRelsScanned; i++) {
+                relState->getSelVectorUnsafe()[0] = relIDVector.state->getSelVector()[i];
+
+                const auto relIDPos = relIDVector.state->getSelVector()[0];
+                const auto relOffset = relIDVector.readNodeOffset(relIDPos);
+                if (relOffset >= StorageConstants::MAX_NUM_ROWS_IN_TABLE) {
+                    DASSERT(localTable);
+                    RelTableDeleteState localDeleteState{tempSrcNodeID, dstNodeIDVector,
+                        relIDVector, direction};
+                    localTable->delete_(transaction, localDeleteState);
+                    continue;
+                }
+                [[maybe_unused]] const auto deleted =
+                    tableData->delete_(transaction, tempSrcNodeID, relIDVector);
+                if (reverseTableData) {
+                    [[maybe_unused]] const auto reverseDeleted =
+                        reverseTableData->delete_(transaction, dstNodeIDVector, relIDVector);
+                    DASSERT(deleted == reverseDeleted);
+                }
+            }
+            relState->getSelVectorUnsafe().setToUnfiltered();
+        }
+    }
+    if (transaction->shouldLogToWAL()) {
+        DASSERT(transaction->isWriteTransaction());
+        transaction->getLocalWAL().logRelDetachDelete(tableID, direction, &srcNodeIDVector);
+    }
+    setHasChanges();
+}
+
 std::vector<RelDataDirection> RelTable::getStorageDirections() const {
     std::vector<RelDataDirection> ret;
     for (const auto& relData : directedRelData) {

--- a/src/storage/wal/records/rel_detach_delete_record_replay.cpp
+++ b/src/storage/wal/records/rel_detach_delete_record_replay.cpp
@@ -14,17 +14,15 @@ void WALReplayer::replayRelDetachDeletionRecord(const WALRecord& walRecord) cons
     auto& table = StorageManager::Get(clientContext)->getTable(tableID)->cast<RelTable>();
     DASSERT(transaction::Transaction::Get(clientContext) &&
             transaction::Transaction::Get(clientContext)->isRecovery());
-    const auto anchorState = deletionRecord.ownedSrcNodeIDVector->state;
-    DASSERT(anchorState->getSelVector().getSelSize() == 1);
     const auto dstNodeIDVector =
         std::make_unique<ValueVector>(LogicalType{LogicalTypeID::INTERNAL_ID});
     const auto relIDVector = std::make_unique<ValueVector>(LogicalType{LogicalTypeID::INTERNAL_ID});
-    dstNodeIDVector->setState(anchorState);
-    relIDVector->setState(anchorState);
-    const auto deleteState = std::make_unique<RelTableDeleteState>(
-        *deletionRecord.ownedSrcNodeIDVector, *dstNodeIDVector, *relIDVector);
-    deleteState->detachDeleteDirection = deletionRecord.direction;
-    table.detachDelete(transaction::Transaction::Get(clientContext), deleteState.get());
+    const auto relState = std::make_shared<DataChunkState>();
+    dstNodeIDVector->setState(relState);
+    relIDVector->setState(relState);
+    table.detachDeleteBatch(transaction::Transaction::Get(clientContext),
+        *deletionRecord.ownedSrcNodeIDVector, *dstNodeIDVector, *relIDVector,
+        deletionRecord.direction);
 }
 
 } // namespace storage


### PR DESCRIPTION
Fixes: #168 

## Summary

Reimplements the detached-delete batching from PR #169 on top of current main.

- batches the relationship-detach phase for DETACH DELETE node execution
- flushes pending batches when the DeleteNode operator exhausts its child and during finalize
- groups multi-label batches by node table before touching relationship tables, preserving filtered match semantics
- logs one generated RelDetachDeleteRecord per source-node batch and replays the ValueVector through detachDeleteBatch

## Validation

- ninja -C build/release
- python3 scripts/run-clang-format.py --clang-format-executable /opt/homebrew/bin/clang-format-18 -r <touched files>
- shell smoke test: 1050-node DETACH DELETE crosses the 1024 batch boundary and removes all attached edges
- shell smoke test: multi-label DETACH DELETE crosses the batch boundary and deletes only the intended table-specific relationship sets
- shell smoke test: persisted reopen after batched DETACH DELETE returns expected node/edge counts, exercising WAL replay of batched detach-delete records

