### PR TITLE
Fix segfault when using ALL() for rel comparison

### DIFF
--- a/src/binder/bind_expression/bind_comparison_expression.cpp
+++ b/src/binder/bind_expression/bind_comparison_expression.cpp
@@ -27,7 +27,14 @@ std::shared_ptr<Expression> ExpressionBinder::bindComparisonExpression(
     return bindComparisonExpression(parsedExpression.getExpressionType(), children);
 }
 
-static bool isNodeOrRel(const Expression& expression) {
+// A node or rel *pattern* expression (e.g. from a MATCH) has an internal ID property and can
+// be rewritten to an internal-ID comparison. A plain variable holding a NODE/REL value (e.g. a
+// lambda variable bound from `relationships(p)`) is a VariableExpression with a NODE/REL logical
+// type but no internal ID, so it must go through the regular value comparison path.
+static bool isNodeOrRelPattern(const Expression& expression) {
+    if (expression.expressionType != ExpressionType::PATTERN) {
+        return false;
+    }
     switch (expression.getDataType().getLogicalTypeID()) {
     case LogicalTypeID::NODE:
     case LogicalTypeID::REL:
@@ -41,20 +48,11 @@ std::shared_ptr<Expression> ExpressionBinder::bindComparisonExpression(
     ExpressionType expressionType, const expression_vector& children) {
     // Rewrite node or rel comparison
     DASSERT(children.size() == 2);
-    if (isNodeOrRel(*children[0]) && isNodeOrRel(*children[1])) {
+    if (isNodeOrRelPattern(*children[0]) && isNodeOrRelPattern(*children[1])) {
         expression_vector newChildren;
-        // For pattern expressions (NODE/REL), use getInternalID() directly
-        // For non-pattern expressions (VARIABLE, FUNCTION, etc.), extract the _ID field
+        newChildren.reserve(children.size());
         for (const auto& child : children) {
-            if (child->expressionType == ExpressionType::PATTERN) {
-                newChildren.push_back(child->constCast<NodeOrRelExpression>().getInternalID());
-            } else {
-                expression_vector extractChildren;
-                extractChildren.push_back(child);
-                extractChildren.push_back(createLiteralExpression(InternalKeyword::ID));
-                newChildren.push_back(
-                    bindScalarFunctionExpression(extractChildren, StructExtractFunctions::name));
-            }
+            newChildren.push_back(child->constCast<NodeOrRelExpression>().getInternalID());
         }
         return bindComparisonExpression(expressionType, newChildren);
     }

--- a/src/binder/expression/node_rel_expression.cpp
+++ b/src/binder/expression/node_rel_expression.cpp
@@ -35,7 +35,10 @@ void NodeOrRelExpression::addEntries(const std::vector<TableCatalogEntry*>& entr
 
 void NodeOrRelExpression::addPropertyExpression(std::shared_ptr<PropertyExpression> property) {
     auto propertyName = property->getPropertyName();
-    DASSERT(!propertyNameToIdx.contains(propertyName));
+    // Idempotent: skip duplicate property expressions
+    if (propertyNameToIdx.contains(propertyName)) {
+        return;
+    }
     propertyNameToIdx.insert({propertyName, propertyExprs.size()});
     propertyExprs.push_back(std::move(property));
 }

--- a/src/planner/operator/logical_distinct.cpp
+++ b/src/planner/operator/logical_distinct.cpp
@@ -10,7 +10,7 @@ void LogicalDistinct::computeFactorizedSchema() {
     createEmptySchema();
     auto groupPos = schema->createGroup();
     for (auto& expression : getKeysAndPayloads()) {
-        schema->insertToGroupAndScope(expression, groupPos);
+        schema->insertToGroupAndScopeMayRepeat(expression, groupPos);
     }
 }
 
@@ -18,7 +18,7 @@ void LogicalDistinct::computeFlatSchema() {
     createEmptySchema();
     schema->createGroup();
     for (auto& expression : getKeysAndPayloads()) {
-        schema->insertToGroupAndScope(expression, 0);
+        schema->insertToGroupAndScopeMayRepeat(expression, 0);
     }
 }
 

--- a/test/test_files/path/path.test
+++ b/test/test_files/path/path.test
@@ -122,3 +122,11 @@ Expected: (LIST) -> INT64
           (ARRAY) -> INT64
           (MAP) -> INT64
           (STRING) -> INT64
+
+-CASE RecursiveRelComparisonBug
+
+-LOG RecursivePathWithAllAndRelComparison
+# Bug: Segfault when using ALL() with relationship comparison in recursive path
+-STATEMENT MATCH (a:person)-[t:knows]->(d:person) WHERE a.ID <> d.ID WITH a, d, t MATCH p = (a)-[:knows*1..3]->(d) WHERE length(p) >= 2 AND ALL (r IN relationships(p) WHERE r <> t) WITH DISTINCT t RETURN count(t);
+---- 1
+12


### PR DESCRIPTION
This is a followup to #608 , completing the porting of the fixes in https://github.com/predictable-labs/ryugraph/pull/2.

Instead of the custom data in the original PR I used the tinysnb dataset.

I also added another change from that PR, defensively avoiding an assert in debug builds in `NodeOrRelExpression::addPropertyExpression`