### PR TITLE
Fix crash on `CAST(... AS MAP(..., JSON))`

### DIFF
--- a/src/function/cast_from_string_functions.cpp
+++ b/src/function/cast_from_string_functions.cpp
@@ -983,6 +983,7 @@ void CastString::copyStringToVector(ValueVector* vector, uint64_t vectorPos,
         CastStringHelper::cast(strVal.data(), strVal.length(), val);
         vector->setValue(vectorPos, val.value);
     } break;
+    case LogicalTypeID::JSON:
     case LogicalTypeID::STRING: {
         if (!utf8proc::Utf8Proc::isValid(strVal.data(), strVal.length())) {
             throw ConversionException{"Invalid UTF8-encoded string."};

--- a/test/test_files/cast/cast_to_nested_types.test
+++ b/test/test_files/cast/cast_to_nested_types.test
@@ -143,6 +143,9 @@ Conversion exception: Map does not allow duplicate keys.
 -STATEMENT RETURN cast("{12=34}", "MAP(UINT8, UINT16)"), cast("{12=}", "MAP(UINT32, UINT64)"), cast("{=43}", "MAP(INT8, INT16)"), cast("{=}", "MAP(INT32, INT64)"), cast("{12=12}", "MAP(float, double)");
 ---- error
 Conversion exception: Map does not allow null as key.
+-STATEMENT RETURN cast('{k={"val":1}}', 'MAP(STRING, JSON)'), cast(null, 'MAP(STRING, JSON)'), cast('{}', 'MAP(STRING, JSON)')
+---- 1
+{k={"val":1}}||{}
 
 -LOG CastToStruct
 -STATEMENT RETURN cast("{ a : { b : {c:[ 3432423 ,-43423 ,31231 ,NULL ]}  } } ", "STRUCT(a STRUCT(b STRUCT(c INT64[])))"), cast("{ a : { b : {c:[]}  } } ", "STRUCT(a STRUCT(b STRUCT(c INT64[])))"), cast("{ a : { b : {c:}  } } ", "STRUCT(a STRUCT(b STRUCT(c INT64[])))"), cast("{ a : { b : {}  } } ", "STRUCT(a STRUCT(b STRUCT(c INT64[])))"), cast("{ a : {} } ", "STRUCT(a STRUCT(b STRUCT(c INT64[])))"), cast("{} ", "STRUCT(a STRUCT(b STRUCT(c INT64[])))");


### PR DESCRIPTION
This PR is the "read" side of https://github.com/LadybugDB/ladybug-python/pull/29.

The following:

```sql
RETURN CAST('{k={"val":1}}' AS MAP(STRING, JSON))
```

Yields:

```
RuntimeError: Assertion failed in file ".../src/function/cast_from_string_functions.cpp"
on line 1050: UNREACHABLE_CODE
```

The problem is in `CastString::copyStringToVector`, which has a missing case for `LogicalTypeID::JSON`. I added that and a test case covering the above and a couple of (somewhat redundant) corner cases.