### PR TITLE
fix(storage): guard CSR getGroup against stale/OOB group indices (SIGSEGV)

### DIFF
--- a/src/include/storage/table/group_collection.h
+++ b/src/include/storage/table/group_collection.h
@@ -49,11 +49,19 @@ public:
     T* getGroup(const common::UniqLock& lock, common::idx_t groupIdx) const {
         DASSERT(lock.isLocked());
         UNUSED(lock);
-        DASSERT(groupIdx < groups.size());
+        // A stale/invalid CSR row can map to an out-of-range group index (e.g.
+        // getQuotientRemainder(INVALID_ROW_IDX)). Returning nullptr instead of
+        // performing an out-of-bounds std::vector access lets callers skip the
+        // stale row rather than dereferencing into undefined behavior (SIGSEGV).
+        if (groupIdx >= groups.size()) {
+            return nullptr;
+        }
         return groups[groupIdx].get();
     }
     T* getGroupNoLock(common::idx_t groupIdx) const {
-        DASSERT(groupIdx < groups.size());
+        if (groupIdx >= groups.size()) {
+            return nullptr;
+        }
         return groups[groupIdx].get();
     }
     void replaceGroup(const common::UniqLock& lock, common::idx_t groupIdx,

--- a/src/storage/table/csr_node_group.cpp
+++ b/src/storage/table/csr_node_group.cpp
@@ -292,6 +292,10 @@ NodeGroupScanResult CSRNodeGroup::scanCommittedInMemSequential(const Transaction
         const auto lock = chunkedGroups.lock();
         chunkedGroup = chunkedGroups.getGroup(lock, chunkIdx);
     }
+    if (chunkedGroup == nullptr) {
+        // Stale/invalid committed-in-memory row: nothing to scan.
+        return NODE_GROUP_SCAN_EMPTY_RESULT;
+    }
     chunkedGroup->scan(transaction, tableState, nodeGroupScanState, startRowInChunk, numRows);
     nodeGroupScanState.nextRowToScan += numRows;
     return NodeGroupScanResult{startRow, numRows};
@@ -318,6 +322,11 @@ NodeGroupScanResult CSRNodeGroup::scanCommittedInMemRandom(const Transaction* tr
             currentChunkIdx = chunkIdx;
             const auto lock = chunkedGroups.lock();
             chunkedGroup = chunkedGroups.getGroup(lock, chunkIdx);
+        }
+        if (chunkedGroup == nullptr) {
+            // Stale/invalid committed-in-memory row: skip it.
+            nextRow++;
+            continue;
         }
         DASSERT(chunkedGroup);
         numSelected += chunkedGroup->lookup(transaction, tableState, nodeGroupScanState, rowInChunk,
@@ -410,6 +419,10 @@ void CSRNodeGroup::update(const Transaction* transaction, CSRNodeGroupScanSource
             StorageConfig::CHUNKED_NODE_GROUP_CAPACITY);
         const auto lock = chunkedGroups.lock();
         const auto chunkedGroup = chunkedGroups.getGroup(lock, chunkIdx);
+        if (chunkedGroup == nullptr) {
+            // Stale/invalid committed-in-memory row: target row no longer exists.
+            return;
+        }
         return chunkedGroup->update(transaction, rowInChunk, columnID, propertyVector);
     }
     default: {
@@ -432,6 +445,10 @@ bool CSRNodeGroup::delete_(const Transaction* transaction, CSRNodeGroupScanSourc
             StorageConfig::CHUNKED_NODE_GROUP_CAPACITY);
         const auto lock = chunkedGroups.lock();
         const auto chunkedGroup = chunkedGroups.getGroup(lock, chunkIdx);
+        if (chunkedGroup == nullptr) {
+            // Stale/invalid committed-in-memory row: nothing to delete.
+            return false;
+        }
         return chunkedGroup->delete_(transaction, rowInChunk);
     }
     default: {
@@ -854,6 +871,10 @@ std::vector<ChunkCheckpointState> CSRNodeGroup::checkpointColumnInRegion(const U
                 auto [chunkIdx, rowInChunk] = StorageUtils::getQuotientRemainder(row,
                     StorageConfig::CHUNKED_NODE_GROUP_CAPACITY);
                 const auto chunkedGroup = chunkedGroups.getGroup(lock, chunkIdx);
+                if (chunkedGroup == nullptr) {
+                    // Stale/invalid committed-in-memory row: skip the insertion write.
+                    continue;
+                }
                 writeInMemoryCSRInsertion(txn, writeCursor, *chunkedGroup, rowInChunk, columnID,
                     chunkState);
             }
@@ -914,7 +935,7 @@ void CSRNodeGroup::collectInMemRegionChangesAndUpdateHeaderLength(const UniqLock
                 auto [chunkIdx, rowInChunk] = StorageUtils::getQuotientRemainder(row,
                     StorageConfig::CHUNKED_NODE_GROUP_CAPACITY);
                 const auto chunkedGroup = chunkedGroups.getGroup(lock, chunkIdx);
-                if (chunkedGroup->isDeleted(txn, rowInChunk)) {
+                if (chunkedGroup == nullptr || chunkedGroup->isDeleted(txn, rowInChunk)) {
                     csrIndex->indices[nodeOffset].turnToNonSequential();
                     csrIndex->indices[nodeOffset].setInvalid(i);
                     numInMemDeletionsInCSR++;
@@ -1118,7 +1139,8 @@ void CSRNodeGroup::populateCSRLengthInMemOnly(const UniqLock& lock, offset_t num
             auto [chunkIdx, rowInChunk] =
                 StorageUtils::getQuotientRemainder(row, StorageConfig::CHUNKED_NODE_GROUP_CAPACITY);
             const auto chunkedGroup = chunkedGroups.getGroup(lock, chunkIdx);
-            const auto isDeleted = chunkedGroup->isDeleted(txn, rowInChunk);
+            const auto isDeleted =
+                (chunkedGroup == nullptr) || chunkedGroup->isDeleted(txn, rowInChunk);
             if (isDeleted) {
                 csrIndex->indices[offset].turnToNonSequential();
                 csrIndex->indices[offset].setInvalid(i);


### PR DESCRIPTION
## Problem

A long-running process doing **relationship deletes + checkpoints** crashes with
`SIGSEGV` during the consolidation/checkpoint phase. The faulting access is
`GroupCollection<ChunkedNodeGroup>::getGroup(groupIdx = 4294967295 / UINT32_MAX)`.

### Root cause

After relationship delete + checkpoint churn, `csrIndex->indices[nodeOffset]` can
retain a **stale row** (an `INVALID_ROW_IDX` sentinel). `getQuotientRemainder(INVALID_ROW_IDX)`
yields an **out-of-range chunk-group index**. `GroupCollection::getGroup` only had a
debug-only `DASSERT(groupIdx < groups.size())` (a no-op in release), so it performed an
**out-of-bounds `std::vector` access** and callers dereferenced the result → undefined
behavior / `SIGSEGV`.

The insertion-write loop in `checkpointColumnInRegion` already guards this case with
`if (row == INVALID_ROW_IDX) continue;`, but the two **checkpoint-collect loops**
(`collectInMemRegionChangesAndUpdateHeaderLength` and `populateCSRLengthInMemOnly`),
plus the scan / `update` / `delete_` paths, do **not** — they dereference the `getGroup`
result directly.

## Fix

- `GroupCollection::getGroup` / `getGroupNoLock` now return `nullptr` for an out-of-range
  index instead of performing an OOB access.
- Every `CSRNodeGroup` deref site handles `nullptr`:
  - scan (`scanCommittedInMemSequential` / `scanCommittedInMemRandom`): skip / empty result;
  - `update`: no-op (target row gone); `delete_`: returns `false`;
  - checkpoint insertion-write: skip;
  - the two checkpoint-collect `isDeleted` loops: treat a stale/null group as **deleted**
    (purges the stale row via `turnToNonSequential()` + `setInvalid(i)`), consistent with
    the engine's existing handling of deleted rows.

This is version-independent (reproduced on 0.15.x–0.17.1) and present on current `main`.

## Validation

Reproduced via a deterministic 120-iteration delete+checkpoint churn test (amplihack-memory
issue #100). Before: `SIGSEGV` mid-churn in `collectInMemRegionChangesAndUpdateHeaderLength`.
After (engine rebuilt from source with this patch): the workload completes cleanly and the
test passes.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>