### PR TITLE
Fix disk_info accounting for hash indexes

### DIFF
--- a/src/function/table/disk_size_info.cpp
+++ b/src/function/table/disk_size_info.cpp
@@ -1,3 +1,5 @@
+#include <unordered_map>
+
 #include "binder/binder.h"
 #include "catalog/catalog.h"
 #include "catalog/catalog_entry/node_table_catalog_entry.h"
@@ -119,8 +121,23 @@ struct DiskSizeEntry {
     uint64_t sizeBytes;
 };
 
+static void appendOrIncrementEntry(std::vector<DiskSizeEntry>& entries,
+    std::unordered_map<std::string, idx_t>& entryLookup, std::string category, std::string name,
+    uint64_t numPages) {
+    const auto key = category + "\n" + name;
+    if (entryLookup.contains(key)) {
+        auto& entry = entries[entryLookup.at(key)];
+        entry.numPages += numPages;
+        entry.sizeBytes += numPages * LBUG_PAGE_SIZE;
+        return;
+    }
+    entryLookup.insert({key, entries.size()});
+    entries.push_back({std::move(category), std::move(name), numPages, numPages * LBUG_PAGE_SIZE});
+}
+
 static std::vector<DiskSizeEntry> collectDiskSizeInfo(const ClientContext* context) {
     std::vector<DiskSizeEntry> entries;
+    std::unordered_map<std::string, idx_t> entryLookup;
     auto storageManager = StorageManager::Get(*context);
     auto catalog = Catalog::Get(*context);
     auto dataFH = storageManager->getDataFH();
@@ -172,10 +189,9 @@ static std::vector<DiskSizeEntry> collectDiskSizeInfo(const ClientContext* conte
                     storageEntry.pageRange.numPages == 0) {
                     continue;
                 }
-                entries.push_back({"index",
+                appendOrIncrementEntry(entries, entryLookup, "index",
                     tableEntry->getName() + "." + indexInfo.name + ":" + storageEntry.component,
-                    storageEntry.pageRange.numPages,
-                    storageEntry.pageRange.numPages * LBUG_PAGE_SIZE});
+                    storageEntry.pageRange.numPages);
             }
         }
     }

--- a/src/function/table/show_indexes.cpp
+++ b/src/function/table/show_indexes.cpp
@@ -1,9 +1,15 @@
+#include <unordered_set>
+
 #include "binder/binder.h"
 #include "catalog/catalog.h"
 #include "catalog/catalog_entry/index_catalog_entry.h"
+#include "catalog/catalog_entry/node_table_catalog_entry.h"
 #include "function/table/bind_data.h"
 #include "function/table/bind_input.h"
 #include "function/table/simple_table_function.h"
+#include "main/client_context.h"
+#include "storage/storage_manager.h"
+#include "storage/table/node_table.h"
 #include "transaction/transaction.h"
 
 using namespace lbug::catalog;
@@ -39,6 +45,21 @@ struct ShowIndexesBindData final : TableFuncBindData {
         return std::make_unique<ShowIndexesBindData>(*this);
     }
 };
+
+static std::string getSeenKey(common::table_id_t tableID, const std::string& indexName) {
+    return std::to_string(tableID) + ":" + indexName;
+}
+
+template<typename ID_TYPE>
+static std::vector<std::string> getPropertyNames(const TableCatalogEntry& tableEntry,
+    const std::vector<ID_TYPE>& propertyIDs) {
+    std::vector<std::string> propertyNames;
+    propertyNames.reserve(propertyIDs.size());
+    for (auto propertyID : propertyIDs) {
+        propertyNames.push_back(tableEntry.getProperty(propertyID).getName());
+    }
+    return propertyNames;
+}
 
 static offset_t internalTableFunc(const TableFuncMorsel& morsel, const TableFuncInput& input,
     DataChunk& output) {
@@ -86,17 +107,14 @@ static std::unique_ptr<TableFuncBindData> bindFunc(const main::ClientContext* co
     std::vector<IndexInfo> indexesInfo;
     auto catalog = Catalog::Get(*context);
     auto transaction = transaction::Transaction::Get(*context);
+    std::unordered_set<std::string> seenIndexes;
     auto indexEntries = catalog->getIndexEntries(transaction);
     for (auto indexEntry : indexEntries) {
         auto tableEntry = catalog->getTableCatalogEntry(transaction, indexEntry->getTableID());
         auto tableName = tableEntry->getName();
         auto indexName = indexEntry->getIndexName();
         auto indexType = indexEntry->getIndexType();
-        auto properties = indexEntry->getPropertyIDs();
-        std::vector<std::string> propertyNames;
-        for (auto& property : properties) {
-            propertyNames.push_back(tableEntry->getProperty(property).getName());
-        }
+        auto propertyNames = getPropertyNames(*tableEntry, indexEntry->getPropertyIDs());
         auto dependencyLoaded = indexEntry->isLoaded();
         std::string indexDefinition;
         if (dependencyLoaded) {
@@ -107,6 +125,30 @@ static std::unique_ptr<TableFuncBindData> bindFunc(const main::ClientContext* co
         }
         indexesInfo.emplace_back(std::move(tableName), std::move(indexName), std::move(indexType),
             std::move(propertyNames), dependencyLoaded, std::move(indexDefinition));
+        seenIndexes.insert(getSeenKey(indexEntry->getTableID(), indexEntry->getIndexName()));
+    }
+
+    auto* storageManager = storage::StorageManager::Get(*context);
+    for (auto* tableEntry :
+        catalog->getNodeTableEntries(transaction, context->useInternalCatalogEntry())) {
+        const auto tableID = tableEntry->getTableID();
+        const auto hasCatalogPKIndex =
+            catalog->containsIndex(transaction, tableID, tableEntry->getPrimaryKeyID());
+        auto* nodeTable = storageManager->getTable(tableID)->ptrCast<storage::NodeTable>();
+        for (auto& indexHolder : nodeTable->getIndexes()) {
+            auto* index = indexHolder.getIndex();
+            const auto& storageIndexInfo = index->getIndexInfo();
+            if (seenIndexes.contains(getSeenKey(tableID, storageIndexInfo.name))) {
+                continue;
+            }
+            if (storageIndexInfo.isPrimary && hasCatalogPKIndex) {
+                continue;
+            }
+            indexesInfo.emplace_back(tableEntry->getName(), storageIndexInfo.name,
+                storageIndexInfo.indexType,
+                getPropertyNames(*tableEntry, storageIndexInfo.columnIDs), index->isLoaded(),
+                "" /* indexDefinition */);
+        }
     }
     return std::make_unique<ShowIndexesBindData>(indexesInfo, bindColumns(*input),
         indexesInfo.size());

--- a/src/function/table/show_indexes.cpp
+++ b/src/function/table/show_indexes.cpp
@@ -136,17 +136,22 @@ static std::unique_ptr<TableFuncBindData> bindFunc(const main::ClientContext* co
             catalog->containsIndex(transaction, tableID, tableEntry->getPrimaryKeyID());
         auto* nodeTable = storageManager->getTable(tableID)->ptrCast<storage::NodeTable>();
         for (auto& indexHolder : nodeTable->getIndexes()) {
-            auto* index = indexHolder.getIndex();
-            const auto& storageIndexInfo = index->getIndexInfo();
+            const auto& storageIndexInfo = indexHolder.getIndexInfo();
+            if (!storageIndexInfo.isPrimary || !storageIndexInfo.isBuiltin) {
+                continue;
+            }
             if (seenIndexes.contains(getSeenKey(tableID, storageIndexInfo.name))) {
                 continue;
             }
             if (storageIndexInfo.isPrimary && hasCatalogPKIndex) {
                 continue;
             }
+            if (!indexHolder.isLoaded()) {
+                continue;
+            }
             indexesInfo.emplace_back(tableEntry->getName(), storageIndexInfo.name,
                 storageIndexInfo.indexType,
-                getPropertyNames(*tableEntry, storageIndexInfo.columnIDs), index->isLoaded(),
+                getPropertyNames(*tableEntry, storageIndexInfo.columnIDs), true,
                 "" /* indexDefinition */);
         }
     }

--- a/src/include/storage/disk_array.h
+++ b/src/include/storage/disk_array.h
@@ -5,10 +5,12 @@
 #include <mutex>
 #include <optional>
 #include <shared_mutex>
+#include <vector>
 
 #include "common/copy_constructors.h"
 #include "common/types/types.h"
 #include "storage/buffer_manager/memory_manager.h"
+#include "storage/page_range.h"
 #include "storage/shadow_utils.h"
 #include "storage/storage_utils.h"
 #include "transaction/transaction.h"
@@ -134,6 +136,7 @@ public:
     void checkpoint();
 
     void reclaimStorage(PageAllocator& pageAllocator) const;
+    std::vector<PageRange> getPageRanges() const;
 
     // Write WriteIterator for making fast bulk changes to the disk array
     // The pages are cached while the elements are stored on the same page
@@ -247,7 +250,7 @@ protected:
     ShadowFile* shadowFile;
     std::vector<PIPWrapper> pips;
     PIPUpdates pipUpdates;
-    std::shared_mutex diskArraySharedMtx;
+    mutable std::shared_mutex diskArraySharedMtx;
     // For write transactions only
     common::page_idx_t lastAPPageIdx;
     common::page_idx_t lastPageOnDisk;
@@ -300,6 +303,7 @@ public:
     inline void reclaimStorage(PageAllocator& pageAllocator) const {
         diskArray.reclaimStorage(pageAllocator);
     }
+    inline std::vector<PageRange> getPageRanges() const { return diskArray.getPageRanges(); }
 
     class WriteIterator {
     public:

--- a/src/include/storage/disk_array_collection.h
+++ b/src/include/storage/disk_array_collection.h
@@ -4,6 +4,7 @@
 
 #include "common/types/types.h"
 #include "disk_array.h"
+#include "storage/page_range.h"
 
 namespace lbug {
 namespace storage {
@@ -48,6 +49,7 @@ public:
     }
 
     void reclaimStorage(PageAllocator& pageAllocator, common::page_idx_t firstHeaderPage) const;
+    std::vector<PageRange> getPageRanges(common::page_idx_t firstHeaderPage) const;
 
     template<typename T>
     std::unique_ptr<DiskArray<T>> getDiskArray(uint32_t idx) {

--- a/src/include/storage/index/hash_index.h
+++ b/src/include/storage/index/hash_index.h
@@ -44,6 +44,7 @@ public:
     virtual bool rollbackInMemory() = 0;
     virtual void rollbackCheckpoint() = 0;
     virtual void reclaimStorage(PageAllocator& pageAllocator) = 0;
+    virtual std::vector<IndexStorageEntry> getStorageEntries() const = 0;
     virtual bool tryLock() = 0;
     virtual std::unique_lock<std::shared_mutex> adoptLock() = 0;
 };
@@ -173,6 +174,7 @@ public:
     bool rollbackInMemory() override;
     void rollbackCheckpoint() override;
     void reclaimStorage(PageAllocator& pageAllocator) override;
+    std::vector<IndexStorageEntry> getStorageEntries() const override;
 
 private:
     bool lookupInPersistentIndex(const transaction::Transaction* transaction, Key key,
@@ -472,6 +474,7 @@ public:
         return indexInfo.keyDataTypes[0];
     }
     void reclaimStorage(PageAllocator& pageAllocator) const override;
+    std::vector<IndexStorageEntry> getStorageEntries() const override;
 
     static LBUG_API std::unique_ptr<Index> load(main::ClientContext* context,
         StorageManager* storageManager, IndexInfo indexInfo, std::span<uint8_t> storageInfoBuffer);

--- a/src/include/storage/index/index.h
+++ b/src/include/storage/index/index.h
@@ -227,6 +227,7 @@ public:
 
     std::string getName() const { return indexInfo.name; }
     bool isLoaded() const { return loaded; }
+    const IndexInfo& getIndexInfo() const { return indexInfo; }
 
     void serialize(common::Serializer& ser) const;
     LBUG_API void load(main::ClientContext* context, StorageManager* storageManager);

--- a/src/include/storage/overflow_file.h
+++ b/src/include/storage/overflow_file.h
@@ -9,6 +9,7 @@
 #include "common/types/types.h"
 #include "storage//file_handle.h"
 #include "storage/index/hash_index_utils.h"
+#include "storage/page_range.h"
 #include "storage/storage_utils.h"
 
 namespace lbug {
@@ -61,6 +62,7 @@ public:
         this->nextPosToWriteTo = nextPosToWriteTo_;
     }
     void reclaimStorage(PageAllocator& pageAllocator);
+    std::vector<PageRange> getPageRanges() const;
 
 private:
     uint8_t* addANewPage(PageAllocator* pageAllocator);
@@ -107,6 +109,7 @@ public:
     void checkpointInMemory();
 
     void reclaimStorage(PageAllocator& pageAllocator) const;
+    std::vector<PageRange> getPageRanges() const;
 
     common::page_idx_t getHeaderPageIdx() const { return headerPageIdx; }
 

--- a/src/storage/disk_array.cpp
+++ b/src/storage/disk_array.cpp
@@ -251,6 +251,32 @@ void DiskArrayInternal::reclaimStorage(PageAllocator& pageAllocator) const {
     }
 }
 
+std::vector<PageRange> DiskArrayInternal::getPageRanges() const {
+    std::shared_lock lck{diskArraySharedMtx};
+    std::vector<PageRange> result;
+    auto appendPIP = [&result](const PIPWrapper& pip) {
+        for (auto pageIdx : pip.pipContents.pageIdxs) {
+            if (pageIdx != ShadowUtils::NULL_PAGE_IDX) {
+                result.emplace_back(pageIdx, 1);
+            }
+        }
+        if (pip.pipPageIdx != ShadowUtils::NULL_PAGE_IDX) {
+            result.emplace_back(pip.pipPageIdx, 1);
+        }
+    };
+    for (auto i = 0u; i < pips.size(); i++) {
+        if (i == pips.size() - 1 && pipUpdates.updatedLastPIP.has_value()) {
+            appendPIP(*pipUpdates.updatedLastPIP);
+        } else {
+            appendPIP(pips[i]);
+        }
+    }
+    for (const auto& newPIP : pipUpdates.newPIPs) {
+        appendPIP(newPIP);
+    }
+    return result;
+}
+
 bool DiskArrayInternal::hasPIPUpdatesNoLock(uint64_t pipIdx) const {
     // This is a request to a pipIdx > pips.size(). Since pips.size() is the original number of pips
     // we started with before the write transaction is updated, we return true, i.e., this PIP is

--- a/src/storage/disk_array_collection.cpp
+++ b/src/storage/disk_array_collection.cpp
@@ -121,5 +121,19 @@ void DiskArrayCollection::reclaimStorage(PageAllocator& pageAllocator,
     }
 }
 
+std::vector<PageRange> DiskArrayCollection::getPageRanges(
+    common::page_idx_t firstHeaderPage) const {
+    std::vector<PageRange> result;
+    auto headerPage = firstHeaderPage;
+    for (page_idx_t indexInMemory = 0; indexInMemory < headersForReadTrx.size(); indexInMemory++) {
+        if (headerPage == INVALID_PAGE_IDX) {
+            break;
+        }
+        result.emplace_back(headerPage, 1);
+        headerPage = headersForReadTrx[indexInMemory]->nextHeaderPage;
+    }
+    return result;
+}
+
 } // namespace storage
 } // namespace lbug

--- a/src/storage/index/hash_index.cpp
+++ b/src/storage/index/hash_index.cpp
@@ -133,6 +133,25 @@ void HashIndex<T>::reclaimStorage(PageAllocator& pageAllocator) {
     oSlots->reclaimStorage(pageAllocator);
 }
 
+static void appendStorageEntries(std::vector<IndexStorageEntry>& entries,
+    std::string_view component, const std::vector<PageRange>& pageRanges) {
+    for (const auto& pageRange : pageRanges) {
+        if (pageRange.startPageIdx == INVALID_PAGE_IDX || pageRange.numPages == 0) {
+            continue;
+        }
+        entries.push_back(IndexStorageEntry{std::string{component}, pageRange,
+            pageRange.numPages * LBUG_PAGE_SIZE});
+    }
+}
+
+template<typename T>
+std::vector<IndexStorageEntry> HashIndex<T>::getStorageEntries() const {
+    std::vector<IndexStorageEntry> entries;
+    appendStorageEntries(entries, "primary_slots", pSlots->getPageRanges());
+    appendStorageEntries(entries, "overflow_slots", oSlots->getPageRanges());
+    return entries;
+}
+
 template<typename T>
 void HashIndex<T>::splitSlots(PageAllocator& pageAllocator, const Transaction* transaction,
     HashIndexHeader& header, slot_id_t numSlotsToSplit) {
@@ -731,6 +750,25 @@ void PrimaryKeyIndex::reclaimStorage(PageAllocator& pageAllocator) const {
     if (firstHeaderPage != INVALID_PAGE_IDX) {
         pageAllocator.freePageRange({getFirstHeaderPage(), NUM_HEADER_PAGES});
     }
+}
+
+std::vector<IndexStorageEntry> PrimaryKeyIndex::getStorageEntries() const {
+    std::vector<IndexStorageEntry> entries;
+    const auto firstHeaderPage = getFirstHeaderPage();
+    if (firstHeaderPage != INVALID_PAGE_IDX) {
+        entries.push_back(IndexStorageEntry{"hash_index_headers",
+            PageRange{firstHeaderPage, NUM_HEADER_PAGES}, NUM_HEADER_PAGES * LBUG_PAGE_SIZE});
+    }
+    appendStorageEntries(entries, "disk_array_headers",
+        hashIndexDiskArrays->getPageRanges(getDiskArrayFirstHeaderPage()));
+    for (auto i = 0u; i < hashIndices.size(); i++) {
+        auto indexEntries = hashIndices[i]->getStorageEntries();
+        entries.insert(entries.end(), indexEntries.begin(), indexEntries.end());
+    }
+    if (overflowFile) {
+        appendStorageEntries(entries, "string_overflow", overflowFile->getPageRanges());
+    }
+    return entries;
 }
 
 page_idx_t PrimaryKeyIndex::getDiskArrayFirstHeaderPage() const {

--- a/src/storage/overflow_file.cpp
+++ b/src/storage/overflow_file.cpp
@@ -170,6 +170,32 @@ void OverflowFileHandle::reclaimStorage(PageAllocator& pageAllocator) {
     }
 }
 
+std::vector<PageRange> OverflowFileHandle::getPageRanges() const {
+    std::vector<PageRange> result;
+    if (startPageIdx == INVALID_PAGE_IDX) {
+        return result;
+    }
+
+    auto pageIdx = startPageIdx;
+    while (true) {
+        if (pageIdx == 0 || pageIdx == INVALID_PAGE_IDX) [[unlikely]] {
+            throw RuntimeException(
+                "The overflow file has been corrupted, this should never happen.");
+        }
+        result.emplace_back(pageIdx, 1);
+
+        if (pageIdx == nextPosToWriteTo.pageIdx) {
+            break;
+        }
+
+        DASSERT(!pageWriteCache.contains(pageIdx));
+        overflowFile.readFromDisk(TransactionType::CHECKPOINT, pageIdx, [&pageIdx](auto* frame) {
+            pageIdx = *reinterpret_cast<page_idx_t*>(frame + END_OF_PAGE);
+        });
+    }
+    return result;
+}
+
 void OverflowFileHandle::read(TransactionType trxType, page_idx_t pageIdx,
     const std::function<void(uint8_t*)>& func) const {
     auto cachedPage = pageWriteCache.find(pageIdx);
@@ -275,6 +301,18 @@ void OverflowFile::reclaimStorage(PageAllocator& pageAllocator) const {
     if (headerPageIdx != INVALID_PAGE_IDX) {
         pageAllocator.freePage(headerPageIdx);
     }
+}
+
+std::vector<PageRange> OverflowFile::getPageRanges() const {
+    std::vector<PageRange> result;
+    if (headerPageIdx != INVALID_PAGE_IDX) {
+        result.emplace_back(headerPageIdx, 1);
+    }
+    for (auto& handle : handles) {
+        auto handlePageRanges = handle->getPageRanges();
+        result.insert(result.end(), handlePageRanges.begin(), handlePageRanges.end());
+    }
+    return result;
 }
 
 } // namespace storage

--- a/src/storage/overflow_file.cpp
+++ b/src/storage/overflow_file.cpp
@@ -188,8 +188,7 @@ std::vector<PageRange> OverflowFileHandle::getPageRanges() const {
             break;
         }
 
-        DASSERT(!pageWriteCache.contains(pageIdx));
-        overflowFile.readFromDisk(TransactionType::CHECKPOINT, pageIdx, [&pageIdx](auto* frame) {
+        read(TransactionType::CHECKPOINT, pageIdx, [&pageIdx](auto* frame) {
             pageIdx = *reinterpret_cast<page_idx_t*>(frame + END_OF_PAGE);
         });
     }

--- a/test/test_files/ddl/ddl_empty.test
+++ b/test/test_files/ddl/ddl_empty.test
@@ -7,6 +7,9 @@
 Table idx_default_person has been created.
 -STATEMENT CREATE (:idx_default_person {ID: 1, name: 'Alice'});
 ---- ok
+-STATEMENT CALL SHOW_INDEXES() RETURN table_name, index_name, index_type, property_names;
+---- 1
+idx_default_person|_PK|HASH|[ID]
 -STATEMENT CREATE INDEX idx_default_person_pk IF NOT EXISTS FOR (p:idx_default_person) ON (p.ID);
 ---- 1
 Index idx_default_person_pk has been created.
@@ -186,7 +189,8 @@ Table art_secondary_person has been created.
 ---- 1
 Index art_secondary_person_name has been created.
 -STATEMENT CALL SHOW_INDEXES() WHERE table_name = 'art_secondary_person' RETURN table_name, index_name, index_type, property_names ORDER BY index_name;
----- 1
+---- 2
+art_secondary_person|_PK|HASH|[ID]
 art_secondary_person|art_secondary_person_name|ART|[name]
 -STATEMENT MATCH (p:art_secondary_person) WHERE p.name = 'Ada' RETURN p.ID, p.rank ORDER BY p.rank DESC;
 ---- 2

--- a/test/test_files/function/call/storage_info.test
+++ b/test/test_files/function/call/storage_info.test
@@ -26,7 +26,7 @@ True
 8
 -STATEMENT CALL storage_info('person') RETURN COUNT(*)
 ---- 1
-58
+78
 # TODO(Guodong/Sam): FIX-ME
 #-STATEMENT CALL storage_info('knows') RETURN COUNT(*)
 #---- 1
@@ -68,3 +68,12 @@ Index storage_info_idx_person_name has been created.
 -STATEMENT CALL disk_info() WHERE category = 'index' AND name = 'storage_info_idx_person.storage_info_idx_person_name:tree' RETURN count(*), min(num_pages) > 0, min(size_bytes) > 0;
 ---- 1
 1|True|True
+-STATEMENT CALL disk_info() WHERE category = 'index' AND name = 'storage_info_idx_person._PK:hash_index_headers' RETURN count(*), min(num_pages) = 2, min(size_bytes) > 0;
+---- 1
+1|True|True
+-STATEMENT CALL disk_info() WHERE category = 'index' AND name STARTS WITH 'storage_info_idx_person._PK' RETURN count(*), sum(num_pages) > 0;
+---- 1
+3|True
+-STATEMENT CALL disk_info() WITH sum(CASE WHEN category = 'unaccounted' THEN num_pages ELSE 0 END) AS unaccounted_pages RETURN unaccounted_pages;
+---- 1
+0


### PR DESCRIPTION
**Summary**

  This PR fixes hash index storage accounting in disk_info() / storage_info() and makes SHOW_INDEXES()
  include the built-in _PK hash index so index visibility is consistent with the underlying storage state.

  **Problem**

  There were two related inconsistencies:

  1. Hash-backed primary-key index storage was not fully reflected in disk_info() / storage_info().
  2. SHOW_INDEXES() did not surface the built-in _PK hash index, even though that index exists physically
     and shows up in storage-oriented views.

  This made it harder to reason about index footprint and led to confusing gaps between catalog and
  storage infrormation.

  What changed

  1. Hash index storage accounting

  - Expose hash index storage through Index::getStorageEntries()
  - Report logical hash index components such as:
      - hash_index_headers
      - disk_array_headers
      - primary_slots
      - overflow_slots when present
      - string_overflow when present

  - Include the relevant disk-array page ranges so allocated hash index pages are accounted for correctly
  - Aggregate repeated disk_info() entries by logical component name instead of emitting a row per page/
    range

  2. SHOW_INDEXES() visibility

  - Include storage-backed built-in _PK indexes in SHOW_INDEXES()
  - Avoid duplicate rows when a catalog-backed PK index already represents the same logical PK index

  3. Tests

  - Added/updated coverage for:
      - hash index storage reporting in disk_info()
      - _PK visibility in SHOW_INDEXES()
      - ART secondary-index expectations now that _PK is included in SHOW_INDEXES()
      - updated storage_info() row count expectations where PK index rows are now included

  Behavior after this change

  SHOW_INDEXES() now reflects both user-created indexes and the built-in _PK hash index when present.

  Example:

  CALL SHOW_INDEXES() WHERE table_name = 't'
  RETURN table_name, index_name, index_type, property_names
  ORDER BY index_name;

  Before:

  t | t_name_idx | ART  | [name]

  After:

  t | _PK        | HASH | [id]
  t | t_name_idx | ART  | [name]

  disk_info() stays summary-oriented and grouped by logical storage component.

  storage_info() stays detailed and emits one row per physical storage range.