### PR TITLE
fix: python build wheels on macos-15

### DIFF
--- a/.github/workflows/python-wheel-workflow.yml
+++ b/.github/workflows/python-wheel-workflow.yml
@@ -72,7 +72,7 @@ jobs:
 
           # Job 3: macOS arm64 build
           - platform: arm64
-            runner: macos-latest
+            runner: macos-15
             os: macos
             deployment-target: '15.0'
 


### PR DESCRIPTION
Should fix this: https://github.com/LadybugDB/ladybug/actions/runs/28321832817/job/83908424071