### PR TITLE
fix: narrow solution for double free crash on destroy

### DIFF
--- a/src/c_api/connection.cpp
+++ b/src/c_api/connection.cpp
@@ -1,3 +1,4 @@
+#include <atomic>
 #include <mutex>
 #include <string>
 #include <unordered_map>
@@ -101,11 +102,12 @@ void lbug_connection_destroy(lbug_connection* connection) {
     if (connection == nullptr) {
         return;
     }
-    if (connection->_connection != nullptr) {
-        auto connectionPtr = static_cast<Connection*>(connection->_connection);
+    std::atomic_ref<void*> atomic_conn(connection->_connection);
+    void* ptr = atomic_conn.exchange(nullptr);
+    if (ptr != nullptr) {
+        auto connectionPtr = static_cast<Connection*>(ptr);
         forgetArrowTableIDs(connectionPtr);
         delete connectionPtr;
-        connection->_connection = nullptr;
     }
 }
 

--- a/src/c_api/database.cpp
+++ b/src/c_api/database.cpp
@@ -1,3 +1,5 @@
+#include <atomic>
+
 #include "c_api/helpers.h"
 #include "c_api/lbug.h"
 #include "common/exception/exception.h"
@@ -31,9 +33,10 @@ void lbug_database_destroy(lbug_database* database) {
     if (database == nullptr) {
         return;
     }
-    if (database->_database != nullptr) {
-        delete static_cast<Database*>(database->_database);
-        database->_database = nullptr;
+    std::atomic_ref<void*> atomic_db(database->_database);
+    void* ptr = atomic_db.exchange(nullptr);
+    if (ptr != nullptr) {
+        delete static_cast<Database*>(ptr);
     }
 }
 


### PR DESCRIPTION
Fixes: #452 

This is a hard to reproduce Heisenbug. Suspected cause: two threads racing on database close/destroy + GC which does an implicit destroy.

A full solution would have to use `std::atomic` on all pointer dereferences on conn and database. We may already be protected by the language runtimes against such races.

The intent is to try the narrow solution first and then go for something more invasive only if necessary.