### PR TITLE
Add stats-aware query optimization

### DIFF
--- a/src/include/optimizer/filter_push_down_optimizer.h
+++ b/src/include/optimizer/filter_push_down_optimizer.h
@@ -6,6 +6,9 @@ namespace lbug {
 namespace main {
 class ClientContext;
 }
+namespace planner {
+class CardinalityEstimator;
+} // namespace planner
 namespace optimizer {
 
 struct PrimaryKeyRangePredicate {
@@ -44,11 +47,15 @@ private:
 
 class FilterPushDownOptimizer {
 public:
-    explicit FilterPushDownOptimizer(main::ClientContext* context) : context{context} {
+    explicit FilterPushDownOptimizer(main::ClientContext* context,
+        const planner::CardinalityEstimator* cardinalityEstimator)
+        : context{context}, cardinalityEstimator{cardinalityEstimator} {
         predicateSet = PredicateSet();
     }
-    explicit FilterPushDownOptimizer(main::ClientContext* context, PredicateSet predicateSet)
-        : predicateSet{std::move(predicateSet)}, context{context} {}
+    explicit FilterPushDownOptimizer(main::ClientContext* context,
+        const planner::CardinalityEstimator* cardinalityEstimator, PredicateSet predicateSet)
+        : predicateSet{std::move(predicateSet)}, context{context},
+          cardinalityEstimator{cardinalityEstimator} {}
 
     void rewrite(planner::LogicalPlan* plan);
 
@@ -83,6 +90,8 @@ private:
     std::shared_ptr<planner::LogicalOperator> appendFilters(
         const binder::expression_vector& predicates,
         std::shared_ptr<planner::LogicalOperator> child);
+    std::shared_ptr<planner::LogicalOperator> appendFiltersStatsAware(
+        binder::expression_vector predicates, std::shared_ptr<planner::LogicalOperator> child);
 
     std::shared_ptr<planner::LogicalOperator> appendScanNodeTable(
         std::shared_ptr<binder::Expression> nodeID, std::vector<common::table_id_t> nodeTableIDs,
@@ -97,6 +106,7 @@ private:
 private:
     PredicateSet predicateSet;
     main::ClientContext* context;
+    const planner::CardinalityEstimator* cardinalityEstimator;
 };
 
 } // namespace optimizer

--- a/src/include/planner/join_order/cardinality_estimator.h
+++ b/src/include/planner/join_order/cardinality_estimator.h
@@ -58,6 +58,8 @@ public:
     cardinality_t estimateScanNode(const LogicalOperator& op) const;
     cardinality_t estimateHashJoin(const std::vector<binder::expression_pair>& joinConditions,
         const LogicalOperator& probeOp, const LogicalOperator& buildOp) const;
+    cardinality_t estimateHashJoin(const binder::expression_vector& joinNodeIDs,
+        const LogicalOperator& probeOp, const LogicalOperator& buildOp) const;
     cardinality_t estimateCrossProduct(const LogicalOperator& probeOp,
         const LogicalOperator& buildOp) const;
     cardinality_t estimateIntersect(const binder::expression_vector& joinNodeIDs,

--- a/src/include/planner/join_order/cost_model.h
+++ b/src/include/planner/join_order/cost_model.h
@@ -12,6 +12,9 @@ public:
         const LogicalPlan& probe, const LogicalPlan& build);
     static uint64_t computeHashJoinCost(const binder::expression_vector& joinNodeIDs,
         const LogicalPlan& probe, const LogicalPlan& build);
+    static uint64_t computeHashJoinCost(const binder::expression_vector& joinNodeIDs,
+        const LogicalPlan& probe, const LogicalPlan& build,
+        cardinality_t estimatedOutputCardinality);
     static uint64_t computeMarkJoinCost(const std::vector<binder::expression_pair>& joinConditions,
         const LogicalPlan& probe, const LogicalPlan& build);
     static uint64_t computeMarkJoinCost(const binder::expression_vector& joinNodeIDs,

--- a/src/optimizer/filter_push_down_optimizer.cpp
+++ b/src/optimizer/filter_push_down_optimizer.cpp
@@ -9,6 +9,7 @@
 #include "binder/expression/property_expression.h"
 #include "binder/expression/scalar_function_expression.h"
 #include "main/client_context.h"
+#include "planner/join_order/cardinality_estimator.h"
 #include "planner/operator/extend/logical_extend.h"
 #include "planner/operator/logical_empty_result.h"
 #include "planner/operator/logical_filter.h"
@@ -59,7 +60,7 @@ std::shared_ptr<LogicalOperator> FilterPushDownOptimizer::visitChildren(
     const std::shared_ptr<LogicalOperator>& op) {
     for (auto i = 0u; i < op->getNumChildren(); ++i) {
         // Start new push down for child.
-        auto optimizer = FilterPushDownOptimizer(context);
+        auto optimizer = FilterPushDownOptimizer(context, cardinalityEstimator);
         op->setChild(i, optimizer.visitOperator(op->getChild(i)));
     }
     op->computeFlatSchema();
@@ -101,10 +102,12 @@ std::shared_ptr<LogicalOperator> FilterPushDownOptimizer::visitCrossProductRepla
     }
     DASSERT(op->getNumChildren() == 2);
     // Push probe side
-    auto probeOptimizer = FilterPushDownOptimizer(context, std::move(probePSet));
+    auto probeOptimizer =
+        FilterPushDownOptimizer(context, cardinalityEstimator, std::move(probePSet));
     op->setChild(0, probeOptimizer.visitOperator(op->getChild(0)));
     // Push build side
-    auto buildOptimizer = FilterPushDownOptimizer(context, std::move(buildPSet));
+    auto buildOptimizer =
+        FilterPushDownOptimizer(context, cardinalityEstimator, std::move(buildPSet));
     op->setChild(1, buildOptimizer.visitOperator(op->getChild(1)));
 
     auto probeSchema = op->getChild(0)->getSchema();
@@ -134,13 +137,17 @@ std::shared_ptr<LogicalOperator> FilterPushDownOptimizer::visitCrossProductRepla
     // For non-id based joins, we disable side way information passing.
     hashJoin->getSIPInfoUnsafe().position = SemiMaskPosition::PROHIBIT;
     hashJoin->computeFlatSchema();
+    if (cardinalityEstimator != nullptr) {
+        hashJoin->setCardinality(cardinalityEstimator->estimateHashJoin(joinConditions,
+            *op->getChild(0), *op->getChild(1)));
+    }
     // Apply remaining predicates.
     predicates.insert(predicates.end(), remainingPSet.nonEqualityPredicates.begin(),
         remainingPSet.nonEqualityPredicates.end());
     if (predicates.empty()) {
         return hashJoin;
     }
-    return appendFilters(predicates, hashJoin);
+    return appendFiltersStatsAware(std::move(predicates), hashJoin);
 }
 
 static ColumnPredicateSet getPredicateSet(const Expression& column,
@@ -285,7 +292,7 @@ std::shared_ptr<LogicalOperator> FilterPushDownOptimizer::finishPushDown(
         return op;
     }
     auto predicates = predicateSet.getAllPredicates();
-    auto root = appendFilters(predicates, op);
+    auto root = appendFiltersStatsAware(std::move(predicates), op);
     predicateSet.clear();
     return root;
 }
@@ -311,6 +318,30 @@ std::shared_ptr<LogicalOperator> FilterPushDownOptimizer::appendFilters(
     auto root = child;
     for (auto& p : predicates) {
         root = appendFilter(p, root);
+    }
+    return root;
+}
+
+std::shared_ptr<LogicalOperator> FilterPushDownOptimizer::appendFiltersStatsAware(
+    expression_vector predicates, std::shared_ptr<LogicalOperator> child) {
+    if (predicates.empty() || cardinalityEstimator == nullptr) {
+        return appendFilters(predicates, std::move(child));
+    }
+    auto root = child;
+    while (!predicates.empty()) {
+        auto bestIdx = 0u;
+        auto bestCardinality = cardinalityEstimator->estimateFilter(*root, *predicates[bestIdx]);
+        for (auto i = 1u; i < predicates.size(); ++i) {
+            const auto cardinality = cardinalityEstimator->estimateFilter(*root, *predicates[i]);
+            if (cardinality < bestCardinality) {
+                bestCardinality = cardinality;
+                bestIdx = i;
+            }
+        }
+        auto predicate = predicates[bestIdx];
+        predicates.erase(predicates.begin() + bestIdx);
+        root = appendFilter(std::move(predicate), root);
+        root->setCardinality(bestCardinality);
     }
     return root;
 }

--- a/src/optimizer/optimizer.cpp
+++ b/src/optimizer/optimizer.cpp
@@ -51,7 +51,7 @@ void Optimizer::optimize(planner::LogicalPlan* plan, main::ClientContext* contex
         auto foreignJoinPushDownOptimizer = ForeignJoinPushDownOptimizer(context);
         foreignJoinPushDownOptimizer.rewrite(plan);
 
-        auto filterPushDownOptimizer = FilterPushDownOptimizer(context);
+        auto filterPushDownOptimizer = FilterPushDownOptimizer(context, &cardinalityEstimator);
         filterPushDownOptimizer.rewrite(plan);
 
         auto projectionPushDownOptimizer =

--- a/src/planner/join_order/cardinality_estimator.cpp
+++ b/src/planner/join_order/cardinality_estimator.cpp
@@ -153,6 +153,16 @@ uint64_t CardinalityEstimator::estimateHashJoin(
     }
 }
 
+uint64_t CardinalityEstimator::estimateHashJoin(const expression_vector& joinNodeIDs,
+    const LogicalOperator& probeOp, const LogicalOperator& buildOp) const {
+    std::vector<expression_pair> joinConditions;
+    joinConditions.reserve(joinNodeIDs.size());
+    for (auto& joinNodeID : joinNodeIDs) {
+        joinConditions.emplace_back(joinNodeID, joinNodeID);
+    }
+    return estimateHashJoin(joinConditions, probeOp, buildOp);
+}
+
 uint64_t CardinalityEstimator::estimateCrossProduct(const LogicalOperator& probeOp,
     const LogicalOperator& buildOp) const {
     return atLeastOne(probeOp.getCardinality() * buildOp.getCardinality());

--- a/src/planner/join_order/cost_model.cpp
+++ b/src/planner/join_order/cost_model.cpp
@@ -20,10 +20,16 @@ uint64_t CostModel::computeHashJoinCost(const std::vector<binder::expression_pai
 
 uint64_t CostModel::computeHashJoinCost(const binder::expression_vector& joinNodeIDs,
     const LogicalPlan& probe, const LogicalPlan& build) {
+    return computeHashJoinCost(joinNodeIDs, probe, build, 0 /* estimatedOutputCardinality */);
+}
+
+uint64_t CostModel::computeHashJoinCost(const binder::expression_vector& joinNodeIDs,
+    const LogicalPlan& probe, const LogicalPlan& build, cardinality_t estimatedOutputCardinality) {
     uint64_t cost = 0ul;
     cost += probe.getCost();
     cost += build.getCost();
     cost += probe.getCardinality();
+    cost += estimatedOutputCardinality;
     cost += PlannerKnobs::BUILD_PENALTY *
             JoinOrderUtil::getJoinKeysFlatCardinality(joinNodeIDs, build.getLastOperatorRef());
     return cost;

--- a/src/planner/plan/append_join.cpp
+++ b/src/planner/plan/append_join.cpp
@@ -42,9 +42,12 @@ void Planner::appendHashJoin(const std::vector<expression_pair>& joinConditions,
         hashJoin->getSIPInfoUnsafe().position = SemiMaskPosition::PROHIBIT_PROBE_TO_BUILD;
     }
     // Update cost
-    hashJoin->setCardinality(cardinalityEstimator.estimateHashJoin(joinConditions,
-        probePlan.getLastOperatorRef(), buildPlan.getLastOperatorRef()));
-    resultPlan.setCost(CostModel::computeHashJoinCost(joinConditions, probePlan, buildPlan));
+    const auto estimatedOutputCardinality = cardinalityEstimator.estimateHashJoin(joinConditions,
+        probePlan.getLastOperatorRef(), buildPlan.getLastOperatorRef());
+    hashJoin->setCardinality(estimatedOutputCardinality);
+    resultPlan.setCost(
+        CostModel::computeHashJoinCost(LogicalHashJoin::getJoinNodeIDs(joinConditions), probePlan,
+            buildPlan, estimatedOutputCardinality));
     resultPlan.setLastOperator(std::move(hashJoin));
 }
 

--- a/src/planner/plan/plan_join_order.cpp
+++ b/src/planner/plan/plan_join_order.cpp
@@ -632,7 +632,10 @@ void Planner::planInnerHashJoin(const SubqueryGraph& subgraph, const SubqueryGra
         getNewlyMatchedExprs(subgraph, otherSubgraph, newSubgraph, context.getWhereExpressions());
     for (auto& leftPlan : context.getPlans(subgraph)) {
         for (auto& rightPlan : context.getPlans(otherSubgraph)) {
-            if (CostModel::computeHashJoinCost(joinNodeIDs, leftPlan, rightPlan) < maxCost) {
+            const auto leftProbeCardinality = cardinalityEstimator.estimateHashJoin(joinNodeIDs,
+                leftPlan.getLastOperatorRef(), rightPlan.getLastOperatorRef());
+            if (CostModel::computeHashJoinCost(joinNodeIDs, leftPlan, rightPlan,
+                    leftProbeCardinality) < maxCost) {
                 auto leftPlanProbeCopy = leftPlan.copy();
                 auto rightPlanBuildCopy = rightPlan.copy();
                 appendHashJoin(joinNodeIDs, JoinType::INNER, leftPlanProbeCopy, rightPlanBuildCopy,
@@ -641,8 +644,10 @@ void Planner::planInnerHashJoin(const SubqueryGraph& subgraph, const SubqueryGra
                 context.addPlan(newSubgraph, std::move(leftPlanProbeCopy));
             }
             // flip build and probe side to get another HashJoin plan
-            if (flipPlan &&
-                CostModel::computeHashJoinCost(joinNodeIDs, rightPlan, leftPlan) < maxCost) {
+            const auto rightProbeCardinality = cardinalityEstimator.estimateHashJoin(joinNodeIDs,
+                rightPlan.getLastOperatorRef(), leftPlan.getLastOperatorRef());
+            if (flipPlan && CostModel::computeHashJoinCost(joinNodeIDs, rightPlan, leftPlan,
+                                rightProbeCardinality) < maxCost) {
                 auto leftPlanBuildCopy = leftPlan.copy();
                 auto rightPlanProbeCopy = rightPlan.copy();
                 appendHashJoin(joinNodeIDs, JoinType::INNER, rightPlanProbeCopy, leftPlanBuildCopy,

--- a/test/optimizer/optimizer_test.cpp
+++ b/test/optimizer/optimizer_test.cpp
@@ -1,9 +1,14 @@
+#include <functional>
 #include <stdexcept>
 
 #include "graph_test/private_graph_test.h"
+#include "planner/join_order/cost_model.h"
+#include "planner/operator/logical_filter.h"
 #include "planner/operator/logical_plan_util.h"
 #include "planner/operator/scan/logical_count_rel_table.h"
+#include "planner/operator/scan/logical_dummy_scan.h"
 #include "test_runner/test_runner.h"
+#include <format>
 
 namespace lbug {
 namespace testing {
@@ -40,6 +45,41 @@ public:
             }
         }
         return false;
+    }
+};
+
+class StatsOptimizerTest : public EmptyDBTest {
+public:
+    void SetUp() override {
+        EmptyDBTest::SetUp();
+        createDBAndConn();
+    }
+
+    std::unique_ptr<planner::LogicalPlan> getRoot(const std::string& query) {
+        auto preparedStatement = conn->prepare(query);
+        if (!preparedStatement->isSuccess()) {
+            throw std::runtime_error("Failed to prepare optimizer test query:\n" + query +
+                                     "\nError:\n" + preparedStatement->getErrorMessage());
+        }
+        auto cachedStatement =
+            conn->getClientContext()->getCachedPreparedStatementManager().getCachedStatement(
+                preparedStatement->getName());
+        return std::move(cachedStatement->logicalPlan);
+    }
+
+    static planner::LogicalFilter* getDeepestFilter(planner::LogicalOperator* op) {
+        planner::LogicalFilter* result = nullptr;
+        std::function<void(planner::LogicalOperator*)> visit;
+        visit = [&](planner::LogicalOperator* current) {
+            if (current->getOperatorType() == planner::LogicalOperatorType::FILTER) {
+                result = current->ptrCast<planner::LogicalFilter>();
+            }
+            for (auto i = 0u; i < current->getNumChildren(); ++i) {
+                visit(current->getChild(i).get());
+            }
+        };
+        visit(op);
+        return result;
     }
 };
 
@@ -399,6 +439,46 @@ TEST_F(OptimizerTest, CountRelTableOptimizer) {
     auto result12 = conn->query(q12);
     ASSERT_TRUE(result12->isSuccess());
     ASSERT_EQ(result12->getNext()->getValue(0)->getValue<int64_t>(), 2);
+}
+
+TEST_F(StatsOptimizerTest, FilterPushDownOrdersMostSelectivePredicateFirst) {
+    ASSERT_TRUE(conn->query("CREATE NODE TABLE stats_node(id INT64, common INT64, rare INT64, "
+                            "PRIMARY KEY(id));")
+                    ->isSuccess());
+    for (auto i = 0; i < 20; ++i) {
+        auto result = conn->query(
+            std::format("CREATE (:stats_node {{id: {}, common: {}, rare: {}}});", i, i % 2, i));
+        ASSERT_TRUE(result->isSuccess()) << result->getErrorMessage();
+    }
+    ASSERT_TRUE(conn->query("ANALYZE stats_node;")->isSuccess());
+
+    auto plan = getRoot("EXPLAIN LOGICAL MATCH (n:stats_node) "
+                        "WHERE n.common = 1 AND n.rare = 7 "
+                        "RETURN n.id;");
+    auto* deepestFilter = getDeepestFilter(plan->getLastOperator().get());
+    ASSERT_NE(nullptr, deepestFilter);
+    ASSERT_NE(std::string::npos, deepestFilter->getPredicate()->toString().find("rare"));
+}
+
+TEST_F(StatsOptimizerTest, HashJoinCostIncludesEstimatedOutputCardinality) {
+    auto leftOp = std::make_shared<planner::LogicalDummyScan>();
+    leftOp->setCardinality(10);
+    leftOp->computeFlatSchema();
+    auto rightOp = std::make_shared<planner::LogicalDummyScan>();
+    rightOp->setCardinality(10);
+    rightOp->computeFlatSchema();
+
+    auto leftPlan = planner::LogicalPlan();
+    leftPlan.setLastOperator(leftOp);
+    auto rightPlan = planner::LogicalPlan();
+    rightPlan.setLastOperator(rightOp);
+
+    auto joinKeys = binder::expression_vector{};
+    const auto smallIntermediateCost =
+        planner::CostModel::computeHashJoinCost(joinKeys, leftPlan, rightPlan, 5);
+    const auto largeIntermediateCost =
+        planner::CostModel::computeHashJoinCost(joinKeys, leftPlan, rightPlan, 500);
+    ASSERT_LT(smallIntermediateCost, largeIntermediateCost);
 }
 
 } // namespace testing


### PR DESCRIPTION
## Summary

- order pushed-down filters by estimated selectivity using collected table stats
- include estimated hash join output cardinality in join enumeration cost
- add focused stats optimizer tests independent of the tinysnb fixture

## Validation

- cmake --build build/release --target optimizer_test planner_tests
- git diff --check
- ./build/release/test/optimizer/optimizer_test --gtest_filter=StatsOptimizerTest.*

