### PR TITLE
Store WAL record lengths

### DIFF
--- a/src/include/common/serializer/buffer_reader.h
+++ b/src/include/common/serializer/buffer_reader.h
@@ -16,6 +16,7 @@ struct BufferReader final : Reader {
     }
 
     bool finished() override { return readSize >= dataSize; }
+    uint64_t getReadOffset() const override { return readSize; }
 
     uint8_t* data;
     size_t dataSize;

--- a/src/include/common/serializer/buffered_file.h
+++ b/src/include/common/serializer/buffered_file.h
@@ -52,7 +52,7 @@ public:
 
     bool finished() override;
 
-    uint64_t getReadOffset() const { return fileOffset - bufferSize + bufferOffset; }
+    uint64_t getReadOffset() const override { return fileOffset - bufferSize + bufferOffset; }
     FileInfo* getFileInfo() const { return &fileInfo; }
 
 private:

--- a/src/include/common/serializer/deserializer.h
+++ b/src/include/common/serializer/deserializer.h
@@ -4,6 +4,7 @@
 #include <limits>
 #include <map>
 #include <memory>
+#include <optional>
 #include <string>
 #include <unordered_map>
 #include <unordered_set>
@@ -33,6 +34,21 @@ public:
     void read(uint8_t* data, uint64_t size) const { reader->read(data, size); }
 
     Reader* getReader() const { return reader.get(); }
+
+    uint64_t getReadOffset() const { return reader->getReadOffset(); }
+    void beginReadLimit(uint64_t size) { readLimit = getReadOffset() + size; }
+    bool hasRemainingData() const { return !readLimit.has_value() || getReadOffset() < *readLimit; }
+    void skipReadLimit() {
+        if (!readLimit.has_value()) {
+            return;
+        }
+        const auto endOffset = *readLimit;
+        const auto readOffset = getReadOffset();
+        if (readOffset < endOffset) {
+            reader->skip(endOffset - readOffset);
+        }
+        readLimit.reset();
+    }
 
     void validateDebuggingInfo(std::string& value, const std::string& expectedVal);
 
@@ -144,6 +160,7 @@ public:
 private:
     std::unique_ptr<Reader> reader;
     uint64_t storageVersion = std::numeric_limits<uint64_t>::max();
+    std::optional<uint64_t> readLimit;
 };
 
 template<>

--- a/src/include/common/serializer/reader.h
+++ b/src/include/common/serializer/reader.h
@@ -15,7 +15,7 @@ public:
     virtual ~Reader() = default;
 
     virtual bool finished() = 0;
-    virtual uint64_t getReadOffset() const = 0;
+    virtual uint64_t getReadOffset() const { return 0; }
     virtual void skip(uint64_t size) {
         std::array<uint8_t, 4096> buffer{};
         while (size > 0) {

--- a/src/include/common/serializer/reader.h
+++ b/src/include/common/serializer/reader.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <algorithm>
+#include <array>
 #include <cstdint>
 
 #include "common/cast.h"
@@ -13,6 +15,15 @@ public:
     virtual ~Reader() = default;
 
     virtual bool finished() = 0;
+    virtual uint64_t getReadOffset() const = 0;
+    virtual void skip(uint64_t size) {
+        std::array<uint8_t, 4096> buffer{};
+        while (size > 0) {
+            const auto numBytesToRead = std::min<uint64_t>(size, buffer.size());
+            read(buffer.data(), numBytesToRead);
+            size -= numBytesToRead;
+        }
+    }
     virtual void onObjectBegin() {};
     virtual void onObjectEnd() {};
 

--- a/src/include/storage/wal/checksum_reader.h
+++ b/src/include/storage/wal/checksum_reader.h
@@ -23,7 +23,7 @@ public:
     // stored value
     void onObjectEnd() override;
 
-    uint64_t getReadOffset() const;
+    uint64_t getReadOffset() const override;
 
 private:
     common::Deserializer deserializer;

--- a/src/include/storage/wal/record/wal_record_base.h
+++ b/src/include/storage/wal/record/wal_record_base.h
@@ -56,6 +56,7 @@ struct WALRecord {
     DELETE_COPY_DEFAULT_MOVE(WALRecord);
 
     virtual void serialize(common::Serializer& serializer) const;
+    static void serializeWithLength(common::Serializer& serializer, const WALRecord& record);
     static std::unique_ptr<WALRecord> deserialize(common::Deserializer& deserializer,
         const main::ClientContext& clientContext);
 

--- a/src/storage/wal/checksum_reader.cpp
+++ b/src/storage/wal/checksum_reader.cpp
@@ -27,7 +27,14 @@ static void resizeBufferIfNeeded(std::unique_ptr<MemoryBuffer>& entryBuffer,
 }
 
 void ChecksumReader::read(uint8_t* data, uint64_t size) {
-    deserializer.read(data, size);
+    try {
+        deserializer.read(data, size);
+    } catch (const std::exception&) {
+        if (currentEntrySize.has_value()) {
+            throw common::StorageException(std::string{checksumMismatchMessage});
+        }
+        throw;
+    }
     if (currentEntrySize.has_value()) {
         resizeBufferIfNeeded(entryBuffer, *currentEntrySize + size);
         std::memcpy(entryBuffer->getData() + *currentEntrySize, data, size);

--- a/src/storage/wal/local_wal.cpp
+++ b/src/storage/wal/local_wal.cpp
@@ -116,7 +116,7 @@ void LocalWAL::addNewWALRecord(const WALRecord& walRecord) {
 void LocalWAL::addNewWALRecordNoLock(const WALRecord& walRecord) {
     DASSERT(walRecord.type != WALRecordType::INVALID_RECORD);
     serializer.getWriter()->onObjectBegin();
-    walRecord.serialize(serializer);
+    WALRecord::serializeWithLength(serializer, walRecord);
     serializer.getWriter()->onObjectEnd();
 }
 

--- a/src/storage/wal/records/copy_table_record.cpp
+++ b/src/storage/wal/records/copy_table_record.cpp
@@ -18,7 +18,9 @@ void CopyTableRecord::serialize(Serializer& serializer) const {
 
 std::unique_ptr<CopyTableRecord> CopyTableRecord::deserialize(Deserializer& deserializer) {
     table_id_t tableID = common::INVALID_TABLE_ID;
-    deserializer.deserializeValue<table_id_t>(tableID);
+    if (deserializer.hasRemainingData()) {
+        deserializer.deserializeValue<table_id_t>(tableID);
+    }
 
     return std::make_unique<CopyTableRecord>(std::move(tableID));
 }

--- a/src/storage/wal/records/create_catalog_entry_record.cpp
+++ b/src/storage/wal/records/create_catalog_entry_record.cpp
@@ -27,7 +27,9 @@ std::unique_ptr<CreateCatalogEntryRecord> CreateCatalogEntryRecord::deserialize(
     auto retVal = std::make_unique<CreateCatalogEntryRecord>();
     retVal->ownedCatalogEntry = CatalogEntry::deserialize(deserializer);
     bool isInternal = false;
-    deserializer.deserializeValue(isInternal);
+    if (deserializer.hasRemainingData()) {
+        deserializer.deserializeValue(isInternal);
+    }
     retVal->isInternal = isInternal;
     return retVal;
 }

--- a/src/storage/wal/records/drop_catalog_entry_record.cpp
+++ b/src/storage/wal/records/drop_catalog_entry_record.cpp
@@ -20,9 +20,13 @@ void DropCatalogEntryRecord::serialize(Serializer& serializer) const {
 std::unique_ptr<DropCatalogEntryRecord> DropCatalogEntryRecord::deserialize(
     Deserializer& deserializer) {
     oid_t entryID = common::INVALID_OID;
-    deserializer.deserializeValue<oid_t>(entryID);
+    if (deserializer.hasRemainingData()) {
+        deserializer.deserializeValue<oid_t>(entryID);
+    }
     catalog::CatalogEntryType entryType{};
-    deserializer.deserializeValue<catalog::CatalogEntryType>(entryType);
+    if (deserializer.hasRemainingData()) {
+        deserializer.deserializeValue<catalog::CatalogEntryType>(entryType);
+    }
 
     return std::make_unique<DropCatalogEntryRecord>(std::move(entryID), std::move(entryType));
 }

--- a/src/storage/wal/records/load_extension_record.cpp
+++ b/src/storage/wal/records/load_extension_record.cpp
@@ -20,8 +20,10 @@ void LoadExtensionRecord::serialize(Serializer& serializer) const {
 std::unique_ptr<LoadExtensionRecord> LoadExtensionRecord::deserialize(Deserializer& deserializer) {
     std::string key;
     std::string path{};
-    deserializer.validateDebuggingInfo(key, "path");
-    deserializer.deserializeValue<std::string>(path);
+    if (deserializer.hasRemainingData()) {
+        deserializer.validateDebuggingInfo(key, "path");
+        deserializer.deserializeValue<std::string>(path);
+    }
 
     return std::make_unique<LoadExtensionRecord>(std::move(path));
 }

--- a/src/storage/wal/records/node_deletion_record.cpp
+++ b/src/storage/wal/records/node_deletion_record.cpp
@@ -27,15 +27,22 @@ std::unique_ptr<NodeDeletionRecord> NodeDeletionRecord::deserialize(Deserializer
     const main::ClientContext& clientContext) {
     std::string key;
     table_id_t tableID = INVALID_TABLE_ID;
-    deserializer.validateDebuggingInfo(key, "table_id");
-    deserializer.deserializeValue<table_id_t>(tableID);
+    if (deserializer.hasRemainingData()) {
+        deserializer.validateDebuggingInfo(key, "table_id");
+        deserializer.deserializeValue<table_id_t>(tableID);
+    }
     offset_t nodeOffset = INVALID_OFFSET;
-    deserializer.validateDebuggingInfo(key, "node_offset");
-    deserializer.deserializeValue<offset_t>(nodeOffset);
-    deserializer.validateDebuggingInfo(key, "pk_vector");
-    auto pkVectorState = std::make_shared<DataChunkState>();
-    auto pkVector =
-        ValueVector::deSerialize(deserializer, MemoryManager::Get(clientContext), pkVectorState);
+    if (deserializer.hasRemainingData()) {
+        deserializer.validateDebuggingInfo(key, "node_offset");
+        deserializer.deserializeValue<offset_t>(nodeOffset);
+    }
+    std::unique_ptr<ValueVector> pkVector;
+    if (deserializer.hasRemainingData()) {
+        deserializer.validateDebuggingInfo(key, "pk_vector");
+        auto pkVectorState = std::make_shared<DataChunkState>();
+        pkVector = ValueVector::deSerialize(deserializer, MemoryManager::Get(clientContext),
+            pkVectorState);
+    }
 
     return std::make_unique<NodeDeletionRecord>(std::move(tableID), std::move(nodeOffset),
         std::move(pkVector));

--- a/src/storage/wal/records/node_update_record.cpp
+++ b/src/storage/wal/records/node_update_record.cpp
@@ -29,18 +29,27 @@ std::unique_ptr<NodeUpdateRecord> NodeUpdateRecord::deserialize(Deserializer& de
     const main::ClientContext& clientContext) {
     std::string key;
     table_id_t tableID = INVALID_TABLE_ID;
-    deserializer.validateDebuggingInfo(key, "table_id");
-    deserializer.deserializeValue<table_id_t>(tableID);
+    if (deserializer.hasRemainingData()) {
+        deserializer.validateDebuggingInfo(key, "table_id");
+        deserializer.deserializeValue<table_id_t>(tableID);
+    }
     column_id_t columnID = INVALID_COLUMN_ID;
-    deserializer.validateDebuggingInfo(key, "column_id");
-    deserializer.deserializeValue<column_id_t>(columnID);
+    if (deserializer.hasRemainingData()) {
+        deserializer.validateDebuggingInfo(key, "column_id");
+        deserializer.deserializeValue<column_id_t>(columnID);
+    }
     offset_t nodeOffset = INVALID_OFFSET;
-    deserializer.validateDebuggingInfo(key, "node_offset");
-    deserializer.deserializeValue<offset_t>(nodeOffset);
-    deserializer.validateDebuggingInfo(key, "property_vector");
-    auto propertyVectorState = std::make_shared<DataChunkState>();
-    auto propertyVector = ValueVector::deSerialize(deserializer, MemoryManager::Get(clientContext),
-        propertyVectorState);
+    if (deserializer.hasRemainingData()) {
+        deserializer.validateDebuggingInfo(key, "node_offset");
+        deserializer.deserializeValue<offset_t>(nodeOffset);
+    }
+    std::unique_ptr<ValueVector> propertyVector;
+    if (deserializer.hasRemainingData()) {
+        deserializer.validateDebuggingInfo(key, "property_vector");
+        auto propertyVectorState = std::make_shared<DataChunkState>();
+        propertyVector = ValueVector::deSerialize(deserializer, MemoryManager::Get(clientContext),
+            propertyVectorState);
+    }
 
     return std::make_unique<NodeUpdateRecord>(std::move(tableID), std::move(columnID),
         std::move(nodeOffset), std::move(propertyVector));

--- a/src/storage/wal/records/rel_deletion_record.cpp
+++ b/src/storage/wal/records/rel_deletion_record.cpp
@@ -29,20 +29,31 @@ std::unique_ptr<RelDeletionRecord> RelDeletionRecord::deserialize(Deserializer& 
     const main::ClientContext& clientContext) {
     std::string key;
     table_id_t tableID = INVALID_TABLE_ID;
-    deserializer.validateDebuggingInfo(key, "table_id");
-    deserializer.deserializeValue<table_id_t>(tableID);
-    deserializer.validateDebuggingInfo(key, "src_node_vector");
-    auto srcNodeIDVectorState = std::make_shared<DataChunkState>();
-    auto srcNodeIDVector = ValueVector::deSerialize(deserializer, MemoryManager::Get(clientContext),
-        srcNodeIDVectorState);
-    deserializer.validateDebuggingInfo(key, "dst_node_vector");
-    auto dstNodeIDVectorState = std::make_shared<DataChunkState>();
-    auto dstNodeIDVector = ValueVector::deSerialize(deserializer, MemoryManager::Get(clientContext),
-        dstNodeIDVectorState);
-    deserializer.validateDebuggingInfo(key, "rel_id_vector");
-    auto relIDVectorState = std::make_shared<DataChunkState>();
-    auto relIDVector =
-        ValueVector::deSerialize(deserializer, MemoryManager::Get(clientContext), relIDVectorState);
+    if (deserializer.hasRemainingData()) {
+        deserializer.validateDebuggingInfo(key, "table_id");
+        deserializer.deserializeValue<table_id_t>(tableID);
+    }
+    std::unique_ptr<ValueVector> srcNodeIDVector;
+    if (deserializer.hasRemainingData()) {
+        deserializer.validateDebuggingInfo(key, "src_node_vector");
+        auto srcNodeIDVectorState = std::make_shared<DataChunkState>();
+        srcNodeIDVector = ValueVector::deSerialize(deserializer, MemoryManager::Get(clientContext),
+            srcNodeIDVectorState);
+    }
+    std::unique_ptr<ValueVector> dstNodeIDVector;
+    if (deserializer.hasRemainingData()) {
+        deserializer.validateDebuggingInfo(key, "dst_node_vector");
+        auto dstNodeIDVectorState = std::make_shared<DataChunkState>();
+        dstNodeIDVector = ValueVector::deSerialize(deserializer, MemoryManager::Get(clientContext),
+            dstNodeIDVectorState);
+    }
+    std::unique_ptr<ValueVector> relIDVector;
+    if (deserializer.hasRemainingData()) {
+        deserializer.validateDebuggingInfo(key, "rel_id_vector");
+        auto relIDVectorState = std::make_shared<DataChunkState>();
+        relIDVector = ValueVector::deSerialize(deserializer, MemoryManager::Get(clientContext),
+            relIDVectorState);
+    }
 
     return std::make_unique<RelDeletionRecord>(std::move(tableID), std::move(srcNodeIDVector),
         std::move(dstNodeIDVector), std::move(relIDVector));

--- a/src/storage/wal/records/rel_detach_delete_record.cpp
+++ b/src/storage/wal/records/rel_detach_delete_record.cpp
@@ -27,15 +27,22 @@ std::unique_ptr<RelDetachDeleteRecord> RelDetachDeleteRecord::deserialize(
     Deserializer& deserializer, const main::ClientContext& clientContext) {
     std::string key;
     table_id_t tableID = INVALID_TABLE_ID;
-    deserializer.validateDebuggingInfo(key, "table_id");
-    deserializer.deserializeValue<table_id_t>(tableID);
+    if (deserializer.hasRemainingData()) {
+        deserializer.validateDebuggingInfo(key, "table_id");
+        deserializer.deserializeValue<table_id_t>(tableID);
+    }
     RelDataDirection direction = RelDataDirection::INVALID;
-    deserializer.validateDebuggingInfo(key, "direction");
-    deserializer.deserializeValue<RelDataDirection>(direction);
-    deserializer.validateDebuggingInfo(key, "src_node_vector");
-    auto srcNodeIDVectorState = std::make_shared<DataChunkState>();
-    auto srcNodeIDVector = ValueVector::deSerialize(deserializer, MemoryManager::Get(clientContext),
-        srcNodeIDVectorState);
+    if (deserializer.hasRemainingData()) {
+        deserializer.validateDebuggingInfo(key, "direction");
+        deserializer.deserializeValue<RelDataDirection>(direction);
+    }
+    std::unique_ptr<ValueVector> srcNodeIDVector;
+    if (deserializer.hasRemainingData()) {
+        deserializer.validateDebuggingInfo(key, "src_node_vector");
+        auto srcNodeIDVectorState = std::make_shared<DataChunkState>();
+        srcNodeIDVector = ValueVector::deSerialize(deserializer, MemoryManager::Get(clientContext),
+            srcNodeIDVectorState);
+    }
 
     return std::make_unique<RelDetachDeleteRecord>(std::move(tableID), std::move(direction),
         std::move(srcNodeIDVector));

--- a/src/storage/wal/records/rel_update_record.cpp
+++ b/src/storage/wal/records/rel_update_record.cpp
@@ -33,27 +33,43 @@ std::unique_ptr<RelUpdateRecord> RelUpdateRecord::deserialize(Deserializer& dese
     const main::ClientContext& clientContext) {
     std::string key;
     table_id_t tableID = INVALID_TABLE_ID;
-    deserializer.validateDebuggingInfo(key, "table_id");
-    deserializer.deserializeValue<table_id_t>(tableID);
+    if (deserializer.hasRemainingData()) {
+        deserializer.validateDebuggingInfo(key, "table_id");
+        deserializer.deserializeValue<table_id_t>(tableID);
+    }
     column_id_t columnID = INVALID_COLUMN_ID;
-    deserializer.validateDebuggingInfo(key, "column_id");
-    deserializer.deserializeValue<column_id_t>(columnID);
-    deserializer.validateDebuggingInfo(key, "src_node_vector");
-    auto srcNodeIDVectorState = std::make_shared<DataChunkState>();
-    auto srcNodeIDVector = ValueVector::deSerialize(deserializer, MemoryManager::Get(clientContext),
-        srcNodeIDVectorState);
-    deserializer.validateDebuggingInfo(key, "dst_node_vector");
-    auto dstNodeIDVectorState = std::make_shared<DataChunkState>();
-    auto dstNodeIDVector = ValueVector::deSerialize(deserializer, MemoryManager::Get(clientContext),
-        dstNodeIDVectorState);
-    deserializer.validateDebuggingInfo(key, "rel_id_vector");
-    auto relIDVectorState = std::make_shared<DataChunkState>();
-    auto relIDVector =
-        ValueVector::deSerialize(deserializer, MemoryManager::Get(clientContext), relIDVectorState);
-    deserializer.validateDebuggingInfo(key, "property_vector");
-    auto propertyVectorState = std::make_shared<DataChunkState>();
-    auto propertyVector = ValueVector::deSerialize(deserializer, MemoryManager::Get(clientContext),
-        propertyVectorState);
+    if (deserializer.hasRemainingData()) {
+        deserializer.validateDebuggingInfo(key, "column_id");
+        deserializer.deserializeValue<column_id_t>(columnID);
+    }
+    std::unique_ptr<ValueVector> srcNodeIDVector;
+    if (deserializer.hasRemainingData()) {
+        deserializer.validateDebuggingInfo(key, "src_node_vector");
+        auto srcNodeIDVectorState = std::make_shared<DataChunkState>();
+        srcNodeIDVector = ValueVector::deSerialize(deserializer, MemoryManager::Get(clientContext),
+            srcNodeIDVectorState);
+    }
+    std::unique_ptr<ValueVector> dstNodeIDVector;
+    if (deserializer.hasRemainingData()) {
+        deserializer.validateDebuggingInfo(key, "dst_node_vector");
+        auto dstNodeIDVectorState = std::make_shared<DataChunkState>();
+        dstNodeIDVector = ValueVector::deSerialize(deserializer, MemoryManager::Get(clientContext),
+            dstNodeIDVectorState);
+    }
+    std::unique_ptr<ValueVector> relIDVector;
+    if (deserializer.hasRemainingData()) {
+        deserializer.validateDebuggingInfo(key, "rel_id_vector");
+        auto relIDVectorState = std::make_shared<DataChunkState>();
+        relIDVector = ValueVector::deSerialize(deserializer, MemoryManager::Get(clientContext),
+            relIDVectorState);
+    }
+    std::unique_ptr<ValueVector> propertyVector;
+    if (deserializer.hasRemainingData()) {
+        deserializer.validateDebuggingInfo(key, "property_vector");
+        auto propertyVectorState = std::make_shared<DataChunkState>();
+        propertyVector = ValueVector::deSerialize(deserializer, MemoryManager::Get(clientContext),
+            propertyVectorState);
+    }
 
     return std::make_unique<RelUpdateRecord>(std::move(tableID), std::move(columnID),
         std::move(srcNodeIDVector), std::move(dstNodeIDVector), std::move(relIDVector),

--- a/src/storage/wal/records/table_insertion_record.cpp
+++ b/src/storage/wal/records/table_insertion_record.cpp
@@ -32,23 +32,31 @@ std::unique_ptr<TableInsertionRecord> TableInsertionRecord::deserialize(Deserial
     const main::ClientContext& clientContext) {
     std::string key;
     table_id_t tableID = INVALID_TABLE_ID;
-    deserializer.validateDebuggingInfo(key, "table_id");
-    deserializer.deserializeValue<table_id_t>(tableID);
+    if (deserializer.hasRemainingData()) {
+        deserializer.validateDebuggingInfo(key, "table_id");
+        deserializer.deserializeValue<table_id_t>(tableID);
+    }
     TableType tableType = TableType::UNKNOWN;
-    deserializer.validateDebuggingInfo(key, "table_type");
-    deserializer.deserializeValue<TableType>(tableType);
+    if (deserializer.hasRemainingData()) {
+        deserializer.validateDebuggingInfo(key, "table_type");
+        deserializer.deserializeValue<TableType>(tableType);
+    }
     row_idx_t numRows = INVALID_ROW_IDX;
-    deserializer.validateDebuggingInfo(key, "num_rows");
-    deserializer.deserializeValue<row_idx_t>(numRows);
+    if (deserializer.hasRemainingData()) {
+        deserializer.validateDebuggingInfo(key, "num_rows");
+        deserializer.deserializeValue<row_idx_t>(numRows);
+    }
     idx_t numVectors = 0;
     std::vector<std::unique_ptr<ValueVector>> vectors;
-    deserializer.validateDebuggingInfo(key, "num_vectors");
-    deserializer.deserializeValue(numVectors);
-    auto vectorsState = DataChunkState::getSingleValueDataChunkState();
-    vectors.reserve(numVectors);
-    for (auto i = 0u; i < numVectors; i++) {
-        vectors.push_back(ValueVector::deSerialize(deserializer, MemoryManager::Get(clientContext),
-            vectorsState));
+    if (deserializer.hasRemainingData()) {
+        deserializer.validateDebuggingInfo(key, "num_vectors");
+        deserializer.deserializeValue(numVectors);
+        auto vectorsState = DataChunkState::getSingleValueDataChunkState();
+        vectors.reserve(numVectors);
+        for (auto i = 0u; i < numVectors; i++) {
+            vectors.push_back(ValueVector::deSerialize(deserializer,
+                MemoryManager::Get(clientContext), vectorsState));
+        }
     }
 
     return std::make_unique<TableInsertionRecord>(std::move(tableID), std::move(tableType),

--- a/src/storage/wal/records/update_sequence_record.cpp
+++ b/src/storage/wal/records/update_sequence_record.cpp
@@ -20,9 +20,13 @@ void UpdateSequenceRecord::serialize(Serializer& serializer) const {
 std::unique_ptr<UpdateSequenceRecord> UpdateSequenceRecord::deserialize(
     Deserializer& deserializer) {
     sequence_id_t sequenceID = 0;
-    deserializer.deserializeValue<sequence_id_t>(sequenceID);
+    if (deserializer.hasRemainingData()) {
+        deserializer.deserializeValue<sequence_id_t>(sequenceID);
+    }
     uint64_t kCount = 0;
-    deserializer.deserializeValue<uint64_t>(kCount);
+    if (deserializer.hasRemainingData()) {
+        deserializer.deserializeValue<uint64_t>(kCount);
+    }
 
     return std::make_unique<UpdateSequenceRecord>(std::move(sequenceID), std::move(kCount));
 }

--- a/src/storage/wal/typespec/templates/wal_record_source.cpp.j2
+++ b/src/storage/wal/typespec/templates/wal_record_source.cpp.j2
@@ -182,7 +182,9 @@ std::unique_ptr<CreateCatalogEntryRecord> CreateCatalogEntryRecord::deserialize(
     auto retVal = std::make_unique<CreateCatalogEntryRecord>();
     retVal->ownedCatalogEntry = CatalogEntry::deserialize(deserializer);
     bool isInternal = false;
-    deserializer.deserializeValue(isInternal);
+    if (deserializer.hasRemainingData()) {
+        deserializer.deserializeValue(isInternal);
+    }
     retVal->isInternal = isInternal;
     return retVal;
 }
@@ -222,24 +224,29 @@ std::unique_ptr<{{ dc.name }}> {{ dc.name }}::deserialize(Deserializer&{% if dc.
 {% set wire_name = wire_names.get(name, name) -%}
 {% set default_value = defaults.get(name, default_zero.get(raw_type, "{}")) -%}
 {% if raw_type == "ValueVector" -%}
+    std::unique_ptr<ValueVector> {{ name }};
+    if (deserializer.hasRemainingData()) {
 {% if debug_fields -%}
-    deserializer.validateDebuggingInfo(key, "{{ wire_name }}");
+        deserializer.validateDebuggingInfo(key, "{{ wire_name }}");
 {% endif -%}
-    auto {{ name }}State = std::make_shared<DataChunkState>();
-    auto {{ name }} = ValueVector::deSerialize(deserializer, MemoryManager::Get(clientContext),
-        {{ name }}State);
+        auto {{ name }}State = std::make_shared<DataChunkState>();
+        {{ name }} = ValueVector::deSerialize(deserializer, MemoryManager::Get(clientContext),
+            {{ name }}State);
+    }
 {% elif raw_type == "std::vector<ValueVector>" -%}
     idx_t num{{ name[0:1]|upper }}{{ name[1:] }} = 0;
     std::vector<std::unique_ptr<ValueVector>> {{ name }};
+    if (deserializer.hasRemainingData()) {
 {% if debug_fields -%}
-    deserializer.validateDebuggingInfo(key, "{{ wire_name }}");
+        deserializer.validateDebuggingInfo(key, "{{ wire_name }}");
 {% endif -%}
-    deserializer.deserializeValue(num{{ name[0:1]|upper }}{{ name[1:] }});
-    auto {{ name }}State = DataChunkState::getSingleValueDataChunkState();
-    {{ name }}.reserve(num{{ name[0:1]|upper }}{{ name[1:] }});
-    for (auto i = 0u; i < num{{ name[0:1]|upper }}{{ name[1:] }}; i++) {
-        {{ name }}.push_back(ValueVector::deSerialize(deserializer, MemoryManager::Get(clientContext),
-            {{ name }}State));
+        deserializer.deserializeValue(num{{ name[0:1]|upper }}{{ name[1:] }});
+        auto {{ name }}State = DataChunkState::getSingleValueDataChunkState();
+        {{ name }}.reserve(num{{ name[0:1]|upper }}{{ name[1:] }});
+        for (auto i = 0u; i < num{{ name[0:1]|upper }}{{ name[1:] }}; i++) {
+            {{ name }}.push_back(ValueVector::deSerialize(deserializer, MemoryManager::Get(clientContext),
+                {{ name }}State));
+        }
     }
 {% else -%}
 {% if default_value == "{}" -%}
@@ -247,10 +254,12 @@ std::unique_ptr<{{ dc.name }}> {{ dc.name }}::deserialize(Deserializer&{% if dc.
 {% else -%}
     {{ type_map.get(raw_type, raw_type) }} {{ name }} = {{ default_value }};
 {% endif -%}
+    if (deserializer.hasRemainingData()) {
 {% if debug_fields -%}
-    deserializer.validateDebuggingInfo(key, "{{ wire_name }}");
+        deserializer.validateDebuggingInfo(key, "{{ wire_name }}");
 {% endif -%}
-    deserializer.deserializeValue<{{ type_map.get(raw_type, raw_type) }}>({{ name }});
+        deserializer.deserializeValue<{{ type_map.get(raw_type, raw_type) }}>({{ name }});
+    }
 {% endif -%}
 {% endfor %}
     return std::make_unique<{{ dc.name }}>(

--- a/src/storage/wal/wal.cpp
+++ b/src/storage/wal/wal.cpp
@@ -89,7 +89,7 @@ void WAL::logAndFlushCheckpointToFrozen(main::ClientContext* context) {
 
     CheckpointRecord walRecord;
     frozenSerializer->getWriter()->onObjectBegin();
-    walRecord.serialize(*frozenSerializer);
+    WALRecord::serializeWithLength(*frozenSerializer, walRecord);
     frozenSerializer->getWriter()->onObjectEnd();
     try {
         frozenSerializer->getWriter()->flush();

--- a/src/storage/wal/wal.cpp
+++ b/src/storage/wal/wal.cpp
@@ -264,7 +264,7 @@ void WAL::addNewWALRecordNoLock(const WALRecord& walRecord) {
     DASSERT(!inMemory);
     DASSERT(serializer != nullptr);
     serializer->getWriter()->onObjectBegin();
-    walRecord.serialize(*serializer);
+    WALRecord::serializeWithLength(*serializer, walRecord);
     serializer->getWriter()->onObjectEnd();
 }
 

--- a/src/storage/wal/wal_record.cpp
+++ b/src/storage/wal/wal_record.cpp
@@ -83,11 +83,8 @@ std::unique_ptr<WALRecord> WALRecord::deserialize(Deserializer& deserializer,
     case WALRecordType::LOAD_EXTENSION_RECORD: {
         walRecord = LoadExtensionRecord::deserialize(deserializer);
     } break;
-    case WALRecordType::INVALID_RECORD: {
-        throw RuntimeException("Corrupted wal file. Read out invalid WAL record type.");
-    }
     default: {
-        UNREACHABLE_CODE;
+        throw RuntimeException("Corrupted wal file. Read out invalid WAL record type.");
     }
     }
     walRecord->type = type;

--- a/src/storage/wal/wal_record.cpp
+++ b/src/storage/wal/wal_record.cpp
@@ -1,6 +1,7 @@
 #include "storage/wal/wal_record.h"
 
 #include "common/exception/runtime.h"
+#include "common/serializer/buffer_writer.h"
 #include "common/serializer/deserializer.h"
 #include "common/serializer/serializer.h"
 #include "main/client_context.h"
@@ -15,11 +16,24 @@ void WALRecord::serialize(Serializer& serializer) const {
     serializer.write(type);
 }
 
+void WALRecord::serializeWithLength(Serializer& serializer, const WALRecord& record) {
+    auto bufferWriter = std::make_shared<BufferWriter>();
+    Serializer bufferSerializer{bufferWriter};
+    record.serialize(bufferSerializer);
+
+    const auto recordLength = bufferWriter->getSize();
+    serializer.write(recordLength);
+    serializer.write(bufferWriter->getBlobData(), recordLength);
+}
+
 std::unique_ptr<WALRecord> WALRecord::deserialize(Deserializer& deserializer,
     const main::ClientContext& clientContext) {
     std::string key;
     auto type = WALRecordType::INVALID_RECORD;
     deserializer.getReader()->onObjectBegin();
+    uint64_t recordLength = 0;
+    deserializer.deserializeValue(recordLength);
+    deserializer.beginReadLimit(recordLength);
     deserializer.validateDebuggingInfo(key, "type");
     deserializer.deserializeValue(type);
     std::unique_ptr<WALRecord> walRecord;
@@ -77,6 +91,7 @@ std::unique_ptr<WALRecord> WALRecord::deserialize(Deserializer& deserializer,
     }
     }
     walRecord->type = type;
+    deserializer.skipReadLimit();
     deserializer.getReader()->onObjectEnd();
     return walRecord;
 }

--- a/src/storage/wal/wal_replayer.cpp
+++ b/src/storage/wal/wal_replayer.cpp
@@ -117,6 +117,7 @@ void WALReplayer::replayFrozenWAL(Checkpointer& checkpointer, bool throwOnWalRep
         if (isLastRecordCheckpoint) {
             ShadowFile::replayShadowPageRecords(clientContext);
             removeFileIfExists(checkpointWalPath);
+            removeFileIfExists(walPath);
             removeFileIfExists(shadowFilePath);
             checkpointer.readCheckpoint();
         } else {

--- a/test/transaction/wal_test.cpp
+++ b/test/transaction/wal_test.cpp
@@ -8,6 +8,10 @@
 #include "common/exception/runtime.h"
 #include "common/exception/storage.h"
 #include "common/file_system/virtual_file_system.h"
+#include "common/serializer/buffer_reader.h"
+#include "common/serializer/buffer_writer.h"
+#include "common/serializer/deserializer.h"
+#include "common/serializer/serializer.h"
 #include "gmock/gmock.h"
 #include "storage/buffer_manager/memory_manager.h"
 #include "storage/storage_utils.h"
@@ -160,6 +164,28 @@ TEST_F(WalTest, WALSyncFailurePoisonsWALAndReturnsAllocatedCommitSequence) {
     EXPECT_THROW(wal.logCommittedWAL(secondLocalWAL, conn->getClientContext(), walCommitSequence),
         RuntimeException);
     EXPECT_EQ(walCommitSequence, 0);
+}
+
+TEST_F(WalTest, WALRecordDeserializeSkipsUnknownTrailingBytes) {
+    auto recordBuffer = std::make_shared<BufferWriter>();
+    Serializer recordSerializer{recordBuffer};
+    lbug::storage::CopyTableRecord record{123};
+    record.serialize(recordSerializer);
+    recordSerializer.write<uint64_t>(456);
+
+    auto walBuffer = std::make_shared<BufferWriter>();
+    Serializer walSerializer{walBuffer};
+    walSerializer.write(recordBuffer->getSize());
+    walSerializer.write(recordBuffer->getBlobData(), recordBuffer->getSize());
+
+    auto walData = walBuffer->getData();
+    Deserializer deserializer{std::make_unique<BufferReader>(walData.data.get(), walData.size)};
+    auto deserialized =
+        lbug::storage::WALRecord::deserialize(deserializer, *conn->getClientContext());
+
+    ASSERT_EQ(deserialized->type, lbug::storage::WALRecordType::COPY_TABLE_RECORD);
+    EXPECT_EQ(deserialized->constCast<lbug::storage::CopyTableRecord>().tableID, 123);
+    EXPECT_TRUE(deserializer.finished());
 }
 
 TEST_F(WalTest, NoWALFile) {

--- a/tools/wal_dump/main.cpp
+++ b/tools/wal_dump/main.cpp
@@ -31,6 +31,27 @@ static WALHeader readWALHeader(Deserializer& deserializer) {
     return header;
 }
 
+static uint64_t getReadOffset(Deserializer& deserializer, bool enableChecksums) {
+    if (enableChecksums) {
+        return deserializer.getReader()->cast<ChecksumReader>()->getReadOffset();
+    }
+    return deserializer.getReader()->cast<BufferedFileReader>()->getReadOffset();
+}
+
+static WALHeader readRawWALHeader(FileInfo& fileInfo) {
+    Deserializer deserializer{std::make_unique<BufferedFileReader>(fileInfo)};
+    return readWALHeader(deserializer);
+}
+
+static Deserializer initDeserializer(FileInfo& fileInfo, lbug::main::ClientContext& clientContext,
+    bool enableChecksums) {
+    if (enableChecksums) {
+        return Deserializer{std::make_unique<ChecksumReader>(fileInfo,
+            *MemoryManager::Get(clientContext), checksumMismatchMessage)};
+    }
+    return Deserializer{std::make_unique<BufferedFileReader>(fileInfo)};
+}
+
 static std::string walRecordTypeToString(WALRecordType type) {
     switch (type) {
     case WALRecordType::BEGIN_TRANSACTION_RECORD:
@@ -259,14 +280,9 @@ int main(int argc, char** argv) {
         auto contextDB = std::make_unique<lbug::main::Database>(":memory:");
         lbug::main::ClientContext clientContext(contextDB.get());
 
-        std::unique_ptr<Reader> reader;
-        if (fileSize >= sizeof(uuid) + sizeof(uint8_t) + sizeof(uint64_t)) {
-            reader = std::make_unique<ChecksumReader>(*fileInfo, *MemoryManager::Get(clientContext),
-                checksumMismatchMessage);
-        } else {
-            reader = std::make_unique<BufferedFileReader>(*fileInfo);
-        }
-        Deserializer deserializer(std::move(reader));
+        auto rawWalHeader = readRawWALHeader(*fileInfo);
+        Deserializer deserializer =
+            initDeserializer(*fileInfo, clientContext, rawWalHeader.enableChecksums);
 
         deserializer.getReader()->onObjectBegin();
         auto walHeader = readWALHeader(deserializer);
@@ -284,12 +300,16 @@ int main(int argc, char** argv) {
         uint64_t lastOffset = 0;
 
         while (!deserializer.finished()) {
-            lastOffset = walHeader.enableChecksums ?
-                             deserializer.getReader()->cast<ChecksumReader>()->getReadOffset() :
-                             deserializer.getReader()->cast<BufferedFileReader>()->getReadOffset();
+            lastOffset = getReadOffset(deserializer, walHeader.enableChecksums);
             auto walRecord = WALRecord::deserialize(deserializer, clientContext);
+            const auto endOffset = getReadOffset(deserializer, walHeader.enableChecksums);
+            const auto framedLength = endOffset - lastOffset;
+            const auto recordLength = framedLength - sizeof(uint64_t) -
+                                      (walHeader.enableChecksums ? sizeof(uint64_t) : 0);
             std::cout << "  Record at offset " << lastOffset << " ("
                       << walRecordTypeToString(walRecord->type) << "):\n";
+            std::cout << "      PayloadLength: " << recordLength << " bytes\n";
+            std::cout << "      FramedLength: " << framedLength << " bytes\n";
             dumpRecord(*walRecord);
             recordCount++;
         }


### PR DESCRIPTION
Fixes: #406 

## Summary
- add length framing around serialized WAL records
- make WAL deserialization skip unknown trailing bytes and generated record readers tolerate missing trailing fields
- add a regression test for skipping future record fields

