### PR TITLE
Add documentation to SubqueryType enum

### DIFF
--- a/src/include/common/enums/subquery_type.h
+++ b/src/include/common/enums/subquery_type.h
@@ -5,9 +5,14 @@
 namespace lbug {
 namespace common {
 
+/**
+ * @brief Enum representing types of subqueries.
+ *
+ * This enum defines the different types of subqueries used in the query engine.
+ */
 enum class SubqueryType : uint8_t {
-    COUNT = 1,
-    EXISTS = 2,
+    COUNT = 1,  /**< Subquery that counts the number of matching rows. */
+    EXISTS = 2, /**< Subquery that checks for the existence of at least one matching row. */
 };
 
 }


### PR DESCRIPTION
### Problem Background
The public enum class `SubqueryType` in `src/include/common/enums/subquery_type.h` is used in the query engine but lacked documentation strings. This reduced code readability and made maintenance harder for contributors and users.

### Changes Made
- Added a Doxygen-style docstring to the `SubqueryType` enum class to describe its purpose in defining subquery types.
- Added docstrings to each enum value (`COUNT` and `EXISTS`) to explain their specific roles.

### Verification
This change only adds documentation and does not alter any code functionality. It can be verified by:
1. Ensuring the code compiles without errors.
2. Reviewing the added documentation for accuracy and clarity.