### PR TITLE
arrow-csr: Memory efficient zero-copy path

### DIFF
--- a/docs/design_arrow_csr_zero_copy.md
+++ b/docs/design_arrow_csr_zero_copy.md
@@ -1,0 +1,271 @@
+# Design: Zero-copy CSR path for `ArrowResultCollector` / `ArrowQueryResult`
+
+## 1. Problem
+
+Reading ~0.75B edges from CSR columnar storage into Arrow CSR memory should
+cost:
+
+| array     | size                | bytes (0.75B edges, ~100M src nodes) |
+|-----------|---------------------|--------------------------------------|
+| `indices` | #edges              | 0.75B × 8 = **6.0 GB**               |
+| `indptr`  | #sourceRows + 1     | 100M × 8 = **0.8 GB**                |
+| `edgeIDs` | #edges (optional)   | 0.75B × 8 = **6.0 GB**               |
+
+Expected total ≈ **6.8 GB** (no rel rowid) or **12.8 GB** (with rel rowid).
+Observed: **~45 GB**. The query runs the `DirectArrowResultCollector` path
+(`getArrowChunks().empty()` is asserted in `arrow_test.cpp`), so the per-column
+`ArrowArray` materialization is *already* skipped. The 45 GB lives entirely in
+`ArrowResultCollectorLocalState::csrMetadata`.
+
+## 2. Root cause — per-batch dense-global `indptr`
+
+`updateDirectCSRMetadata` builds, per local collector (one per thread/batch), a
+CSR whose `indptr` is indexed by **global** source row id. To stay indexable it
+fills `indptr` densely from global row 0 up to the batch's max source row, then
+`executeInternal` pads the tail:
+
+```cpp
+while (localState.nextSourceRowID + 1 < metadata.numSourceRows) {
+    localState.nextSourceRowID++;
+    metadata.indptr.push_back(static_cast<int64_t>(metadata.indices.size()));
+}
+```
+
+So **every batch's `indptr` has `numSourceRows + 1` entries** (≈800 MB each),
+regardless of how many distinct source rows that batch actually touches. With
+~49–56 parallel batches (one per thread over a 0.75B-edge scan), the indptr
+memory alone is `B × 800 MB ≈ 40–45 GB`. The `indices` (6 GB) and `edgeIDs`
+(6 GB) are *not* duplicated per batch — each edge lives in exactly one batch —
+so they are already at their theoretical size. **The entire ~38 GB of bloat is
+`indptr` duplicated across batches.**
+
+The `kwayMergeCSRChunks` merge then copies the per-batch `indices`/`edgeIDs`
+into a single flat `CSRMetadata` (cached in `combinedCSR`) while the per-batch
+`csrChunks` vector stays alive in `ArrowQueryResult`, so the *transient* peak at
+first consumer access is even higher (~per-batch 45 GB + merged 12.8 GB). The
+45 GB the user sees is the steady-state pre-merge cost.
+
+There is also a secondary issue: `kwayMergeCSRChunks` is
+`O(maxSrcRow × numChunks)` (it loops every global source row × every chunk),
+which is ~5 billion iterations for this query — slow, but dominated by the
+memory problem.
+
+## 3. The invariant we can exploit
+
+Two properties of the scan make a sparse per-batch representation correct:
+
+1. **CSR storage + monotonic morsel acquisition ⇒ per-thread source rows are
+   non-decreasing.** The rel table is a `CSRNodeGroup`; a `ScanRelTable` extend
+   emits each bound node's outgoing edges contiguously. The bound-node scan
+   hands out morsels from an atomic counter
+   (`ScanNodeTableSharedState::nextMorsel` does `currentCommittedGroupIdx++`),
+   so each thread receives a *strictly increasing* sequence of morsels, hence a
+   non-decreasing sequence of `srcRowID`s. (`sourceMode` is single-threaded and
+   therefore not the 45 GB case; the parallel extend path is.)
+
+2. **Each source row's edges land in exactly one batch.** A source row (node)
+   is scanned in exactly one morsel, which goes to exactly one thread. So the
+   per-batch sets of touched source rows are **disjoint** and each is sorted.
+
+Consequence: a batch never needs a dense global `indptr`. It only needs to
+record *which* source rows it touched and *how many edges* each has — a sparse
+CSR. The global dense `indptr` (800 MB) is reconstructed **once**, at merge
+time, by unioning the disjoint sorted per-batch source-row sets.
+
+The existing code already enforces the precondition: if `srcRowID` ever
+decreases within a batch (e.g. `ORDER BY` a non-src column reorders tuples),
+`updateDirectCSRMetadata` sets `csrMetadataValid = false` and drops the
+metadata. The sparse design inherits exactly this bail-out — no new ordering
+requirement is introduced.
+
+## 4. Proposed data structure — sparse per-batch CSR
+
+Replace the dense-global `indptr` in the per-batch `CSRMetadata` with a sparse
+run representation. While the source row is non-decreasing we record, per
+distinct source row, its id and its edge count:
+
+```
+struct CSRMetadata {            // per-batch, as collected
+    std::vector<int64_t> indices;     // dst rowids, source-sorted within batch  (6 GB total across batches)
+    std::vector<int64_t> edgeIDs;     // optional, parallel to indices           (6 GB total)
+    // SPARSE indptr — replaces the dense global std::vector<int64_t> indptr:
+    std::vector<int64_t> srcRows;     // distinct source rows touched, increasing (100M total across batches = 0.8 GB)
+    std::vector<int64_t> counts;      // #edges per srcRows[i]                    (100M total = 0.8 GB)
+    bool hasEdgeIDs = false;
+    int64_t numSourceRows = 0;
+};
+```
+
+Per-batch overhead drops from `numSourceRows × 8` (800 MB) to
+`distinctSrcRowsInBatch × 16` (≈ a few MB). **Summed across all batches the
+sparse structure is 100M × 16 = 1.6 GB**, replacing the 40+ GB of duplicated
+dense `indptr`.
+
+### Build (replace `updateDirectCSRMetadata`)
+
+State carried in `ArrowResultCollectorLocalState`: `currentSourceRowID`,
+`currentRowCount` (edges seen for the current source row).
+
+```
+on each (src, dst [, edge]):
+    if src < currentSourceRowID:          // ordering violated (ORDER BY non-src)
+        csrMetadataValid = false; reset; return
+    if src != currentSourceRowID:
+        srcRows.push_back(currentSourceRowID)
+        counts .push_back(currentRowCount)
+        currentSourceRowID = src
+        currentRowCount = 0
+    indices.push_back(dst)                // (and edgeIDs.push_back(edge))
+    currentRowCount++
+on batch end:
+    if currentRowCount > 0 (or we saw any edge):
+        srcRows.push_back(currentSourceRowID)
+        counts .push_back(currentRowCount)
+```
+
+No gap-filling, no trailing pad to `numSourceRows` — those are the merge's job.
+The dense `indptr` member is removed from the per-batch struct entirely.
+
+### Merge (replace `kwayMergeCSRChunks`)
+
+Inputs: `chunks[]`, each `{srcRows, counts, indices, edgeIDs}` with disjoint,
+sorted `srcRows`. Output: one flat `CSRMetadata{indptr, indices, edgeIDs}`.
+
+Because the `srcRows` partition is disjoint and each chunk's edges are already
+grouped by source row, this is a **union of sorted disjoint runs**, not a
+general k-way merge:
+
+1. One pass to sum `counts` → `totalEdges` (reserve `indices`/`edgeIDs`).
+2. Build the merged `indices`/`edgeIDs` by emitting each chunk's edges in
+   **global source-row order**. Concretely: a min-heap (or, since disjoint, a
+   simple k-way finger) over the chunks' `srcRows` cursors; pop the smallest
+   next source row, copy that source row's `counts[i]` edges from the owning
+   chunk into the merged `indices`, and record `indptr[src]` = current merged
+   offset. Source rows not present in any chunk get
+   `indptr[src] = indptr[src-1]` (empty). This is
+   `O(totalSrcRows + totalEdges × log(numChunks))`; with disjoint runs the heap
+   is tiny and the `indices` copy is a sequential write per source row.
+
+   *The `indices` copy is a 6 GB write — unavoidable while the API exposes a
+   flat `indices` vector (see Phase 2 to eliminate it).*
+
+3. Pad `indptr` to `numSourceRows + 1` (trailing empty nodes), as today.
+
+`mergeCSRMetadata` (the FIXED_ORDER pairwise path) is folded into the same
+sparse merge: FIXED_ORDER-by-src already preserves the non-decreasing
+invariant, so it takes the same cheap path. FIXED_ORDER-by-non-src already
+bails out with `csrMetadataValid = false` today and is unaffected.
+
+## 5. Memory accounting
+
+Steady state after collection, before merge (the 45 GB regime the user sees):
+
+| component                       | before (dense indptr) | after (sparse)        |
+|---------------------------------|-----------------------|-----------------------|
+| per-batch `indices`             | 6.0 GB                | 6.0 GB                |
+| per-batch `edgeIDs` (optional)  | 6.0 GB                | 6.0 GB                |
+| per-batch `indptr` / sparse     | B × 0.8 ≈ **40 GB**   | 1.6 GB (srcRows+counts) |
+| **total (no rel rowid)**        | **~46 GB**            | **~7.6 GB**           |
+| **total (with rel rowid)**      | **~52 GB**            | **~13.6 GB**          |
+
+Peak at first `combineCSRChunks()` (per-batch chunks still referenced by
+`csrChunks` while merged `combinedCSR` is built):
+
+| component                       | before                | after (Phase 1)       |
+|---------------------------------|-----------------------|-----------------------|
+| per-batch sparse + indices/edge | ~52 GB                | ~13.6 GB              |
+| merged indptr + indices + edge  | +12.8 GB              | +12.8 GB              |
+| **peak (with rel rowid)**       | **~65 GB**            | **~26 GB**            |
+
+## 6. Phased plan
+
+### Phase 1 — sparse per-batch CSR + flat merge (API-compatible, the big win)
+
+- Introduce `CSRMetadata::{srcRows, counts}` (sparse) on the **per-batch** path;
+  remove the dense `indptr` from per-batch collection.
+- Rewrite `updateDirectCSRMetadata` / `updateCSRMetadata` to the run-based
+  builder in §4. Drop the gap-fill and trailing-pad loops from
+  `executeInternal` / `DirectArrowResultCollector::executeInternal`.
+- Rewrite `kwayMergeCSRChunks` to the disjoint-union merge in §4. The merged
+  `CSRMetadata` retains the *dense* `indptr` + flat `indices`/`edgeIDs` so
+  `getCSRArrowArrays()`, `makeCSRArrowArray` (which already aliases the merged
+  vector), and the existing test (`metadata.indices[idx]`,
+  `metadata.indptr[src]`) are unchanged.
+- Fold `mergeCSRMetadata` (FIXED_ORDER pairwise) into the sparse merge, or keep
+  it as a thin sort-then-sparse-merge shim for the FIXED_ORDER-by-non-src bail
+  case.
+- **Result: 45 GB → ~7.6 GB steady-state (no rel rowid), ~13.6 GB with rel
+  rowid. No API change, no consumer change.** This alone closes the reported
+  gap.
+
+### Phase 2 — chunked zero-copy `indices` (reach the theoretical floor)
+
+The merged `indices`/`edgeIDs` are currently a 6 GB *copy* of the per-batch
+vectors. Eliminate the copy and the transient peak by exposing the output as
+**chunked** Arrow arrays (which is what the user described: "chunked array
+indptr and chunked array indices"):
+
+- `ArrowQueryResult` keeps the per-batch `indices`/`edgeIDs` vectors *as the
+  Arrow chunks* (one `ArrowArray` per batch, aliasing each batch's vector via
+  the existing `CSRArrowArrayHolder` mechanism — already zero-copy from vector
+  to `ArrowArray`).
+- `indptr` stays a single dense `ArrowArray` (800 MB), but its values are
+  **global offsets into the logical concatenation of the indices chunks**.
+  Because each source row's edges live in exactly one chunk, every
+  `[indptr[i], indptr[i+1])` range falls within a single chunk; the consumer
+  resolves `globalOffset → (chunkIdx, localOffset)` via a tiny chunk-offset
+  table (numChunks entries).
+- `getCSRArrowArrays()` returns `CSRArrowArrays` whose `indices`/`edgeIDs`
+  become `ArrowChunkedArray` (the existing `ArrowChunkedArray` view type already
+  models this). pyarrow consumers can use the chunks directly or call
+  `combine_chunks()` on their own memory budget if they need a flat array.
+
+Phase 2 peak = per-batch indices (6 GB) + edgeIDs (6 GB) + dense indptr
+(0.8 GB) + sparse srcRows/counts (1.6 GB, freed once indptr is built) =
+**~12.8 GB with rel rowid, ~6.8 GB without — the theoretical minimum.** No
+tuple materialization at any point: `src` is never stored per edge, only the
+run-length sparse structure (1.6 GB) which is derived from the scan's
+non-decreasing source order.
+
+Phase 2 is an API widening (flat `indices` → chunked `indices`); the C++ test
+that does `metadata.indices[idx]` would move to a chunked-accessor. Land
+Phase 1 first (pure win, no API change), then Phase 2 as a follow-on.
+
+## 7. Edge cases & invariants preserved
+
+- **Ordering violation (`ORDER BY` non-src):** `csrMetadataValid = false` as
+  today; batch contributes no CSR. Unchanged.
+- **Empty batch / no edges:** `srcRows` empty; merge skips it. `indptr` still
+  padded to `numSourceRows + 1` of zeros.
+- **Single batch (1 thread / source mode):** sparse struct has 100M srcRows +
+  counts (1.6 GB) instead of dense 0.8 GB indptr — *slightly worse* for the
+  single-threaded case, but the merge collapses it to the 0.8 GB dense indptr
+  and frees the sparse struct. Net neutral vs. today for 1 thread, massive win
+  for many threads. (If single-thread perf matters, the merge can special-case
+  `chunks.size() == 1` to build the dense `indptr` directly from `counts`
+  without copying `indices` — Phase 2 makes this free in general.)
+- **Disjoint-srcRows invariant:** relied on for the union merge. It holds
+  because a source node is scanned in exactly one morsel → one thread. If a
+  future scan mode ever splits a source node's edges across morsels (it does
+  not today), the merge must fall back to a general k-way merge by src; add a
+  debug assert that per-batch `srcRows` sets are disjoint (sum of `counts` ==
+  total `indices`).
+- **`makeCSRArrowArray` aliasing:** unchanged — it already aliases the merged
+  `CSRMetadata` vectors via a `shared_ptr` to `combinedCSR`. Phase 2 reuses the
+  same holder to alias per-batch vectors instead.
+- **Determinism / batch order:** the disjoint-union merge emits source rows in
+  global id order regardless of batch index, so NO_ORDER / INSERTION_ORDER /
+  FIXED_ORDER-by-src all produce identical output. Batch-index ordering only
+  matters for the chunk *layout* in Phase 2, not for correctness.
+
+## 8. Files touched
+
+- `src/processor/operator/arrow_result_collector.cpp` (+ header) —
+  `updateDirectCSRMetadata`, `updateCSRMetadata`, `mergeCSRMetadata`, the
+  trailing-pad loops in both `executeInternal`s; `CSRMetadata` per-batch shape.
+- `src/main/query_result/arrow_query_result.cpp` (+ header) —
+  `kwayMergeCSRChunks`; `CSRMetadata` struct; `combineCSRChunks`; (Phase 2)
+  `getCSRArrowArrays` / `ArrowChunkedArray` for `indices`.
+- Tests: `test/api/arrow_test.cpp`, `test/api/arrow_csr_rel_table_test.cpp`,
+  `test/api/fwd_arrow_repro_test.cpp` — unchanged for Phase 1 (they consume the
+  merged dense API); new chunked-access tests for Phase 2.

--- a/src/include/main/query_result/arrow_query_result.h
+++ b/src/include/main/query_result/arrow_query_result.h
@@ -14,9 +14,25 @@ class ArrowQueryResult : public QueryResult {
 
 public:
     struct CSRMetadata {
+        // Dense global indptr. Populated ONLY on the merged result produced
+        // by combineCSRChunks()/kwayMergeCSRChunks(); per-batch chunks leave
+        // this empty and use the sparse (srcRows, counts) representation
+        // below instead, so a batch only pays for the distinct source rows
+        // it actually touched (not numSourceRows+1 entries).
         std::vector<int64_t> indptr;
         std::vector<int64_t> indices;
         std::vector<int64_t> edgeIDs;
+        // Sparse per-batch CSR representation: srcRows[i] is a global source
+        // row id touched by this batch (strictly increasing, since the rel
+        // scan emits edges in non-decreasing source order per thread and
+        // morsel acquisition is monotonic), and counts[i] is the number of
+        // edges for that source row. The edges for srcRows[i] live at
+        // indices[offset..offset+counts[i]-1] where offset = sum(counts[0..i-1]).
+        // Per-batch srcRows sets are disjoint (a source node is scanned in
+        // exactly one morsel -> one thread), so the merge is a union of
+        // sorted disjoint runs, not a general k-way merge.
+        std::vector<int64_t> srcRows;
+        std::vector<int64_t> counts;
         bool hasEdgeIDs = false;
         // Total number of source (node) rows in the table. Used to pad
         // trailing empty rows in indptr; set at plan-mapping time from the

--- a/src/include/main/query_result/arrow_query_result.h
+++ b/src/include/main/query_result/arrow_query_result.h
@@ -150,15 +150,20 @@ public:
     // The actual k-way merge across batches runs lazily on the first call
     // to combineCSRChunks() / getCSRMetadata() / getCSRArrowArrays(); the
     // merged result is cached. NO_ORDER / INSERTION_ORDER queries take
-    // zero work at result-construction time.
-    bool hasCSRMetadata() const { return !csrChunks.empty(); }
+    // zero work at result-construction time. combineCSRChunks() std::moves
+    // and consumes the per-batch chunks (freeing them incrementally as they
+    // are copied into the merged arrays), so csrChunks is empty afterwards;
+    // hasCSRMetadata() remains true via the cached merged result.
+    bool hasCSRMetadata() const { return !csrChunks.empty() || combinedCSR != nullptr; }
     const CSRMetadata& getCSRMetadata() const { return combineCSRChunks(); }
     CSRArrowArrays getCSRArrowArrays() const;
 
-    // Per-batch CSR chunks (in batch_index order). No merge is performed
-    // until combineCSRChunks() is called; this is the ChunkedArray-style
-    // view exposed for callers that want to combine on the consumer side
-    // (e.g. python users constructing pyarrow.ChunkedArray).
+    // Per-batch CSR chunks (in batch_index order), before merging. No merge
+    // is performed until combineCSRChunks() is called; this is the
+    // ChunkedArray-style view for callers that want to combine on the
+    // consumer side. NOTE: combineCSRChunks() consumes (moves) these chunks
+    // to free their memory as the merged arrays are built, so this returns
+    // an empty vector after the first merge call.
     const std::vector<CSRMetadata>& getCSRChunks() const { return csrChunks; }
 
     // K-way merge the per-batch CSR chunks in batch_index order into a
@@ -176,7 +181,10 @@ private:
     int64_t chunkSize_;
     uint64_t numTuples = 0;
     uint64_t cursor = 0;
-    std::vector<CSRMetadata> csrChunks;
+    // Mutable because combineCSRChunks() (a const accessor, called from the
+    // const getCSRMetadata()/getCSRArrowArrays()) std::moves these chunks
+    // into the merge to free their memory as the merged arrays are built.
+    mutable std::vector<CSRMetadata> csrChunks;
     mutable std::shared_ptr<const CSRMetadata> combinedCSR;
 };
 

--- a/src/include/processor/operator/arrow_result_collector.h
+++ b/src/include/processor/operator/arrow_result_collector.h
@@ -89,8 +89,11 @@ struct ArrowResultCollectorLocalState {
     std::vector<common::sel_t> chunkCursors;
     std::unique_ptr<FlatTuple> tuple;
     std::optional<main::ArrowQueryResult::CSRMetadata> csrMetadata;
-    int64_t nextSourceRowID = 0;
+    // Current source row being accumulated and how many edges have been
+    // seen for it. Used by the sparse per-batch CSR builder to emit a
+    // (srcRow, count) run when the source row changes.
     int64_t currentSourceRowID = -1;
+    int64_t currentRowCount = 0;
     bool csrMetadataValid = true;
 
     // Advance cursor.

--- a/src/main/query_result/arrow_query_result.cpp
+++ b/src/main/query_result/arrow_query_result.cpp
@@ -1,6 +1,7 @@
 #include "main/query_result/arrow_query_result.h"
 
 #include <array>
+#include <queue>
 
 #include "common/arrow/arrow_row_batch.h"
 #include "common/exception/not_implemented.h"
@@ -71,15 +72,53 @@ static ArrowQueryResult::CSRArrowArray makeCSRArrowArray(
     return result;
 }
 
-// K-way merge of per-batch CSR metadata chunks (in batch_index order)
-// into a single flat CSRMetadata. Each chunk's indptr is indexed by
-// GLOBAL source row id: the per-batch CSR tracker fills indptr densely
-// from global row 0 up to that chunk's max source row, with a trailing
-// sentinel equal to indices.size(). For each global source row in
-// ascending order, emit edges from each chunk in batch_index order;
-// within a chunk the per-batch tracker already groups entries by
-// source row in scan order, so emitting in (src, batch_index,
-// scan_order_within_batch) order is correct without any global sort.
+// Build a dense global indptr of size numSourceRows+1 from sparse
+// (srcRows, counts) runs. indptr[src+1] is set to counts[i] for the
+// touched src = srcRows[i], then prefix-summed so indptr[src] gives the
+// offset of src's edges in the (source-sorted) indices vector. Source
+// rows absent from srcRows keep their slot at 0, i.e. no edges. Returns
+// an empty vector on validation failure (bad src/count, or the
+// disjointness invariant is violated — a source row appearing more than
+// once would silently corrupt the merged CSR).
+static std::vector<int64_t> buildDenseIndptr(int64_t numSourceRows,
+    const std::vector<int64_t>& srcRows, const std::vector<int64_t>& counts) {
+    std::vector<int64_t> indptr(static_cast<size_t>(numSourceRows) + 1, 0);
+    for (auto i = 0u; i < srcRows.size(); ++i) {
+        const auto src = srcRows[i];
+        const auto count = counts[i];
+        if (src < 0 || src >= numSourceRows || count < 0) {
+            return {};
+        }
+        if (indptr[static_cast<size_t>(src) + 1] != 0) {
+            return {};
+        }
+        indptr[static_cast<size_t>(src) + 1] = count;
+    }
+    for (size_t i = 0; i + 1 < indptr.size(); ++i) {
+        indptr[i + 1] += indptr[i];
+    }
+    return indptr;
+}
+
+// K-way merge of per-batch sparse CSR metadata chunks (in batch_index
+// order) into a single flat CSRMetadata with a dense global indptr.
+// Per-batch chunks carry (srcRows, counts) sparse runs — NOT a dense
+// global indptr — so a batch only pays for the distinct source rows it
+// touched (the old dense representation cost numSourceRows+1 entries per
+// batch, i.e. ~B x 800MB for a 100M-node table, which was the 45GB
+// blow-up). The rel scan emits edges in non-decreasing source order per
+// thread (CSR storage + monotonic morsel acquisition), and each source
+// node is scanned in exactly one morsel -> one thread, so per-batch
+// srcRows sets are disjoint and sorted: this is a union of sorted
+// disjoint runs, not a general k-way merge.
+//
+// Single-chunk fast path: the chunk's indices are already laid out in
+// source-row order, so we move indices/edgeIDs through without copying
+// and synthesize the dense indptr from (srcRows, counts).
+//
+// Multi-chunk path: k-way merge by source row via a min-heap, copying
+// edges into merged.indices in global source order, then prefix-sum the
+// per-source-row counts into the dense indptr.
 //
 // Runs lazily on first consumer request via combineCSRChunks(), not at
 // result-construction time, so result construction stays zero-work for
@@ -89,16 +128,11 @@ static ArrowQueryResult::CSRMetadata kwayMergeCSRChunks(
     if (chunks.empty()) {
         return ArrowQueryResult::CSRMetadata{};
     }
-    if (chunks.size() == 1) {
-        return std::move(chunks[0]);
-    }
     const auto& first = chunks.front();
     const auto hasEdgeIDs = first.hasEdgeIDs;
 
-    int64_t maxSrcRow = 0;
-    size_t totalIndices = 0;
     int64_t numSourceRows = 0;
-    bool sawChunk = false;
+    size_t totalIndices = 0;
     for (const auto& c : chunks) {
         if (c.hasEdgeIDs != hasEdgeIDs) {
             return ArrowQueryResult::CSRMetadata{};
@@ -106,65 +140,89 @@ static ArrowQueryResult::CSRMetadata kwayMergeCSRChunks(
         if (c.hasEdgeIDs && c.edgeIDs.size() != c.indices.size()) {
             return ArrowQueryResult::CSRMetadata{};
         }
+        if (c.srcRows.size() != c.counts.size()) {
+            return ArrowQueryResult::CSRMetadata{};
+        }
+        int64_t sumCounts = 0;
+        for (auto cnt : c.counts) {
+            if (cnt < 0) {
+                return ArrowQueryResult::CSRMetadata{};
+            }
+            sumCounts += cnt;
+        }
+        if (static_cast<size_t>(sumCounts) != c.indices.size()) {
+            return ArrowQueryResult::CSRMetadata{};
+        }
         if (c.numSourceRows > numSourceRows) {
             numSourceRows = c.numSourceRows;
         }
-        if (c.indptr.size() < 2) {
-            continue;
-        }
-        if (c.indptr.back() != static_cast<int64_t>(c.indices.size())) {
-            return ArrowQueryResult::CSRMetadata{};
-        }
-        const auto numSrcRows = static_cast<int64_t>(c.indptr.size() - 1);
-        if (numSrcRows > maxSrcRow) {
-            maxSrcRow = numSrcRows;
-        }
         totalIndices += c.indices.size();
-        sawChunk = true;
     }
+
     ArrowQueryResult::CSRMetadata merged;
     merged.hasEdgeIDs = hasEdgeIDs;
     merged.numSourceRows = numSourceRows;
-    merged.indptr.push_back(0);
-    if (!sawChunk || maxSrcRow == 0) {
-        // Pad to numSourceRows + 1 entries even when there are no edges.
-        for (int64_t i = 0; i < numSourceRows; ++i) {
-            merged.indptr.push_back(0);
+
+    if (chunks.size() == 1) {
+        auto& c = chunks[0];
+        merged.indices = std::move(c.indices);
+        merged.edgeIDs = std::move(c.edgeIDs);
+        merged.indptr = buildDenseIndptr(numSourceRows, c.srcRows, c.counts);
+        if (merged.indptr.empty()) {
+            return ArrowQueryResult::CSRMetadata{};
         }
         return merged;
     }
+
     merged.indices.reserve(totalIndices);
     if (hasEdgeIDs) {
         merged.edgeIDs.reserve(totalIndices);
     }
-    for (int64_t src = 0; src < maxSrcRow; ++src) {
-        for (const auto& c : chunks) {
-            if (static_cast<size_t>(src + 1) >= c.indptr.size()) {
-                continue;
-            }
-            const auto begin = c.indptr[src];
-            const auto end = c.indptr[src + 1];
-            if (begin < 0 || end < begin || static_cast<uint64_t>(end) > c.indices.size()) {
-                return ArrowQueryResult::CSRMetadata{};
-            }
-            for (auto idx = begin; idx < end; ++idx) {
-                const auto u = static_cast<uint64_t>(idx);
-                merged.indices.push_back(c.indices[u]);
-                if (hasEdgeIDs) {
-                    merged.edgeIDs.push_back(c.edgeIDs[u]);
-                }
+    merged.indptr.assign(static_cast<size_t>(numSourceRows) + 1, 0);
+
+    struct HeapItem {
+        int64_t src;
+        size_t chunk;
+        size_t cursor;
+    };
+    auto cmp = [](const HeapItem& a, const HeapItem& b) { return a.src > b.src; };
+    std::priority_queue<HeapItem, std::vector<HeapItem>, decltype(cmp)> heap(cmp);
+    std::vector<int64_t> chunkLocalOff(chunks.size(), 0);
+    for (size_t ci = 0; ci < chunks.size(); ++ci) {
+        if (!chunks[ci].srcRows.empty()) {
+            heap.push({chunks[ci].srcRows[0], ci, 0});
+        }
+    }
+    while (!heap.empty()) {
+        const auto top = heap.top();
+        heap.pop();
+        const auto src = top.src;
+        auto& c = chunks[top.chunk];
+        const auto count = c.counts[top.cursor];
+        const int64_t localOff = chunkLocalOff[top.chunk];
+        if (src < 0 || src >= numSourceRows || count < 0 ||
+            static_cast<uint64_t>(localOff + count) > c.indices.size()) {
+            return ArrowQueryResult::CSRMetadata{};
+        }
+        if (merged.indptr[static_cast<size_t>(src) + 1] != 0) {
+            return ArrowQueryResult::CSRMetadata{};
+        }
+        for (int64_t j = 0; j < count; ++j) {
+            const auto u = static_cast<uint64_t>(localOff + j);
+            merged.indices.push_back(c.indices[u]);
+            if (hasEdgeIDs) {
+                merged.edgeIDs.push_back(c.edgeIDs[u]);
             }
         }
-        merged.indptr.push_back(static_cast<int64_t>(merged.indices.size()));
+        chunkLocalOff[top.chunk] += count;
+        merged.indptr[static_cast<size_t>(src) + 1] = count;
+        const size_t next = top.cursor + 1;
+        if (next < c.srcRows.size()) {
+            heap.push({c.srcRows[next], top.chunk, next});
+        }
     }
-    // Fill trailing empty source rows (nodes after the last source row
-    // with edges in any chunk). maxSrcRow is the highest numSrcRows
-    // (indptr.size() - 1) across all chunks; if it is less than
-    // numSourceRows, the trailing node rows have zero edges and need
-    // empty entries in the merged indptr so the CSR is indexable up
-    // to numSourceRows - 1.
-    for (int64_t src = maxSrcRow; src < numSourceRows; ++src) {
-        merged.indptr.push_back(static_cast<int64_t>(merged.indices.size()));
+    for (size_t i = 0; i + 1 < merged.indptr.size(); ++i) {
+        merged.indptr[i + 1] += merged.indptr[i];
     }
     return merged;
 }

--- a/src/main/query_result/arrow_query_result.cpp
+++ b/src/main/query_result/arrow_query_result.cpp
@@ -150,7 +150,10 @@ static ArrowQueryResult::CSRMetadata kwayMergeCSRChunks(
             }
             sumCounts += cnt;
         }
-        if (static_cast<size_t>(sumCounts) != c.indices.size()) {
+        // Sparse-run form: sum(counts) must equal indices.size(). Legacy
+        // dense form (empty srcRows, pre-set indptr): skip this check,
+        // there are no per-source counts to sum.
+        if (!c.srcRows.empty() && static_cast<size_t>(sumCounts) != c.indices.size()) {
             return ArrowQueryResult::CSRMetadata{};
         }
         if (c.numSourceRows > numSourceRows) {
@@ -167,9 +170,17 @@ static ArrowQueryResult::CSRMetadata kwayMergeCSRChunks(
         auto& c = chunks[0];
         merged.indices = std::move(c.indices);
         merged.edgeIDs = std::move(c.edgeIDs);
-        merged.indptr = buildDenseIndptr(numSourceRows, c.srcRows, c.counts);
-        if (merged.indptr.empty()) {
-            return ArrowQueryResult::CSRMetadata{};
+        // Sparse-run form (production path): rebuild the dense indptr from
+        // (srcRows, counts). Legacy dense form (test fixtures / older
+        // callers that set indptr directly with empty srcRows): keep the
+        // provided indptr as-is.
+        if (!c.srcRows.empty()) {
+            merged.indptr = buildDenseIndptr(numSourceRows, c.srcRows, c.counts);
+            if (merged.indptr.empty()) {
+                return ArrowQueryResult::CSRMetadata{};
+            }
+        } else {
+            merged.indptr = std::move(c.indptr);
         }
         return merged;
     }
@@ -219,6 +230,18 @@ static ArrowQueryResult::CSRMetadata kwayMergeCSRChunks(
         const size_t next = top.cursor + 1;
         if (next < c.srcRows.size()) {
             heap.push({c.srcRows[next], top.chunk, next});
+        } else {
+            // This chunk's source rows are all consumed and its edges have
+            // been copied into the merged arrays. Free its vectors now so the
+            // merge doesn't hold the full per-batch set + the merged copy at
+            // once. Chunks whose max source row is low are freed early; those
+            // spanning near numSourceRows are freed late. This is safe: a
+            // chunk with an exhausted cursor is never pushed again, and the
+            // heap loop only touches c when popping a live cursor entry.
+            std::vector<int64_t>().swap(c.indices);
+            std::vector<int64_t>().swap(c.edgeIDs);
+            std::vector<int64_t>().swap(c.srcRows);
+            std::vector<int64_t>().swap(c.counts);
         }
     }
     for (size_t i = 0; i + 1 < merged.indptr.size(); ++i) {
@@ -335,7 +358,13 @@ const ArrowQueryResult::CSRMetadata& ArrowQueryResult::combineCSRChunks() const 
     if (combinedCSR) {
         return *combinedCSR;
     }
-    combinedCSR = std::make_shared<const CSRMetadata>(kwayMergeCSRChunks(csrChunks));
+    // std::move the per-batch chunks into the merge so that (a) we don't
+    // copy ~6GB of per-batch indices/edgeIDs into the function argument,
+    // and (b) kwayMergeCSRChunks can free each chunk's vectors as soon as
+    // its source rows are consumed, keeping the transient peak (per-batch
+    // + merged) low instead of holding both for the whole merge. csrChunks
+    // is left empty; hasCSRMetadata() stays true via combinedCSR.
+    combinedCSR = std::make_shared<const CSRMetadata>(kwayMergeCSRChunks(std::move(csrChunks)));
     return *combinedCSR;
 }
 

--- a/src/processor/operator/arrow_result_collector.cpp
+++ b/src/processor/operator/arrow_result_collector.cpp
@@ -23,7 +23,6 @@ static void updateDirectCSRMetadata(const CSRTrackingInfo& info, const std::vect
     const auto dstRowID = values[info.dstRowIDColIdx];
     if (!localState.csrMetadata.has_value()) {
         main::ArrowQueryResult::CSRMetadata metadata;
-        metadata.indptr.push_back(0);
         metadata.hasEdgeIDs = info.hasRelRowID();
         metadata.numSourceRows = info.numSourceRows;
         localState.csrMetadata = std::move(metadata);
@@ -34,39 +33,43 @@ static void updateDirectCSRMetadata(const CSRTrackingInfo& info, const std::vect
         localState.csrMetadata.reset();
         return;
     }
+    // Sparse per-batch CSR build. The rel scan emits edges in non-decreasing
+    // source order per thread, so we record one (srcRow, count) run per
+    // distinct source row instead of a dense global indptr (which would
+    // cost numSourceRows+1 entries per batch). The trailing run is flushed
+    // in executeInternal(); the global dense indptr is reconstructed once
+    // by kwayMergeCSRChunks() on first consumer request.
     if (localState.currentSourceRowID == -1) {
-        while (localState.nextSourceRowID < srcRowID) {
-            metadata.indptr.push_back(static_cast<int64_t>(metadata.indices.size()));
-            localState.nextSourceRowID++;
-        }
         localState.currentSourceRowID = srcRowID;
+        localState.currentRowCount = 0;
     } else if (srcRowID != localState.currentSourceRowID) {
         if (srcRowID < localState.currentSourceRowID) {
             localState.csrMetadataValid = false;
             localState.csrMetadata.reset();
             return;
         }
-        metadata.indptr.push_back(static_cast<int64_t>(metadata.indices.size()));
-        localState.nextSourceRowID = localState.currentSourceRowID + 1;
-        while (localState.nextSourceRowID < srcRowID) {
-            metadata.indptr.push_back(static_cast<int64_t>(metadata.indices.size()));
-            localState.nextSourceRowID++;
-        }
+        metadata.srcRows.push_back(localState.currentSourceRowID);
+        metadata.counts.push_back(localState.currentRowCount);
         localState.currentSourceRowID = srcRowID;
+        localState.currentRowCount = 0;
     }
     metadata.indices.push_back(dstRowID);
     if (info.hasRelRowID()) {
         metadata.edgeIDs.push_back(values[info.relRowIDColIdx]);
     }
+    localState.currentRowCount++;
 }
 
-// Deterministic pairwise merge of two CSR metadata chunks into one. Used
-// only in FIXED_ORDER mode (ORDER BY / TopK on the data path), where per-
-// batch chunks are collapsed to a single sorted chunk to preserve global
-// order. The cheap NO_ORDER / INSERTION_ORDER path does not call this — it
-// moves per-batch chunks into arraysByBatchIndex and the final k-way
-// merge across batches runs lazily in ArrowQueryResult::combineCSRChunks()
-// on first consumer request.
+// Deterministic pairwise merge of two sparse CSR metadata chunks into one.
+// Used only in FIXED_ORDER mode (ORDER BY / TopK on the data path), where
+// per-batch chunks are collapsed to a single sorted chunk under key 0 to
+// preserve global order. Materializes (src, dst, edge) entries and sorts by
+// (src, edge, dst), then rebuilds the sparse (srcRows, counts) runs. The
+// cheap NO_ORDER / INSERTION_ORDER path does not call this — it moves
+// per-batch chunks into arraysByBatchIndex and the final k-way merge across
+// batches runs lazily in ArrowQueryResult::combineCSRChunks() on first
+// consumer request. FIXED_ORDER is inherently more expensive (it must sort);
+// the common NO_ORDER rel-scan path takes the sparse run build instead.
 static std::optional<main::ArrowQueryResult::CSRMetadata> mergeCSRMetadata(
     main::ArrowQueryResult::CSRMetadata left, main::ArrowQueryResult::CSRMetadata right) {
     if (left.hasEdgeIDs != right.hasEdgeIDs) {
@@ -82,20 +85,23 @@ static std::optional<main::ArrowQueryResult::CSRMetadata> mergeCSRMetadata(
         if (metadata.hasEdgeIDs && metadata.edgeIDs.size() != metadata.indices.size()) {
             return false;
         }
-        if (metadata.indptr.empty()) {
-            return true;
+        if (metadata.srcRows.size() != metadata.counts.size()) {
+            return false;
         }
-        for (auto src = 0u; src + 1 < metadata.indptr.size(); ++src) {
-            const auto begin = metadata.indptr[src];
-            const auto end = metadata.indptr[src + 1];
-            if (begin < 0 || end < begin || static_cast<uint64_t>(end) > metadata.indices.size()) {
+        int64_t offset = 0;
+        for (auto i = 0u; i < metadata.srcRows.size(); ++i) {
+            const auto src = metadata.srcRows[i];
+            const auto count = metadata.counts[i];
+            if (src < 0 || count < 0 ||
+                static_cast<uint64_t>(offset + count) > metadata.indices.size()) {
                 return false;
             }
-            for (auto idx = begin; idx < end; ++idx) {
-                const auto idxAsOffset = static_cast<uint64_t>(idx);
+            for (auto j = 0; j < count; ++j) {
+                const auto idxAsOffset = static_cast<uint64_t>(offset + j);
                 const auto edge = metadata.hasEdgeIDs ? metadata.edgeIDs[idxAsOffset] : -1;
-                entries.push_back({static_cast<int64_t>(src), metadata.indices[idxAsOffset], edge});
+                entries.push_back({src, metadata.indices[idxAsOffset], edge});
             }
+            offset += count;
         }
         return true;
     };
@@ -107,31 +113,30 @@ static std::optional<main::ArrowQueryResult::CSRMetadata> mergeCSRMetadata(
     });
     main::ArrowQueryResult::CSRMetadata merged;
     merged.hasEdgeIDs = left.hasEdgeIDs;
-    merged.numSourceRows = left.numSourceRows;
-    merged.indptr.push_back(0);
-    int64_t nextSourceRowID = 0;
+    merged.numSourceRows = std::max(left.numSourceRows, right.numSourceRows);
+    int64_t curSrc = -1;
+    int64_t curCount = 0;
     for (const auto& entry : entries) {
         if (entry.src < 0 || entry.dst < 0 || (merged.hasEdgeIDs && entry.edge < 0)) {
             return std::nullopt;
         }
-        while (nextSourceRowID < entry.src) {
-            merged.indptr.push_back(static_cast<int64_t>(merged.indices.size()));
-            nextSourceRowID++;
+        if (entry.src != curSrc) {
+            if (curSrc >= 0 && curCount > 0) {
+                merged.srcRows.push_back(curSrc);
+                merged.counts.push_back(curCount);
+            }
+            curSrc = entry.src;
+            curCount = 0;
         }
         merged.indices.push_back(entry.dst);
         if (merged.hasEdgeIDs) {
             merged.edgeIDs.push_back(entry.edge);
         }
+        curCount++;
     }
-    merged.indptr.push_back(static_cast<int64_t>(merged.indices.size()));
-    // Fill trailing empty source rows (nodes after the last source row with
-    // edges). nextSourceRowID is the last distinct src value; the sentinel
-    // push above already covers row nextSourceRowID - 1, so we need
-    // numSourceRows - nextSourceRowID - 1 more pushes.
-    if (merged.numSourceRows > 0) {
-        for (int64_t src = nextSourceRowID; src + 1 < merged.numSourceRows; ++src) {
-            merged.indptr.push_back(static_cast<int64_t>(merged.indices.size()));
-        }
+    if (curSrc >= 0 && curCount > 0) {
+        merged.srcRows.push_back(curSrc);
+        merged.counts.push_back(curCount);
     }
     return merged;
 }
@@ -152,7 +157,6 @@ static void updateCSRMetadata(const CSRTrackingInfo& info, FlatTuple& tuple,
     const auto dstRowID = tuple.getValue(info.dstRowIDColIdx)->getValue<int64_t>();
     if (!localState.csrMetadata.has_value()) {
         main::ArrowQueryResult::CSRMetadata metadata;
-        metadata.indptr.push_back(0);
         metadata.hasEdgeIDs = info.hasRelRowID();
         metadata.numSourceRows = info.numSourceRows;
         localState.csrMetadata = std::move(metadata);
@@ -163,30 +167,26 @@ static void updateCSRMetadata(const CSRTrackingInfo& info, FlatTuple& tuple,
         localState.csrMetadata.reset();
         return;
     }
+    // See updateDirectCSRMetadata for the sparse run rationale.
     if (localState.currentSourceRowID == -1) {
-        while (localState.nextSourceRowID < srcRowID) {
-            metadata.indptr.push_back(static_cast<int64_t>(metadata.indices.size()));
-            localState.nextSourceRowID++;
-        }
         localState.currentSourceRowID = srcRowID;
+        localState.currentRowCount = 0;
     } else if (srcRowID != localState.currentSourceRowID) {
         if (srcRowID < localState.currentSourceRowID) {
             localState.csrMetadataValid = false;
             localState.csrMetadata.reset();
             return;
         }
-        metadata.indptr.push_back(static_cast<int64_t>(metadata.indices.size()));
-        localState.nextSourceRowID = localState.currentSourceRowID + 1;
-        while (localState.nextSourceRowID < srcRowID) {
-            metadata.indptr.push_back(static_cast<int64_t>(metadata.indices.size()));
-            localState.nextSourceRowID++;
-        }
+        metadata.srcRows.push_back(localState.currentSourceRowID);
+        metadata.counts.push_back(localState.currentRowCount);
         localState.currentSourceRowID = srcRowID;
+        localState.currentRowCount = 0;
     }
     metadata.indices.push_back(dstRowID);
     if (info.hasRelRowID()) {
         metadata.edgeIDs.push_back(tuple.getValue(info.relRowIDColIdx)->getValue<int64_t>());
     }
+    localState.currentRowCount++;
 }
 
 bool ArrowResultCollectorLocalState::advance() {
@@ -277,16 +277,13 @@ void ArrowResultCollector::executeInternal(ExecutionContext* context) {
     if (rowBatch->size() > 0) {
         localState.arrays.push_back(rowBatch->toArray(info.columnTypes));
     }
-    if (localState.csrMetadata.has_value()) {
+    // Flush the trailing source row's run into the sparse (srcRows, counts)
+    // representation. The global dense indptr (with trailing empty-row
+    // padding) is reconstructed once by kwayMergeCSRChunks() at merge time.
+    if (localState.csrMetadata.has_value() && localState.currentSourceRowID != -1) {
         auto& metadata = *localState.csrMetadata;
-        metadata.indptr.push_back(static_cast<int64_t>(metadata.indices.size()));
-        // Fill trailing empty source rows (nodes after the last source row
-        // with edges). Without this padding, consumers see an indptr shorter
-        // than numSourceRows + 1 and silently skip trailing node rows.
-        while (localState.nextSourceRowID + 1 < metadata.numSourceRows) {
-            localState.nextSourceRowID++;
-            metadata.indptr.push_back(static_cast<int64_t>(metadata.indices.size()));
-        }
+        metadata.srcRows.push_back(localState.currentSourceRowID);
+        metadata.counts.push_back(localState.currentRowCount);
     }
     sharedState->merge(std::move(localState.arrays), localState.batchIndex,
         std::move(localState.csrMetadata));
@@ -408,16 +405,13 @@ void DirectArrowResultCollector::executeInternal(ExecutionContext* context) {
             }
         }
     }
-    if (localState.csrMetadata.has_value()) {
+    // Flush the trailing source row's run into the sparse (srcRows, counts)
+    // representation. The global dense indptr (with trailing empty-row
+    // padding) is reconstructed once by kwayMergeCSRChunks() at merge time.
+    if (localState.csrMetadata.has_value() && localState.currentSourceRowID != -1) {
         auto& metadata = *localState.csrMetadata;
-        metadata.indptr.push_back(static_cast<int64_t>(metadata.indices.size()));
-        // Fill trailing empty source rows (nodes after the last source row
-        // with edges). Without this padding, consumers see an indptr shorter
-        // than numSourceRows + 1 and silently skip trailing node rows.
-        while (localState.nextSourceRowID + 1 < metadata.numSourceRows) {
-            localState.nextSourceRowID++;
-            metadata.indptr.push_back(static_cast<int64_t>(metadata.indices.size()));
-        }
+        metadata.srcRows.push_back(localState.currentSourceRowID);
+        metadata.counts.push_back(localState.currentRowCount);
     }
     sharedState->merge({}, localState.batchIndex, std::move(localState.csrMetadata));
 }

--- a/test/api/arrow_test.cpp
+++ b/test/api/arrow_test.cpp
@@ -32,12 +32,26 @@ TEST(ArrowQueryResultTest, exportsCSRMetadataAsZeroCopyArrowArrays) {
     ASSERT_EQ(csrArrays.indptr.array.length, static_cast<int64_t>(storedMetadata.indptr.size()));
     ASSERT_EQ(csrArrays.indices.array.length, static_cast<int64_t>(storedMetadata.indices.size()));
     ASSERT_EQ(csrArrays.edgeIDs->array.length, static_cast<int64_t>(storedMetadata.edgeIDs.size()));
+    // No validity bitmap (the array is non-nullable).
     ASSERT_EQ(csrArrays.indptr.array.buffers[0], nullptr);
     ASSERT_EQ(csrArrays.indices.array.buffers[0], nullptr);
     ASSERT_EQ(csrArrays.edgeIDs->array.buffers[0], nullptr);
-    ASSERT_EQ(csrArrays.indptr.array.buffers[1], storedMetadata.indptr.data());
-    ASSERT_EQ(csrArrays.indices.array.buffers[1], storedMetadata.indices.data());
-    ASSERT_EQ(csrArrays.edgeIDs->array.buffers[1], storedMetadata.edgeIDs.data());
+    // Value-equivalence: the exported Arrow data buffers hold the merged
+    // CSR values. We check the contents rather than the backing pointer,
+    // so the test does not break if the merge path changes whether it moves
+    // or copies the per-batch vectors.
+    const auto* indptrData = static_cast<const int64_t*>(csrArrays.indptr.array.buffers[1]);
+    const auto* indicesData = static_cast<const int64_t*>(csrArrays.indices.array.buffers[1]);
+    const auto* edgeIDsData = static_cast<const int64_t*>(csrArrays.edgeIDs->array.buffers[1]);
+    ASSERT_NE(indptrData, nullptr);
+    ASSERT_NE(indicesData, nullptr);
+    ASSERT_NE(edgeIDsData, nullptr);
+    ASSERT_EQ(std::vector<int64_t>(indptrData, indptrData + storedMetadata.indptr.size()),
+        (std::vector<int64_t>{0, 2, 3}));
+    ASSERT_EQ(std::vector<int64_t>(indicesData, indicesData + storedMetadata.indices.size()),
+        (std::vector<int64_t>{4, 5, 6}));
+    ASSERT_EQ(std::vector<int64_t>(edgeIDsData, edgeIDsData + storedMetadata.edgeIDs.size()),
+        (std::vector<int64_t>{10, 11, 12}));
 }
 
 TEST_F(ArrowTest, resultToArrow) {


### PR DESCRIPTION
Cuts peak RSS from 45GB to around 16GB.

Details in the design doc.