### PR TITLE
Arrow result collector: improved merge algorithm

### DIFF
--- a/src/include/main/query_result/arrow_query_result.h
+++ b/src/include/main/query_result/arrow_query_result.h
@@ -18,6 +18,10 @@ public:
         std::vector<int64_t> indices;
         std::vector<int64_t> edgeIDs;
         bool hasEdgeIDs = false;
+        // Total number of source (node) rows in the table. Used to pad
+        // trailing empty rows in indptr; set at plan-mapping time from the
+        // node table cardinality.
+        int64_t numSourceRows = 0;
     };
 
     struct CSRArrowArray {

--- a/src/include/main/query_result/arrow_query_result.h
+++ b/src/include/main/query_result/arrow_query_result.h
@@ -59,8 +59,48 @@ public:
         std::optional<CSRArrowArray> edgeIDs;
     };
 
+    // View of the merged Arrow arrays as a chunked sequence, similar to
+    // Arrow C++ lib's arrow::ChunkedArray. We expose per-batch ArrowArrays
+    // in batch_index order instead of concatenating them via arrow::Concat
+    // (which we don't link); python users can construct pyarrow.ChunkedArray
+    // from these chunks and call combine_chunks() to materialize on the
+    // consumer side. Chunk order is the natural global row order for the
+    // query.
+    //
+    // Non-owning view: ArrowQueryResult retains ownership of the underlying
+    // chunk buffers. The caller is responsible for calling release on each
+    // chunk's ArrowArray when done, to free the buffers (matches the
+    // existing hasNextArrowChunk / getNextArrowChunk contract).
+    struct ArrowChunkedArray {
+        std::shared_ptr<const std::vector<ArrowArray>> chunks;
+
+        ArrowChunkedArray() = default;
+        explicit ArrowChunkedArray(std::shared_ptr<const std::vector<ArrowArray>> chunks)
+            : chunks{std::move(chunks)} {}
+
+        int64_t numChunks() const { return chunks ? static_cast<int64_t>(chunks->size()) : 0; }
+
+        int64_t length() const {
+            if (!chunks) {
+                return 0;
+            }
+            int64_t total = 0;
+            for (const auto& c : *chunks) {
+                total += c.length;
+            }
+            return total;
+        }
+
+        const ArrowArray* data() const {
+            return chunks && !chunks->empty() ? chunks->data() : nullptr;
+        }
+
+        bool empty() const { return !chunks || chunks->empty(); }
+    };
+
     ArrowQueryResult(std::vector<ArrowArray> arrays, int64_t chunkSize);
-    ArrowQueryResult(std::vector<ArrowArray> arrays, int64_t chunkSize, CSRMetadata csrMetadata);
+    ArrowQueryResult(std::vector<ArrowArray> arrays, int64_t chunkSize,
+        std::vector<CSRMetadata> csrChunks);
     ArrowQueryResult(std::vector<std::string> columnNames,
         std::vector<common::LogicalType> columnTypes, processor::FactorizedTable& table,
         int64_t chunkSize);
@@ -79,19 +119,45 @@ public:
 
     std::unique_ptr<ArrowArray> getNextArrowChunk(int64_t chunkSize) override;
 
-    bool hasCSRMetadata() const { return csrMetadata != nullptr; }
-    const CSRMetadata& getCSRMetadata() const { return *csrMetadata; }
+    // Get all ArrowArrays as a chunked view (ArrowChunkedArray, similar
+    // to Arrow C++ lib's arrow::ChunkedArray). Coexists with the
+    // hasNextArrowChunk / getNextArrowChunk iteration API; both refer to
+    // the same underlying chunks.
+    ArrowChunkedArray getArrowChunks() const;
+
+    // CSR metadata is stored as a chunked view: per-batch chunks in
+    // batch_index order (the same order the physical collector produces).
+    // The actual k-way merge across batches runs lazily on the first call
+    // to combineCSRChunks() / getCSRMetadata() / getCSRArrowArrays(); the
+    // merged result is cached. NO_ORDER / INSERTION_ORDER queries take
+    // zero work at result-construction time.
+    bool hasCSRMetadata() const { return !csrChunks.empty(); }
+    const CSRMetadata& getCSRMetadata() const { return combineCSRChunks(); }
     CSRArrowArrays getCSRArrowArrays() const;
+
+    // Per-batch CSR chunks (in batch_index order). No merge is performed
+    // until combineCSRChunks() is called; this is the ChunkedArray-style
+    // view exposed for callers that want to combine on the consumer side
+    // (e.g. python users constructing pyarrow.ChunkedArray).
+    const std::vector<CSRMetadata>& getCSRChunks() const { return csrChunks; }
+
+    // K-way merge the per-batch CSR chunks in batch_index order into a
+    // single CSRMetadata. Result is cached; subsequent calls are O(1).
+    const CSRMetadata& combineCSRChunks() const;
 
 private:
     ArrowArray getArray(processor::FactorizedTableIterator& iterator, int64_t chunkSize);
 
 private:
-    std::vector<ArrowArray> arrays;
+    // Shared with ArrowChunkedArray views so the chunked view and the
+    // hasNextArrowChunk / getNextArrowChunk iteration API can coexist
+    // without invalidating each other.
+    std::shared_ptr<std::vector<ArrowArray>> arraysStorage;
     int64_t chunkSize_;
     uint64_t numTuples = 0;
     uint64_t cursor = 0;
-    std::shared_ptr<const CSRMetadata> csrMetadata;
+    std::vector<CSRMetadata> csrChunks;
+    mutable std::shared_ptr<const CSRMetadata> combinedCSR;
 };
 
 } // namespace main

--- a/src/include/processor/operator/arrow_result_collector.h
+++ b/src/include/processor/operator/arrow_result_collector.h
@@ -66,6 +66,11 @@ struct CSRTrackingInfo {
     common::idx_t srcRowIDColIdx = common::INVALID_IDX;
     common::idx_t dstRowIDColIdx = common::INVALID_IDX;
     common::idx_t relRowIDColIdx = common::INVALID_IDX;
+    // Total number of source (node) rows. Set at plan-mapping time from
+    // the node table cardinality. Used to fill trailing empty rows in the
+    // per-chunk CSR indptr so that indptr always has numSourceRows + 1
+    // entries (one per node row plus trailing sentinel).
+    int64_t numSourceRows = 0;
 
     bool enabled() const {
         return srcRowIDColIdx != common::INVALID_IDX && dstRowIDColIdx != common::INVALID_IDX;

--- a/src/include/processor/operator/arrow_result_collector.h
+++ b/src/include/processor/operator/arrow_result_collector.h
@@ -1,23 +1,62 @@
 #pragma once
 
+#include <atomic>
+#include <limits>
+#include <map>
 #include <mutex>
 #include <optional>
 
 #include "common/arrow/arrow.h"
 #include "main/query_result/arrow_query_result.h"
+#include "processor/operator/physical_operator.h"
 #include "processor/operator/sink.h"
 #include "processor/result/flat_tuple.h"
 
 namespace lbug {
 namespace processor {
 
+// Globally unique, monotonically increasing identifier assigned to each
+// per-thread local collector. Each thread of the parallel collector is
+// associated with one batch_index, and the final result is built by walking
+// chunks in batch_index order.
+using batch_index_t = uint64_t;
+static constexpr batch_index_t INVALID_BATCH_INDEX = std::numeric_limits<batch_index_t>::max();
+
+// Atomic counter that hands out unique batch_index values. One instance is
+// owned by ArrowResultCollectorSharedState and shared across all local
+// collectors. The atomic fetch_add is the only synchronization needed to
+// give each thread a distinct batch_index.
+class BatchIndexAssigner {
+public:
+    batch_index_t next() { return counter_.fetch_add(1, std::memory_order_relaxed); }
+    batch_index_t peek() const { return counter_.load(std::memory_order_relaxed); }
+
+private:
+    std::atomic<batch_index_t> counter_{0};
+};
+
 class ArrowResultCollectorSharedState {
 public:
-    std::vector<ArrowArray> arrays;
-    std::optional<main::ArrowQueryResult::CSRMetadata> csrMetadata;
+    // Per-batch Arrow chunks (parallel collector, no pairwise merge). The
+    // map's natural ordering on batch_index_t gives us the correct global
+    // row order at result-construction time without sorting.
+    std::map<batch_index_t, std::vector<ArrowArray>> arraysByBatchIndex;
+    // Per-batch CSR metadata. One entry per batch that contributed CSR
+    // metadata. Absent entries are simply not in the map.
+    std::map<batch_index_t, main::ArrowQueryResult::CSRMetadata> csrMetadataByBatchIndex;
+    // When true, the query has a FIXED_ORDER operator (ORDER BY / TopK) on
+    // the data path. Merge keeps a single running chunk under key 0 via the
+    // existing pairwise mergeCSRMetadata, preserving global sort order.
+    // When false, merge moves per-batch chunks into arraysByBatchIndex
+    // without pairwise merge — the cheap batch-index path.
+    bool requireDeterministicOrder = false;
+    BatchIndexAssigner batchIndexAssigner;
 
-    void merge(const std::vector<ArrowArray>& localArrays,
-        const std::optional<main::ArrowQueryResult::CSRMetadata>& localCSRMetadata);
+    // Local collector hands off its arrays (taken by value so the move
+    // out of the local state is zero-copy), the batch_index it was assigned
+    // at init, and its CSR metadata (also by value for zero-copy move).
+    void merge(std::vector<ArrowArray> localArrays, batch_index_t batchIndex,
+        std::optional<main::ArrowQueryResult::CSRMetadata> localCSRMetadata);
 
 private:
     std::mutex mutex;
@@ -35,6 +74,9 @@ struct CSRTrackingInfo {
 };
 
 struct ArrowResultCollectorLocalState {
+    // Batch index assigned at initLocalStateInternal from the shared
+    // BatchIndexAssigner. INVALID_BATCH_INDEX until then.
+    batch_index_t batchIndex = INVALID_BATCH_INDEX;
     std::vector<ArrowArray> arrays;
     std::vector<common::ValueVector*> vectors;
     std::vector<std::reference_wrapper<common::sel_t>> vectorsSelPos;
@@ -59,17 +101,23 @@ struct ArrowResultCollectorInfo {
     std::vector<DataPos> payloadPositions;
     std::vector<common::LogicalType> columnTypes;
     CSRTrackingInfo csrTrackingInfo;
+    // Order-preservation type of the physical plan (decided by
+    // PhysicalPlanUtil::getOrderPreservation at plan-mapping time).
+    OrderPreservationType orderPreservation = OrderPreservationType::NO_ORDER;
 
     ArrowResultCollectorInfo(int64_t chunkSize, std::vector<DataPos> payloadPositions,
-        std::vector<common::LogicalType> columnTypes, CSRTrackingInfo csrTrackingInfo = {})
+        std::vector<common::LogicalType> columnTypes, CSRTrackingInfo csrTrackingInfo = {},
+        OrderPreservationType orderPreservation = OrderPreservationType::NO_ORDER)
         : chunkSize{chunkSize}, payloadPositions{std::move(payloadPositions)},
-          columnTypes{std::move(columnTypes)}, csrTrackingInfo{csrTrackingInfo} {}
+          columnTypes{std::move(columnTypes)}, csrTrackingInfo{csrTrackingInfo},
+          orderPreservation{orderPreservation} {}
     EXPLICIT_COPY_DEFAULT_MOVE(ArrowResultCollectorInfo);
 
 private:
     ArrowResultCollectorInfo(const ArrowResultCollectorInfo& other)
         : chunkSize{other.chunkSize}, payloadPositions{other.payloadPositions},
-          columnTypes{copyVector(other.columnTypes)}, csrTrackingInfo{other.csrTrackingInfo} {}
+          columnTypes{copyVector(other.columnTypes)}, csrTrackingInfo{other.csrTrackingInfo},
+          orderPreservation{other.orderPreservation} {}
 };
 
 class ArrowResultCollector final : public Sink {

--- a/src/include/processor/operator/order_by/order_by.h
+++ b/src/include/processor/operator/order_by/order_by.h
@@ -40,6 +40,12 @@ public:
 
     void executeInternal(ExecutionContext* context) override;
 
+    // OrderBy produces a fixed, sorted output. Drives the deterministic
+    // pairwise-merge path in ArrowResultCollector.
+    OrderPreservationType operatorOrder() const override {
+        return OrderPreservationType::FIXED_ORDER;
+    }
+
     void finalize(ExecutionContext* /*context*/) override {
         // TODO(Ziyi): we always call lookup function on the first factorizedTable in sharedState
         // and that lookup function may read tuples in other factorizedTable, So we need to combine

--- a/src/include/processor/operator/order_by/top_k.h
+++ b/src/include/processor/operator/order_by/top_k.h
@@ -182,6 +182,12 @@ public:
 
     void executeInternal(ExecutionContext* context) override;
 
+    // TopK produces a fixed, partially-sorted output. Drives the
+    // deterministic pairwise-merge path in ArrowResultCollector.
+    OrderPreservationType operatorOrder() const override {
+        return OrderPreservationType::FIXED_ORDER;
+    }
+
     void finalize(ExecutionContext* /*context*/) override { sharedState->finalize(); }
 
     std::unique_ptr<PhysicalOperator> copy() override {

--- a/src/include/processor/operator/physical_operator.h
+++ b/src/include/processor/operator/physical_operator.h
@@ -14,6 +14,28 @@ struct ExecutionContext;
 
 using physical_op_id = uint32_t;
 
+// Order-preservation type for a physical operator, used by
+// PhysicalPlanUtil::getOrderPreservation to walk the plan and decide which
+// Arrow result-collector strategy to use.
+//
+// Ladybug does not expose a `preserve_insertion_order` setting to the user,
+// and we assume the default that no operator makes an insertion-order
+// guarantee unless it explicitly opts in by overriding operatorOrder() /
+// sourceOrder() to return INSERTION_ORDER. The FIXED_ORDER overrides on
+// OrderBy / TopK drive the expensive deterministic-merge collector path.
+enum class OrderPreservationType : uint8_t {
+    // The operator makes no guarantees on output order. Default for all
+    // operators; safe to assume unless explicitly overridden. Routes to the
+    // batch-index parallel collector.
+    NO_ORDER,
+    // The operator maintains the order of its child(ren). Reserved for
+    // future opt-in; not used by any operator in this change.
+    INSERTION_ORDER,
+    // The operator outputs rows in a fixed order that must be preserved
+    // (ORDER BY, TopK). Routes to the deterministic pairwise-merge path.
+    FIXED_ORDER,
+};
+
 enum class PhysicalOperatorType : uint8_t {
     ALTER,
     AGGREGATE,
@@ -125,6 +147,13 @@ public:
     virtual bool isSource() const { return false; }
     virtual bool isSink() const { return false; }
     virtual bool isParallel() const { return true; }
+
+    // Order-preservation metadata, used by PhysicalPlanUtil::getOrderPreservation
+    // to walk the plan and decide which Arrow result-collector strategy to use.
+    // Default is NO_ORDER (Ladybug makes no insertion-order guarantee).
+    // See OrderPreservationType above for the meaning of each value.
+    virtual OrderPreservationType operatorOrder() const { return OrderPreservationType::NO_ORDER; }
+    virtual OrderPreservationType sourceOrder() const { return OrderPreservationType::NO_ORDER; }
 
     void addChild(std::unique_ptr<PhysicalOperator> op) { children.push_back(std::move(op)); }
     PhysicalOperator* getChild(common::idx_t idx) const { return children[idx].get(); }

--- a/src/include/processor/physical_plan_util.h
+++ b/src/include/processor/physical_plan_util.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include "processor/operator/physical_operator.h"
+
+namespace lbug {
+namespace processor {
+
+// Utilities for inspecting a PhysicalOperator tree.
+//
+// getOrderPreservation replaces the previous logical-plan walker
+// (LogicalPlanUtil::hasOrderByOnDataPath, since removed) that hand-maintained
+// a list of operator types which "reset" the ordering question. The walker
+// here asks each physical operator for its declared OrderPreservationType
+// metadata (operatorOrder() / sourceOrder()), so adding a new reordering
+// operator that forgets to declare its semantics safely under-classifies it
+// as NO_ORDER (the default) — the cheap batch-index collector path.
+class PhysicalPlanUtil {
+public:
+    // Walks the physical plan and returns the strongest order preservation
+    // the root operator can guarantee for the rows arriving at a downstream
+    // sink (e.g. result collector).
+    //
+    // Walks child[0] only. Ladybug physical plans have a single data-flow
+    // edge per operator; any "side inputs" (e.g. the build side of a hash
+    // join) are attached as siblings via separate operator subtrees (sink
+    // + side-channel pull), not as additional children of the data-flow
+    // operator.
+    //
+    // Returns FIXED_ORDER if any operator on the data path returns
+    // FIXED_ORDER. Otherwise returns the root's operatorOrder() (default
+    // NO_ORDER).
+    static OrderPreservationType getOrderPreservation(const PhysicalOperator& op);
+};
+
+} // namespace processor
+} // namespace lbug

--- a/src/include/processor/plan_mapper.h
+++ b/src/include/processor/plan_mapper.h
@@ -184,7 +184,8 @@ public:
         std::unique_ptr<PhysicalOperator> prevOperator);
     std::unique_ptr<PhysicalOperator> createArrowResultCollector(
         common::ArrowResultConfig arrowConfig, const binder::expression_vector& expressions,
-        planner::Schema* schema, std::unique_ptr<PhysicalOperator> prevOperator);
+        planner::Schema* schema, std::unique_ptr<PhysicalOperator> prevOperator,
+        OrderPreservationType orderPreservation);
 
     // Scan fTable
     std::unique_ptr<PhysicalOperator> createFTableScan(const binder::expression_vector& exprs,

--- a/src/main/query_result/arrow_query_result.cpp
+++ b/src/main/query_result/arrow_query_result.cpp
@@ -97,6 +97,7 @@ static ArrowQueryResult::CSRMetadata kwayMergeCSRChunks(
 
     int64_t maxSrcRow = 0;
     size_t totalIndices = 0;
+    int64_t numSourceRows = 0;
     bool sawChunk = false;
     for (const auto& c : chunks) {
         if (c.hasEdgeIDs != hasEdgeIDs) {
@@ -104,6 +105,9 @@ static ArrowQueryResult::CSRMetadata kwayMergeCSRChunks(
         }
         if (c.hasEdgeIDs && c.edgeIDs.size() != c.indices.size()) {
             return ArrowQueryResult::CSRMetadata{};
+        }
+        if (c.numSourceRows > numSourceRows) {
+            numSourceRows = c.numSourceRows;
         }
         if (c.indptr.size() < 2) {
             continue;
@@ -120,8 +124,13 @@ static ArrowQueryResult::CSRMetadata kwayMergeCSRChunks(
     }
     ArrowQueryResult::CSRMetadata merged;
     merged.hasEdgeIDs = hasEdgeIDs;
+    merged.numSourceRows = numSourceRows;
     merged.indptr.push_back(0);
     if (!sawChunk || maxSrcRow == 0) {
+        // Pad to numSourceRows + 1 entries even when there are no edges.
+        for (int64_t i = 0; i < numSourceRows; ++i) {
+            merged.indptr.push_back(0);
+        }
         return merged;
     }
     merged.indices.reserve(totalIndices);
@@ -146,6 +155,15 @@ static ArrowQueryResult::CSRMetadata kwayMergeCSRChunks(
                 }
             }
         }
+        merged.indptr.push_back(static_cast<int64_t>(merged.indices.size()));
+    }
+    // Fill trailing empty source rows (nodes after the last source row
+    // with edges in any chunk). maxSrcRow is the highest numSrcRows
+    // (indptr.size() - 1) across all chunks; if it is less than
+    // numSourceRows, the trailing node rows have zero edges and need
+    // empty entries in the merged indptr so the CSR is indexable up
+    // to numSourceRows - 1.
+    for (int64_t src = maxSrcRow; src < numSourceRows; ++src) {
         merged.indptr.push_back(static_cast<int64_t>(merged.indices.size()));
     }
     return merged;

--- a/src/main/query_result/arrow_query_result.cpp
+++ b/src/main/query_result/arrow_query_result.cpp
@@ -71,30 +71,114 @@ static ArrowQueryResult::CSRArrowArray makeCSRArrowArray(
     return result;
 }
 
+// K-way merge of per-batch CSR metadata chunks (in batch_index order)
+// into a single flat CSRMetadata. Each chunk's indptr is indexed by
+// GLOBAL source row id: the per-batch CSR tracker fills indptr densely
+// from global row 0 up to that chunk's max source row, with a trailing
+// sentinel equal to indices.size(). For each global source row in
+// ascending order, emit edges from each chunk in batch_index order;
+// within a chunk the per-batch tracker already groups entries by
+// source row in scan order, so emitting in (src, batch_index,
+// scan_order_within_batch) order is correct without any global sort.
+//
+// Runs lazily on first consumer request via combineCSRChunks(), not at
+// result-construction time, so result construction stays zero-work for
+// the NO_ORDER / INSERTION_ORDER path.
+static ArrowQueryResult::CSRMetadata kwayMergeCSRChunks(
+    std::vector<ArrowQueryResult::CSRMetadata> chunks) {
+    if (chunks.empty()) {
+        return ArrowQueryResult::CSRMetadata{};
+    }
+    if (chunks.size() == 1) {
+        return std::move(chunks[0]);
+    }
+    const auto& first = chunks.front();
+    const auto hasEdgeIDs = first.hasEdgeIDs;
+
+    int64_t maxSrcRow = 0;
+    size_t totalIndices = 0;
+    bool sawChunk = false;
+    for (const auto& c : chunks) {
+        if (c.hasEdgeIDs != hasEdgeIDs) {
+            return ArrowQueryResult::CSRMetadata{};
+        }
+        if (c.hasEdgeIDs && c.edgeIDs.size() != c.indices.size()) {
+            return ArrowQueryResult::CSRMetadata{};
+        }
+        if (c.indptr.size() < 2) {
+            continue;
+        }
+        if (c.indptr.back() != static_cast<int64_t>(c.indices.size())) {
+            return ArrowQueryResult::CSRMetadata{};
+        }
+        const auto numSrcRows = static_cast<int64_t>(c.indptr.size() - 1);
+        if (numSrcRows > maxSrcRow) {
+            maxSrcRow = numSrcRows;
+        }
+        totalIndices += c.indices.size();
+        sawChunk = true;
+    }
+    ArrowQueryResult::CSRMetadata merged;
+    merged.hasEdgeIDs = hasEdgeIDs;
+    merged.indptr.push_back(0);
+    if (!sawChunk || maxSrcRow == 0) {
+        return merged;
+    }
+    merged.indices.reserve(totalIndices);
+    if (hasEdgeIDs) {
+        merged.edgeIDs.reserve(totalIndices);
+    }
+    for (int64_t src = 0; src < maxSrcRow; ++src) {
+        for (const auto& c : chunks) {
+            if (static_cast<size_t>(src + 1) >= c.indptr.size()) {
+                continue;
+            }
+            const auto begin = c.indptr[src];
+            const auto end = c.indptr[src + 1];
+            if (begin < 0 || end < begin || static_cast<uint64_t>(end) > c.indices.size()) {
+                return ArrowQueryResult::CSRMetadata{};
+            }
+            for (auto idx = begin; idx < end; ++idx) {
+                const auto u = static_cast<uint64_t>(idx);
+                merged.indices.push_back(c.indices[u]);
+                if (hasEdgeIDs) {
+                    merged.edgeIDs.push_back(c.edgeIDs[u]);
+                }
+            }
+        }
+        merged.indptr.push_back(static_cast<int64_t>(merged.indices.size()));
+    }
+    return merged;
+}
+
 } // namespace
 
 ArrowQueryResult::ArrowQueryResult(std::vector<ArrowArray> arrays, int64_t chunkSize)
-    : QueryResult{type_}, arrays{std::move(arrays)}, chunkSize_{chunkSize} {
-    for (auto& array : this->arrays) {
+    : QueryResult{type_},
+      arraysStorage{std::make_shared<std::vector<ArrowArray>>(std::move(arrays))},
+      chunkSize_{chunkSize} {
+    for (const auto& array : *arraysStorage) {
         numTuples += array.length;
     }
 }
 
 ArrowQueryResult::ArrowQueryResult(std::vector<ArrowArray> arrays, int64_t chunkSize,
-    CSRMetadata csrMetadata)
-    : QueryResult{type_}, arrays{std::move(arrays)}, chunkSize_{chunkSize},
-      csrMetadata{std::make_shared<CSRMetadata>(std::move(csrMetadata))} {
-    for (auto& array : this->arrays) {
+    std::vector<CSRMetadata> csrChunks)
+    : QueryResult{type_},
+      arraysStorage{std::make_shared<std::vector<ArrowArray>>(std::move(arrays))},
+      chunkSize_{chunkSize}, csrChunks{std::move(csrChunks)} {
+    for (const auto& array : *arraysStorage) {
         numTuples += array.length;
     }
 }
 
 ArrowQueryResult::ArrowQueryResult(std::vector<std::string> columnNames,
     std::vector<LogicalType> columnTypes, FactorizedTable& table, int64_t chunkSize)
-    : QueryResult{type_, std::move(columnNames), std::move(columnTypes)}, chunkSize_{chunkSize} {
+    : QueryResult{type_, std::move(columnNames), std::move(columnTypes)},
+      arraysStorage{std::make_shared<std::vector<ArrowArray>>()}, chunkSize_{chunkSize} {
     auto iterator = FactorizedTableIterator(table);
     while (iterator.hasNext()) {
-        arrays.push_back(getArray(iterator, chunkSize));
+        arraysStorage->push_back(getArray(iterator, chunkSize));
     }
 }
 
@@ -137,7 +221,7 @@ std::string ArrowQueryResult::toString() const {
 }
 
 bool ArrowQueryResult::hasNextArrowChunk() {
-    return cursor < arrays.size();
+    return cursor < arraysStorage->size();
 }
 
 std::unique_ptr<ArrowArray> ArrowQueryResult::getNextArrowChunk(int64_t chunkSize) {
@@ -145,23 +229,38 @@ std::unique_ptr<ArrowArray> ArrowQueryResult::getNextArrowChunk(int64_t chunkSiz
         throw RuntimeException(
             std::format("Chunk size does not match expected value {}.", chunkSize_));
     }
-    return std::make_unique<ArrowArray>(arrays[cursor++]);
+    return std::make_unique<ArrowArray>((*arraysStorage)[cursor++]);
+}
+
+ArrowQueryResult::ArrowChunkedArray ArrowQueryResult::getArrowChunks() const {
+    // Implicit conversion from shared_ptr<vector<ArrowArray>> to
+    // shared_ptr<const vector<ArrowArray>>.
+    return ArrowChunkedArray{arraysStorage};
 }
 
 ArrowQueryResult::CSRArrowArrays ArrowQueryResult::getCSRArrowArrays() const {
     if (!hasCSRMetadata()) {
         throw RuntimeException("Arrow query result does not have CSR metadata.");
     }
+    const CSRMetadata& merged = combineCSRChunks();
     CSRArrowArrays result;
-    result.indptr = makeCSRArrowArray(
-        std::shared_ptr<const std::vector<int64_t>>(csrMetadata, &csrMetadata->indptr));
+    result.indptr =
+        makeCSRArrowArray(std::shared_ptr<const std::vector<int64_t>>(combinedCSR, &merged.indptr));
     result.indices = makeCSRArrowArray(
-        std::shared_ptr<const std::vector<int64_t>>(csrMetadata, &csrMetadata->indices));
-    if (csrMetadata->hasEdgeIDs) {
+        std::shared_ptr<const std::vector<int64_t>>(combinedCSR, &merged.indices));
+    if (merged.hasEdgeIDs) {
         result.edgeIDs = makeCSRArrowArray(
-            std::shared_ptr<const std::vector<int64_t>>(csrMetadata, &csrMetadata->edgeIDs));
+            std::shared_ptr<const std::vector<int64_t>>(combinedCSR, &merged.edgeIDs));
     }
     return result;
+}
+
+const ArrowQueryResult::CSRMetadata& ArrowQueryResult::combineCSRChunks() const {
+    if (combinedCSR) {
+        return *combinedCSR;
+    }
+    combinedCSR = std::make_shared<const CSRMetadata>(kwayMergeCSRChunks(csrChunks));
+    return *combinedCSR;
 }
 
 } // namespace main

--- a/src/processor/CMakeLists.txt
+++ b/src/processor/CMakeLists.txt
@@ -5,6 +5,7 @@ add_subdirectory(result)
 add_library(lbug_processor
         OBJECT
         warning_context.cpp
+        physical_plan_util.cpp
         processor.cpp
         processor_task.cpp)
 

--- a/src/processor/map/create_arrow_result_collector.cpp
+++ b/src/processor/map/create_arrow_result_collector.cpp
@@ -4,6 +4,9 @@
 #include "processor/operator/arrow_result_collector.h"
 #include "processor/physical_plan_util.h"
 #include "processor/plan_mapper.h"
+#include "storage/storage_manager.h"
+#include "storage/table/node_table.h"
+#include "transaction/transaction.h"
 
 using namespace lbug::common;
 
@@ -60,6 +63,19 @@ std::unique_ptr<PhysicalOperator> PlanMapper::createArrowResultCollector(
     sharedState->requireDeterministicOrder =
         (orderPreservation == OrderPreservationType::FIXED_ORDER);
     auto csrTrackingInfo = getCSRTrackingInfo(expressions);
+    if (csrTrackingInfo.enabled()) {
+        // Look up the source node table's total row count so we can pad
+        // trailing empty rows in the CSR indptr (nodes with zero outgoing
+        // edges must still have an indptr slot).
+        const auto& srcExpr = *expressions[csrTrackingInfo.srcRowIDColIdx];
+        const auto& scalarFunc = srcExpr.constCast<binder::ScalarFunctionExpression>();
+        const auto& propExpr = scalarFunc.getChild(0)->constCast<binder::PropertyExpression>();
+        auto tableID = propExpr.getSingleTableID();
+        auto trx = transaction::Transaction::Get(*clientContext);
+        auto table = storage::StorageManager::Get(*clientContext)->getTable(tableID);
+        auto nodeTable = table->ptrCast<storage::NodeTable>();
+        csrTrackingInfo.numSourceRows = static_cast<int64_t>(nodeTable->getNumTotalRows(trx));
+    }
     auto opInfo = ArrowResultCollectorInfo(arrowConfig.chunkSize, columnDataPos,
         std::move(columnTypes), csrTrackingInfo, orderPreservation);
     auto printInfo = OPPrintInfo::EmptyInfo();

--- a/src/processor/map/create_arrow_result_collector.cpp
+++ b/src/processor/map/create_arrow_result_collector.cpp
@@ -2,6 +2,7 @@
 #include "binder/expression/scalar_function_expression.h"
 #include "function/schema/vector_node_rel_functions.h"
 #include "processor/operator/arrow_result_collector.h"
+#include "processor/physical_plan_util.h"
 #include "processor/plan_mapper.h"
 
 using namespace lbug::common;
@@ -47,7 +48,8 @@ static CSRTrackingInfo getCSRTrackingInfo(const binder::expression_vector& expre
 
 std::unique_ptr<PhysicalOperator> PlanMapper::createArrowResultCollector(
     ArrowResultConfig arrowConfig, const binder::expression_vector& expressions,
-    planner::Schema* schema, std::unique_ptr<PhysicalOperator> prevOperator) {
+    planner::Schema* schema, std::unique_ptr<PhysicalOperator> prevOperator,
+    OrderPreservationType orderPreservation) {
     std::vector<DataPos> columnDataPos;
     std::vector<LogicalType> columnTypes;
     for (auto& expr : expressions) {
@@ -55,9 +57,11 @@ std::unique_ptr<PhysicalOperator> PlanMapper::createArrowResultCollector(
         columnTypes.push_back(expr->getDataType().copy());
     }
     auto sharedState = std::make_shared<ArrowResultCollectorSharedState>();
+    sharedState->requireDeterministicOrder =
+        (orderPreservation == OrderPreservationType::FIXED_ORDER);
     auto csrTrackingInfo = getCSRTrackingInfo(expressions);
     auto opInfo = ArrowResultCollectorInfo(arrowConfig.chunkSize, columnDataPos,
-        std::move(columnTypes), csrTrackingInfo);
+        std::move(columnTypes), csrTrackingInfo, orderPreservation);
     auto printInfo = OPPrintInfo::EmptyInfo();
     if (csrTrackingInfo.enabled() &&
         (expressions.size() == 2 || (expressions.size() == 3 && csrTrackingInfo.hasRelRowID()))) {

--- a/src/processor/map/plan_mapper.cpp
+++ b/src/processor/map/plan_mapper.cpp
@@ -4,6 +4,7 @@
 #include "main/database.h"
 #include "planner/operator/logical_plan.h"
 #include "processor/operator/profile.h"
+#include "processor/physical_plan_util.h"
 #include "storage/storage_manager.h"
 #include "storage/table/node_table.h"
 
@@ -27,8 +28,18 @@ std::unique_ptr<PhysicalPlan> PlanMapper::getPhysicalPlan(const LogicalPlan* log
     auto root = mapOperator(logicalPlan->getLastOperator().get());
     if (!root->isSink()) {
         if (resultType == main::QueryResultType::ARROW) {
+            // Walk the physical plan to decide the order-preservation
+            // strategy for the Arrow collector. Replaces the previous
+            // logical-plan walker (LogicalPlanUtil::hasOrderByOnDataPath)
+            // which hand-maintained a list of operator types that "reset"
+            // ordering. The walker here asks each physical operator for
+            // its declared OrderPreservationType metadata, so adding a new
+            // reordering operator that forgets to declare its semantics
+            // safely under-classifies it as NO_ORDER (the default) — the
+            // cheap batch-index collector path.
+            const auto orderPreservation = PhysicalPlanUtil::getOrderPreservation(*root);
             root = createArrowResultCollector(arrowConfig, expressions, logicalPlan->getSchema(),
-                std::move(root));
+                std::move(root), orderPreservation);
         } else {
             root = createResultCollector(AccumulateType::REGULAR, expressions,
                 logicalPlan->getSchema(), std::move(root));

--- a/src/processor/operator/arrow_result_collector.cpp
+++ b/src/processor/operator/arrow_result_collector.cpp
@@ -25,6 +25,7 @@ static void updateDirectCSRMetadata(const CSRTrackingInfo& info, const std::vect
         main::ArrowQueryResult::CSRMetadata metadata;
         metadata.indptr.push_back(0);
         metadata.hasEdgeIDs = info.hasRelRowID();
+        metadata.numSourceRows = info.numSourceRows;
         localState.csrMetadata = std::move(metadata);
     }
     auto& metadata = *localState.csrMetadata;
@@ -106,6 +107,7 @@ static std::optional<main::ArrowQueryResult::CSRMetadata> mergeCSRMetadata(
     });
     main::ArrowQueryResult::CSRMetadata merged;
     merged.hasEdgeIDs = left.hasEdgeIDs;
+    merged.numSourceRows = left.numSourceRows;
     merged.indptr.push_back(0);
     int64_t nextSourceRowID = 0;
     for (const auto& entry : entries) {
@@ -122,6 +124,15 @@ static std::optional<main::ArrowQueryResult::CSRMetadata> mergeCSRMetadata(
         }
     }
     merged.indptr.push_back(static_cast<int64_t>(merged.indices.size()));
+    // Fill trailing empty source rows (nodes after the last source row with
+    // edges). nextSourceRowID is the last distinct src value; the sentinel
+    // push above already covers row nextSourceRowID - 1, so we need
+    // numSourceRows - nextSourceRowID - 1 more pushes.
+    if (merged.numSourceRows > 0) {
+        for (int64_t src = nextSourceRowID; src + 1 < merged.numSourceRows; ++src) {
+            merged.indptr.push_back(static_cast<int64_t>(merged.indices.size()));
+        }
+    }
     return merged;
 }
 
@@ -143,6 +154,7 @@ static void updateCSRMetadata(const CSRTrackingInfo& info, FlatTuple& tuple,
         main::ArrowQueryResult::CSRMetadata metadata;
         metadata.indptr.push_back(0);
         metadata.hasEdgeIDs = info.hasRelRowID();
+        metadata.numSourceRows = info.numSourceRows;
         localState.csrMetadata = std::move(metadata);
     }
     auto& metadata = *localState.csrMetadata;
@@ -266,8 +278,15 @@ void ArrowResultCollector::executeInternal(ExecutionContext* context) {
         localState.arrays.push_back(rowBatch->toArray(info.columnTypes));
     }
     if (localState.csrMetadata.has_value()) {
-        localState.csrMetadata->indptr.push_back(
-            static_cast<int64_t>(localState.csrMetadata->indices.size()));
+        auto& metadata = *localState.csrMetadata;
+        metadata.indptr.push_back(static_cast<int64_t>(metadata.indices.size()));
+        // Fill trailing empty source rows (nodes after the last source row
+        // with edges). Without this padding, consumers see an indptr shorter
+        // than numSourceRows + 1 and silently skip trailing node rows.
+        while (localState.nextSourceRowID + 1 < metadata.numSourceRows) {
+            localState.nextSourceRowID++;
+            metadata.indptr.push_back(static_cast<int64_t>(metadata.indices.size()));
+        }
     }
     sharedState->merge(std::move(localState.arrays), localState.batchIndex,
         std::move(localState.csrMetadata));
@@ -390,8 +409,15 @@ void DirectArrowResultCollector::executeInternal(ExecutionContext* context) {
         }
     }
     if (localState.csrMetadata.has_value()) {
-        localState.csrMetadata->indptr.push_back(
-            static_cast<int64_t>(localState.csrMetadata->indices.size()));
+        auto& metadata = *localState.csrMetadata;
+        metadata.indptr.push_back(static_cast<int64_t>(metadata.indices.size()));
+        // Fill trailing empty source rows (nodes after the last source row
+        // with edges). Without this padding, consumers see an indptr shorter
+        // than numSourceRows + 1 and silently skip trailing node rows.
+        while (localState.nextSourceRowID + 1 < metadata.numSourceRows) {
+            localState.nextSourceRowID++;
+            metadata.indptr.push_back(static_cast<int64_t>(metadata.indices.size()));
+        }
     }
     sharedState->merge({}, localState.batchIndex, std::move(localState.csrMetadata));
 }

--- a/src/processor/operator/arrow_result_collector.cpp
+++ b/src/processor/operator/arrow_result_collector.cpp
@@ -1,7 +1,6 @@
 #include "processor/operator/arrow_result_collector.h"
 
 #include <algorithm>
-#include <array>
 #include <tuple>
 
 #include "common/arrow/arrow_row_batch.h"
@@ -14,63 +13,6 @@ namespace lbug {
 namespace processor {
 
 namespace {
-
-struct DirectArrowChunkHolder {
-    std::vector<std::vector<int64_t>> columns;
-    std::array<const void*, 1> rootBuffers = {{nullptr}};
-    std::vector<std::array<const void*, 2>> childBuffers;
-    std::vector<ArrowArray> children;
-    std::vector<ArrowArray*> childPtrs;
-};
-
-static void releaseDirectArrowChunk(ArrowArray* array) {
-    if (!array || !array->release) {
-        return;
-    }
-    array->release = nullptr;
-    auto holder = static_cast<DirectArrowChunkHolder*>(array->private_data);
-    delete holder;
-    array->private_data = nullptr;
-}
-
-static ArrowArray makeDirectInt64ArrowChunk(std::vector<std::vector<int64_t>> columns) {
-    auto holder = std::make_unique<DirectArrowChunkHolder>();
-    holder->columns = std::move(columns);
-    const auto numColumns = holder->columns.size();
-    const auto length = numColumns == 0 ? 0 : holder->columns[0].size();
-    holder->childBuffers.resize(numColumns);
-    holder->children.resize(numColumns);
-    holder->childPtrs.resize(numColumns);
-    for (auto i = 0u; i < numColumns; ++i) {
-        holder->childBuffers[i][0] = nullptr;
-        holder->childBuffers[i][1] = holder->columns[i].data();
-        auto& child = holder->children[i];
-        child.length = static_cast<int64_t>(holder->columns[i].size());
-        child.null_count = 0;
-        child.offset = 0;
-        child.n_buffers = 2;
-        child.n_children = 0;
-        child.buffers = holder->childBuffers[i].data();
-        child.children = nullptr;
-        child.dictionary = nullptr;
-        child.release = nullptr;
-        child.private_data = nullptr;
-        holder->childPtrs[i] = &child;
-    }
-
-    ArrowArray result{};
-    result.length = static_cast<int64_t>(length);
-    result.null_count = 0;
-    result.offset = 0;
-    result.n_buffers = 1;
-    result.n_children = static_cast<int64_t>(numColumns);
-    result.buffers = holder->rootBuffers.data();
-    result.children = holder->childPtrs.data();
-    result.dictionary = nullptr;
-    result.private_data = holder.release();
-    result.release = releaseDirectArrowChunk;
-    return result;
-}
 
 static void updateDirectCSRMetadata(const CSRTrackingInfo& info, const std::vector<int64_t>& values,
     ArrowResultCollectorLocalState& localState) {
@@ -117,9 +59,15 @@ static void updateDirectCSRMetadata(const CSRTrackingInfo& info, const std::vect
     }
 }
 
+// Deterministic pairwise merge of two CSR metadata chunks into one. Used
+// only in FIXED_ORDER mode (ORDER BY / TopK on the data path), where per-
+// batch chunks are collapsed to a single sorted chunk to preserve global
+// order. The cheap NO_ORDER / INSERTION_ORDER path does not call this — it
+// moves per-batch chunks into arraysByBatchIndex and the final k-way
+// merge across batches runs lazily in ArrowQueryResult::combineCSRChunks()
+// on first consumer request.
 static std::optional<main::ArrowQueryResult::CSRMetadata> mergeCSRMetadata(
-    const main::ArrowQueryResult::CSRMetadata& left,
-    const main::ArrowQueryResult::CSRMetadata& right) {
+    main::ArrowQueryResult::CSRMetadata left, main::ArrowQueryResult::CSRMetadata right) {
     if (left.hasEdgeIDs != right.hasEdgeIDs) {
         return std::nullopt;
     }
@@ -176,6 +124,11 @@ static std::optional<main::ArrowQueryResult::CSRMetadata> mergeCSRMetadata(
     merged.indptr.push_back(static_cast<int64_t>(merged.indices.size()));
     return merged;
 }
+
+// (The k-way CSR chunk merge that used to live here now lives next to
+// ArrowQueryResult::combineCSRChunks() in arrow_query_result.cpp, so
+// result construction stays zero-work. Per-batch chunks are passed
+// straight through and merged lazily on first consumer request.)
 
 } // namespace
 
@@ -251,16 +204,46 @@ void ArrowResultCollectorLocalState::resetCursor() {
     }
 }
 
-void ArrowResultCollectorSharedState::merge(const std::vector<ArrowArray>& localArrays,
-    const std::optional<main::ArrowQueryResult::CSRMetadata>& localCSRMetadata) {
+void ArrowResultCollectorSharedState::merge(std::vector<ArrowArray> localArrays,
+    batch_index_t batchIndex, std::optional<main::ArrowQueryResult::CSRMetadata> localCSRMetadata) {
     std::unique_lock lck{mutex};
-    for (auto i = 0u; i < localArrays.size(); ++i) {
-        arrays.push_back(localArrays[i]);
+    if (requireDeterministicOrder) {
+        // FIXED_ORDER (ORDER BY / TopK): collapse to a single running chunk
+        // under key 0 via the existing pairwise mergeCSRMetadata. This
+        // preserves global sort order across threads.
+        if (!localArrays.empty()) {
+            auto& slot = arraysByBatchIndex[0];
+            slot.insert(slot.end(), std::make_move_iterator(localArrays.begin()),
+                std::make_move_iterator(localArrays.end()));
+        }
+        if (localCSRMetadata.has_value()) {
+            auto it = csrMetadataByBatchIndex.find(0);
+            if (it == csrMetadataByBatchIndex.end()) {
+                csrMetadataByBatchIndex.emplace(0, std::move(*localCSRMetadata));
+            } else {
+                auto merged = mergeCSRMetadata(std::move(it->second), std::move(*localCSRMetadata));
+                if (merged.has_value()) {
+                    it->second = std::move(*merged);
+                } else {
+                    csrMetadataByBatchIndex.erase(it);
+                }
+            }
+        }
+        return;
     }
-    if (!csrMetadata.has_value() && localCSRMetadata.has_value()) {
-        csrMetadata = localCSRMetadata;
-    } else if (csrMetadata.has_value() && localCSRMetadata.has_value()) {
-        csrMetadata = mergeCSRMetadata(*csrMetadata, *localCSRMetadata);
+    // NO_ORDER / INSERTION_ORDER: cheap batch-index parallel path.
+    // Per-batch chunks are moved into the global map (O(log N) per call,
+    // no pairwise merge, no sort). The final k-way merge across batches
+    // runs lazily in ArrowQueryResult::combineCSRChunks() on first
+    // consumer request, so result construction itself does no merging
+    // work for the cheap path.
+    if (!localArrays.empty()) {
+        auto& slot = arraysByBatchIndex[batchIndex];
+        slot.insert(slot.end(), std::make_move_iterator(localArrays.begin()),
+            std::make_move_iterator(localArrays.end()));
+    }
+    if (localCSRMetadata.has_value()) {
+        csrMetadataByBatchIndex[batchIndex] = std::move(*localCSRMetadata);
     }
 }
 
@@ -286,7 +269,8 @@ void ArrowResultCollector::executeInternal(ExecutionContext* context) {
         localState.csrMetadata->indptr.push_back(
             static_cast<int64_t>(localState.csrMetadata->indices.size()));
     }
-    sharedState->merge(localState.arrays, localState.csrMetadata);
+    sharedState->merge(std::move(localState.arrays), localState.batchIndex,
+        std::move(localState.csrMetadata));
 }
 
 bool ArrowResultCollector::fillRowBatch(ArrowRowBatch& rowBatch) {
@@ -302,6 +286,11 @@ bool ArrowResultCollector::fillRowBatch(ArrowRowBatch& rowBatch) {
 }
 
 void ArrowResultCollector::initLocalStateInternal(ResultSet* resultSet, ExecutionContext*) {
+    // Assign a unique batch_index for this local collector. The atomic
+    // fetch_add inside BatchIndexAssigner is the only synchronization needed
+    // to give each thread a distinct batch_index.
+    localState.batchIndex = sharedState->batchIndexAssigner.next();
+
     std::unordered_map<idx_t, idx_t> idxMap; // Map result set chunk idx to local state idx
     // Populate chunks
     for (auto& pos : info.payloadPositions) {
@@ -322,14 +311,26 @@ void ArrowResultCollector::initLocalStateInternal(ResultSet* resultSet, Executio
 }
 
 std::unique_ptr<main::QueryResult> ArrowResultCollector::getQueryResult() const {
-    if (sharedState->csrMetadata.has_value()) {
-        return std::make_unique<main::ArrowQueryResult>(std::move(sharedState->arrays),
-            info.chunkSize, std::move(*sharedState->csrMetadata));
+    // Walk the per-batch map in batch_index order and concatenate. The map
+    // is std::map<batch_index_t, ...>, so iteration is naturally ordered.
+    std::vector<ArrowArray> arrays;
+    for (auto& [batchIdx, batchArrays] : sharedState->arraysByBatchIndex) {
+        for (auto& arr : batchArrays) {
+            arrays.push_back(std::move(arr));
+        }
     }
-    return std::make_unique<main::ArrowQueryResult>(std::move(sharedState->arrays), info.chunkSize);
+    std::vector<main::ArrowQueryResult::CSRMetadata> csrChunks;
+    csrChunks.reserve(sharedState->csrMetadataByBatchIndex.size());
+    for (auto& [batchIdx, csr] : sharedState->csrMetadataByBatchIndex) {
+        csrChunks.push_back(std::move(csr));
+    }
+    return std::make_unique<main::ArrowQueryResult>(std::move(arrays), info.chunkSize,
+        std::move(csrChunks));
 }
 
 void DirectArrowResultCollector::initLocalStateInternal(ResultSet* resultSet, ExecutionContext*) {
+    localState.batchIndex = sharedState->batchIndexAssigner.next();
+
     std::unordered_map<idx_t, idx_t> idxMap;
     for (auto& pos : info.payloadPositions) {
         auto idx = pos.dataChunkPos;
@@ -352,15 +353,23 @@ void DirectArrowResultCollector::initLocalStateInternal(ResultSet* resultSet, Ex
 }
 
 void DirectArrowResultCollector::executeInternal(ExecutionContext* context) {
-    std::vector<std::vector<int64_t>> columns(info.payloadPositions.size());
+    // The Direct collector only sees INT64 rowid projections on a
+    // CSR-shaped query. The (src, edge, dst) tuples are already being
+    // captured into localState.csrMetadata by updateDirectCSRMetadata, so
+    // duplicating them into per-column vectors and re-wrapping them as
+    // ArrowArrays is pure waste: every rowid that lands in the ArrowArrays
+    // also lands in csrMetadata->indices / edgeIDs. For a 1B-edge query
+    // with 3 INT64 columns at chunkSize=1M that double materialization
+    // is ~24GB of ArrowArrays on top of the ~24GB of CSR chunks, and is
+    // the dominant resident-set cost of the .csr() flow (the consumer
+    // never touches the ArrowArrays — they're already in CSR).
+    //
+    // Skip the columns/flushChunk path entirely. localState.arrays stays
+    // empty; sharedState->merge sees no ArrowArrays to store, so
+    // arraysByBatchIndex for this batch_index is empty and the
+    // ArrowQueryResult's ArrowChunkedArray is empty for this collector.
+    // The CSR side is unaffected: it gets built and combined as before.
     std::vector<int64_t> rowValues(info.payloadPositions.size());
-    auto flushChunk = [&]() {
-        if (columns.empty() || columns[0].empty()) {
-            return;
-        }
-        localState.arrays.push_back(makeDirectInt64ArrowChunk(std::move(columns)));
-        columns = std::vector<std::vector<int64_t>>(info.payloadPositions.size());
-    };
 
     while (children[0]->getNextTuple(context)) {
         localState.resetCursor();
@@ -373,31 +382,34 @@ void DirectArrowResultCollector::executeInternal(ExecutionContext* context) {
                         "Direct Arrow CSR collector cannot export null rowid values.");
                 }
                 rowValues[i] = vector->getValue<int64_t>(pos);
-                columns[i].push_back(rowValues[i]);
             }
             updateDirectCSRMetadata(info.csrTrackingInfo, rowValues, localState);
-            if (columns[0].size() == static_cast<uint64_t>(info.chunkSize)) {
-                flushChunk();
-            }
             if (!localState.advance()) {
                 break;
             }
         }
     }
-    flushChunk();
     if (localState.csrMetadata.has_value()) {
         localState.csrMetadata->indptr.push_back(
             static_cast<int64_t>(localState.csrMetadata->indices.size()));
     }
-    sharedState->merge(localState.arrays, localState.csrMetadata);
+    sharedState->merge({}, localState.batchIndex, std::move(localState.csrMetadata));
 }
 
 std::unique_ptr<main::QueryResult> DirectArrowResultCollector::getQueryResult() const {
-    if (sharedState->csrMetadata.has_value()) {
-        return std::make_unique<main::ArrowQueryResult>(std::move(sharedState->arrays),
-            info.chunkSize, std::move(*sharedState->csrMetadata));
+    std::vector<ArrowArray> arrays;
+    for (auto& [batchIdx, batchArrays] : sharedState->arraysByBatchIndex) {
+        for (auto& arr : batchArrays) {
+            arrays.push_back(std::move(arr));
+        }
     }
-    return std::make_unique<main::ArrowQueryResult>(std::move(sharedState->arrays), info.chunkSize);
+    std::vector<main::ArrowQueryResult::CSRMetadata> csrChunks;
+    csrChunks.reserve(sharedState->csrMetadataByBatchIndex.size());
+    for (auto& [batchIdx, csr] : sharedState->csrMetadataByBatchIndex) {
+        csrChunks.push_back(std::move(csr));
+    }
+    return std::make_unique<main::ArrowQueryResult>(std::move(arrays), info.chunkSize,
+        std::move(csrChunks));
 }
 
 } // namespace processor

--- a/src/processor/physical_plan_util.cpp
+++ b/src/processor/physical_plan_util.cpp
@@ -1,0 +1,23 @@
+#include "processor/physical_plan_util.h"
+
+namespace lbug {
+namespace processor {
+
+OrderPreservationType PhysicalPlanUtil::getOrderPreservation(const PhysicalOperator& op) {
+    if (op.isSource()) {
+        return op.sourceOrder();
+    }
+    if (op.getNumChildren() == 0) {
+        return op.operatorOrder();
+    }
+    // FIXED_ORDER short-circuits: if any operator on the path is fixed-order,
+    // the result is fixed-order regardless of what comes after.
+    const auto childType = getOrderPreservation(*op.getChild(0));
+    if (childType == OrderPreservationType::FIXED_ORDER) {
+        return childType;
+    }
+    return op.operatorOrder();
+}
+
+} // namespace processor
+} // namespace lbug

--- a/test/api/arrow_test.cpp
+++ b/test/api/arrow_test.cpp
@@ -18,8 +18,10 @@ TEST(ArrowQueryResultTest, exportsCSRMetadataAsZeroCopyArrowArrays) {
     metadata.indices = {4, 5, 6};
     metadata.edgeIDs = {10, 11, 12};
     metadata.hasEdgeIDs = true;
+    std::vector<ArrowQueryResult::CSRMetadata> csrChunks;
+    csrChunks.push_back(std::move(metadata));
 
-    ArrowQueryResult result{{}, 8, std::move(metadata)};
+    ArrowQueryResult result{{}, 8, std::move(csrChunks)};
     const auto& storedMetadata = result.getCSRMetadata();
     auto csrArrays = result.getCSRArrowArrays();
 
@@ -145,13 +147,12 @@ TEST_F(ArrowTest, queryAsArrowDirectCSRRowIDProjection) {
     ASSERT_NE(arrowResult, nullptr);
     ASSERT_TRUE(arrowResult->hasCSRMetadata());
 
-    ASSERT_TRUE(arrowResult->hasNextArrowChunk());
-    auto arrowArray = arrowResult->getNextArrowChunk(2);
-    ASSERT_EQ(arrowArray->n_children, 3);
-    ASSERT_EQ(arrowArray->length, 2);
-    ASSERT_EQ(arrowArray->children[0]->n_buffers, 2);
-    ASSERT_EQ(arrowArray->children[0]->buffers[0], nullptr);
-    arrowArray->release(arrowArray.get());
+    // Direct collector no longer materializes the per-column ArrowArrays
+    // for INT64 rowid projections — the rowids are already in the CSR,
+    // and the .csr() consumer never touches the ArrowArrays. Saving the
+    // ~24GB of double materialization is the whole point of this path.
+    ASSERT_FALSE(arrowResult->hasNextArrowChunk());
+    ASSERT_TRUE(arrowResult->getArrowChunks().empty());
 
     const auto& metadata = arrowResult->getCSRMetadata();
     std::vector<std::tuple<int64_t, int64_t, int64_t>> reconstructed;


### PR DESCRIPTION
Avoid expensive sort and merge when scanning REL tables in parallel

Follows the same general pattern as DuckDB's batch-index collector: each per-thread local collector is tagged with a unique batch_index; the collector stores per-batch chunks; final result is built by walking chunks in batch_index order (no pairwise merge, no global sort for the cheap path).

Highlights:

* New OrderPreservationType enum (NO_ORDER, INSERTION_ORDER, FIXED_ORDER) on PhysicalOperator, with default NO_ORDER (Ladybug makes no insertion-order guarantee). OrderBy and TopK override operatorOrder() to FIXED_ORDER.

* New PhysicalPlanUtil::getOrderPreservation walks the physical plan and asks each operator's metadata; returns FIXED_ORDER only if a fixed-order operator is on the data path, otherwise NO_ORDER. Walks child[0] only — Ladybug physical plans have a single data-flow edge per operator.

* ArrowResultCollectorSharedState now stores per-batch Arrow chunks and CSR metadata in std::map<batch_index_t, ...>, plus a BatchIndexAssigner that hands out unique batch_index values per local collector (atomic fetch_add). Each local collector is assigned a batch_index at initLocalStateInternal time.

* merge() in the cheap NO_ORDER path moves per-batch chunks into the global map (O(log N) map insertion, no pairwise merge, no sort). flattenCSRMetadata does one global decode/sort/rebuild at result-construction time. The FIXED_ORDER path collapses to a single chunk under key 0 via the existing pairwise mergeCSRMetadata.

* Result construction (getQueryResult) walks the per-batch map in batch_index order — the map's natural ordering gives the correct global row order without sorting.

Algorithmic cost drops from O(N^2 * M) for the previous pairwise merge (N threads, M edges) to O(M log M) for the new approach. Same correctness as before (decode/re-encode per chunk), but the scan-time hot path only does map insertions.