### PR TITLE
stats: fix cardinality estimation bug

### DIFF
--- a/src/storage/stats/column_stats.cpp
+++ b/src/storage/stats/column_stats.cpp
@@ -16,12 +16,18 @@ void ColumnStats::update(const common::ValueVector* vector) {
         if (!hashes) {
             hashes = std::make_unique<common::ValueVector>(common::LogicalTypeID::UINT64);
         }
+        const auto& selVector = vector->state->getSelVector();
         hashes->state = vector->state;
-        function::VectorHashFunction::computeHash(*vector, vector->state->getSelVector(), *hashes,
+        function::VectorHashFunction::computeHash(*vector, selVector, *hashes,
             hashes->state->getSelVector());
         DASSERT(hashes->hasNoNullsGuarantee());
-        for (auto i = 0u; i < hashes->state->getSelVector().getSelSize(); i++) {
-            hll->insertElement(hashes->getValue<common::hash_t>(i));
+        // computeHash writes each hash at the position selected by the selection vector, so we must
+        // read back using those same selected positions. Iterating flat positions is only correct
+        // when the selection vector is unfiltered (e.g. batch inserts), and would read stale slots
+        // for filtered selections (e.g. one-tuple-at-a-time inserts from UNWIND), collapsing the
+        // distinct-value estimate.
+        for (auto i = 0u; i < selVector.getSelSize(); i++) {
+            hll->insertElement(hashes->getValue<common::hash_t>(selVector[i]));
         }
         hashes->state = nullptr;
         hashes->setAllNonNull();


### PR DESCRIPTION
Honor selection vector so we estimate the same cardinality regardless of inserting 1 row at a time or using `UNWIND`

```
CREATE NODE TABLE stats_node(
    id INT64,
    common INT64,
    rare INT64,
    PRIMARY KEY(id)
);

UNWIND range(0, 19) AS i
CREATE (:stats_node {id: i, common: i % 2, rare: i});

ANALYZE stats_node;

EXPLAIN  LOGICAL
MATCH (n:stats_node)
WHERE n.common = 1 AND n.rare = 7
RETURN n.id;
```

now produces the same query plan as using 20 individual `CREATE` statements.