### PR TITLE
Fix wasm lbug_shared compatibility alias

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -523,6 +523,15 @@ foreach(ext IN LISTS STATICALLY_LINKED_EXTENSIONS)
     endif()
 endforeach()
 
+# Emscripten does not produce a useful native shared lib here; the wasm package
+# and tests link everything into final JS/wasm artifacts. Keep the legacy
+# lbug_shared target name available for existing consumers, but make it resolve
+# to the static wasm library after real library setup and static extension
+# linking are complete.
+if(EMSCRIPTEN AND TARGET lbug AND NOT TARGET lbug_shared)
+    add_library(lbug_shared ALIAS lbug)
+endif()
+
 if (${BUILD_TESTS} OR ${BUILD_EXTENSION_TESTS})
     add_subdirectory(test)
 elseif (${BUILD_BENCHMARK})


### PR DESCRIPTION
## Summary

- Add a wasm-only CMake alias so existing lbug_shared consumers resolve to the static lbug target when shared builds are disabled for Emscripten.
- Document why the alias is intentionally static-backed for wasm.

## Root cause

The wasm build now intentionally disables BUILD_SHARED_LBUG and builds only the static lbug target, but nightly wasm test helper targets still link through the legacy lbug_shared target name. That produced -llbug_shared during the Emscripten link even though no shared library is built.

## Validation

- cmake -B /private/tmp/lbug-cmake-wasm-alias-check -G Ninja -DBUILD_SHELL=OFF -DBUILD_TESTS=OFF -DBUILD_SINGLE_FILE_HEADER=OFF .
- git diff --check -- src/CMakeLists.txt