### PR TITLE
Fix WASM httpfs package build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -352,6 +352,11 @@ set(LBUG_NODEJS_PRECOMPILED_LIB_PATH "" CACHE FILEPATH "Deprecated alias for LBU
 option(ENABLE_BACKTRACES "Enable backtrace printing for fatal signals and termination" FALSE)
 option(PREFER_SYSTEM_DEPS "Only download certain deps if not found on the system" TRUE)
 
+if(BUILD_WASM)
+    set(BUILD_SHARED_LBUG FALSE CACHE BOOL "Build the shared liblbug library." FORCE)
+    set(BUILD_STATIC_LBUG TRUE CACHE BOOL "Build the bundled static liblbug archive." FORCE)
+endif()
+
 if(LBUG_NODEJS_USE_PRECOMPILED_LIB)
     set(LBUG_API_USE_PRECOMPILED_LIB TRUE)
 endif()


### PR DESCRIPTION
## Summary
- disable the shared liblbug target for BUILD_WASM configurations
- keep the static liblbug target enabled so lbug_wasm can still link statically with httpfs
- avoid applying browser/executable Emscripten export flags to the unnecessary shared-library link step

## Background
The last successful WASM nightly used c7cd886194a1f1c8d257053465e7251bec19ab77. The failing run used a3615f7cfb753ebb9a9e79980e30499c7b766b3d. The breaking change was a8a3982b8133, which made the WASM package build static-link httpfs via BUILD_EXTENSIONS=httpfs and EXTENSION_STATIC_LINK_LIST=httpfs. That exposed the existing shared-library WASM link path, where Emscripten 6.0.0 rejects _free in EXPORTED_FUNCTIONS while linking liblbug_shared.

## Verification
- cmake -S . -B build/wasm-cmake-check -G Ninja -DBUILD_WASM=TRUE -DBUILD_BENCHMARK=FALSE -DBUILD_TESTS=FALSE -DBUILD_SHELL=FALSE -DBUILD_EXTENSIONS=httpfs -DEXTENSION_STATIC_LINK_LIST=httpfs -DBUILD_SINGLE_FILE_HEADER=OFF
- confirmed BUILD_SHARED_LBUG=FALSE and BUILD_STATIC_LBUG=TRUE in build/wasm-cmake-check/CMakeCache.txt
- confirmed generated targets include lbug and not lbug_shared
- cmake -B build/release -G Ninja -DCMAKE_BUILD_TYPE=Release .
- confirmed normal Release keeps BUILD_SHARED_LBUG=ON and BUILD_STATIC_LBUG=ON

https://github.com/LadybugDB/ladybug/actions/runs/27117626256