### PR TITLE
add COPY FROM SKIP_DUPLICATE_PK feature

### DIFF
--- a/src/binder/bind/copy/bind_copy_from.cpp
+++ b/src/binder/bind/copy/bind_copy_from.cpp
@@ -23,6 +23,25 @@ static void throwTableNotExist(const std::string& tableName) {
     throw BinderException(std::format("Table {} does not exist.", tableName));
 }
 
+static bool getBoolCopyOption(const options_t& parsingOptions, const char* optionName,
+    bool defaultValue) {
+    const auto it = parsingOptions.find(optionName);
+    if (it == parsingOptions.end()) {
+        return defaultValue;
+    }
+    const auto& value = *it->second;
+    auto strValue = value.toString();
+    StringUtils::toUpper(strValue);
+    if (strValue == "TRUE" || strValue == "1") {
+        return true;
+    }
+    if (strValue == "FALSE" || strValue == "0") {
+        return false;
+    }
+    throw BinderException(
+        std::format("The type of copy parsing option {} must be a boolean.", optionName));
+}
+
 std::unique_ptr<BoundStatement> Binder::bindLegacyCopyRelGroupFrom(const Statement& statement) {
     auto& copyFrom = statement.constCast<CopyFrom>();
     auto catalog = Catalog::Get(*clientContext);
@@ -117,6 +136,17 @@ BoundCopyFromInfo Binder::bindCopyNodeFromInfo(std::string tableName,
     const std::vector<PropertyDefinition>& properties, const BaseScanSource* source,
     const options_t& parsingOptions, const std::vector<std::string>& expectedColumnNames,
     const std::vector<LogicalType>& expectedColumnTypes, bool byColumn) {
+    const auto skipDuplicatePK = getBoolCopyOption(parsingOptions,
+        CopyConstants::SKIP_DUPLICATE_PK_OPTION_NAME, CopyConstants::DEFAULT_SKIP_DUPLICATE_PK);
+    const auto ignoreErrors = getBoolCopyOption(parsingOptions,
+        CopyConstants::IGNORE_ERRORS_OPTION_NAME, CopyConstants::DEFAULT_IGNORE_ERRORS);
+    if (skipDuplicatePK && ignoreErrors) {
+        throw BinderException("SKIP_DUPLICATE_PK cannot be used together with IGNORE_ERRORS.");
+    }
+    if (skipDuplicatePK && source->type != ScanSourceType::FILE) {
+        throw BinderException(
+            "SKIP_DUPLICATE_PK is only supported for COPY FROM files into node tables.");
+    }
     auto boundSource =
         bindScanSource(source, parsingOptions, expectedColumnNames, expectedColumnTypes);
     expression_vector warningDataExprs = boundSource->getWarningColumns();
@@ -140,7 +170,7 @@ BoundCopyFromInfo Binder::bindCopyNodeFromInfo(std::string tableName,
     auto offset =
         createInvisibleVariable(std::string(InternalKeyword::ROW_OFFSET), LogicalType::INT64());
     return BoundCopyFromInfo(tableName, TableType::NODE, std::move(boundSource), std::move(offset),
-        std::move(columns), std::move(evaluateTypes), nullptr /* extraInfo */);
+        std::move(columns), std::move(evaluateTypes), nullptr /* extraInfo */, skipDuplicatePK);
 }
 
 std::unique_ptr<BoundStatement> Binder::bindCopyNodeFrom(const Statement& statement,
@@ -186,6 +216,11 @@ BoundCopyFromInfo Binder::bindCopyRelFromInfo(std::string tableName,
     const options_t& parsingOptions, const std::vector<std::string>& expectedColumnNames,
     const std::vector<LogicalType>& expectedColumnTypes, const NodeTableCatalogEntry* fromTable,
     const NodeTableCatalogEntry* toTable) {
+    if (getBoolCopyOption(parsingOptions, CopyConstants::SKIP_DUPLICATE_PK_OPTION_NAME,
+            CopyConstants::DEFAULT_SKIP_DUPLICATE_PK)) {
+        throw BinderException(
+            "SKIP_DUPLICATE_PK is only supported for COPY FROM files into node tables.");
+    }
     auto boundSource =
         bindScanSource(source, parsingOptions, expectedColumnNames, expectedColumnTypes);
     expression_vector warningDataExprs = boundSource->getWarningColumns();
@@ -225,7 +260,7 @@ BoundCopyFromInfo Binder::bindCopyRelFromInfo(std::string tableName,
     auto extraCopyRelInfo = std::make_unique<ExtraBoundCopyRelInfo>(fromTable->getName(),
         toTable->getName(), internalIDColumnIndices, lookupInfos);
     return BoundCopyFromInfo(tableName, TableType::REL, boundSource->copy(), offset,
-        std::move(columnExprs), std::move(evaluateTypes), std::move(extraCopyRelInfo));
+        std::move(columnExprs), std::move(evaluateTypes), std::move(extraCopyRelInfo), false);
 }
 
 std::unique_ptr<BoundStatement> Binder::bindCopyRelFrom(const Statement& statement,

--- a/src/common/copier_config/csv_reader_config.cpp
+++ b/src/common/copier_config/csv_reader_config.cpp
@@ -33,6 +33,9 @@ static void bindBoolParsingOption(CSVReaderConfig& config, const std::string& op
         config.option.allowUnbracedList = optionValue;
     } else if (optionName == CopyConstants::IGNORE_ERRORS_OPTION_NAME) {
         config.option.ignoreErrors = optionValue;
+    } else if (optionName == CopyConstants::SKIP_DUPLICATE_PK_OPTION_NAME) {
+        // COPY-level option. The CSV reader accepts it during parsing, but duplicate-PK handling
+        // is implemented in the node-table insert pipeline rather than in the file reader.
     } else if (optionName == "AUTODETECT" || optionName == "AUTO_DETECT") {
         config.option.autoDetection = optionValue;
     } else {

--- a/src/include/binder/bound_scan_source.h
+++ b/src/include/binder/bound_scan_source.h
@@ -20,6 +20,9 @@ struct BoundBaseScanSource {
     virtual bool getIgnoreErrorsOption() const {
         return common::CopyConstants::DEFAULT_IGNORE_ERRORS;
     };
+    virtual bool getSkipDuplicatePKOption() const {
+        return common::CopyConstants::DEFAULT_SKIP_DUPLICATE_PK;
+    };
     virtual common::column_id_t getNumWarningDataColumns() const { return 0; }
 
     virtual std::unique_ptr<BoundBaseScanSource> copy() const = 0;
@@ -44,6 +47,10 @@ struct BoundTableScanSource final : BoundBaseScanSource {
     expression_vector getColumns() override { return info.bindData->columns; }
     expression_vector getWarningColumns() const override;
     bool getIgnoreErrorsOption() const override;
+    bool getSkipDuplicatePKOption() const override {
+        return info.bindData->constPtrCast<function::ScanFileBindData>()
+            ->getSkipDuplicatePKOption();
+    }
     common::column_id_t getNumWarningDataColumns() const override {
         switch (type) {
         case common::ScanSourceType::FILE:

--- a/src/include/binder/copy/bound_copy_from.h
+++ b/src/include/binder/copy/bound_copy_from.h
@@ -2,6 +2,7 @@
 
 #include "binder/bound_scan_source.h"
 #include "binder/expression/expression.h"
+#include "binder/expression/literal_expression.h"
 #include "common/enums/column_evaluate_type.h"
 #include "common/enums/table_type.h"
 #include "index_look_up_info.h"
@@ -31,14 +32,16 @@ struct LBUG_API BoundCopyFromInfo {
     expression_vector columnExprs;
     std::vector<common::ColumnEvaluateType> columnEvaluateTypes;
     std::unique_ptr<ExtraBoundCopyFromInfo> extraInfo;
+    bool skipDuplicatePK;
 
     BoundCopyFromInfo(std::string tableName, common::TableType tableType,
         std::unique_ptr<BoundBaseScanSource> source, std::shared_ptr<Expression> offset,
         expression_vector columnExprs, std::vector<common::ColumnEvaluateType> columnEvaluateTypes,
-        std::unique_ptr<ExtraBoundCopyFromInfo> extraInfo)
+        std::unique_ptr<ExtraBoundCopyFromInfo> extraInfo, bool skipDuplicatePK = false)
         : tableName{std::move(tableName)}, tableType{tableType}, source{std::move(source)},
           offset{std::move(offset)}, columnExprs{std::move(columnExprs)},
-          columnEvaluateTypes{std::move(columnEvaluateTypes)}, extraInfo{std::move(extraInfo)} {}
+          columnEvaluateTypes{std::move(columnEvaluateTypes)}, extraInfo{std::move(extraInfo)},
+          skipDuplicatePK{skipDuplicatePK} {}
 
     EXPLICIT_COPY_DEFAULT_MOVE(BoundCopyFromInfo);
 
@@ -50,11 +53,13 @@ struct LBUG_API BoundCopyFromInfo {
     }
 
     bool getIgnoreErrorsOption() const { return source ? source->getIgnoreErrorsOption() : false; }
+    bool getSkipDuplicatePKOption() const { return skipDuplicatePK; }
 
 private:
     BoundCopyFromInfo(const BoundCopyFromInfo& other)
         : tableName{other.tableName}, tableType{other.tableType}, offset{other.offset},
-          columnExprs{other.columnExprs}, columnEvaluateTypes{other.columnEvaluateTypes} {
+          columnExprs{other.columnExprs}, columnEvaluateTypes{other.columnEvaluateTypes},
+          skipDuplicatePK{other.skipDuplicatePK} {
         source = other.source ? other.source->copy() : nullptr;
         if (other.extraInfo) {
             extraInfo = other.extraInfo->copy();
@@ -88,12 +93,28 @@ class BoundCopyFrom final : public BoundStatement {
 
 public:
     explicit BoundCopyFrom(BoundCopyFromInfo info)
-        : BoundStatement{statementType_, BoundStatementResult::createSingleStringColumnResult()},
+        : BoundStatement{statementType_,
+              info.getSkipDuplicatePKOption() ?
+                  createSkipDuplicatePKResult() :
+                  BoundStatementResult::createSingleStringColumnResult()},
           info{std::move(info)} {}
 
     const BoundCopyFromInfo* getInfo() const { return &info; }
 
 private:
+    static BoundStatementResult createSkipDuplicatePKResult() {
+        auto result = BoundStatementResult::createSingleStringColumnResult();
+        auto skippedCount = std::make_shared<LiteralExpression>(common::Value{int64_t(0)},
+            "skipped_duplicate_pk_count");
+        auto skippedPKs = std::make_shared<LiteralExpression>(
+            common::Value{common::LogicalType::LIST(common::LogicalType::STRING()),
+                std::vector<std::unique_ptr<common::Value>>{}},
+            "skipped_duplicate_pks");
+        result.addColumn("skipped_duplicate_pk_count", skippedCount);
+        result.addColumn("skipped_duplicate_pks", skippedPKs);
+        return result;
+    }
+
     BoundCopyFromInfo info;
 };
 

--- a/src/include/common/constants.h
+++ b/src/include/common/constants.h
@@ -105,12 +105,14 @@ struct CopyConstants {
     static constexpr uint64_t PARALLEL_BLOCK_SIZE = INITIAL_BUFFER_SIZE / 2;
 
     static constexpr const char* IGNORE_ERRORS_OPTION_NAME = "IGNORE_ERRORS";
+    static constexpr const char* SKIP_DUPLICATE_PK_OPTION_NAME = "SKIP_DUPLICATE_PK";
 
     static constexpr const char* FROM_OPTION_NAME = "FROM";
     static constexpr const char* TO_OPTION_NAME = "TO";
 
     static constexpr const char* BOOL_CSV_PARSING_OPTIONS[] = {"HEADER", "PARALLEL",
-        "LIST_UNBRACED", "AUTODETECT", "AUTO_DETECT", CopyConstants::IGNORE_ERRORS_OPTION_NAME};
+        "LIST_UNBRACED", "AUTODETECT", "AUTO_DETECT", CopyConstants::IGNORE_ERRORS_OPTION_NAME,
+        CopyConstants::SKIP_DUPLICATE_PK_OPTION_NAME};
     static constexpr bool DEFAULT_CSV_HAS_HEADER = false;
     static constexpr bool DEFAULT_CSV_PARALLEL = true;
 
@@ -124,6 +126,7 @@ struct CopyConstants {
     static constexpr char DEFAULT_CSV_LIST_BEGIN_CHAR = '[';
     static constexpr char DEFAULT_CSV_LIST_END_CHAR = ']';
     static constexpr bool DEFAULT_IGNORE_ERRORS = false;
+    static constexpr bool DEFAULT_SKIP_DUPLICATE_PK = false;
     static constexpr bool DEFAULT_CSV_AUTO_DETECT = true;
     static constexpr bool DEFAULT_CSV_SET_DIALECT = false;
     static constexpr std::array DEFAULT_CSV_DELIMITER_SEARCH_SPACE = {',', ';', '\t', '|'};

--- a/src/include/function/table/scan_file_function.h
+++ b/src/include/function/table/scan_file_function.h
@@ -64,6 +64,11 @@ struct LBUG_API ScanFileBindData : public TableFuncBindData {
             common::CopyConstants::DEFAULT_IGNORE_ERRORS);
     }
 
+    bool getSkipDuplicatePKOption() const {
+        return fileScanInfo.getOption(common::CopyConstants::SKIP_DUPLICATE_PK_OPTION_NAME,
+            common::CopyConstants::DEFAULT_SKIP_DUPLICATE_PK);
+    }
+
     std::unique_ptr<TableFuncBindData> copy() const override {
         return std::make_unique<ScanFileBindData>(*this);
     }

--- a/src/include/main/prepared_statement.h
+++ b/src/include/main/prepared_statement.h
@@ -31,6 +31,7 @@ struct CachedPreparedStatement {
     std::shared_ptr<parser::Statement> parsedStatement;
     std::unique_ptr<planner::LogicalPlan> logicalPlan;
     std::vector<std::shared_ptr<binder::Expression>> columns;
+    std::vector<std::string> columnNames;
 
     CachedPreparedStatement();
     ~CachedPreparedStatement();

--- a/src/include/processor/operator/persistent/node_batch_insert.h
+++ b/src/include/processor/operator/persistent/node_batch_insert.h
@@ -45,16 +45,18 @@ private:
 struct NodeBatchInsertInfo final : BatchInsertInfo {
     evaluator::evaluator_vector_t columnEvaluators;
     std::vector<common::ColumnEvaluateType> evaluateTypes;
+    bool skipDuplicatePK;
 
     NodeBatchInsertInfo(std::string tableName, std::vector<common::LogicalType> warningColumnTypes,
         std::vector<std::unique_ptr<evaluator::ExpressionEvaluator>> columnEvaluators,
-        std::vector<common::ColumnEvaluateType> evaluateTypes)
+        std::vector<common::ColumnEvaluateType> evaluateTypes, bool skipDuplicatePK)
         : BatchInsertInfo{std::move(tableName), std::move(warningColumnTypes)},
-          columnEvaluators{std::move(columnEvaluators)}, evaluateTypes{std::move(evaluateTypes)} {}
+          columnEvaluators{std::move(columnEvaluators)}, evaluateTypes{std::move(evaluateTypes)},
+          skipDuplicatePK{skipDuplicatePK} {}
 
     NodeBatchInsertInfo(const NodeBatchInsertInfo& other)
         : BatchInsertInfo{other}, columnEvaluators{copyVector(other.columnEvaluators)},
-          evaluateTypes{other.evaluateTypes} {}
+          evaluateTypes{other.evaluateTypes}, skipDuplicatePK{other.skipDuplicatePK} {}
 
     std::unique_ptr<BatchInsertInfo> copy() const override {
         return std::make_unique<NodeBatchInsertInfo>(*this);
@@ -68,6 +70,7 @@ struct NodeBatchInsertSharedState final : BatchInsertSharedState {
     std::optional<IndexBuilder> globalIndexBuilder;
     std::unique_ptr<NoIndexPKValidator> noIndexPKValidator;
     bool usePrimaryKeyIndexCommitInsert;
+    bool skipDuplicatePK;
 
     function::TableFuncSharedState* tableFuncSharedState;
 
@@ -76,12 +79,14 @@ struct NodeBatchInsertSharedState final : BatchInsertSharedState {
     // The sharedNodeGroup is to accumulate left data within local node groups in NodeBatchInsert
     // ops.
     std::unique_ptr<storage::InMemChunkedNodeGroup> sharedNodeGroup;
+    std::shared_ptr<DuplicatePKSkipResult> duplicatePKSkipResult;
 
     explicit NodeBatchInsertSharedState(std::shared_ptr<FactorizedTable> fTable)
         : BatchInsertSharedState{std::move(fTable)}, pkColumnID{0},
           globalIndexBuilder(std::nullopt), noIndexPKValidator{nullptr},
-          usePrimaryKeyIndexCommitInsert{false}, tableFuncSharedState{nullptr},
-          sharedNodeGroup{nullptr} {}
+          usePrimaryKeyIndexCommitInsert{false}, skipDuplicatePK{false},
+          tableFuncSharedState{nullptr}, sharedNodeGroup{nullptr},
+          duplicatePKSkipResult{std::make_shared<DuplicatePKSkipResult>()} {}
 
     void initPKIndex(const ExecutionContext* context);
 };
@@ -90,6 +95,7 @@ struct NodeBatchInsertLocalState final : BatchInsertLocalState {
     std::optional<NodeBatchInsertErrorHandler> errorHandler;
 
     std::optional<IndexBuilder> localIndexBuilder;
+    DuplicatePKSkipResult duplicatePKSkipResult;
 
     std::shared_ptr<common::DataChunkState> columnState;
     std::vector<common::ValueVector*> columnVectors;

--- a/src/include/processor/operator/persistent/node_batch_insert_error_handler.h
+++ b/src/include/processor/operator/persistent/node_batch_insert_error_handler.h
@@ -11,11 +11,24 @@ class NodeTable;
 }
 
 namespace processor {
+enum class NodeCopyErrorKind : uint8_t {
+    DUPLICATE_PK,
+    NULL_PK,
+    OTHER,
+};
+
+struct DuplicatePKSkipResult {
+    common::row_idx_t skippedCount = 0;
+    std::vector<std::string> pks;
+    std::mutex mtx;
+};
+
 template<typename T>
 struct IndexBuilderError {
     std::string message;
     T key;
     common::nodeID_t nodeID;
+    NodeCopyErrorKind kind = NodeCopyErrorKind::OTHER;
 
     // CSV Reader data
     std::optional<WarningSourceData> warningData;
@@ -25,10 +38,17 @@ class NodeBatchInsertErrorHandler {
 public:
     NodeBatchInsertErrorHandler(ExecutionContext* context, common::LogicalTypeID pkType,
         storage::NodeTable* nodeTable, bool ignoreErrors,
-        std::shared_ptr<common::row_idx_t> sharedErrorCounter, std::mutex* sharedErrorCounterMtx);
+        std::shared_ptr<common::row_idx_t> sharedErrorCounter, std::mutex* sharedErrorCounterMtx,
+        bool skipDuplicatePK, DuplicatePKSkipResult* duplicatePKSkipResult);
 
     template<typename T>
     void handleError(IndexBuilderError<T> error) {
+        if (error.kind == NodeCopyErrorKind::DUPLICATE_PK && skipDuplicatePK) {
+            recordSkippedDuplicatePK(error.key);
+            setCurrentErroneousRow(error.key, error.nodeID);
+            deleteCurrentErroneousRow();
+            return;
+        }
         baseErrorHandler.handleError(std::move(error.message), std::move(error.warningData));
 
         setCurrentErroneousRow(error.key, error.nodeID);
@@ -38,6 +58,20 @@ public:
     void flushStoredErrors();
 
 private:
+    template<typename T>
+    void recordSkippedDuplicatePK(const T& key) {
+        duplicatePKSkipResult->skippedCount++;
+        std::string keyStr;
+        if constexpr (std::same_as<T, std::string>) {
+            keyStr = key;
+        } else if constexpr (std::same_as<T, common::string_t>) {
+            keyStr = std::string{key.getAsString()};
+        } else {
+            keyStr = common::TypeUtils::toString(key);
+        }
+        duplicatePKSkipResult->pks.push_back(std::move(keyStr));
+    }
+
     template<typename T>
     void setCurrentErroneousRow(const T& key, common::nodeID_t nodeID) {
         keyVector->setValue<T>(0, key);
@@ -54,6 +88,8 @@ private:
     // vectors that are reused by each deletion
     std::shared_ptr<common::ValueVector> keyVector;
     std::shared_ptr<common::ValueVector> offsetVector;
+    bool skipDuplicatePK;
+    DuplicatePKSkipResult* duplicatePKSkipResult;
 
     BatchInsertErrorHandler baseErrorHandler;
 };

--- a/src/include/processor/result/factorized_table_util.h
+++ b/src/include/processor/result/factorized_table_util.h
@@ -19,10 +19,14 @@ public:
     // last operator in the pipeline must be resultCollector.
     static void appendStringToTable(FactorizedTable* factorizedTable, const std::string& outputMsg,
         storage::MemoryManager* memoryManager);
+    static void appendNodeCopyResultToTable(FactorizedTable* factorizedTable,
+        const std::string& outputMsg, int64_t skippedDuplicatePKCount,
+        const std::vector<std::string>& skippedDuplicatePKs, storage::MemoryManager* memoryManager);
     static std::shared_ptr<FactorizedTable> getFactorizedTableForOutputMsg(
         const std::string& outputMsg, storage::MemoryManager* memoryManager);
     static LBUG_API std::shared_ptr<FactorizedTable> getSingleStringColumnFTable(
         storage::MemoryManager* mm);
+    static std::shared_ptr<FactorizedTable> getNodeCopyResultFTable(storage::MemoryManager* mm);
 };
 
 } // namespace processor

--- a/src/main/client_context.cpp
+++ b/src/main/client_context.cpp
@@ -525,6 +525,8 @@ ClientContext::PrepareResult ClientContext::prepareNoLock(
                 preparedStatement->unknownParameters = expressionBinder->getUnknownParameters();
                 preparedStatement->parameterMap = expressionBinder->getKnownParameters();
                 cachedStatement->columns = boundStatement->getStatementResult()->getColumns();
+                cachedStatement->columnNames =
+                    boundStatement->getStatementResult()->getColumnNames();
                 auto planner = Planner(this);
                 auto bestPlan = planner.planStatement(*boundStatement);
                 optimizer::Optimizer::optimize(&bestPlan, this, planner.getCardinalityEstimator());

--- a/src/main/prepared_statement.cpp
+++ b/src/main/prepared_statement.cpp
@@ -15,6 +15,9 @@ CachedPreparedStatement::CachedPreparedStatement() = default;
 CachedPreparedStatement::~CachedPreparedStatement() = default;
 
 std::vector<std::string> CachedPreparedStatement::getColumnNames() const {
+    if (!columnNames.empty()) {
+        return columnNames;
+    }
     std::vector<std::string> names;
     for (auto& column : columns) {
         names.push_back(column->toString());

--- a/src/processor/map/map_copy_from.cpp
+++ b/src/processor/map/map_copy_from.cpp
@@ -48,9 +48,12 @@ std::unique_ptr<PhysicalOperator> PlanMapper::mapCopyNodeFrom(
     const auto outFSchema = copyFrom.getSchema();
     auto prevOperator = mapOperator(copyFrom.getChild(0).get());
     auto fTable =
-        FactorizedTableUtils::getSingleStringColumnFTable(MemoryManager::Get(*clientContext));
+        copyFromInfo->getSkipDuplicatePKOption() ?
+            FactorizedTableUtils::getNodeCopyResultFTable(MemoryManager::Get(*clientContext)) :
+            FactorizedTableUtils::getSingleStringColumnFTable(MemoryManager::Get(*clientContext));
 
     auto sharedState = std::make_shared<NodeBatchInsertSharedState>(fTable);
+    sharedState->skipDuplicatePK = copyFromInfo->getSkipDuplicatePKOption();
     if (prevOperator->getOperatorType() == PhysicalOperatorType::TABLE_FUNCTION_CALL) {
         const auto call = prevOperator->ptrCast<TableFunctionCall>();
         sharedState->tableFuncSharedState = call->getSharedState().get();
@@ -66,7 +69,7 @@ std::unique_ptr<PhysicalOperator> PlanMapper::mapCopyNodeFrom(
     }
     auto info = std::make_unique<NodeBatchInsertInfo>(copyFromInfo->tableName,
         std::move(warningColumnTypes), std::move(columnEvaluators),
-        copyFromInfo->columnEvaluateTypes);
+        copyFromInfo->columnEvaluateTypes, copyFromInfo->getSkipDuplicatePKOption());
     auto printInfo = std::make_unique<NodeBatchInsertPrintInfo>(copyFromInfo->tableName);
     auto batchInsert = std::make_unique<NodeBatchInsert>(std::move(info), std::move(sharedState),
         std::move(prevOperator), getOperatorID(), std::move(printInfo));

--- a/src/processor/operator/persistent/index_builder.cpp
+++ b/src/processor/operator/persistent/index_builder.cpp
@@ -90,6 +90,7 @@ void IndexBuilderGlobalQueues::maybeConsumeIndex(size_t index,
                                         erroneousEntry.second,
                                         nodeTable->getTableID(),
                                     },
+                                .kind = NodeCopyErrorKind::DUPLICATE_PK,
                                 .warningData = erroneousEntryWarningData});
                         insertBufferOffset += 1; // skip the erroneous index then continue
                     }
@@ -200,6 +201,7 @@ bool IndexBuilder::checkNonNullConstraint(const ColumnChunkData& chunk,
                     .key = {},
                     .nodeID =
                         nodeID_t{nodeOffset + chunkOffset, sharedState->nodeTable->getTableID()},
+                    .kind = NodeCopyErrorKind::NULL_PK,
                     .warningData = getWarningDataFromChunks(warningData, chunkOffset)});
             });
         return false;

--- a/src/processor/operator/persistent/node_batch_insert.cpp
+++ b/src/processor/operator/persistent/node_batch_insert.cpp
@@ -110,6 +110,11 @@ void NodeBatchInsertSharedState::initPKIndex(const ExecutionContext* context) {
     auto* pkIndex = nodeTable->tryGetPKIndex();
     if (!pkIndex) {
         if (nodeTable->tryGetPrimaryKeyIndex() != nullptr) {
+            if (skipDuplicatePK) {
+                throw RuntimeException(
+                    "SKIP_DUPLICATE_PK is only supported for node tables with a primary-key "
+                    "hash index.");
+            }
             globalIndexBuilder.reset();
             noIndexPKValidator.reset();
             usePrimaryKeyIndexCommitInsert = true;
@@ -119,6 +124,11 @@ void NodeBatchInsertSharedState::initPKIndex(const ExecutionContext* context) {
             throw RuntimeException(
                 "COPY into a non-empty primary-key node table without a hash index is not "
                 "supported.");
+        }
+        if (skipDuplicatePK) {
+            throw RuntimeException(
+                "SKIP_DUPLICATE_PK is only supported for node tables with a primary-key hash "
+                "index.");
         }
         globalIndexBuilder.reset();
         noIndexPKValidator = createNoIndexPKValidator(pkType);
@@ -197,6 +207,8 @@ void NodeBatchInsert::executeInternal(ExecutionContext* context) {
     const auto clientContext = context->clientContext;
     std::optional<ProducerToken> token;
     auto nodeLocalState = localState->ptrCast<NodeBatchInsertLocalState>();
+    const auto nodeSharedState =
+        dynamic_cast_checked<NodeBatchInsertSharedState*>(sharedState.get());
     if (nodeLocalState->localIndexBuilder) {
         token = nodeLocalState->localIndexBuilder->getProducerToken();
     }
@@ -222,6 +234,16 @@ void NodeBatchInsert::executeInternal(ExecutionContext* context) {
         nodeLocalState->errorHandler->flushStoredErrors();
     }
     const auto nodeInfo = info->ptrCast<NodeBatchInsertInfo>();
+    if (nodeInfo->skipDuplicatePK) {
+        std::lock_guard lck{nodeSharedState->duplicatePKSkipResult->mtx};
+        nodeSharedState->duplicatePKSkipResult->skippedCount +=
+            nodeLocalState->duplicatePKSkipResult.skippedCount;
+        nodeSharedState->duplicatePKSkipResult->pks.insert(
+            nodeSharedState->duplicatePKSkipResult->pks.end(),
+            std::make_move_iterator(nodeLocalState->duplicatePKSkipResult.pks.begin()),
+            std::make_move_iterator(nodeLocalState->duplicatePKSkipResult.pks.end()));
+        nodeLocalState->duplicatePKSkipResult.pks.clear();
+    }
     sharedState->table->cast<NodeTable>().mergeStats(nodeInfo->insertColumnIDs,
         nodeLocalState->stats);
 }
@@ -266,9 +288,17 @@ NodeBatchInsertErrorHandler NodeBatchInsert::createErrorHandler(ExecutionContext
     const auto nodeSharedState =
         dynamic_cast_checked<NodeBatchInsertSharedState*>(sharedState.get());
     auto* nodeTable = dynamic_cast_checked<NodeTable*>(sharedState->table);
+    const auto* nodeInfo = info->ptrCast<NodeBatchInsertInfo>();
+    auto* duplicatePKSkipResult = nodeSharedState->duplicatePKSkipResult.get();
+    if (localState != nullptr) {
+        const auto nodeLocalState =
+            dynamic_cast_checked<NodeBatchInsertLocalState*>(localState.get());
+        duplicatePKSkipResult = &nodeLocalState->duplicatePKSkipResult;
+    }
     return NodeBatchInsertErrorHandler{context, nodeSharedState->pkType.getLogicalTypeID(),
         nodeTable, WarningContext::Get(*context->clientContext)->getIgnoreErrorsOption(),
-        sharedState->numErroredRows, &sharedState->erroredRowMutex};
+        sharedState->numErroredRows, &sharedState->erroredRowMutex, nodeInfo->skipDuplicatePK,
+        duplicatePKSkipResult};
 }
 
 static void commitPrimaryKeyIndexInsertions(Transaction* transaction, NodeTable& nodeTable,
@@ -421,11 +451,33 @@ void NodeBatchInsert::finalize(ExecutionContext* context) {
 }
 
 void NodeBatchInsert::finalizeInternal(ExecutionContext* context) {
-    auto outputMsg = std::format("{} tuples have been copied to the {} table.",
-        sharedState->getNumRows() - sharedState->getNumErroredRows(), info->tableName);
     auto clientContext = context->clientContext;
-    FactorizedTableUtils::appendStringToTable(sharedState->fTable.get(), outputMsg,
-        MemoryManager::Get(*clientContext));
+    const auto* nodeInfo = info->ptrCast<NodeBatchInsertInfo>();
+    const auto* nodeSharedState =
+        dynamic_cast_checked<NodeBatchInsertSharedState*>(sharedState.get());
+    if (nodeInfo->skipDuplicatePK) {
+        std::lock_guard lck{nodeSharedState->duplicatePKSkipResult->mtx};
+        // Duplicate-PK rows are counted in getNumRows() because they are appended before index
+        // validation, but they do not contribute to getNumErroredRows() because they bypass the
+        // generic warning/error path. We subtract skippedCount here to convert the appended-row
+        // count into the final copied-row count. This relies on duplicate-row deletion not
+        // decrementing numRows and on the duplicate skip path not incrementing numErroredRows.
+        DASSERT(
+            sharedState->getNumRows() >= sharedState->getNumErroredRows() +
+                                             nodeSharedState->duplicatePKSkipResult->skippedCount);
+        auto outputMsg = std::format("{} tuples have been copied to the {} table.",
+            sharedState->getNumRows() - sharedState->getNumErroredRows() -
+                nodeSharedState->duplicatePKSkipResult->skippedCount,
+            info->tableName);
+        FactorizedTableUtils::appendNodeCopyResultToTable(sharedState->fTable.get(), outputMsg,
+            nodeSharedState->duplicatePKSkipResult->skippedCount,
+            nodeSharedState->duplicatePKSkipResult->pks, MemoryManager::Get(*clientContext));
+    } else {
+        auto outputMsg = std::format("{} tuples have been copied to the {} table.",
+            sharedState->getNumRows() - sharedState->getNumErroredRows(), info->tableName);
+        FactorizedTableUtils::appendStringToTable(sharedState->fTable.get(), outputMsg,
+            MemoryManager::Get(*clientContext));
+    }
 
     const auto warningCount =
         WarningContext::Get(*clientContext)->getWarningCount(context->queryID);
@@ -434,8 +486,14 @@ void NodeBatchInsert::finalizeInternal(ExecutionContext* context) {
             std::format("{} warnings encountered during copy. Use 'CALL "
                         "show_warnings() RETURN *' to view the actual warnings. Query ID: {}",
                 warningCount, context->queryID);
-        FactorizedTableUtils::appendStringToTable(sharedState->fTable.get(), warningMsg,
-            MemoryManager::Get(*clientContext));
+        if (nodeInfo->skipDuplicatePK) {
+            FactorizedTableUtils::appendNodeCopyResultToTable(sharedState->fTable.get(), warningMsg,
+                0 /* skippedDuplicatePKCount */, {} /* skippedDuplicatePKs */,
+                MemoryManager::Get(*clientContext));
+        } else {
+            FactorizedTableUtils::appendStringToTable(sharedState->fTable.get(), warningMsg,
+                MemoryManager::Get(*clientContext));
+        }
     }
 }
 

--- a/src/processor/operator/persistent/node_batch_insert_error_handler.cpp
+++ b/src/processor/operator/persistent/node_batch_insert_error_handler.cpp
@@ -10,12 +10,14 @@ namespace processor {
 
 NodeBatchInsertErrorHandler::NodeBatchInsertErrorHandler(ExecutionContext* context,
     LogicalTypeID pkType, storage::NodeTable* nodeTable, bool ignoreErrors,
-    std::shared_ptr<row_idx_t> sharedErrorCounter, std::mutex* sharedErrorCounterMtx)
+    std::shared_ptr<row_idx_t> sharedErrorCounter, std::mutex* sharedErrorCounterMtx,
+    bool skipDuplicatePK, DuplicatePKSkipResult* duplicatePKSkipResult)
     : nodeTable(nodeTable), context(context),
       keyVector(std::make_shared<ValueVector>(pkType,
           storage::MemoryManager::Get(*context->clientContext))),
       offsetVector(std::make_shared<ValueVector>(LogicalTypeID::INTERNAL_ID,
           storage::MemoryManager::Get(*context->clientContext))),
+      skipDuplicatePK{skipDuplicatePK}, duplicatePKSkipResult{duplicatePKSkipResult},
       baseErrorHandler(context, ignoreErrors, sharedErrorCounter, sharedErrorCounterMtx) {
     keyVector->state = DataChunkState::getSingleValueDataChunkState();
     offsetVector->state = DataChunkState::getSingleValueDataChunkState();

--- a/src/processor/operator/persistent/reader/parquet/parquet_reader.cpp
+++ b/src/processor/operator/persistent/reader/parquet/parquet_reader.cpp
@@ -695,9 +695,14 @@ static std::unique_ptr<TableFuncBindData> bindFunc(main::ClientContext* context,
     const TableFuncBindInput* input) {
     auto scanInput = dynamic_cast_checked<ExtraScanTableFuncBindInput*>(input->extraInput.get());
     const auto& options = scanInput->fileScanInfo.options;
-    if (options.size() > 1 ||
-        (options.size() == 1 && !options.contains(CopyConstants::IGNORE_ERRORS_OPTION_NAME))) {
-        throw BinderException{"Copy from Parquet cannot have options other than IGNORE_ERRORS."};
+    if (options.size() > 2 ||
+        (options.size() == 1 && !options.contains(CopyConstants::IGNORE_ERRORS_OPTION_NAME) &&
+            !options.contains(CopyConstants::SKIP_DUPLICATE_PK_OPTION_NAME)) ||
+        (options.size() == 2 &&
+            (!options.contains(CopyConstants::IGNORE_ERRORS_OPTION_NAME) ||
+                !options.contains(CopyConstants::SKIP_DUPLICATE_PK_OPTION_NAME)))) {
+        throw BinderException{"Copy from Parquet cannot have options other than IGNORE_ERRORS and "
+                              "SKIP_DUPLICATE_PK."};
     }
     std::vector<std::string> detectedColumnNames;
     std::vector<LogicalType> detectedColumnTypes;

--- a/src/processor/result/factorized_table_util.cpp
+++ b/src/processor/result/factorized_table_util.cpp
@@ -51,6 +51,37 @@ void FactorizedTableUtils::appendStringToTable(FactorizedTable* factorizedTable,
     factorizedTable->append(std::vector<ValueVector*>{outputMsgVector.get()});
 }
 
+void FactorizedTableUtils::appendNodeCopyResultToTable(FactorizedTable* factorizedTable,
+    const std::string& outputMsg, int64_t skippedDuplicatePKCount,
+    const std::vector<std::string>& skippedDuplicatePKs, MemoryManager* memoryManager) {
+    auto outputMsgVector = std::make_shared<ValueVector>(LogicalTypeID::STRING, memoryManager);
+    auto skippedCountVector = std::make_shared<ValueVector>(LogicalTypeID::INT64, memoryManager);
+    auto skippedPKVector =
+        std::make_shared<ValueVector>(LogicalType::LIST(LogicalType::STRING()), memoryManager);
+
+    outputMsgVector->state = DataChunkState::getSingleValueDataChunkState();
+    skippedCountVector->state = DataChunkState::getSingleValueDataChunkState();
+    skippedPKVector->state = DataChunkState::getSingleValueDataChunkState();
+
+    auto outputStr = string_t();
+    outputStr.overflowPtr =
+        reinterpret_cast<uint64_t>(StringVector::getInMemOverflowBuffer(outputMsgVector.get())
+                                       ->allocateSpace(outputMsg.length()));
+    outputStr.set(outputMsg);
+    outputMsgVector->setValue(0, outputStr);
+    skippedCountVector->setValue<int64_t>(0, skippedDuplicatePKCount);
+
+    auto listEntry = ListVector::addList(skippedPKVector.get(), skippedDuplicatePKs.size());
+    skippedPKVector->setValue<list_entry_t>(0, listEntry);
+    auto dataVector = ListVector::getDataVector(skippedPKVector.get());
+    for (auto i = 0u; i < skippedDuplicatePKs.size(); ++i) {
+        dataVector->setValue<std::string>(listEntry.offset + i, skippedDuplicatePKs[i]);
+    }
+
+    factorizedTable->append(std::vector<ValueVector*>{outputMsgVector.get(),
+        skippedCountVector.get(), skippedPKVector.get()});
+}
+
 std::shared_ptr<FactorizedTable> FactorizedTableUtils::getFactorizedTableForOutputMsg(
     const std::string& outputMsg, MemoryManager* memoryManager) {
     auto table = getSingleStringColumnFTable(memoryManager);
@@ -62,6 +93,15 @@ std::shared_ptr<FactorizedTable> FactorizedTableUtils::getSingleStringColumnFTab
     MemoryManager* mm) {
     std::vector<LogicalType> typeVec;
     typeVec.push_back(LogicalType::STRING());
+    auto fTableSchema = createFlatTableSchema(std::move(typeVec));
+    return std::make_shared<FactorizedTable>(mm, std::move(fTableSchema));
+}
+
+std::shared_ptr<FactorizedTable> FactorizedTableUtils::getNodeCopyResultFTable(MemoryManager* mm) {
+    std::vector<LogicalType> typeVec;
+    typeVec.push_back(LogicalType::STRING());
+    typeVec.push_back(LogicalType::INT64());
+    typeVec.push_back(LogicalType::LIST(LogicalType::STRING()));
     auto fTableSchema = createFlatTableSchema(std::move(typeVec));
     return std::make_shared<FactorizedTable>(mm, std::move(fTableSchema));
 }

--- a/test/api/api_test.cpp
+++ b/test/api/api_test.cpp
@@ -200,6 +200,25 @@ TEST_F(ApiTest, SingleQueryHasNextQueryResult) {
     ASSERT_FALSE(result->hasNextQueryResult());
 }
 
+TEST_F(ApiTest, CopySkipDuplicatePKPreservesResultColumnNames) {
+    ASSERT_TRUE(conn->query("CREATE NODE TABLE copy_user(ID STRING, name STRING, PRIMARY KEY(ID));")
+                    ->isSuccess());
+    auto result = conn->query(std::format("COPY copy_user FROM \"{}\" (SKIP_DUPLICATE_PK=true);",
+        TestHelper::appendLbugRootPath("dataset/copy-fault-tests/duplicate-ids/vOrg.csv")));
+    ASSERT_TRUE(result->isSuccess());
+
+    const auto columnNames = result->getColumnNames();
+    ASSERT_EQ(columnNames.size(), 3);
+    EXPECT_EQ(columnNames[0], "result");
+    EXPECT_EQ(columnNames[1], "skipped_duplicate_pk_count");
+    EXPECT_EQ(columnNames[2], "skipped_duplicate_pks");
+
+    ASSERT_TRUE(result->hasNext());
+    auto tuple = result->getNext();
+    EXPECT_EQ(tuple->getValue(1)->getValue<int64_t>(), 1);
+    EXPECT_EQ(tuple->getValue(2)->toString(), "[10]");
+}
+
 TEST_F(ApiTest, Prepare) {
     auto result = conn->prepare("");
     ASSERT_EQ(result->getErrorMessage(), "Connection exception: Query is empty.");

--- a/test/test_files/copy/copy_node_parquet.test
+++ b/test/test_files/copy/copy_node_parquet.test
@@ -57,7 +57,7 @@
 -LOG CopyWithOptionsErrorTest
 -STATEMENT COPY tableOfTypes FROM "${LBUG_ROOT_DIRECTORY}/dataset/copy-test/node/parquet/types_50k*.parquet" (HEADER=true);
 ---- error
-Binder exception: Copy from Parquet cannot have options other than IGNORE_ERRORS.
+Binder exception: Copy from Parquet cannot have options other than IGNORE_ERRORS and SKIP_DUPLICATE_PK.
 
 -CASE IgnoreErrorsTest
 -STATEMENT COPY person FROM "${LBUG_ROOT_DIRECTORY}/dataset/copy-test/node/parquet/invalid_pk_col.parquet" (IGNORE_ERRORS=true);
@@ -73,3 +73,8 @@ Found duplicated primary key value 2, which violates the uniqueness constraint o
 3
 4
 5
+
+-CASE SkipDuplicatePKStillErrorsOnNullPKTest
+-STATEMENT COPY person FROM "${LBUG_ROOT_DIRECTORY}/dataset/copy-test/node/parquet/invalid_pk_col.parquet" (SKIP_DUPLICATE_PK=true);
+---- error
+Copy exception: Found NULL, which violates the non-null constraint of the primary key column.

--- a/test/test_files/exceptions/copy/duplicated.test
+++ b/test/test_files/exceptions/copy/duplicated.test
@@ -109,3 +109,89 @@ Found duplicated primary key value 10, which violates the uniqueness constraint 
 -STATEMENT CALL show_warnings() RETURN message, file_path, skipped_line_or_record, line_number
 ---- 1
 Found duplicated primary key value 10, which violates the uniqueness constraint of the primary key column.|${LBUG_ROOT_DIRECTORY}/dataset/copy-fault-tests/duplicate-ids/vOrg.csv|10,Ziyi|4
+
+-CASE DuplicateIntIDsSkipDuplicatePK
+-STATEMENT COPY person FROM "${LBUG_ROOT_DIRECTORY}/dataset/copy-fault-tests/duplicate-ids/vPerson.csv"(SKIP_DUPLICATE_PK=true)
+---- 1
+3 tuples have been copied to the person table.|1|[10]
+-STATEMENT MATCH (p:person) RETURN p.*
+---- 3
+10|Guodong
+24|Semih
+31|Xiyang
+-STATEMENT CALL show_warnings() RETURN COUNT(*)
+---- 1
+0
+
+-CASE ManyDuplicateIntIDsSkipDuplicatePK
+-STATEMENT COPY person FROM "${LBUG_ROOT_DIRECTORY}/dataset/copy-fault-tests/duplicate-ids/vPersonManyDuplicates.csv"(SKIP_DUPLICATE_PK=true, PARALLEL=false)
+---- 1
+2 tuples have been copied to the person table.|28|[10,10,10,10,10,10,10,10,10,10,10,10,10,10,10,10,10,10,10,10,10,10,10,10,10,10,10,10]
+-STATEMENT MATCH (p:person) RETURN p.*
+---- 2
+10|a
+11|aa
+-STATEMENT CALL show_warnings() RETURN COUNT(*)
+---- 1
+0
+
+-CASE DuplicateStringIDsSkipDuplicatePK
+-STATEMENT COPY org FROM "${LBUG_ROOT_DIRECTORY}/dataset/copy-fault-tests/duplicate-ids/vOrg.csv"(SKIP_DUPLICATE_PK=true)
+---- 1
+3 tuples have been copied to the org table.|1|[10]
+-STATEMENT MATCH (o:org) RETURN o.*
+---- 3
+10|Guodong
+24|Semih
+31|Xiyang
+-STATEMENT CALL show_warnings() RETURN COUNT(*)
+---- 1
+0
+
+-CASE DuplicateAgainstExistingRowsSkipDuplicatePK
+-STATEMENT CREATE NODE TABLE seeded(ID INT64, name STRING, PRIMARY KEY(ID))
+---- ok
+-STATEMENT CREATE (p:seeded {ID: 10, name: 'seed'})
+---- ok
+-STATEMENT COPY seeded FROM "${LBUG_ROOT_DIRECTORY}/dataset/copy-fault-tests/duplicate-ids/vPerson.csv"(SKIP_DUPLICATE_PK=true)
+---- 1
+2 tuples have been copied to the seeded table.|2|[10,10]
+-STATEMENT MATCH (p:seeded) RETURN p.ID, p.name ORDER BY p.ID, p.name
+---- 3
+10|seed
+24|Semih
+31|Xiyang
+-STATEMENT CALL show_warnings() RETURN COUNT(*)
+---- 1
+0
+
+-CASE MultiFileDuplicateIntIDsSkipDuplicatePK
+-STATEMENT COPY person FROM ["${LBUG_ROOT_DIRECTORY}/dataset/copy-fault-tests/duplicate-ids/vPerson.csv", "${LBUG_ROOT_DIRECTORY}/dataset/copy-fault-tests/duplicate-ids/vPersonManyDuplicates.csv"](SKIP_DUPLICATE_PK=true, PARALLEL=false)
+---- 1
+4 tuples have been copied to the person table.|30|[10,10,10,10,10,10,10,10,10,10,10,10,10,10,10,10,10,10,10,10,10,10,10,10,10,10,10,10,10,10]
+-STATEMENT MATCH (p:person) RETURN p.ID
+---- 4
+10
+24
+31
+11
+-STATEMENT CALL show_warnings() RETURN COUNT(*)
+---- 1
+0
+
+-CASE SkipDuplicatePKCannotCombineIgnoreErrors
+-STATEMENT COPY person FROM "${LBUG_ROOT_DIRECTORY}/dataset/copy-fault-tests/duplicate-ids/vPerson.csv"(IGNORE_ERRORS=true, SKIP_DUPLICATE_PK=true)
+---- error
+Binder exception: SKIP_DUPLICATE_PK cannot be used together with IGNORE_ERRORS.
+
+-CASE SkipDuplicatePKNotSupportedForRelCopy
+-STATEMENT CREATE REL TABLE likes(FROM person TO person, date DATE, MANY_MANY)
+---- ok
+-STATEMENT COPY likes FROM "${LBUG_ROOT_DIRECTORY}/dataset/tinysnb/eLikes.csv"(SKIP_DUPLICATE_PK=true)
+---- error
+Binder exception: SKIP_DUPLICATE_PK is only supported for COPY FROM files into node tables.
+
+-CASE SkipDuplicatePKNotSupportedForSubqueryCopy
+-STATEMENT COPY person FROM (UNWIND [10, 10, 24] AS id RETURN id, 'x' AS fName) (SKIP_DUPLICATE_PK=true)
+---- error
+Binder exception: SKIP_DUPLICATE_PK is only supported for COPY FROM files into node tables.


### PR DESCRIPTION
# COPY FROM `SKIP_DUPLICATE_PK` Requirements

## 1. Background

Ladybug currently supports `COPY FROM` into node tables with primary-key validation. When duplicate primary keys are encountered:

- with `IGNORE_ERRORS=false`, the query fails
- with `IGNORE_ERRORS=true`, the query continues and the duplicated rows are skipped

The existing `IGNORE_ERRORS=true` behavior is already close to the desired outcome, but it has two practical limitations for repeated-PK-heavy imports:

1. duplicate-PK details are written into the warning pipeline and become visible through `CALL show_warnings() RETURN *`
2. large warning volumes can increase session memory usage unnecessarily when the caller only needs the conflicting PK values

This proposal introduces a focused option for file-based `COPY FROM`:

```cypher
SKIP_DUPLICATE_PK=true
```

The new option should behave similarly to `IGNORE_ERRORS=true` for file imports, but with a special treatment for duplicate primary-key conflicts:

- duplicated PK rows are skipped and import continues
- duplicate-PK details are not written into the warning system
- duplicate PK values are returned directly in the `COPY` result
- all other errors continue to follow the existing behavior

## 2. Goal

Add `SKIP_DUPLICATE_PK=true` for `COPY FROM` on CSV and Parquet files targeting node tables, so that:

- duplicate PK rows do not abort the import
- duplicate PK rows are skipped
- duplicate PK values are returned in a structured result
- duplicate PK details do not enter `WarningContext`
- non-duplicate-PK behavior remains aligned with existing file-import behavior

## 3. Non-Goals

This work does not include:

- `COPY FROM` subquery support
- relationship-table `COPY`
- changing `CALL show_warnings()` behavior
- changing generic `IGNORE_ERRORS` semantics
- changing `INSERT`, `MERGE`, or non-`COPY` write paths
- introducing new dedicated Python API methods
- first-phase support for no-index PK validation paths

## 4. Scope

Included:

- `COPY <node_table> FROM "<file>.csv" (SKIP_DUPLICATE_PK=true)`
- `COPY <node_table> FROM "<file>.parquet" (SKIP_DUPLICATE_PK=true)`
- multi-file CSV / Parquet imports
- imports into node tables with primary-key hash-index support

Excluded:

- `COPY <node_table> FROM (<subquery>)`
- `COPY <rel_table> ...`
- `COPY FROM npy`
- node tables without a usable primary-key hash-index path for duplicate skip

## 5. Syntax

New option:

```cypher
SKIP_DUPLICATE_PK=true
```

Examples:

```cypher
COPY User FROM "user.csv" (SKIP_DUPLICATE_PK=true);
COPY User FROM "user.parquet" (SKIP_DUPLICATE_PK=true);
COPY User FROM ["a.csv", "b.csv"] (SKIP_DUPLICATE_PK=true);
```

## 6. Semantics

## 6.1 Default Behavior

If `SKIP_DUPLICATE_PK` is not specified, existing behavior remains unchanged.

## 6.2 Behavior When Enabled

When `SKIP_DUPLICATE_PK=true` is specified for file-based node copy:

- if a row conflicts with an already existing PK in the target table:
  - skip the row
  - continue import
  - record the conflicting PK value for the final result
  - do not write the duplicate-PK detail into warnings

- if a row conflicts with an earlier row from the same `COPY` execution:
  - keep the first successful row
  - skip the later conflicting row
  - record the conflicting PK value for the final result
  - do not write the duplicate-PK detail into warnings

- if the error is not a duplicate-PK conflict:
  - follow the existing flow
  - do not convert the new option into a generic "ignore everything" mode

## 6.3 Interaction With Other Errors

The intent is:

- duplicate PK gets special handling
- everything else remains on the existing path

In particular:

- `NULL PK` remains on the existing path
- CSV parsing errors remain on the existing path
- Parquet schema / decode errors remain on the existing path
- cast / conversion errors remain on the existing path

That means the new option is not a replacement for all current error handling. It is a focused extension on top of current file-copy behavior, specifically for duplicated primary keys.

## 6.4 Warning Behavior

When `SKIP_DUPLICATE_PK=true`:

- duplicate-PK conflicts must not be appended to `WarningContext`
- duplicate-PK conflicts must not appear in:

```cypher
CALL show_warnings() RETURN *;
```

All non-duplicate-PK warnings remain unchanged and continue to use the existing warning pipeline.

## 7. Result Contract

For compatibility:

- if `SKIP_DUPLICATE_PK` is not enabled, `COPY` keeps the existing single-string result schema
- if `SKIP_DUPLICATE_PK=true`, `COPY` returns an extended schema

Recommended extended schema:

- `result: STRING`
- `skipped_duplicate_pk_count: INT64`
- `skipped_duplicate_pks: STRING[]`

Example:

| result | skipped_duplicate_pk_count | skipped_duplicate_pks |
| --- | ---: | --- |
| `997 tuples have been copied to the User table.` | 3 | `["u01","u15","u99"]` |

Notes:

- PK values should be returned as strings regardless of physical PK type
- returning a fixed `STRING[]` is preferred for Python API usability

## 8. Python API Expectations

No dedicated Python API change is required if the result is exposed as a normal query result set.

Expected usage:

```python
res = conn.execute("COPY User FROM 'user.csv' (SKIP_DUPLICATE_PK=true)")
row = res.get_next()
row["skipped_duplicate_pks"]
```

Implication:

- existing client code that assumes `COPY` always returns exactly one string column may need to handle the extended schema when the new option is enabled
- client code that reads by column name should remain straightforward

## 9. Compatibility Requirements

- disabled by default
- no change to existing `IGNORE_ERRORS` behavior when the new option is absent
- no change to `COPY FROM` subquery behavior, because subquery support is out of scope
- no change to rel-table copy semantics
- no change to `show_warnings()` contract

## 10. Validation Requirements

The feature should be considered complete when all of the following are true:

1. CSV node copy with duplicated PKs can continue with `SKIP_DUPLICATE_PK=true`
2. Parquet node copy with duplicated PKs can continue with `SKIP_DUPLICATE_PK=true`
3. duplicate PK values are returned in the final result
4. duplicate PK values do not appear in `show_warnings()`
5. non-duplicate errors still follow the existing path
6. subquery copy does not accept the new option
7. rel copy does not accept the new option

## 11. Current Test Coverage

Covered by current tests:

- CSV duplicate PK skip for integer PKs
- CSV duplicate PK skip for string PKs
- repeated duplicate PK values returned in result
- duplicate conflicts against already existing rows
- warning suppression for duplicate PKs
- rel copy rejection
- subquery copy rejection
- Parquet option validation
- Parquet `NULL PK` still failing on the existing path

Recommended future additions:

- multi-file `SKIP_DUPLICATE_PK=true` result verification
- an explicit test for stable result column names in CLI / query-result metadata
