### PR TITLE
optimization: skip merging arrow results if ordering is not specified

### DIFF
--- a/src/include/planner/operator/logical_plan_util.h
+++ b/src/include/planner/operator/logical_plan_util.h
@@ -9,6 +9,15 @@ class LogicalPlanUtil {
 public:
     static std::string encodeJoin(LogicalPlan& logicalPlan);
 
+    // Returns true if the primary data-flow path from `op` downward contains an
+    // ORDER BY that actually orders the rows arriving at a result collector.
+    // Only the main data-flow child (child 0) is followed; side inputs (e.g. the
+    // build side of a hash join) do not appear in the output row stream.
+    // Operators that combine independent subplans (UNION_ALL, INTERSECT,
+    // CROSS_PRODUCT, RECURSIVE_EXTEND) restart the ordering question: an
+    // ORDER BY inside one arm does not make the combined result ordered.
+    static bool hasOrderByOnDataPath(const LogicalOperator& op);
+
 private:
     static std::string encode(LogicalOperator* logicalOperator);
     static void encodeRecursive(LogicalOperator* logicalOperator, std::string& encodeString);

--- a/src/include/processor/operator/arrow_result_collector.h
+++ b/src/include/processor/operator/arrow_result_collector.h
@@ -14,10 +14,26 @@ namespace processor {
 class ArrowResultCollectorSharedState {
 public:
     std::vector<ArrowArray> arrays;
-    std::optional<main::ArrowQueryResult::CSRMetadata> csrMetadata;
+    // Per-thread CSR metadata chunks, accumulated in thread-finish order.
+    // Stored as a chunked list (rather than a single merged metadata) so the
+    // merge is zero-copy: we just move each thread's vectors in via push_back.
+    // Flattening into a single CSRMetadata is deferred to result-construction
+    // time (ArrowResultCollector::getQueryResult), where it is paid once.
+    // - When requireDeterministicOrder is true, this is collapsed to a single
+    //   chunk holding the globally-sorted result of the deterministic merge.
+    // - When false, this holds one chunk per thread in finish order, and the
+    //   per-thread source-row groupings are preserved.
+    // Empty means no CSR metadata.
+    std::vector<main::ArrowQueryResult::CSRMetadata> csrMetadata;
+    // When false, the query has no ORDER BY and the CSR metadata from multiple
+    // local collectors can be merged in any order. The cheap path skips the
+    // expensive sort+copy and instead stores per-thread chunks (zero-copy).
+    bool requireDeterministicOrder = true;
 
+    // localCSRMetadata is taken by value so the caller can move its
+    // per-thread metadata in; this is the key to a zero-copy merge.
     void merge(const std::vector<ArrowArray>& localArrays,
-        const std::optional<main::ArrowQueryResult::CSRMetadata>& localCSRMetadata);
+        std::optional<main::ArrowQueryResult::CSRMetadata> localCSRMetadata);
 
 private:
     std::mutex mutex;
@@ -59,17 +75,21 @@ struct ArrowResultCollectorInfo {
     std::vector<DataPos> payloadPositions;
     std::vector<common::LogicalType> columnTypes;
     CSRTrackingInfo csrTrackingInfo;
+    bool requireDeterministicOrder = true;
 
     ArrowResultCollectorInfo(int64_t chunkSize, std::vector<DataPos> payloadPositions,
-        std::vector<common::LogicalType> columnTypes, CSRTrackingInfo csrTrackingInfo = {})
+        std::vector<common::LogicalType> columnTypes, CSRTrackingInfo csrTrackingInfo = {},
+        bool requireDeterministicOrder = true)
         : chunkSize{chunkSize}, payloadPositions{std::move(payloadPositions)},
-          columnTypes{std::move(columnTypes)}, csrTrackingInfo{csrTrackingInfo} {}
+          columnTypes{std::move(columnTypes)}, csrTrackingInfo{csrTrackingInfo},
+          requireDeterministicOrder{requireDeterministicOrder} {}
     EXPLICIT_COPY_DEFAULT_MOVE(ArrowResultCollectorInfo);
 
 private:
     ArrowResultCollectorInfo(const ArrowResultCollectorInfo& other)
         : chunkSize{other.chunkSize}, payloadPositions{other.payloadPositions},
-          columnTypes{copyVector(other.columnTypes)}, csrTrackingInfo{other.csrTrackingInfo} {}
+          columnTypes{copyVector(other.columnTypes)}, csrTrackingInfo{other.csrTrackingInfo},
+          requireDeterministicOrder{other.requireDeterministicOrder} {}
 };
 
 class ArrowResultCollector final : public Sink {

--- a/src/include/processor/plan_mapper.h
+++ b/src/include/processor/plan_mapper.h
@@ -184,7 +184,8 @@ public:
         std::unique_ptr<PhysicalOperator> prevOperator);
     std::unique_ptr<PhysicalOperator> createArrowResultCollector(
         common::ArrowResultConfig arrowConfig, const binder::expression_vector& expressions,
-        planner::Schema* schema, std::unique_ptr<PhysicalOperator> prevOperator);
+        planner::Schema* schema, std::unique_ptr<PhysicalOperator> prevOperator,
+        bool requireDeterministicOrder);
 
     // Scan fTable
     std::unique_ptr<PhysicalOperator> createFTableScan(const binder::expression_vector& exprs,

--- a/src/planner/operator/logical_plan_util.cpp
+++ b/src/planner/operator/logical_plan_util.cpp
@@ -106,5 +106,24 @@ void LogicalPlanUtil::encodeFilter(LogicalOperator*, std::string& encodedString)
     encodedString += "Filter()";
 }
 
+bool LogicalPlanUtil::hasOrderByOnDataPath(const LogicalOperator& op) {
+    if (op.getOperatorType() == LogicalOperatorType::ORDER_BY) {
+        return true;
+    }
+    switch (op.getOperatorType()) {
+    case LogicalOperatorType::UNION_ALL:
+    case LogicalOperatorType::INTERSECT:
+    case LogicalOperatorType::CROSS_PRODUCT:
+    case LogicalOperatorType::RECURSIVE_EXTEND:
+        return false;
+    default:
+        break;
+    }
+    if (op.getNumChildren() == 0) {
+        return false;
+    }
+    return hasOrderByOnDataPath(*op.getChild(0));
+}
+
 } // namespace planner
 } // namespace lbug

--- a/src/processor/map/create_arrow_result_collector.cpp
+++ b/src/processor/map/create_arrow_result_collector.cpp
@@ -47,7 +47,8 @@ static CSRTrackingInfo getCSRTrackingInfo(const binder::expression_vector& expre
 
 std::unique_ptr<PhysicalOperator> PlanMapper::createArrowResultCollector(
     ArrowResultConfig arrowConfig, const binder::expression_vector& expressions,
-    planner::Schema* schema, std::unique_ptr<PhysicalOperator> prevOperator) {
+    planner::Schema* schema, std::unique_ptr<PhysicalOperator> prevOperator,
+    bool requireDeterministicOrder) {
     std::vector<DataPos> columnDataPos;
     std::vector<LogicalType> columnTypes;
     for (auto& expr : expressions) {
@@ -55,9 +56,10 @@ std::unique_ptr<PhysicalOperator> PlanMapper::createArrowResultCollector(
         columnTypes.push_back(expr->getDataType().copy());
     }
     auto sharedState = std::make_shared<ArrowResultCollectorSharedState>();
+    sharedState->requireDeterministicOrder = requireDeterministicOrder;
     auto csrTrackingInfo = getCSRTrackingInfo(expressions);
     auto opInfo = ArrowResultCollectorInfo(arrowConfig.chunkSize, columnDataPos,
-        std::move(columnTypes), csrTrackingInfo);
+        std::move(columnTypes), csrTrackingInfo, requireDeterministicOrder);
     auto printInfo = OPPrintInfo::EmptyInfo();
     if (csrTrackingInfo.enabled() &&
         (expressions.size() == 2 || (expressions.size() == 3 && csrTrackingInfo.hasRelRowID()))) {

--- a/src/processor/map/plan_mapper.cpp
+++ b/src/processor/map/plan_mapper.cpp
@@ -3,6 +3,7 @@
 #include "main/client_context.h"
 #include "main/database.h"
 #include "planner/operator/logical_plan.h"
+#include "planner/operator/logical_plan_util.h"
 #include "processor/operator/profile.h"
 #include "storage/storage_manager.h"
 #include "storage/table/node_table.h"
@@ -27,8 +28,10 @@ std::unique_ptr<PhysicalPlan> PlanMapper::getPhysicalPlan(const LogicalPlan* log
     auto root = mapOperator(logicalPlan->getLastOperator().get());
     if (!root->isSink()) {
         if (resultType == main::QueryResultType::ARROW) {
+            const auto requireDeterministicOrder =
+                LogicalPlanUtil::hasOrderByOnDataPath(*logicalPlan->getLastOperator());
             root = createArrowResultCollector(arrowConfig, expressions, logicalPlan->getSchema(),
-                std::move(root));
+                std::move(root), requireDeterministicOrder);
         } else {
             root = createResultCollector(AccumulateType::REGULAR, expressions,
                 logicalPlan->getSchema(), std::move(root));

--- a/src/processor/operator/arrow_result_collector.cpp
+++ b/src/processor/operator/arrow_result_collector.cpp
@@ -118,8 +118,7 @@ static void updateDirectCSRMetadata(const CSRTrackingInfo& info, const std::vect
 }
 
 static std::optional<main::ArrowQueryResult::CSRMetadata> mergeCSRMetadata(
-    const main::ArrowQueryResult::CSRMetadata& left,
-    const main::ArrowQueryResult::CSRMetadata& right) {
+    main::ArrowQueryResult::CSRMetadata left, main::ArrowQueryResult::CSRMetadata right) {
     if (left.hasEdgeIDs != right.hasEdgeIDs) {
         return std::nullopt;
     }
@@ -174,6 +173,65 @@ static std::optional<main::ArrowQueryResult::CSRMetadata> mergeCSRMetadata(
         }
     }
     merged.indptr.push_back(static_cast<int64_t>(merged.indices.size()));
+    return merged;
+}
+
+// Flatten a chunked list of per-thread CSR metadata into a single flat
+// CSRMetadata. This is the one place we pay for materializing the merged
+// CSR (a single O(n) copy of indptr/indices/edgeIDs) — the scan-time merge
+// in ArrowResultCollectorSharedState::merge is zero-copy (push_back moves).
+// Takes the chunk vector by value so the single-chunk fast path is also
+// zero-copy: we just move the sole chunk out.
+static main::ArrowQueryResult::CSRMetadata flattenCSRMetadata(
+    std::vector<main::ArrowQueryResult::CSRMetadata> chunks) {
+    if (chunks.empty()) {
+        return main::ArrowQueryResult::CSRMetadata{};
+    }
+    if (chunks.size() == 1) {
+        return std::move(chunks[0]);
+    }
+    const auto& first = chunks.front();
+    main::ArrowQueryResult::CSRMetadata merged;
+    merged.hasEdgeIDs = first.hasEdgeIDs;
+    size_t totalIndptr = 0, totalIndices = 0, totalEdgeIDs = 0;
+    for (const auto& c : chunks) {
+        if (c.hasEdgeIDs != merged.hasEdgeIDs) {
+            // Mismatched shapes across threads; fall back to empty metadata
+            // (caller treats empty as "no CSR metadata").
+            return main::ArrowQueryResult::CSRMetadata{};
+        }
+        if (c.hasEdgeIDs && c.edgeIDs.size() != c.indices.size()) {
+            return main::ArrowQueryResult::CSRMetadata{};
+        }
+        totalIndptr += c.indptr.size();
+        totalIndices += c.indices.size();
+        totalEdgeIDs += c.edgeIDs.size();
+    }
+    merged.indptr.reserve(totalIndptr);
+    merged.indices.reserve(totalIndices);
+    if (merged.hasEdgeIDs) {
+        merged.edgeIDs.reserve(totalEdgeIDs);
+    }
+    int64_t offset = 0;
+    for (auto& c : chunks) {
+        merged.indptr.insert(merged.indptr.end(), c.indptr.begin(), c.indptr.end());
+        if (offset > 0) {
+            // Re-base this chunk's indptr values by the running offset.
+            // Each chunk's indptr is 0-based within the chunk (its first
+            // entry is 0); after concatenation it must point into the
+            // merged indices array, so add the offset to every entry of
+            // this chunk (including the first).
+            const auto base = merged.indptr.size() - c.indptr.size();
+            for (auto i = base; i < merged.indptr.size(); ++i) {
+                merged.indptr[i] += offset;
+            }
+        }
+        merged.indices.insert(merged.indices.end(), c.indices.begin(), c.indices.end());
+        if (merged.hasEdgeIDs) {
+            merged.edgeIDs.insert(merged.edgeIDs.end(), c.edgeIDs.begin(), c.edgeIDs.end());
+        }
+        offset += static_cast<int64_t>(c.indices.size());
+    }
     return merged;
 }
 
@@ -252,15 +310,41 @@ void ArrowResultCollectorLocalState::resetCursor() {
 }
 
 void ArrowResultCollectorSharedState::merge(const std::vector<ArrowArray>& localArrays,
-    const std::optional<main::ArrowQueryResult::CSRMetadata>& localCSRMetadata) {
+    std::optional<main::ArrowQueryResult::CSRMetadata> localCSRMetadata) {
     std::unique_lock lck{mutex};
     for (auto i = 0u; i < localArrays.size(); ++i) {
         arrays.push_back(localArrays[i]);
     }
-    if (!csrMetadata.has_value() && localCSRMetadata.has_value()) {
-        csrMetadata = localCSRMetadata;
-    } else if (csrMetadata.has_value() && localCSRMetadata.has_value()) {
-        csrMetadata = mergeCSRMetadata(*csrMetadata, *localCSRMetadata);
+    if (!localCSRMetadata.has_value()) {
+        return;
+    }
+    if (csrMetadata.empty()) {
+        // First thread contributing CSR metadata: move it in (zero-copy).
+        csrMetadata.push_back(std::move(*localCSRMetadata));
+        return;
+    }
+    if (requireDeterministicOrder) {
+        // Deterministic merge: collapse to a single chunk holding the
+        // globally-sorted result. mergeCSRMetadata takes by value, so both
+        // the accumulated chunk and the new thread's metadata are moved in
+        // (no extra copies beyond the entries/sort inside mergeCSRMetadata).
+        auto merged = mergeCSRMetadata(std::move(csrMetadata[0]), std::move(*localCSRMetadata));
+        csrMetadata.clear();
+        if (merged.has_value()) {
+            csrMetadata.push_back(std::move(*merged));
+        }
+        // On nullopt (e.g. hasEdgeIDs mismatch) we drop CSR metadata.
+    } else {
+        // No ORDER BY: row order is undefined. Append this thread's metadata
+        // as a new chunk (zero-copy move of the vectors). The per-thread
+        // source-row groupings are preserved, and the chunks are flattened
+        // in finish order at result-construction time.
+        if (csrMetadata.front().hasEdgeIDs != localCSRMetadata->hasEdgeIDs) {
+            // Mismatched shapes across threads; drop CSR metadata entirely.
+            csrMetadata.clear();
+            return;
+        }
+        csrMetadata.push_back(std::move(*localCSRMetadata));
     }
 }
 
@@ -286,7 +370,7 @@ void ArrowResultCollector::executeInternal(ExecutionContext* context) {
         localState.csrMetadata->indptr.push_back(
             static_cast<int64_t>(localState.csrMetadata->indices.size()));
     }
-    sharedState->merge(localState.arrays, localState.csrMetadata);
+    sharedState->merge(localState.arrays, std::move(localState.csrMetadata));
 }
 
 bool ArrowResultCollector::fillRowBatch(ArrowRowBatch& rowBatch) {
@@ -322,9 +406,13 @@ void ArrowResultCollector::initLocalStateInternal(ResultSet* resultSet, Executio
 }
 
 std::unique_ptr<main::QueryResult> ArrowResultCollector::getQueryResult() const {
-    if (sharedState->csrMetadata.has_value()) {
+    if (!sharedState->csrMetadata.empty()) {
+        // Flatten the per-thread chunks into a single CSRMetadata. This is
+        // the one O(n) copy of the merge pipeline, paid here at result-
+        // construction time rather than during the 100M-row scan.
+        auto flatCSR = flattenCSRMetadata(std::move(sharedState->csrMetadata));
         return std::make_unique<main::ArrowQueryResult>(std::move(sharedState->arrays),
-            info.chunkSize, std::move(*sharedState->csrMetadata));
+            info.chunkSize, std::move(flatCSR));
     }
     return std::make_unique<main::ArrowQueryResult>(std::move(sharedState->arrays), info.chunkSize);
 }
@@ -389,13 +477,14 @@ void DirectArrowResultCollector::executeInternal(ExecutionContext* context) {
         localState.csrMetadata->indptr.push_back(
             static_cast<int64_t>(localState.csrMetadata->indices.size()));
     }
-    sharedState->merge(localState.arrays, localState.csrMetadata);
+    sharedState->merge(localState.arrays, std::move(localState.csrMetadata));
 }
 
 std::unique_ptr<main::QueryResult> DirectArrowResultCollector::getQueryResult() const {
-    if (sharedState->csrMetadata.has_value()) {
+    if (!sharedState->csrMetadata.empty()) {
+        auto flatCSR = flattenCSRMetadata(std::move(sharedState->csrMetadata));
         return std::make_unique<main::ArrowQueryResult>(std::move(sharedState->arrays),
-            info.chunkSize, std::move(*sharedState->csrMetadata));
+            info.chunkSize, std::move(flatCSR));
     }
     return std::make_unique<main::ArrowQueryResult>(std::move(sharedState->arrays), info.chunkSize);
 }

--- a/test/planner/CMakeLists.txt
+++ b/test/planner/CMakeLists.txt
@@ -1,1 +1,1 @@
-add_lbug_test(planner_tests cardinality_test.cpp)
+add_lbug_test(planner_tests cardinality_test.cpp logical_plan_util_test.cpp)

--- a/test/planner/logical_plan_util_test.cpp
+++ b/test/planner/logical_plan_util_test.cpp
@@ -1,0 +1,65 @@
+#include "graph_test/private_graph_test.h"
+#include "planner/operator/logical_plan_util.h"
+#include "test_runner/test_runner.h"
+
+using namespace lbug::planner;
+using namespace lbug::testing;
+
+class LogicalPlanUtilTest : public DBTest {
+public:
+    std::string getInputDir() override {
+        return TestHelper::appendLbugRootPath("dataset/tinysnb/");
+    }
+
+    bool hasOrderBy(const std::string& query) {
+        auto plan = TestRunner::getLogicalPlan(query, *conn);
+        return LogicalPlanUtil::hasOrderByOnDataPath(*plan->getLastOperator());
+    }
+};
+
+// --- Positive: ORDER BY is on the data-flow path, so the expensive
+// deterministic CSR metadata merge is required. ---
+TEST_F(LogicalPlanUtilTest, SimpleOrderByIsOnDataPath) {
+    EXPECT_TRUE(hasOrderBy("MATCH (a:person) RETURN a ORDER BY a.rowid"));
+}
+
+TEST_F(LogicalPlanUtilTest, OrderByUnderLimitIsOnDataPath) {
+    EXPECT_TRUE(hasOrderBy("MATCH (a:person) RETURN a ORDER BY a.rowid LIMIT 5"));
+}
+
+TEST_F(LogicalPlanUtilTest, OrderByUnderFilterIsOnDataPath) {
+    EXPECT_TRUE(hasOrderBy("MATCH (a:person) WHERE a.age > 18 RETURN a ORDER BY a.rowid"));
+}
+
+TEST_F(LogicalPlanUtilTest, OrderByUnderProjectionIsOnDataPath) {
+    // RETURN clause produces a projection; ORDER BY is its child on the data path.
+    EXPECT_TRUE(hasOrderBy("MATCH (a:person)-[:knows]->(b:person) "
+                           "RETURN a.fName, b.fName ORDER BY a.rowid"));
+}
+
+// --- Negative: no effective ORDER BY on the data path, so the expensive
+// merge must be skipped. ---
+TEST_F(LogicalPlanUtilTest, NoOrderByReturnsFalse) {
+    EXPECT_FALSE(hasOrderBy("MATCH (a:person) RETURN a"));
+}
+
+TEST_F(LogicalPlanUtilTest, JoinWithoutOrderByReturnsFalse) {
+    EXPECT_FALSE(hasOrderBy("MATCH (a:person)-[r:knows]->(b:person) RETURN a, b"));
+}
+
+TEST_F(LogicalPlanUtilTest, UnionWithoutOrderByReturnsFalse) {
+    // UNION combines independent subplans; with no outer ORDER BY the
+    // combined result is unordered, so the walker must stop at the UNION.
+    EXPECT_FALSE(
+        hasOrderBy("MATCH (a:person) RETURN a.fName UNION MATCH (b:person) RETURN b.fName"));
+}
+
+TEST_F(LogicalPlanUtilTest, RecursiveExtendWithoutOrderByReturnsFalse) {
+    // Recursive traversal starts a new subplan; with no outer ORDER BY the
+    // result is unordered, so the walker must stop at RECURSIVE_EXTEND.
+    EXPECT_FALSE(hasOrderBy("MATCH (a:person)-[:knows*1..2]->(b:person) RETURN a.rowid, b.rowid"));
+}
+
+TEST_F(LogicalPlanUtilTest, AggregateWithoutOrderByReturnsFalse) {
+    EXPECT_FALSE(hasOrderBy("MATCH (a:person) RETURN count(*)"));
+}


### PR DESCRIPTION
This helps avoid copies and sorting when scanning a rel table without ORDER BY.