### PR TITLE
Fix SSL CA certificate detection for extension downloads

### DIFF
--- a/src/extension/extension.cpp
+++ b/src/extension/extension.cpp
@@ -1,6 +1,8 @@
 #include "extension/extension.h"
 
+#include <array>
 #include <cstdlib>
+#include <filesystem>
 
 #include "common/exception/io.h"
 #include "common/string_utils.h"
@@ -256,6 +258,51 @@ std::optional<ExtensionProxyConfig> ExtensionUtils::getProxyConfigForURL(const s
         proxyURL = getProxyEnv({"LADYBUG_ALL_PROXY", "all_proxy", "ALL_PROXY"});
     }
     return proxyURL.empty() ? std::nullopt : parseProxyConfig(proxyURL);
+}
+
+std::optional<ExtensionCaCertPath> ExtensionUtils::getCaCertPath() {
+    namespace fs = std::filesystem;
+    std::error_code ec;
+
+    // 1. Respect SSL_CERT_FILE environment variable (OpenSSL standard).
+    if (const char* env = std::getenv("SSL_CERT_FILE")) { // NOLINT(*-mt-unsafe)
+        if (fs::exists(env, ec) && !fs::is_empty(env, ec)) {
+            return ExtensionCaCertPath{env, ""};
+        }
+    }
+    // 2. Respect SSL_CERT_DIR environment variable (OpenSSL standard).
+    if (const char* env = std::getenv("SSL_CERT_DIR")) { // NOLINT(*-mt-unsafe)
+        if (fs::is_directory(env, ec)) {
+            return ExtensionCaCertPath{"", env};
+        }
+    }
+    // 3. Probe well-known CA bundle file locations by distro.
+    constexpr std::array<const char*, 6> wellKnownFiles = {
+        "/etc/ssl/certs/ca-certificates.crt", // Debian / Ubuntu
+        "/etc/pki/tls/certs/ca-bundle.crt",   // RHEL / Fedora / CentOS
+        "/etc/ssl/ca-bundle.pem",             // openSUSE
+        "/etc/ssl/certs/ca-bundle.crt",       // Alpine / Arch (alt)
+        "/etc/pki/tls/cert.pem",              // RHEL / Fedora (alternate)
+        "/etc/ssl/cert.pem",                  // macOS (Homebrew openssl), some BSDs
+    };
+    for (const auto* path : wellKnownFiles) {
+        if (fs::exists(path, ec) && !fs::is_empty(path, ec)) {
+            return ExtensionCaCertPath{path, ""};
+        }
+    }
+    // 4. Probe well-known CApath directories (Debian hashed-symlink layout).
+    constexpr std::array<const char*, 2> wellKnownDirs = {
+        "/etc/ssl/certs",     // Debian / Ubuntu (hashed symlinks)
+        "/etc/pki/tls/certs", // RHEL (fallback, mixed)
+    };
+    for (const auto* path : wellKnownDirs) {
+        if (fs::is_directory(path, ec)) {
+            return ExtensionCaCertPath{"", path};
+        }
+    }
+    // No CA bundle found - let OpenSSL fall back to its compile-time defaults
+    // (SSL_CTX_set_default_verify_paths on Linux; Windows cert store on Windows).
+    return std::nullopt;
 }
 
 std::string ExtensionUtils::getExtensionFileName(const std::string& name) {

--- a/src/extension/extension_installer.cpp
+++ b/src/extension/extension_installer.cpp
@@ -22,8 +22,19 @@ void applyProxyConfig(httplib::Client& client, const ExtensionRepoInfo& repoInfo
     }
 }
 
+void configureSSLCerts(httplib::Client& client, const ExtensionRepoInfo& repoInfo) {
+    // Only relevant for https - plain http/file clients have no SSL context.
+    if (repoInfo.hostURL.rfind("https://", 0) != 0) {
+        return;
+    }
+    if (auto caCertPath = ExtensionUtils::getCaCertPath()) {
+        client.set_ca_cert_path(caCertPath->caCertFilePath, caCertPath->caCertDirPath);
+    }
+}
+
 httplib::Client createExtensionDownloadClient(const ExtensionRepoInfo& repoInfo) {
     httplib::Client client(repoInfo.hostURL.c_str());
+    configureSSLCerts(client, repoInfo);
     applyProxyConfig(client, repoInfo);
     return client;
 }

--- a/src/include/extension/extension.h
+++ b/src/include/extension/extension.h
@@ -49,6 +49,11 @@ struct ExtensionProxyConfig {
     std::string password;
 };
 
+struct ExtensionCaCertPath {
+    std::string caCertFilePath;
+    std::string caCertDirPath;
+};
+
 enum class ExtensionSource : uint8_t { OFFICIAL, USER, STATIC_LINKED };
 
 struct ExtensionSourceUtils {
@@ -99,6 +104,8 @@ struct LBUG_API ExtensionUtils {
     static std::optional<ExtensionProxyConfig> getProxyConfigForURL(const std::string& url);
 
     static std::optional<ExtensionProxyConfig> parseProxyConfig(const std::string& proxyURL);
+
+    static std::optional<ExtensionCaCertPath> getCaCertPath();
 
     static std::string getExtensionFileName(const std::string& name);
 

--- a/test/common/CMakeLists.txt
+++ b/test/common/CMakeLists.txt
@@ -3,6 +3,7 @@ add_lbug_test(types_test
         uint128_test.cpp
         date_test.cpp
         extension_proxy_test.cpp
+        extension_ca_cert_test.cpp
         interval_test.cpp
         null_mask_test.cpp
         string_test.cpp

--- a/test/common/extension_ca_cert_test.cpp
+++ b/test/common/extension_ca_cert_test.cpp
@@ -1,0 +1,140 @@
+#include <cstdlib>
+#include <filesystem>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "extension/extension.h"
+#include "gtest/gtest.h"
+
+#ifdef _WIN32
+#include <stdlib.h>
+#endif
+
+using namespace lbug::extension;
+
+namespace {
+
+const std::vector<std::string> CA_CERT_ENV_VARS = {"SSL_CERT_FILE", "SSL_CERT_DIR"};
+
+void setEnv(const std::string& key, const std::string& value) {
+#ifdef _WIN32
+    _putenv_s(key.c_str(), value.c_str());
+#else
+    setenv(key.c_str(), value.c_str(), 1);
+#endif
+}
+
+void unsetEnv(const std::string& key) {
+#ifdef _WIN32
+    _putenv_s(key.c_str(), "");
+#else
+    unsetenv(key.c_str());
+#endif
+}
+
+class ScopedCaCertEnv {
+public:
+    ScopedCaCertEnv() {
+        for (auto& key : CA_CERT_ENV_VARS) {
+            const auto value = std::getenv(key.c_str()); // NOLINT(*-mt-unsafe)
+            savedEnv.push_back(value == nullptr ? std::nullopt : std::optional<std::string>{value});
+            unsetEnv(key);
+        }
+    }
+
+    ~ScopedCaCertEnv() {
+        for (auto i = 0u; i < CA_CERT_ENV_VARS.size(); ++i) {
+            if (savedEnv[i]) {
+                setEnv(CA_CERT_ENV_VARS[i], *savedEnv[i]);
+            } else {
+                unsetEnv(CA_CERT_ENV_VARS[i]);
+            }
+        }
+    }
+
+private:
+    std::vector<std::optional<std::string>> savedEnv;
+};
+
+bool isReadableNonEmptyFile(const std::string& path) {
+    std::error_code ec;
+    return std::filesystem::exists(path, ec) && !std::filesystem::is_empty(path, ec);
+}
+
+bool isReadableDir(const std::string& path) {
+    std::error_code ec;
+    return std::filesystem::is_directory(path, ec);
+}
+
+} // namespace
+
+TEST(ExtensionCaCertTest, UsesSSLCertFileWhenSetAndExisting) {
+    ScopedCaCertEnv env;
+    // Use a path that is guaranteed to exist on Linux CI; skip otherwise.
+    const std::string knownFile = std::filesystem::exists("/etc/hostname") ? "/etc/hostname" : "";
+    if (knownFile.empty()) {
+        GTEST_SKIP() << "No known file to use as SSL_CERT_FILE stand-in on this host";
+    }
+    setEnv("SSL_CERT_FILE", knownFile);
+
+    auto caCertPath = ExtensionUtils::getCaCertPath();
+    ASSERT_TRUE(caCertPath.has_value());
+    EXPECT_EQ(caCertPath->caCertFilePath, knownFile);
+    EXPECT_TRUE(caCertPath->caCertDirPath.empty());
+}
+
+TEST(ExtensionCaCertTest, IgnoresStaleSSLCertFileAndFallsThrough) {
+    ScopedCaCertEnv env;
+    setEnv("SSL_CERT_FILE", "/nonexistent/path/that/does/not/exist.crt");
+
+    auto caCertPath = ExtensionUtils::getCaCertPath();
+    // It must NOT return the stale env path.
+    if (caCertPath.has_value()) {
+        EXPECT_NE(caCertPath->caCertFilePath, "/nonexistent/path/that/does/not/exist.crt");
+    }
+    // Either returns a well-known path/dir, or nullopt (let OpenSSL defaults apply).
+}
+
+TEST(ExtensionCaCertTest, UsesSSLCertDirWhenSetAndIsDirectory) {
+    ScopedCaCertEnv env;
+    const std::string knownDir = std::filesystem::exists("/tmp") ? "/tmp" : "";
+    if (knownDir.empty()) {
+        GTEST_SKIP() << "No /tmp directory to use as SSL_CERT_DIR stand-in on this host";
+    }
+    setEnv("SSL_CERT_DIR", knownDir);
+
+    auto caCertPath = ExtensionUtils::getCaCertPath();
+    ASSERT_TRUE(caCertPath.has_value());
+    EXPECT_EQ(caCertPath->caCertDirPath, knownDir);
+    EXPECT_TRUE(caCertPath->caCertFilePath.empty());
+}
+
+TEST(ExtensionCaCertTest, EnvFilePrecedenceOverEnvDir) {
+    ScopedCaCertEnv env;
+    const std::string knownFile = std::filesystem::exists("/etc/hostname") ? "/etc/hostname" : "";
+    const std::string knownDir = std::filesystem::exists("/tmp") ? "/tmp" : "";
+    if (knownFile.empty() || knownDir.empty()) {
+        GTEST_SKIP() << "Need both a known file and a known dir on this host";
+    }
+    setEnv("SSL_CERT_FILE", knownFile);
+    setEnv("SSL_CERT_DIR", knownDir);
+
+    auto caCertPath = ExtensionUtils::getCaCertPath();
+    ASSERT_TRUE(caCertPath.has_value());
+    EXPECT_EQ(caCertPath->caCertFilePath, knownFile);
+    EXPECT_TRUE(caCertPath->caCertDirPath.empty());
+}
+
+TEST(ExtensionCaCertTest, ReturnsNulloptOrValidPathWhenNoEnvSet) {
+    ScopedCaCertEnv env;
+    auto caCertPath = ExtensionUtils::getCaCertPath();
+    if (caCertPath.has_value()) {
+        // If it returns a value, it must be a real readable path.
+        EXPECT_TRUE(isReadableNonEmptyFile(caCertPath->caCertFilePath) ||
+                    isReadableDir(caCertPath->caCertDirPath));
+        // Never both empty.
+        EXPECT_FALSE(caCertPath->caCertFilePath.empty() && caCertPath->caCertDirPath.empty());
+    }
+    // std::nullopt is also acceptable: OpenSSL defaults will apply.
+}


### PR DESCRIPTION
Extension downloads over HTTPS fail with SSL verification errors when a Ladybug wheel built on one Linux distro (e.g. RHEL) is run on another (e.g. Debian). The vendored httplib (v0.14.2) falls back to OpenSSL's compile-time default CA paths, which don't match the runtime system's CA bundle location.

This PR adds `ExtensionUtils::getCaCertPath()` which probes for a usable CA bundle in order: `SSL_CERT_FILE`/`SSL_CERT_DIR` env vars, then well-known distro paths (Debian, RHEL, openSUSE, Alpine, macOS Homebrew), then CApath directories. The result is wired into the extension download client via `set_ca_cert_path()`. If nothing is found, it returns `std::nullopt` and OpenSSL's defaults apply (preserving existing behavior).

## Limitation

macOS Keychain loading is not supported by the vendored httplib v0.14.2 (that support was added in later upstream versions). On a clean macOS install without a Homebrew-provided CA bundle at `/etc/ssl/cert.pem`, the probe will find nothing and fall back to OpenSSL defaults, which may still fail. Probably the real fix for macOS is upgrading the vendored httplib.