### PR TITLE
Fix WAL TypeSpec build graph

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -431,7 +431,7 @@ function(add_lbug_api_test TEST_NAME)
 endfunction()
 
 # Windows doesn't support dynamic lookup, so we have to link extensions against lbug.
-if (MSVC AND (NOT BUILD_EXTENSIONS EQUAL "") AND NOT LBUG_API_USE_PRECOMPILED_LIB)
+if (MSVC AND (NOT "${BUILD_EXTENSIONS}" STREQUAL "") AND NOT LBUG_API_USE_PRECOMPILED_LIB)
     set(BUILD_LBUG TRUE)
 endif ()
 

--- a/src/storage/wal/CMakeLists.txt
+++ b/src/storage/wal/CMakeLists.txt
@@ -5,16 +5,7 @@ file(GLOB WAL_TYPESPEC_RECORD_SPECS CONFIGURE_DEPENDS
 file(GLOB WAL_TYPESPEC_TEMPLATES CONFIGURE_DEPENDS
         ${PROJECT_SOURCE_DIR}/src/storage/wal/typespec/templates/*.j2)
 
-set(WAL_TYPESPEC_GENERATED_FILES)
-foreach(WAL_TYPESPEC_RECORD_SPEC IN LISTS WAL_TYPESPEC_RECORD_SPECS)
-        get_filename_component(WAL_TYPESPEC_RECORD_NAME ${WAL_TYPESPEC_RECORD_SPEC} NAME_WE)
-        list(APPEND WAL_TYPESPEC_GENERATED_FILES
-                ${PROJECT_SOURCE_DIR}/src/include/storage/wal/record/${WAL_TYPESPEC_RECORD_NAME}.h
-                ${PROJECT_SOURCE_DIR}/src/storage/wal/records/${WAL_TYPESPEC_RECORD_NAME}.cpp)
-endforeach()
-
-add_custom_command(
-        OUTPUT ${WAL_TYPESPEC_GENERATED_FILES}
+add_custom_target(generate_wal_typespec
         COMMAND ${Python3_EXECUTABLE} ${PROJECT_SOURCE_DIR}/scripts/generate_wal_typespec.py
         DEPENDS
                 ${PROJECT_SOURCE_DIR}/scripts/generate_wal_typespec.py
@@ -24,9 +15,6 @@ add_custom_command(
         WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
         COMMENT "Generating WAL record files from TypeSpec"
         VERBATIM)
-
-add_custom_target(generate_wal_typespec
-        DEPENDS ${WAL_TYPESPEC_GENERATED_FILES})
 
 add_library(lbug_storage_wal
         OBJECT
@@ -63,8 +51,6 @@ add_library(lbug_storage_wal
         records/copy_table_record_replay.cpp
         records/update_sequence_record_replay.cpp
         records/load_extension_record_replay.cpp)
-
-add_dependencies(lbug_storage_wal generate_wal_typespec)
 
 set(ALL_OBJECT_FILES
         ${ALL_OBJECT_FILES} $<TARGET_OBJECTS:lbug_storage_wal>

--- a/src/storage/wal/typespec/README.md
+++ b/src/storage/wal/typespec/README.md
@@ -6,9 +6,14 @@ WAL record declarations live in `records/*.tsp` and are generated with:
 python3 scripts/generate_wal_typespec.py
 ```
 
-Normal CMake builds also depend on the generated WAL files through the
-`generate_wal_typespec` target, so editing an existing `.tsp`, template, or the generator
-will regenerate the checked-in `.h`/`.cpp` files before the WAL sources compile.
+Normal CMake builds compile the checked-in `.h`/`.cpp` files directly. They do not
+regenerate WAL records, because doing so makes ordinary builds depend on TypeSpec
+codegen tools and source-tree timestamp behavior. To regenerate through CMake, build the
+explicit target:
+
+```bash
+cmake --build build/release --target generate_wal_typespec
+```
 
 For review without touching checked-in C++ files:
 


### PR DESCRIPTION
## Summary
- keep WAL TypeSpec regeneration as an explicit target instead of a normal build dependency
- compile checked-in WAL record sources directly during ordinary builds
- fix the MSVC extension-build check to compare BUILD_EXTENSIONS as a string
- update WAL TypeSpec docs to describe explicit regeneration

## Verification
- cmake -B build/release -G Ninja -DCMAKE_BUILD_TYPE=Release .
- cmake --build build/release --target lbug_storage_wal -j 2
- confirmed no generated WAL record files changed