### PR TITLE
fix: crash in ANY graph INSERT with property strings >12 chars

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,8 @@ make release
 # Debug build (with debug symbols)
 make debug
 
-# RelWithDebInfo (recommended for testing with stack traces)
+# RelWithDebInfo
+# (Not recommended due to size. Use only for testing with stack traces)
 make relwithdebinfo
 
 # Full build with all components

--- a/src/binder/bind/bind_updating_clause.cpp
+++ b/src/binder/bind/bind_updating_clause.cpp
@@ -265,7 +265,8 @@ void Binder::bindInsertNode(std::shared_ptr<NodeExpression> node,
             if (literalExpr && !literalExpr->isNull()) {
                 auto val = literalExpr->getValue();
                 // Create a temporary ValueVector of size 1 and reuse json_extension::jsonify
-                ValueVector tempVec(val.getDataType().copy());
+                auto mm = storage::MemoryManager::Get(*clientContext);
+                ValueVector tempVec(val.getDataType().copy(), mm);
                 tempVec.state = DataChunkState::getSingleValueDataChunkState();
                 tempVec.copyFromValue(0, val);
                 jsonVal = json_extension::jsonify(mutWrapper, tempVec, 0);
@@ -415,7 +416,8 @@ void Binder::bindInsertRel(std::shared_ptr<RelExpression> rel,
             if (literalExpr && !literalExpr->isNull()) {
                 auto val = literalExpr->getValue();
                 // Create a temporary ValueVector of size 1 and reuse json_extension::jsonify
-                ValueVector tempVec(val.getDataType().copy());
+                auto mm = storage::MemoryManager::Get(*clientContext);
+                ValueVector tempVec(val.getDataType().copy(), mm);
                 tempVec.state = DataChunkState::getSingleValueDataChunkState();
                 tempVec.copyFromValue(0, val);
                 jsonVal = json_extension::jsonify(mutWrapper, tempVec, 0);


### PR DESCRIPTION
Fixes: #628 