### PR TITLE
Fix segfault on `label()` of list element

### DIFF
--- a/src/binder/bind_expression/bind_comparison_expression.cpp
+++ b/src/binder/bind_expression/bind_comparison_expression.cpp
@@ -5,6 +5,7 @@
 #include "catalog/catalog.h"
 #include "common/exception/binder.h"
 #include "function/built_in_function_utils.h"
+#include "function/struct/vector_struct_functions.h"
 #include "transaction/transaction.h"
 #include <format>
 
@@ -42,8 +43,19 @@ std::shared_ptr<Expression> ExpressionBinder::bindComparisonExpression(
     DASSERT(children.size() == 2);
     if (isNodeOrRel(*children[0]) && isNodeOrRel(*children[1])) {
         expression_vector newChildren;
-        newChildren.push_back(children[0]->constCast<NodeOrRelExpression>().getInternalID());
-        newChildren.push_back(children[1]->constCast<NodeOrRelExpression>().getInternalID());
+        // For pattern expressions (NODE/REL), use getInternalID() directly
+        // For non-pattern expressions (VARIABLE, FUNCTION, etc.), extract the _ID field
+        for (const auto& child : children) {
+            if (child->expressionType == ExpressionType::PATTERN) {
+                newChildren.push_back(child->constCast<NodeOrRelExpression>().getInternalID());
+            } else {
+                expression_vector extractChildren;
+                extractChildren.push_back(child);
+                extractChildren.push_back(createLiteralExpression(InternalKeyword::ID));
+                newChildren.push_back(
+                    bindScalarFunctionExpression(extractChildren, StructExtractFunctions::name));
+            }
+        }
         return bindComparisonExpression(expressionType, newChildren);
     }
 

--- a/src/function/pattern/label_function.cpp
+++ b/src/function/pattern/label_function.cpp
@@ -88,7 +88,8 @@ std::shared_ptr<Expression> LabelFunction::rewriteFunc(const RewriteFunctionBind
         return expressionBinder->createNullLiteralExpression();
     }
     expression_vector children;
-    if (argument->expressionType == ExpressionType::VARIABLE) {
+    // For non-pattern expressions (VARIABLE, FUNCTION, etc.), extract the _LABEL field
+    if (argument->expressionType != ExpressionType::PATTERN) {
         children.push_back(input.arguments[0]);
         children.push_back(expressionBinder->createLiteralExpression(InternalKeyword::LABEL));
         return expressionBinder->bindScalarFunctionExpression(children,

--- a/test/test_files/function/comparison.test
+++ b/test/test_files/function/comparison.test
@@ -377,3 +377,24 @@ False
 -STATEMENT MATCH (a:person), (b:person) WHERE a.fName = "Alice" AND b.fName = "Bob" RETURN ID(a) >= ID(b);
 ---- 1
 False
+
+-LOG EqualityInPatternExpressions
+-STATEMENT MATCH p = (n)-[:knows]->(m:person {ID: 2}) WITH nodes(p) AS ns RETURN ns[1] = ns[1];
+---- 3
+True
+True
+True
+
+-LOG InequalityInPatternExpressions
+-STATEMENT MATCH p = (n)-[:knows]->(m:person {ID: 2}) WITH nodes(p) AS ns RETURN ns[1] <> ns[2];
+---- 3
+True
+True
+True
+
+-LOG FalseEqualityInPatternExpressions
+-STATEMENT MATCH p = (n)-[:knows]->(m:person {ID: 2}) WITH nodes(p) AS ns RETURN ns[1] = ns[2];
+---- 3
+False
+False
+False

--- a/test/test_files/function/label.test
+++ b/test/test_files/function/label.test
@@ -41,3 +41,9 @@ workAt
 -STATEMENT RETURN labels(null);
 ---- 1
 
+-LOG LabelOnPathNodeExtract
+-STATEMENT MATCH p = (n)-[:knows]->(m:person {ID: 2}) WITH nodes(p) AS ns RETURN label(ns[1]);
+---- 3
+person
+person
+person


### PR DESCRIPTION
This PR fixes this segfault

```sql
import database 'dataset/demo-db/parquet';
MATCH p = (n)-[:LivesIn]->(m:City) WITH nodes(p) AS ns RETURN label(ns[1]);
```

And another one on comparisons like `ns[1] <> ns[0]`.

Here is the original bug report https://github.com/kuzudb/kuzu/issues/6050, addressed in Ryu with https://github.com/predictable-labs/ryugraph/pull/2

Despite the claim in #184 , this was never ported to ladybug, hence this PR.

The problem is incorrect binding of non-pattern exprs in `label()` and in comparisons. I added some new test cases for the latter.

Another two fixes were missing from that PR. I'll prepare separate ones for them
