### PR TITLE
Fix overflow when compressing int128 columns with INT128_MIN bound 

### DIFF
--- a/src/storage/compression/compression.cpp
+++ b/src/storage/compression/compression.cpp
@@ -542,6 +542,17 @@ template<IntegerBitpackingType T>
 BitpackInfo<T> IntegerBitpacking<T>::getPackingInfo(const CompressionMetadata& metadata) {
     auto max = metadata.max.get<T>();
     auto min = metadata.min.get<T>();
+    constexpr auto fullBitWidth = static_cast<uint8_t>(sizeof(T) * 8);
+    if constexpr (std::same_as<T, int128_t>) {
+        // INT128_MIN cannot be negated so frame-of-reference math around this value
+        // can throw while computing abs(), min/max deltas, or value - offset.
+        // Force a raw full-width layout here. The metadata layer will turn
+        // full-width integer bitpacking into UNCOMPRESSED storage instead of
+        // doing unsafe signed arithmetic.
+        if (min.high == std::numeric_limits<int64_t>::min() && min.low == 0) {
+            return BitpackInfo<T>{fullBitWidth, false, T{}};
+        }
+    }
     bool hasNegative = false;
     T offset = 0;
     uint8_t bitWidth = 0;
@@ -571,6 +582,14 @@ BitpackInfo<T> IntegerBitpacking<T>::getPackingInfo(const CompressionMetadata& m
         bitWidth =
             static_cast<uint8_t>(numeric_utils::bitWidth((U)std::max(abs<T>(min), abs<T>(max))));
         hasNegative = false;
+    }
+    if constexpr (std::same_as<T, int128_t>) {
+        // Full-width int128_t bitpacking is not useful and can interact badly with
+        // signed INT128 edge values. Normalize it to raw full-width/no-offset metadata
+        // so ColumnChunkMetadata falls back to UNCOMPRESSED for correctness.
+        if (bitWidth >= fullBitWidth) {
+            return BitpackInfo<T>{fullBitWidth, false, T{}};
+        }
     }
     return BitpackInfo<T>{bitWidth, hasNegative, offset};
 }
@@ -727,6 +746,13 @@ void IntegerBitpacking<T>::packPartialChunk(const U* srcBuffer, uint8_t* dstBuff
 template<IntegerBitpackingType T>
 void IntegerBitpacking<T>::copyValuesToTempChunkWithOffset(const U* srcBuffer, U* tmpBuffer,
     BitpackInfo<T> info, size_t numValuesToCopy) const {
+    if (info.offset == 0) {
+        // With no frame-of-reference offset there is nothing to subtract. Copy the raw
+        // unsigned representation so values such as INT128_MIN do not go through signed
+        // arithmetic unnecessarily.
+        std::copy_n(srcBuffer, numValuesToCopy, tmpBuffer);
+        return;
+    }
     for (auto j = 0u; j < numValuesToCopy; j++) {
         tmpBuffer[j] = static_cast<U>((T)(srcBuffer[j]) - info.offset);
     }

--- a/test/storage/compression_test.cpp
+++ b/test/storage/compression_test.cpp
@@ -1,4 +1,5 @@
 #include <algorithm>
+#include <limits>
 
 #include "common/exception/not_implemented.h"
 #include "common/exception/storage.h"
@@ -10,6 +11,7 @@
 #include "gtest/gtest.h"
 #include "storage/compression/compression.h"
 #include "storage/storage_utils.h"
+#include "storage/table/column_chunk_metadata.h"
 
 using namespace lbug::common;
 using namespace lbug::storage;
@@ -367,6 +369,26 @@ TEST(CompressionTests, IntegerPackingTest128NegativeSimple) {
 
     auto alg = IntegerBitpacking<lbug::common::int128_t>();
     test_compression(alg, src, false);
+}
+
+TEST(CompressionTests, IntegerPackingTest128MinEdgeCase) {
+    // INT128_MIN cannot be negated. UUID nil is stored internally as flipped
+    // INT128_MIN, so a non-constant UUID chunk used to crash when compression tried
+    // to compute frame-of-reference deltas. Such ranges must fall back to raw storage.
+    lbug::common::int128_t minValue{};
+    minValue.high = std::numeric_limits<int64_t>::min();
+    minValue.low = 0;
+    auto maxValue = minValue + lbug::common::int128_t{1};
+
+    auto alg = std::make_shared<IntegerBitpacking<lbug::common::int128_t>>();
+    const auto dataType = lbug::common::LogicalType::INT128();
+    auto getMetadata = GetCompressionMetadata(alg, dataType);
+    const auto metadata =
+        getMetadata(std::span<const uint8_t>{}, 2, StorageValue(minValue), StorageValue(maxValue));
+
+    // This is the important behavior: avoid INT128 bitpacking when the range starts at
+    // INT128_MIN, because bitpacking's offset math would need unsafe signed subtraction.
+    EXPECT_EQ(metadata.compMeta.compression, CompressionType::UNCOMPRESSED);
 }
 
 TEST(CompressionTests, IntegerPackingTest128CompressFullChunkLargeWidth) {


### PR DESCRIPTION
This PR addresses an INT128 bitpacking overflow when a chunk range starts at INT128_MIN. I triggered this when storing UUID nil values in a table because UUIDs are stored with the MSB flipped internally, so I hit a

```
RuntimeError: Overflow exception: INT128 is out of range: cannot negate INT128_MIN
```

Here's a test that can go anywhere in the python-api test suite to reproduce:

```py
def test_copy_from_pandas_uuid_int128_min_persistent(conn_db_empty: ConnDB) -> None:
    conn, _ = conn_db_empty
    conn.execute("CREATE NODE TABLE T(id UUID PRIMARY KEY)")
    df = pd.DataFrame(
        {
            "id": [
                # UUID nil is stored internally as flipped INT128_MIN. Together with
                # a second value, this forces a non-constant persistent chunk and
                # crashes while computing INT128 bitpacking offsets.
                UUID("00000000-0000-0000-0000-000000000000"),
                UUID("00000000-0000-0000-0000-000000000001"),
            ]
        }
    )

    conn.execute("COPY T FROM df")

    result = conn.execute("MATCH (t:T) RETURN t.id ORDER BY t.id")
    assert result.get_all() == [
        [UUID("00000000-0000-0000-0000-000000000000")],
        [UUID("00000000-0000-0000-0000-000000000001")],
    ]
```

The test is for UUIDs, but the bug affects any regular INT128 column if it is persisted and has a non-constant chunk with min == INT128_MIN.
 
The problem is that frame-of-reference INT128 bitpacking can require subtracting INT128_MIN, which overflows. Falling back to uncompressed storage for this edge case should be correct, and addresses the issue without changing UUID representation or storage format

### Changes:

- Detect int128_t metadata ranges starting at INT128_MIN and force full-width/no-offset packing info so existing metadata selection falls back to UNCOMPRESSED.
- Avoid unnecessary signed subtraction when bitpacking offset is zero.
- Add C++ regression coverage for INT128_MIN compression metadata.

The only downside I can think of is that INT128 chunks whose range starts at INT128_MIN now fall back to UNCOMPRESSED, so those rare (?) chunks use more disk space.

### DISCLAIMER

I have **heavily** relied on a friendly LLM to locate the culprit and fix it. I am way above my head with the column compression stuff, so even though I applied my best judgment, I can't claim this is 100% correct. Sorry about that.

PS: I think that UUIDs should use a uint128 representation, now that there is one such type (it was a late addition to Kuzu IIRC), but the changes would be extensive and change the format on disk, requiring db migration, and potentially touching *a lot* of files. This fix was necessary anyway and solves my problem with UUIDs. So, win-win? :D

PPS: I have a separate PR to python-api with the test above to guard against the UUID bug explicitly, but it's redundant-ish with this fix.
