### PR TITLE
Handle integer-backed Arrow decimals via logical type metadata

### DIFF
--- a/docs/snowflake_arrow_handling.md
+++ b/docs/snowflake_arrow_handling.md
@@ -1,0 +1,46 @@
+# Snowflake Arrow Handling
+
+This document lists the Snowflake-specific Arrow metadata cases currently handled by Ladybug.
+
+## Supported Cases
+
+| Snowflake signal | Example metadata | Arrow physical storage | Ladybug result | Notes |
+| --- | --- | --- | --- | --- |
+| Raw Snowflake decimal type via `DATA_TYPE` | `DATA_TYPE=NUMBER(12,4)` | Any Arrow storage type | `DECIMAL(12,4)` | Parsed from Snowflake table-schema metadata. |
+| Raw Snowflake decimal type via `DATA_TYPE` with implicit scale | `DATA_TYPE=NUMBER(18)` | Any Arrow storage type | `DECIMAL(18,0)` | Missing scale defaults to `0`. |
+| Raw Snowflake decimal aliases via `DATA_TYPE` | `DATA_TYPE=NUMERIC(10,3)` or `DATA_TYPE=DECIMAL(10,3)` | Any Arrow storage type | `DECIMAL(10,3)` | Matching is case-insensitive and whitespace-tolerant. |
+| Snowflake logical decimal metadata | `logicalType=FIXED`, `precision=7`, `scale=2` | Integer-backed Arrow (`INT8/16/32/64`, `UINT8/16/32/64`) | `DECIMAL(7,2)` | Used for query-result Arrow schemas. |
+| Snowflake logical decimal metadata | `logicalType=FIXED`, `precision=9`, `scale=2` | Float-backed Arrow (`FLOAT`, `DOUBLE`) | `DECIMAL(9,2)` | Values are cast into decimal backing storage during scan. |
+| Snowflake raw type fallback to logical metadata | malformed `DATA_TYPE` plus valid `logicalType=FIXED` metadata | Integer-backed or float-backed Arrow | `DECIMAL(p,s)` from `logicalType` metadata | If raw `DATA_TYPE` parsing fails, Snowflake `logicalType` parsing is tried next. |
+| Snowflake metadata precedence over generic metadata | `DATA_TYPE=NUMBER(12,4)` plus generic `logicalType=DECIMAL`, `precision=9`, `scale=3` | Any Arrow storage type | `DECIMAL(12,4)` | Snowflake raw type metadata wins over generic metadata. |
+
+## Current Scope
+
+Only Snowflake decimal semantics are handled today.
+
+Specifically:
+
+- `NUMBER(p,s)`
+- `NUMBER(p)`
+- `NUMERIC(p,s)`
+- `DECIMAL(p,s)`
+- `logicalType=FIXED`
+
+## Not Yet Handled
+
+The Snowflake ADBC driver documents additional logical types that are not currently interpreted in a Snowflake-specific way here, including:
+
+- `real`
+- `date`
+- `time`
+- `timestamp_ltz`
+- `timestamp_ntz`
+- `timestamp_tz`
+- `text`
+- `binary`
+- `variant`
+- `object`
+- `array`
+- `boolean`
+
+For those, Ladybug currently relies on the standard Arrow physical type unless future Snowflake-specific decoding is added.

--- a/src/common/arrow/CMakeLists.txt
+++ b/src/common/arrow/CMakeLists.txt
@@ -2,6 +2,10 @@ add_library(lbug_common_arrow
         OBJECT
         arrow_array_scan.cpp
         arrow_converter.cpp
+        arrow_schema_metadata_generic_decoder.cpp
+        arrow_schema_metadata_snowflake_decoder.cpp
+        arrow_schema_metadata_utils.cpp
+        arrow_schema_metadata.cpp
         arrow_null_mask_tree.cpp
         arrow_row_batch.cpp
         arrow_type.cpp)

--- a/src/common/arrow/arrow_array_scan.cpp
+++ b/src/common/arrow/arrow_array_scan.cpp
@@ -478,10 +478,20 @@ static void scanArrowArrayRunEndEncoded(const ArrowSchema* schema, const ArrowAr
 void ArrowConverter::fromArrowArray(const ArrowSchema* schema, const ArrowArray* array,
     ValueVector& outputVector, ArrowNullMaskTree* mask, uint64_t srcOffset, uint64_t dstOffset,
     uint64_t count) {
+    return fromArrowArray(schema, array, outputVector, mask, srcOffset, dstOffset, count, nullptr);
+}
+
+void ArrowConverter::fromArrowArray(const ArrowSchema* schema, const ArrowArray* array,
+    ValueVector& outputVector, ArrowNullMaskTree* mask, uint64_t srcOffset, uint64_t dstOffset,
+    uint64_t count, const std::optional<ArrowLogicalTypeInfo>* logicalTypeInfo) {
     const auto arrowType = schema->format;
-    if (auto logicalTypeInfo = tryGetArrowLogicalTypeInfo(schema);
-        logicalTypeInfo.has_value() &&
-        logicalTypeInfo->type == ArrowLogicalTypeInfo::Type::DECIMAL) {
+    std::optional<ArrowLogicalTypeInfo> parsedLogicalTypeInfo;
+    if (logicalTypeInfo == nullptr) {
+        parsedLogicalTypeInfo = tryGetArrowLogicalTypeInfo(schema);
+        logicalTypeInfo = &parsedLogicalTypeInfo;
+    }
+    if (logicalTypeInfo->has_value() &&
+        (*logicalTypeInfo)->type == ArrowLogicalTypeInfo::Type::DECIMAL) {
         switch (arrowType[0]) {
         case 'c':
             return scanArrowArrayIntegerBackedDecimal<int8_t>(array, outputVector, mask, srcOffset,

--- a/src/common/arrow/arrow_array_scan.cpp
+++ b/src/common/arrow/arrow_array_scan.cpp
@@ -1,9 +1,11 @@
 #include "common/arrow/arrow_converter.h"
+#include "common/arrow/arrow_schema_metadata.h"
 #include "common/exception/runtime.h"
 #include "common/types/int128_t.h"
 #include "common/types/interval_t.h"
 #include "common/types/types.h"
 #include "common/vector/value_vector.h"
+#include "function/cast/functions/cast_decimal.h"
 #include "function/cast/functions/numeric_limits.h"
 
 namespace lbug {
@@ -56,6 +58,74 @@ static void scanArrowArrayFixedSizePrimitiveAndCastTo(const ArrowArray* array,
             outputVector.setValue<DST>(i + dstOffset, (DST)curValue);
         }
     });
+}
+
+template<typename SRC>
+static void scanArrowArrayIntegerBackedDecimal(const ArrowArray* array, ValueVector& outputVector,
+    ArrowNullMaskTree* mask, uint64_t srcOffset, uint64_t dstOffset, uint64_t count) {
+    switch (outputVector.dataType.getPhysicalType()) {
+    case PhysicalTypeID::INT16:
+        return scanArrowArrayFixedSizePrimitiveAndCastTo<SRC, int16_t>(array, outputVector, mask,
+            srcOffset, dstOffset, count);
+    case PhysicalTypeID::INT32:
+        return scanArrowArrayFixedSizePrimitiveAndCastTo<SRC, int32_t>(array, outputVector, mask,
+            srcOffset, dstOffset, count);
+    case PhysicalTypeID::INT64:
+        return scanArrowArrayFixedSizePrimitiveAndCastTo<SRC, int64_t>(array, outputVector, mask,
+            srcOffset, dstOffset, count);
+    case PhysicalTypeID::INT128:
+        return scanArrowArrayFixedSizePrimitiveAndCastTo<SRC, int128_t>(array, outputVector, mask,
+            srcOffset, dstOffset, count);
+    default:
+        throw RuntimeException(
+            "Invalid decimal output type: " +
+            PhysicalTypeUtils::toString(outputVector.dataType.getPhysicalType()));
+    }
+}
+
+template<typename SRC, typename DST>
+static void castArrowArrayDecimalValue(SRC input, ValueVector& outputVector, uint64_t pos) {
+    DST output{};
+    function::CastToDecimal::operation(input, output, outputVector, outputVector);
+    outputVector.setValue<DST>(pos, output);
+}
+
+template<typename SRC, typename DST>
+static void scanArrowArrayDecimalWithCastTo(const ArrowArray* array, ValueVector& outputVector,
+    ArrowNullMaskTree* mask, uint64_t srcOffset, uint64_t dstOffset, uint64_t count) {
+    auto arrayBuffer = (const SRC*)array->buffers[1];
+
+    mask->copyToValueVector(&outputVector, dstOffset, count);
+
+    rowIter(outputVector, count, [&](auto i) {
+        if (!mask->isNull(i)) {
+            castArrowArrayDecimalValue<SRC, DST>(arrayBuffer[i + srcOffset], outputVector,
+                i + dstOffset);
+        }
+    });
+}
+
+template<typename SRC>
+static void scanArrowArrayDecimalWithCast(const ArrowArray* array, ValueVector& outputVector,
+    ArrowNullMaskTree* mask, uint64_t srcOffset, uint64_t dstOffset, uint64_t count) {
+    switch (outputVector.dataType.getPhysicalType()) {
+    case PhysicalTypeID::INT16:
+        return scanArrowArrayDecimalWithCastTo<SRC, int16_t>(array, outputVector, mask, srcOffset,
+            dstOffset, count);
+    case PhysicalTypeID::INT32:
+        return scanArrowArrayDecimalWithCastTo<SRC, int32_t>(array, outputVector, mask, srcOffset,
+            dstOffset, count);
+    case PhysicalTypeID::INT64:
+        return scanArrowArrayDecimalWithCastTo<SRC, int64_t>(array, outputVector, mask, srcOffset,
+            dstOffset, count);
+    case PhysicalTypeID::INT128:
+        return scanArrowArrayDecimalWithCastTo<SRC, int128_t>(array, outputVector, mask, srcOffset,
+            dstOffset, count);
+    default:
+        throw RuntimeException(
+            "Invalid decimal output type: " +
+            PhysicalTypeUtils::toString(outputVector.dataType.getPhysicalType()));
+    }
 }
 
 template<>
@@ -409,6 +479,44 @@ void ArrowConverter::fromArrowArray(const ArrowSchema* schema, const ArrowArray*
     ValueVector& outputVector, ArrowNullMaskTree* mask, uint64_t srcOffset, uint64_t dstOffset,
     uint64_t count) {
     const auto arrowType = schema->format;
+    if (auto logicalTypeInfo = tryGetArrowLogicalTypeInfo(schema);
+        logicalTypeInfo.has_value() &&
+        logicalTypeInfo->type == ArrowLogicalTypeInfo::Type::DECIMAL) {
+        switch (arrowType[0]) {
+        case 'c':
+            return scanArrowArrayIntegerBackedDecimal<int8_t>(array, outputVector, mask, srcOffset,
+                dstOffset, count);
+        case 'C':
+            return scanArrowArrayIntegerBackedDecimal<uint8_t>(array, outputVector, mask, srcOffset,
+                dstOffset, count);
+        case 's':
+            return scanArrowArrayIntegerBackedDecimal<int16_t>(array, outputVector, mask, srcOffset,
+                dstOffset, count);
+        case 'S':
+            return scanArrowArrayIntegerBackedDecimal<uint16_t>(array, outputVector, mask,
+                srcOffset, dstOffset, count);
+        case 'i':
+            return scanArrowArrayIntegerBackedDecimal<int32_t>(array, outputVector, mask, srcOffset,
+                dstOffset, count);
+        case 'I':
+            return scanArrowArrayIntegerBackedDecimal<uint32_t>(array, outputVector, mask,
+                srcOffset, dstOffset, count);
+        case 'l':
+            return scanArrowArrayIntegerBackedDecimal<int64_t>(array, outputVector, mask, srcOffset,
+                dstOffset, count);
+        case 'L':
+            return scanArrowArrayIntegerBackedDecimal<uint64_t>(array, outputVector, mask,
+                srcOffset, dstOffset, count);
+        case 'f':
+            return scanArrowArrayDecimalWithCast<float>(array, outputVector, mask, srcOffset,
+                dstOffset, count);
+        case 'g':
+            return scanArrowArrayDecimalWithCast<double>(array, outputVector, mask, srcOffset,
+                dstOffset, count);
+        default:
+            break;
+        }
+    }
     if (array->dictionary != nullptr) {
         switch (arrowType[0]) {
         case 'c':

--- a/src/common/arrow/arrow_schema_metadata.cpp
+++ b/src/common/arrow/arrow_schema_metadata.cpp
@@ -1,0 +1,25 @@
+#include "common/arrow/arrow_schema_metadata.h"
+
+#include "arrow_schema_metadata_internal.h"
+
+namespace lbug {
+namespace common {
+
+std::optional<ArrowLogicalTypeInfo> tryGetArrowLogicalTypeInfo(const ArrowSchema* schema) {
+    if (schema == nullptr || schema->format == nullptr || schema->metadata == nullptr) {
+        return std::nullopt;
+    }
+    const auto metadata = readArrowMetadata(schema->metadata);
+    if (auto snowflakeRawDataTypeInfo = tryParseSnowflakeRawDataTypeInfo(metadata);
+        snowflakeRawDataTypeInfo.has_value()) {
+        return snowflakeRawDataTypeInfo;
+    }
+    if (auto snowflakeTypeInfo = tryParseSnowflakeLogicalTypeInfo(schema, metadata);
+        snowflakeTypeInfo.has_value()) {
+        return snowflakeTypeInfo;
+    }
+    return tryParseGenericIntegerBackedDecimalMetadata(schema, metadata);
+}
+
+} // namespace common
+} // namespace lbug

--- a/src/common/arrow/arrow_schema_metadata_generic_decoder.cpp
+++ b/src/common/arrow/arrow_schema_metadata_generic_decoder.cpp
@@ -1,0 +1,35 @@
+#include "arrow_schema_metadata_internal.h"
+
+namespace lbug {
+namespace common {
+
+std::optional<ArrowLogicalTypeInfo> tryParseGenericIntegerBackedDecimalMetadata(
+    const ArrowSchema* schema, const ArrowMetadataMap& metadata) {
+    if (!isIntegralArrowStorageType(schema->format)) {
+        return std::nullopt;
+    }
+    const auto logicalType = getMetadataValue(metadata, "logicaltype");
+    if (!logicalType.has_value()) {
+        return std::nullopt;
+    }
+    const auto normalized = toLower(*logicalType);
+    if (normalized != "decimal" && normalized != "number" && normalized != "numeric") {
+        return std::nullopt;
+    }
+    const auto precision = getMetadataValue(metadata, "precision");
+    const auto scale = getMetadataValue(metadata, "scale");
+    if (!precision.has_value() || !scale.has_value()) {
+        return std::nullopt;
+    }
+    const auto parsedPrecision = tryParseUint32(*precision);
+    const auto parsedScale = tryParseUint32(*scale);
+    if (!parsedPrecision.has_value() || !parsedScale.has_value() ||
+        !isValidDecimalParameters(*parsedPrecision, *parsedScale)) {
+        return std::nullopt;
+    }
+    return ArrowLogicalTypeInfo{ArrowLogicalTypeInfo::Source::GENERIC_METADATA,
+        ArrowLogicalTypeInfo::Type::DECIMAL, ArrowDecimalTypeInfo{*parsedPrecision, *parsedScale}};
+}
+
+} // namespace common
+} // namespace lbug

--- a/src/common/arrow/arrow_schema_metadata_internal.h
+++ b/src/common/arrow/arrow_schema_metadata_internal.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <map>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "common/arrow/arrow_schema_metadata.h"
+
+namespace lbug {
+namespace common {
+
+using ArrowMetadataMap = std::map<std::string, std::string>;
+
+bool isIntegralArrowStorageType(const char* arrowType);
+bool isFloatingArrowStorageType(const char* arrowType);
+std::string toLower(std::string value);
+ArrowMetadataMap readArrowMetadata(const char* metadata);
+std::string trim(std::string value);
+std::vector<std::string> splitCommaSeparated(std::string value);
+std::optional<std::string> getMetadataValue(const ArrowMetadataMap& metadata,
+    const std::string& key);
+std::optional<uint32_t> tryParseUint32(const std::string& value);
+bool isValidDecimalParameters(uint32_t precision, uint32_t scale);
+
+std::optional<ArrowLogicalTypeInfo> tryParseSnowflakeRawDataTypeInfo(
+    const ArrowMetadataMap& metadata);
+std::optional<ArrowLogicalTypeInfo> tryParseSnowflakeLogicalTypeInfo(const ArrowSchema* schema,
+    const ArrowMetadataMap& metadata);
+std::optional<ArrowLogicalTypeInfo> tryParseGenericIntegerBackedDecimalMetadata(
+    const ArrowSchema* schema, const ArrowMetadataMap& metadata);
+
+} // namespace common
+} // namespace lbug

--- a/src/common/arrow/arrow_schema_metadata_snowflake_decoder.cpp
+++ b/src/common/arrow/arrow_schema_metadata_snowflake_decoder.cpp
@@ -1,0 +1,86 @@
+#include "arrow_schema_metadata_internal.h"
+
+namespace lbug {
+namespace common {
+
+namespace {
+
+std::optional<ArrowDecimalTypeInfo> tryParseSnowflakeDecimalType(const std::string& rawDataType) {
+    auto normalized = toLower(trim(rawDataType));
+    const auto openParen = normalized.find('(');
+    if (openParen == std::string::npos) {
+        return std::nullopt;
+    }
+    const auto typeName = trim(normalized.substr(0, openParen));
+    if (typeName != "number" && typeName != "numeric" && typeName != "decimal") {
+        return std::nullopt;
+    }
+    const auto closeParen = normalized.find(')', openParen + 1);
+    if (closeParen == std::string::npos) {
+        return std::nullopt;
+    }
+    auto args = splitCommaSeparated(normalized.substr(openParen + 1, closeParen - openParen - 1));
+    if (args.empty() || args.size() > 2) {
+        return std::nullopt;
+    }
+    const auto precision = tryParseUint32(args[0]);
+    if (!precision.has_value()) {
+        return std::nullopt;
+    }
+    auto scale = std::optional<uint32_t>{0};
+    if (args.size() == 2) {
+        scale = tryParseUint32(args[1]);
+    }
+    if (!scale.has_value() || !isValidDecimalParameters(*precision, *scale)) {
+        return std::nullopt;
+    }
+    return ArrowDecimalTypeInfo{*precision, *scale};
+}
+
+} // namespace
+
+std::optional<ArrowLogicalTypeInfo> tryParseSnowflakeRawDataTypeInfo(
+    const ArrowMetadataMap& metadata) {
+    const auto rawDataType = getMetadataValue(metadata, "data_type");
+    if (!rawDataType.has_value()) {
+        return std::nullopt;
+    }
+    const auto decimalInfo = tryParseSnowflakeDecimalType(*rawDataType);
+    if (!decimalInfo.has_value()) {
+        return std::nullopt;
+    }
+    return ArrowLogicalTypeInfo{ArrowLogicalTypeInfo::Source::SNOWFLAKE,
+        ArrowLogicalTypeInfo::Type::DECIMAL, *decimalInfo};
+}
+
+std::optional<ArrowLogicalTypeInfo> tryParseSnowflakeLogicalTypeInfo(const ArrowSchema* schema,
+    const ArrowMetadataMap& metadata) {
+    if (!isIntegralArrowStorageType(schema->format) &&
+        !isFloatingArrowStorageType(schema->format)) {
+        return std::nullopt;
+    }
+    const auto logicalType = getMetadataValue(metadata, "logicaltype");
+    if (!logicalType.has_value()) {
+        return std::nullopt;
+    }
+    const auto normalized = toLower(*logicalType);
+    if (normalized != "fixed") {
+        return std::nullopt;
+    }
+    const auto precision = getMetadataValue(metadata, "precision");
+    const auto scale = getMetadataValue(metadata, "scale");
+    if (!precision.has_value() || !scale.has_value()) {
+        return std::nullopt;
+    }
+    const auto parsedPrecision = tryParseUint32(*precision);
+    const auto parsedScale = tryParseUint32(*scale);
+    if (!parsedPrecision.has_value() || !parsedScale.has_value() ||
+        !isValidDecimalParameters(*parsedPrecision, *parsedScale)) {
+        return std::nullopt;
+    }
+    return ArrowLogicalTypeInfo{ArrowLogicalTypeInfo::Source::SNOWFLAKE,
+        ArrowLogicalTypeInfo::Type::DECIMAL, ArrowDecimalTypeInfo{*parsedPrecision, *parsedScale}};
+}
+
+} // namespace common
+} // namespace lbug

--- a/src/common/arrow/arrow_schema_metadata_utils.cpp
+++ b/src/common/arrow/arrow_schema_metadata_utils.cpp
@@ -1,0 +1,145 @@
+#include <algorithm>
+#include <cctype>
+#include <cstring>
+#include <limits>
+
+#include "arrow_schema_metadata_internal.h"
+#include "common/constants.h"
+
+namespace lbug {
+namespace common {
+
+bool isIntegralArrowStorageType(const char* arrowType) {
+    switch (arrowType[0]) {
+    case 'c':
+    case 'C':
+    case 's':
+    case 'S':
+    case 'i':
+    case 'I':
+    case 'l':
+    case 'L':
+        return true;
+    default:
+        return false;
+    }
+}
+
+bool isFloatingArrowStorageType(const char* arrowType) {
+    return arrowType[0] == 'f' || arrowType[0] == 'g';
+}
+
+std::string toLower(std::string value) {
+    std::transform(value.begin(), value.end(), value.begin(),
+        [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+    return value;
+}
+
+ArrowMetadataMap readArrowMetadata(const char* metadata) {
+    ArrowMetadataMap result;
+    if (metadata == nullptr) {
+        return result;
+    }
+    const auto* ptr = reinterpret_cast<const uint8_t*>(metadata);
+    size_t bytesRead = 0;
+    auto tryReadInt32 = [&](int32_t& out) {
+        if (std::numeric_limits<size_t>::max() - bytesRead < sizeof(int32_t)) {
+            return false;
+        }
+        memcpy(&out, ptr, sizeof(int32_t));
+        ptr += sizeof(int32_t);
+        bytesRead += sizeof(int32_t);
+        return true;
+    };
+    auto tryReadString = [&](std::string& out) {
+        int32_t len = 0;
+        if (!tryReadInt32(len) || len < 0) {
+            return false;
+        }
+        const auto lenSize = static_cast<size_t>(len);
+        if (std::numeric_limits<size_t>::max() - bytesRead < lenSize) {
+            return false;
+        }
+        out.assign(reinterpret_cast<const char*>(ptr), lenSize);
+        ptr += lenSize;
+        bytesRead += lenSize;
+        return true;
+    };
+
+    int32_t numEntries = 0;
+    if (!tryReadInt32(numEntries) || numEntries < 0) {
+        return {};
+    }
+    for (auto i = 0; i < numEntries; ++i) {
+        std::string key;
+        std::string value;
+        // ArrowSchema.metadata does not expose an outer byte length, so we can validate shape
+        // (negative lengths, arithmetic overflow) but not fully bounds-check truncated buffers.
+        if (!tryReadString(key) || !tryReadString(value)) {
+            return {};
+        }
+
+        result.emplace(toLower(std::move(key)), std::move(value));
+    }
+    return result;
+}
+
+std::string trim(std::string value) {
+    value.erase(value.begin(),
+        std::find_if(value.begin(), value.end(), [](unsigned char c) { return !std::isspace(c); }));
+    value.erase(
+        std::find_if(value.rbegin(), value.rend(), [](unsigned char c) { return !std::isspace(c); })
+            .base(),
+        value.end());
+    return value;
+}
+
+std::vector<std::string> splitCommaSeparated(std::string value) {
+    std::vector<std::string> result;
+    size_t start = 0;
+    while (start <= value.size()) {
+        const auto end = value.find(',', start);
+        auto part =
+            end == std::string::npos ? value.substr(start) : value.substr(start, end - start);
+        result.push_back(trim(std::move(part)));
+        if (end == std::string::npos) {
+            break;
+        }
+        start = end + 1;
+    }
+    return result;
+}
+
+std::optional<std::string> getMetadataValue(const ArrowMetadataMap& metadata,
+    const std::string& key) {
+    const auto entry = metadata.find(key);
+    if (entry == metadata.end()) {
+        return std::nullopt;
+    }
+    return entry->second;
+}
+
+std::optional<uint32_t> tryParseUint32(const std::string& value) {
+    if (value.empty()) {
+        return std::nullopt;
+    }
+    uint32_t parsed = 0;
+    for (auto c : value) {
+        if (!std::isdigit(static_cast<unsigned char>(c))) {
+            return std::nullopt;
+        }
+        const auto digit = static_cast<uint32_t>(c - '0');
+        if (parsed > (std::numeric_limits<uint32_t>::max() - digit) / 10) {
+            return std::nullopt;
+        }
+        parsed = parsed * 10 + digit;
+    }
+    return parsed;
+}
+
+bool isValidDecimalParameters(uint32_t precision, uint32_t scale) {
+    return precision > 0 && precision <= DECIMAL_PRECISION_LIMIT && scale <= precision;
+}
+
+} // namespace common
+} // namespace lbug

--- a/src/common/arrow/arrow_type.cpp
+++ b/src/common/arrow/arrow_type.cpp
@@ -1,4 +1,5 @@
 #include "common/arrow/arrow_converter.h"
+#include "common/arrow/arrow_schema_metadata.h"
 #include "common/exception/not_implemented.h"
 #include "common/string_utils.h"
 
@@ -15,6 +16,13 @@ LogicalType ArrowConverter::fromArrowSchema(const ArrowSchema* schema) {
     // logical type of the dict
     if (schema->dictionary != nullptr) {
         return fromArrowSchema(schema->dictionary);
+    }
+    if (auto logicalTypeInfo = tryGetArrowLogicalTypeInfo(schema); logicalTypeInfo.has_value()) {
+        switch (logicalTypeInfo->type) {
+        case ArrowLogicalTypeInfo::Type::DECIMAL:
+            return LogicalType::DECIMAL(logicalTypeInfo->decimal.precision,
+                logicalTypeInfo->decimal.scale);
+        }
     }
     switch (arrowType[0]) {
     case 'n':

--- a/src/include/common/arrow/arrow_converter.h
+++ b/src/include/common/arrow/arrow_converter.h
@@ -3,8 +3,10 @@
 #include <string>
 #include <vector>
 
+#include "common/api.h"
 #include "common/arrow/arrow.h"
 #include "common/arrow/arrow_nullmask_tree.h"
+#include "common/arrow/arrow_schema_metadata.h"
 
 struct ArrowSchema;
 
@@ -20,7 +22,7 @@ struct ArrowSchemaHolder {
     std::vector<std::unique_ptr<char[]>> ownedMetadatas;
 };
 
-class ArrowConverter {
+class LBUG_API ArrowConverter {
 public:
     static std::unique_ptr<ArrowSchema> toArrowSchema(const std::vector<LogicalType>& dataTypes,
         const std::vector<std::string>& columnNames, bool fallbackExtensionTypes);
@@ -29,6 +31,9 @@ public:
     static void fromArrowArray(const ArrowSchema* schema, const ArrowArray* array,
         ValueVector& outputVector, ArrowNullMaskTree* mask, uint64_t srcOffset, uint64_t dstOffset,
         uint64_t count);
+    static void fromArrowArray(const ArrowSchema* schema, const ArrowArray* array,
+        ValueVector& outputVector, ArrowNullMaskTree* mask, uint64_t srcOffset, uint64_t dstOffset,
+        uint64_t count, const std::optional<ArrowLogicalTypeInfo>* logicalTypeInfo);
     static void fromArrowArray(const ArrowSchema* schema, const ArrowArray* array,
         ValueVector& outputVector);
 

--- a/src/include/common/arrow/arrow_schema_metadata.h
+++ b/src/include/common/arrow/arrow_schema_metadata.h
@@ -3,6 +3,7 @@
 #include <cstdint>
 #include <optional>
 
+#include "common/api.h"
 #include "common/arrow/arrow.h"
 
 namespace lbug {
@@ -28,7 +29,7 @@ struct ArrowLogicalTypeInfo {
     ArrowDecimalTypeInfo decimal;
 };
 
-std::optional<ArrowLogicalTypeInfo> tryGetArrowLogicalTypeInfo(const ArrowSchema* schema);
+LBUG_API std::optional<ArrowLogicalTypeInfo> tryGetArrowLogicalTypeInfo(const ArrowSchema* schema);
 
 } // namespace common
 } // namespace lbug

--- a/src/include/common/arrow/arrow_schema_metadata.h
+++ b/src/include/common/arrow/arrow_schema_metadata.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <cstdint>
+#include <optional>
+
+#include "common/arrow/arrow.h"
+
+namespace lbug {
+namespace common {
+
+struct ArrowDecimalTypeInfo {
+    uint32_t precision;
+    uint32_t scale;
+};
+
+struct ArrowLogicalTypeInfo {
+    enum class Source : uint8_t {
+        SNOWFLAKE,
+        GENERIC_METADATA,
+    };
+
+    enum class Type : uint8_t {
+        DECIMAL,
+    };
+
+    Source source;
+    Type type;
+    ArrowDecimalTypeInfo decimal;
+};
+
+std::optional<ArrowLogicalTypeInfo> tryGetArrowLogicalTypeInfo(const ArrowSchema* schema);
+
+} // namespace common
+} // namespace lbug

--- a/src/include/storage/table/arrow_node_table.h
+++ b/src/include/storage/table/arrow_node_table.h
@@ -6,6 +6,7 @@
 
 #include "catalog/catalog_entry/node_table_catalog_entry.h"
 #include "common/arrow/arrow.h"
+#include "common/arrow/arrow_schema_metadata.h"
 #include "common/cast.h"
 #include "common/exception/runtime.h"
 #include "function/table/table_function.h"
@@ -122,6 +123,7 @@ private:
 private:
     ArrowSchemaWrapper schema;
     std::vector<ArrowArrayWrapper> arrays;
+    std::vector<std::optional<common::ArrowLogicalTypeInfo>> columnLogicalTypeInfos;
     std::vector<size_t> batchStartOffsets;
     size_t totalRows;
     std::string arrowId;                           // ID in registry for cleanup

--- a/src/include/storage/table/arrow_rel_table.h
+++ b/src/include/storage/table/arrow_rel_table.h
@@ -7,6 +7,7 @@
 
 #include "catalog/catalog_entry/rel_group_catalog_entry.h"
 #include "common/arrow/arrow.h"
+#include "common/arrow/arrow_schema_metadata.h"
 #include "storage/table/arrow_table_support.h"
 #include "storage/table/columnar_rel_table_base.h"
 #include "storage/table/node_table.h"
@@ -69,6 +70,7 @@ private:
     common::offset_t findCSRSourceOffset(common::offset_t relOffset) const;
     bool readArrowValueAtOffset(const ArrowSchemaWrapper& arrowSchema,
         const std::vector<ArrowArrayWrapper>& arrowArrays, const std::vector<size_t>& startOffsets,
+        const std::vector<std::optional<common::ArrowLogicalTypeInfo>>& logicalTypeInfos,
         int64_t columnIdx, common::offset_t rowOffset, common::ValueVector& outputVector,
         uint64_t dstOffset) const;
 
@@ -77,9 +79,11 @@ private:
     ArrowRelTableLayout layout;
     ArrowSchemaWrapper schema;
     std::vector<ArrowArrayWrapper> arrays;
+    std::vector<std::optional<common::ArrowLogicalTypeInfo>> columnLogicalTypeInfos;
     std::vector<size_t> batchStartOffsets;
     ArrowSchemaWrapper indptrSchema;
     std::vector<ArrowArrayWrapper> indptrArrays;
+    std::vector<std::optional<common::ArrowLogicalTypeInfo>> indptrColumnLogicalTypeInfos;
     std::vector<size_t> indptrBatchStartOffsets;
     std::unordered_map<common::column_id_t, int64_t> propertyColumnToArrowColumnIdx;
     size_t totalRows = 0;

--- a/src/storage/table/arrow_node_table.cpp
+++ b/src/storage/table/arrow_node_table.cpp
@@ -24,6 +24,21 @@ static uint64_t getArrowBatchLength(const ArrowArrayWrapper& array) {
     return 0;
 }
 
+static std::vector<std::optional<common::ArrowLogicalTypeInfo>> resolveColumnLogicalTypeInfos(
+    const ArrowSchemaWrapper& schema) {
+    std::vector<std::optional<common::ArrowLogicalTypeInfo>> result;
+    if (schema.n_children <= 0 || schema.children == nullptr) {
+        return result;
+    }
+    result.reserve(static_cast<size_t>(schema.n_children));
+    for (int64_t i = 0; i < schema.n_children; ++i) {
+        result.push_back(schema.children[i] == nullptr ?
+                             std::nullopt :
+                             common::tryGetArrowLogicalTypeInfo(schema.children[i]));
+    }
+    return result;
+}
+
 ArrowNodeTable::ArrowNodeTable(const StorageManager* storageManager,
     const catalog::NodeTableCatalogEntry* nodeTableEntry, MemoryManager* memoryManager,
     ArrowSchemaWrapper schema, std::vector<ArrowArrayWrapper> arrays, std::string arrowId)
@@ -35,6 +50,7 @@ ArrowNodeTable::ArrowNodeTable(const StorageManager* storageManager,
     if (!this->schema.format) {
         throw common::RuntimeException("Arrow schema format cannot be null");
     }
+    columnLogicalTypeInfos = resolveColumnLogicalTypeInfos(this->schema);
     batchStartOffsets.reserve(this->arrays.size());
     for (const auto& array : this->arrays) {
         batchStartOffsets.push_back(totalRows);
@@ -203,10 +219,14 @@ void ArrowNodeTable::copyArrowMorselToOutputVectors(const ArrowArrayWrapper& bat
         auto& outputVector = *outputVectors[outCol];
         auto* childArray = batch.children[arrowColIdx];
         auto* childSchema = schema.children[arrowColIdx];
+        const auto* logicalTypeInfo =
+            static_cast<size_t>(arrowColIdx) < columnLogicalTypeInfos.size() ?
+                &columnLogicalTypeInfos[arrowColIdx] :
+                nullptr;
         common::ArrowNullMaskTree nullMask(childSchema, childArray, childArray->offset,
             childArray->length);
         common::ArrowConverter::fromArrowArray(childSchema, childArray, outputVector, &nullMask,
-            childArray->offset + currentMorselStartOffset, 0, numRowsToCopy);
+            childArray->offset + currentMorselStartOffset, 0, numRowsToCopy, logicalTypeInfo);
     }
 }
 
@@ -245,11 +265,15 @@ bool ArrowNodeTable::lookupPK([[maybe_unused]] const transaction::Transaction* t
         }
         auto* pkChildArray = batch.children[pkArrowColumnIdx];
         auto* pkChildSchema = schema.children[pkArrowColumnIdx];
+        const auto* logicalTypeInfo =
+            static_cast<size_t>(pkArrowColumnIdx) < columnLogicalTypeInfos.size() ?
+                &columnLogicalTypeInfos[pkArrowColumnIdx] :
+                nullptr;
         common::ArrowNullMaskTree nullMask(pkChildSchema, pkChildArray, pkChildArray->offset,
             pkChildArray->length);
         for (uint64_t rowIdx = 0; rowIdx < batchLength; ++rowIdx) {
             common::ArrowConverter::fromArrowArray(pkChildSchema, pkChildArray, *arrowPKVector,
-                &nullMask, pkChildArray->offset + rowIdx, 0, 1);
+                &nullMask, pkChildArray->offset + rowIdx, 0, 1, logicalTypeInfo);
             if (arrowPKVector->isNull(0)) {
                 continue;
             }

--- a/src/storage/table/arrow_rel_table.cpp
+++ b/src/storage/table/arrow_rel_table.cpp
@@ -38,6 +38,21 @@ static int64_t findColumnIdx(const ArrowSchemaWrapper& schema, const std::string
     return -1;
 }
 
+static std::vector<std::optional<ArrowLogicalTypeInfo>> resolveColumnLogicalTypeInfos(
+    const ArrowSchemaWrapper& schema) {
+    std::vector<std::optional<ArrowLogicalTypeInfo>> result;
+    if (schema.n_children <= 0 || schema.children == nullptr) {
+        return result;
+    }
+    result.reserve(static_cast<size_t>(schema.n_children));
+    for (int64_t i = 0; i < schema.n_children; ++i) {
+        result.push_back(schema.children[i] == nullptr ?
+                             std::nullopt :
+                             tryGetArrowLogicalTypeInfo(schema.children[i]));
+    }
+    return result;
+}
+
 void ArrowRelTableScanState::setToTable(const transaction::Transaction* transaction, Table* table_,
     std::vector<column_id_t> columnIDs_, std::vector<ColumnPredicateSet> columnPredicateSets_,
     RelDataDirection direction_) {
@@ -72,6 +87,8 @@ ArrowRelTable::ArrowRelTable(catalog::RelGroupCatalogEntry* relGroupEntry, table
     if (!this->schema.format) {
         throw RuntimeException("Arrow schema format cannot be null");
     }
+    columnLogicalTypeInfos = resolveColumnLogicalTypeInfos(this->schema);
+    indptrColumnLogicalTypeInfos = resolveColumnLogicalTypeInfos(this->indptrSchema);
     if (!this->fromNodeTable || !this->toNodeTable) {
         throw RuntimeException(
             "Arrow relationship table requires source and destination node tables");
@@ -209,9 +226,11 @@ void ArrowRelTable::initScanState([[maybe_unused]] transaction::Transaction* tra
 }
 
 static void readSingleArrowValue(const ArrowSchema* schema, const ArrowArray* array,
-    ValueVector& outputVector, uint64_t srcOffset, uint64_t dstOffset) {
+    ValueVector& outputVector, uint64_t srcOffset, uint64_t dstOffset,
+    const std::optional<ArrowLogicalTypeInfo>* logicalTypeInfo = nullptr) {
     ArrowNullMaskTree nullMask(schema, array, array->offset, array->length);
-    ArrowConverter::fromArrowArray(schema, array, outputVector, &nullMask, srcOffset, dstOffset, 1);
+    ArrowConverter::fromArrowArray(schema, array, outputVector, &nullMask, srcOffset, dstOffset, 1,
+        logicalTypeInfo);
 }
 
 bool ArrowRelTable::scanInternal(transaction::Transaction* transaction, TableScanState& scanState) {
@@ -262,14 +281,22 @@ bool ArrowRelTable::scanFlat(transaction::Transaction* transaction, TableScanSta
         auto* dstChildSchema = schema.children[toColumnIdx];
         auto srcOffsetToRead = srcChildArray->offset + srcOffsetInBatch;
         auto dstOffsetToRead = dstChildArray->offset + srcOffsetInBatch;
+        const auto* srcLogicalTypeInfo =
+            static_cast<size_t>(fromColumnIdx) < columnLogicalTypeInfos.size() ?
+                &columnLogicalTypeInfos[fromColumnIdx] :
+                nullptr;
+        const auto* dstLogicalTypeInfo =
+            static_cast<size_t>(toColumnIdx) < columnLogicalTypeInfos.size() ?
+                &columnLogicalTypeInfos[toColumnIdx] :
+                nullptr;
         readSingleArrowValue(srcChildSchema, srcChildArray, *relScanState.arrowSrcKeyVector,
-            srcOffsetToRead, 0);
+            srcOffsetToRead, 0, srcLogicalTypeInfo);
         if (relScanState.arrowSrcKeyVector->isNull(0)) {
             relScanState.arrowCurrentBatchOffset++;
             continue;
         }
         readSingleArrowValue(dstChildSchema, dstChildArray, *relScanState.arrowDstKeyVector,
-            dstOffsetToRead, 0);
+            dstOffsetToRead, 0, dstLogicalTypeInfo);
         if (relScanState.arrowDstKeyVector->isNull(0)) {
             relScanState.arrowCurrentBatchOffset++;
             continue;
@@ -331,8 +358,12 @@ bool ArrowRelTable::scanFlat(transaction::Transaction* transaction, TableScanSta
             }
             auto* childArray = batch.children[arrowColIdx];
             auto* childSchema = schema.children[arrowColIdx];
+            const auto* logicalTypeInfo =
+                static_cast<size_t>(arrowColIdx) < columnLogicalTypeInfos.size() ?
+                    &columnLogicalTypeInfos[arrowColIdx] :
+                    nullptr;
             readSingleArrowValue(childSchema, childArray, *relScanState.outputVectors[outCol],
-                childArray->offset + srcOffsetInBatch, outputCount);
+                childArray->offset + srcOffsetInBatch, outputCount, logicalTypeInfo);
         }
         outputCount++;
         relScanState.arrowCurrentBatchOffset++;
@@ -426,7 +457,7 @@ bool ArrowRelTable::scanCSR(TableScanState& scanState) {
                 if (outCol >= outputToArrowColumnIdx.size() || outputToArrowColumnIdx[outCol] < 0) {
                     continue;
                 }
-                readArrowValueAtOffset(schema, arrays, batchStartOffsets,
+                readArrowValueAtOffset(schema, arrays, batchStartOffsets, columnLogicalTypeInfos,
                     outputToArrowColumnIdx[outCol], relOffset, *relScanState.outputVectors[outCol],
                     outputCount);
             }
@@ -476,7 +507,7 @@ bool ArrowRelTable::scanCSR(TableScanState& scanState) {
                 if (outCol >= outputToArrowColumnIdx.size() || outputToArrowColumnIdx[outCol] < 0) {
                     continue;
                 }
-                readArrowValueAtOffset(schema, arrays, batchStartOffsets,
+                readArrowValueAtOffset(schema, arrays, batchStartOffsets, columnLogicalTypeInfos,
                     outputToArrowColumnIdx[outCol], relOffset, *relScanState.outputVectors[outCol],
                     outputCount);
             }
@@ -509,8 +540,8 @@ bool ArrowRelTable::scanCSR(TableScanState& scanState) {
 
 bool ArrowRelTable::readCSRValue(ValueVector& outputVector, offset_t relOffset,
     uint64_t dstOffset) const {
-    return readArrowValueAtOffset(schema, arrays, batchStartOffsets, csrNbrColumnIdx, relOffset,
-        outputVector, dstOffset);
+    return readArrowValueAtOffset(schema, arrays, batchStartOffsets, columnLogicalTypeInfos,
+        csrNbrColumnIdx, relOffset, outputVector, dstOffset);
 }
 
 bool ArrowRelTable::readIndptr(offset_t srcOffset, offset_t& result) const {
@@ -518,7 +549,7 @@ bool ArrowRelTable::readIndptr(offset_t srcOffset, offset_t& result) const {
     ValueVector valueVector{LogicalType::UINT64(), memoryManager, singleValueState};
     valueVector.state->setToFlat();
     if (!readArrowValueAtOffset(indptrSchema, indptrArrays, indptrBatchStartOffsets,
-            csrIndptrColumnIdx, srcOffset, valueVector, 0) ||
+            indptrColumnLogicalTypeInfos, csrIndptrColumnIdx, srcOffset, valueVector, 0) ||
         valueVector.isNull(0)) {
         return false;
     }
@@ -555,7 +586,8 @@ offset_t ArrowRelTable::findCSRSourceOffset(offset_t relOffset) const {
 
 bool ArrowRelTable::readArrowValueAtOffset(const ArrowSchemaWrapper& arrowSchema,
     const std::vector<ArrowArrayWrapper>& arrowArrays, const std::vector<size_t>& startOffsets,
-    int64_t columnIdx, offset_t rowOffset, ValueVector& outputVector, uint64_t dstOffset) const {
+    const std::vector<std::optional<ArrowLogicalTypeInfo>>& logicalTypeInfos, int64_t columnIdx,
+    offset_t rowOffset, ValueVector& outputVector, uint64_t dstOffset) const {
     if (columnIdx < 0 || arrowArrays.empty() || startOffsets.size() != arrowArrays.size()) {
         return false;
     }
@@ -575,8 +607,11 @@ bool ArrowRelTable::readArrowValueAtOffset(const ArrowSchemaWrapper& arrowSchema
         }
         auto* childArray = batch.children[columnIdx];
         auto* childSchema = arrowSchema.children[columnIdx];
+        const auto* logicalTypeInfo = static_cast<size_t>(columnIdx) < logicalTypeInfos.size() ?
+                                          &logicalTypeInfos[columnIdx] :
+                                          nullptr;
         readSingleArrowValue(childSchema, childArray, outputVector, childArray->offset + rowInBatch,
-            dstOffset);
+            dstOffset, logicalTypeInfo);
         return true;
     }
     return false;

--- a/test/api/arrow_test.cpp
+++ b/test/api/arrow_test.cpp
@@ -1,10 +1,59 @@
+#include <cstring>
+#include <string>
+#include <vector>
+
 #include "api_test/api_test.h"
+#include "arrow_test_utils.h"
+#include "common/arrow/arrow_converter.h"
+#include "common/arrow/arrow_schema_metadata.h"
 #include "common/exception/runtime.h"
+#include "common/types/types.h"
+#include "common/vector/value_vector.h"
 #include "main/query_result/arrow_query_result.h"
 
 using namespace lbug::common;
 using namespace lbug::main;
 using namespace lbug::testing;
+
+namespace {
+
+std::vector<char> serializeArrowMetadata(
+    const std::vector<std::pair<std::string, std::string>>& entries) {
+    auto size = sizeof(int32_t);
+    for (const auto& [key, value] : entries) {
+        size += sizeof(int32_t) + key.size() + sizeof(int32_t) + value.size();
+    }
+    std::vector<char> bytes(size);
+    auto* ptr = bytes.data();
+    const auto numEntries = static_cast<int32_t>(entries.size());
+    memcpy(ptr, &numEntries, sizeof(int32_t));
+    ptr += sizeof(int32_t);
+    for (const auto& [key, value] : entries) {
+        const auto keySize = static_cast<int32_t>(key.size());
+        memcpy(ptr, &keySize, sizeof(int32_t));
+        ptr += sizeof(int32_t);
+        memcpy(ptr, key.data(), key.size());
+        ptr += key.size();
+        const auto valueSize = static_cast<int32_t>(value.size());
+        memcpy(ptr, &valueSize, sizeof(int32_t));
+        ptr += sizeof(int32_t);
+        memcpy(ptr, value.data(), value.size());
+        ptr += value.size();
+    }
+    return bytes;
+}
+
+void appendInt32(std::vector<char>& bytes, int32_t value) {
+    const auto* ptr = reinterpret_cast<const char*>(&value);
+    bytes.insert(bytes.end(), ptr, ptr + sizeof(int32_t));
+}
+
+void appendString(std::vector<char>& bytes, const std::string& value) {
+    appendInt32(bytes, static_cast<int32_t>(value.size()));
+    bytes.insert(bytes.end(), value.begin(), value.end());
+}
+
+} // namespace
 
 class ArrowTest : public ApiTest {};
 
@@ -52,6 +101,331 @@ TEST(ArrowQueryResultTest, exportsCSRMetadataAsZeroCopyArrowArrays) {
         (std::vector<int64_t>{4, 5, 6}));
     ASSERT_EQ(std::vector<int64_t>(edgeIDsData, edgeIDsData + storedMetadata.edgeIDs.size()),
         (std::vector<int64_t>{10, 11, 12}));
+}
+
+TEST(ArrowConverterTest, bindsIntegerBackedSnowflakeDecimalMetadataAsDecimal) {
+    ArrowSchema schema{};
+    createSchema<int64_t>(&schema, "amount");
+    auto metadata =
+        serializeArrowMetadata({{"logicalType", "FIXED"}, {"precision", "7"}, {"scale", "2"}});
+    schema.metadata = metadata.data();
+
+    const auto type = ArrowConverter::fromArrowSchema(&schema);
+    const auto logicalTypeInfo = tryGetArrowLogicalTypeInfo(&schema);
+
+    ASSERT_EQ(type.getLogicalTypeID(), LogicalTypeID::DECIMAL);
+    ASSERT_EQ(DecimalType::getPrecision(type), 7u);
+    ASSERT_EQ(DecimalType::getScale(type), 2u);
+    ASSERT_TRUE(logicalTypeInfo.has_value());
+    ASSERT_EQ(logicalTypeInfo->source, ArrowLogicalTypeInfo::Source::SNOWFLAKE);
+    schema.release(&schema);
+}
+
+TEST(ArrowConverterTest, bindsSnowflakeRawDataTypeMetadataAsDecimal) {
+    ArrowSchema schema{};
+    createSchema<int64_t>(&schema, "amount");
+    auto metadata = serializeArrowMetadata({{"DATA_TYPE", "NUMBER(12, 4)"}});
+    schema.metadata = metadata.data();
+
+    const auto type = ArrowConverter::fromArrowSchema(&schema);
+    const auto logicalTypeInfo = tryGetArrowLogicalTypeInfo(&schema);
+
+    ASSERT_EQ(type.getLogicalTypeID(), LogicalTypeID::DECIMAL);
+    ASSERT_EQ(DecimalType::getPrecision(type), 12u);
+    ASSERT_EQ(DecimalType::getScale(type), 4u);
+    ASSERT_TRUE(logicalTypeInfo.has_value());
+    ASSERT_EQ(logicalTypeInfo->source, ArrowLogicalTypeInfo::Source::SNOWFLAKE);
+    schema.release(&schema);
+}
+
+TEST(ArrowConverterTest, bindsSnowflakeRawNumberMetadataWithoutExplicitScaleAsDecimal) {
+    ArrowSchema schema{};
+    createSchema<int64_t>(&schema, "amount");
+    auto metadata = serializeArrowMetadata({{"DATA_TYPE", "NUMBER(18)"}});
+    schema.metadata = metadata.data();
+
+    const auto type = ArrowConverter::fromArrowSchema(&schema);
+    const auto logicalTypeInfo = tryGetArrowLogicalTypeInfo(&schema);
+
+    ASSERT_EQ(type.getLogicalTypeID(), LogicalTypeID::DECIMAL);
+    ASSERT_EQ(DecimalType::getPrecision(type), 18u);
+    ASSERT_EQ(DecimalType::getScale(type), 0u);
+    ASSERT_TRUE(logicalTypeInfo.has_value());
+    ASSERT_EQ(logicalTypeInfo->source, ArrowLogicalTypeInfo::Source::SNOWFLAKE);
+    schema.release(&schema);
+}
+
+TEST(ArrowConverterTest, bindsSnowflakeRawNumericMetadataWithWhitespaceAsDecimal) {
+    ArrowSchema schema{};
+    createSchema<int64_t>(&schema, "amount");
+    auto metadata = serializeArrowMetadata({{"DATA_TYPE", " numeric ( 10 , 3 ) "}});
+    schema.metadata = metadata.data();
+
+    const auto type = ArrowConverter::fromArrowSchema(&schema);
+
+    ASSERT_EQ(type.getLogicalTypeID(), LogicalTypeID::DECIMAL);
+    ASSERT_EQ(DecimalType::getPrecision(type), 10u);
+    ASSERT_EQ(DecimalType::getScale(type), 3u);
+    schema.release(&schema);
+}
+
+TEST(ArrowConverterTest, bindsGenericIntegerBackedDecimalMetadataAsDecimal) {
+    ArrowSchema schema{};
+    createSchema<int64_t>(&schema, "amount");
+    auto metadata =
+        serializeArrowMetadata({{"logicalType", "DECIMAL"}, {"precision", "9"}, {"scale", "3"}});
+    schema.metadata = metadata.data();
+
+    const auto type = ArrowConverter::fromArrowSchema(&schema);
+    const auto logicalTypeInfo = tryGetArrowLogicalTypeInfo(&schema);
+
+    ASSERT_EQ(type.getLogicalTypeID(), LogicalTypeID::DECIMAL);
+    ASSERT_EQ(DecimalType::getPrecision(type), 9u);
+    ASSERT_EQ(DecimalType::getScale(type), 3u);
+    ASSERT_TRUE(logicalTypeInfo.has_value());
+    ASSERT_EQ(logicalTypeInfo->source, ArrowLogicalTypeInfo::Source::GENERIC_METADATA);
+    schema.release(&schema);
+}
+
+TEST(ArrowConverterTest, malformedIntegerBackedDecimalMetadataFallsBackToPhysicalType) {
+    ArrowSchema schema{};
+    createSchema<int64_t>(&schema, "amount");
+    auto metadata =
+        serializeArrowMetadata({{"logicalType", "FIXED"}, {"precision", "bad"}, {"scale", "2"}});
+    schema.metadata = metadata.data();
+
+    const auto type = ArrowConverter::fromArrowSchema(&schema);
+
+    ASSERT_EQ(type.getLogicalTypeID(), LogicalTypeID::INT64);
+    schema.release(&schema);
+}
+
+TEST(ArrowConverterTest, negativeSnowflakeDecimalMetadataFallsBackToPhysicalType) {
+    ArrowSchema schema{};
+    createSchema<int64_t>(&schema, "amount");
+    auto metadata =
+        serializeArrowMetadata({{"logicalType", "FIXED"}, {"precision", "-1"}, {"scale", "2"}});
+    schema.metadata = metadata.data();
+
+    const auto type = ArrowConverter::fromArrowSchema(&schema);
+
+    ASSERT_EQ(type.getLogicalTypeID(), LogicalTypeID::INT64);
+    schema.release(&schema);
+}
+
+TEST(ArrowConverterTest, overflowSnowflakeDecimalMetadataFallsBackToPhysicalType) {
+    ArrowSchema schema{};
+    createSchema<int64_t>(&schema, "amount");
+    auto metadata = serializeArrowMetadata(
+        {{"logicalType", "FIXED"}, {"precision", "4294967296"}, {"scale", "2"}});
+    schema.metadata = metadata.data();
+
+    const auto type = ArrowConverter::fromArrowSchema(&schema);
+
+    ASSERT_EQ(type.getLogicalTypeID(), LogicalTypeID::INT64);
+    schema.release(&schema);
+}
+
+TEST(ArrowConverterTest, invalidSnowflakeDecimalScaleFallsBackToPhysicalType) {
+    ArrowSchema schema{};
+    createSchema<int64_t>(&schema, "amount");
+    auto metadata =
+        serializeArrowMetadata({{"logicalType", "FIXED"}, {"precision", "4"}, {"scale", "5"}});
+    schema.metadata = metadata.data();
+
+    const auto type = ArrowConverter::fromArrowSchema(&schema);
+
+    ASSERT_EQ(type.getLogicalTypeID(), LogicalTypeID::INT64);
+    schema.release(&schema);
+}
+
+TEST(ArrowConverterTest, negativeMetadataEntryCountFallsBackToPhysicalType) {
+    ArrowSchema schema{};
+    createSchema<int64_t>(&schema, "amount");
+    std::vector<char> metadata;
+    appendInt32(metadata, -1);
+    schema.metadata = metadata.data();
+
+    const auto type = ArrowConverter::fromArrowSchema(&schema);
+
+    ASSERT_EQ(type.getLogicalTypeID(), LogicalTypeID::INT64);
+    ASSERT_FALSE(tryGetArrowLogicalTypeInfo(&schema).has_value());
+    schema.release(&schema);
+}
+
+TEST(ArrowConverterTest, negativeMetadataKeyLengthFallsBackToPhysicalType) {
+    ArrowSchema schema{};
+    createSchema<int64_t>(&schema, "amount");
+    std::vector<char> metadata;
+    appendInt32(metadata, 1);
+    appendInt32(metadata, -1);
+    schema.metadata = metadata.data();
+
+    const auto type = ArrowConverter::fromArrowSchema(&schema);
+
+    ASSERT_EQ(type.getLogicalTypeID(), LogicalTypeID::INT64);
+    ASSERT_FALSE(tryGetArrowLogicalTypeInfo(&schema).has_value());
+    schema.release(&schema);
+}
+
+TEST(ArrowConverterTest, negativeMetadataValueLengthFallsBackToPhysicalType) {
+    ArrowSchema schema{};
+    createSchema<int64_t>(&schema, "amount");
+    std::vector<char> metadata;
+    appendInt32(metadata, 1);
+    appendString(metadata, "logicalType");
+    appendInt32(metadata, -1);
+    schema.metadata = metadata.data();
+
+    const auto type = ArrowConverter::fromArrowSchema(&schema);
+
+    ASSERT_EQ(type.getLogicalTypeID(), LogicalTypeID::INT64);
+    ASSERT_FALSE(tryGetArrowLogicalTypeInfo(&schema).has_value());
+    schema.release(&schema);
+}
+
+TEST(ArrowConverterTest, invalidGenericDecimalScaleFallsBackToPhysicalType) {
+    ArrowSchema schema{};
+    createSchema<int64_t>(&schema, "amount");
+    auto metadata =
+        serializeArrowMetadata({{"logicalType", "DECIMAL"}, {"precision", "6"}, {"scale", "7"}});
+    schema.metadata = metadata.data();
+
+    const auto type = ArrowConverter::fromArrowSchema(&schema);
+
+    ASSERT_EQ(type.getLogicalTypeID(), LogicalTypeID::INT64);
+    ASSERT_FALSE(tryGetArrowLogicalTypeInfo(&schema).has_value());
+    schema.release(&schema);
+}
+
+TEST(ArrowConverterTest, genericDecimalMetadataDoesNotBindFloatBackedStorage) {
+    ArrowSchema schema{};
+    createSchema<double>(&schema, "amount");
+    auto metadata =
+        serializeArrowMetadata({{"logicalType", "DECIMAL"}, {"precision", "9"}, {"scale", "2"}});
+    schema.metadata = metadata.data();
+
+    const auto type = ArrowConverter::fromArrowSchema(&schema);
+
+    ASSERT_EQ(type.getLogicalTypeID(), LogicalTypeID::DOUBLE);
+    ASSERT_FALSE(tryGetArrowLogicalTypeInfo(&schema).has_value());
+    schema.release(&schema);
+}
+
+TEST(ArrowConverterTest, malformedSnowflakeRawDataTypeFallsBackToSnowflakeLogicalTypeMetadata) {
+    ArrowSchema schema{};
+    createSchema<int64_t>(&schema, "amount");
+    auto metadata = serializeArrowMetadata({{"DATA_TYPE", "NUMBER(bad,2)"},
+        {"logicalType", "FIXED"}, {"precision", "7"}, {"scale", "2"}});
+    schema.metadata = metadata.data();
+
+    const auto type = ArrowConverter::fromArrowSchema(&schema);
+    const auto logicalTypeInfo = tryGetArrowLogicalTypeInfo(&schema);
+
+    ASSERT_EQ(type.getLogicalTypeID(), LogicalTypeID::DECIMAL);
+    ASSERT_EQ(DecimalType::getPrecision(type), 7u);
+    ASSERT_EQ(DecimalType::getScale(type), 2u);
+    ASSERT_TRUE(logicalTypeInfo.has_value());
+    ASSERT_EQ(logicalTypeInfo->source, ArrowLogicalTypeInfo::Source::SNOWFLAKE);
+    schema.release(&schema);
+}
+
+TEST(ArrowConverterTest, malformedSnowflakeRawDataTypeFallsBackToGenericLogicalTypeMetadata) {
+    ArrowSchema schema{};
+    createSchema<int64_t>(&schema, "amount");
+    auto metadata = serializeArrowMetadata({{"DATA_TYPE", "NUMBER(bad,2)"},
+        {"logicalType", "DECIMAL"}, {"precision", "7"}, {"scale", "2"}});
+    schema.metadata = metadata.data();
+
+    const auto type = ArrowConverter::fromArrowSchema(&schema);
+    const auto logicalTypeInfo = tryGetArrowLogicalTypeInfo(&schema);
+
+    ASSERT_EQ(type.getLogicalTypeID(), LogicalTypeID::DECIMAL);
+    ASSERT_EQ(DecimalType::getPrecision(type), 7u);
+    ASSERT_EQ(DecimalType::getScale(type), 2u);
+    ASSERT_TRUE(logicalTypeInfo.has_value());
+    ASSERT_EQ(logicalTypeInfo->source, ArrowLogicalTypeInfo::Source::GENERIC_METADATA);
+    schema.release(&schema);
+}
+
+TEST(ArrowConverterTest,
+    snowflakeRawDataTypeMetadataTakesPrecedenceOverGenericLogicalTypeMetadata) {
+    ArrowSchema schema{};
+    createSchema<int64_t>(&schema, "amount");
+    auto metadata = serializeArrowMetadata({{"DATA_TYPE", "NUMBER(12,4)"},
+        {"logicalType", "DECIMAL"}, {"precision", "9"}, {"scale", "3"}});
+    schema.metadata = metadata.data();
+
+    const auto type = ArrowConverter::fromArrowSchema(&schema);
+    const auto logicalTypeInfo = tryGetArrowLogicalTypeInfo(&schema);
+
+    ASSERT_EQ(type.getLogicalTypeID(), LogicalTypeID::DECIMAL);
+    ASSERT_EQ(DecimalType::getPrecision(type), 12u);
+    ASSERT_EQ(DecimalType::getScale(type), 4u);
+    ASSERT_TRUE(logicalTypeInfo.has_value());
+    ASSERT_EQ(logicalTypeInfo->source, ArrowLogicalTypeInfo::Source::SNOWFLAKE);
+    schema.release(&schema);
+}
+
+TEST(ArrowConverterTest, scansFloatBackedSnowflakeDecimalMetadataIntoDecimalStorage) {
+    ArrowSchema schema{};
+    createSchema<double>(&schema, "amount");
+    auto metadata =
+        serializeArrowMetadata({{"logicalType", "FIXED"}, {"precision", "9"}, {"scale", "2"}});
+    schema.metadata = metadata.data();
+
+    ArrowArray array{};
+    createDoubleArray(&array, {1.25, -2.50, 100.01});
+    ValueVector outputVector{LogicalType::DECIMAL(9, 2)};
+
+    ArrowConverter::fromArrowArray(&schema, &array, outputVector);
+
+    ASSERT_EQ(outputVector.getValue<int32_t>(0), 125);
+    ASSERT_EQ(outputVector.getValue<int32_t>(1), -250);
+    ASSERT_EQ(outputVector.getValue<int32_t>(2), 10001);
+    array.release(&array);
+    schema.release(&schema);
+}
+
+TEST(ArrowConverterTest, scansFloat32BackedSnowflakeDecimalMetadataIntoDecimalStorage) {
+    ArrowSchema schema{};
+    createSchema<float>(&schema, "amount");
+    auto metadata =
+        serializeArrowMetadata({{"logicalType", "FIXED"}, {"precision", "8"}, {"scale", "1"}});
+    schema.metadata = metadata.data();
+
+    ArrowArray array{};
+    createFloatArray(&array, {1.5F, -2.0F, 12.3F});
+    ValueVector outputVector{LogicalType::DECIMAL(8, 1)};
+
+    ArrowConverter::fromArrowArray(&schema, &array, outputVector);
+
+    ASSERT_EQ(outputVector.getValue<int32_t>(0), 15);
+    ASSERT_EQ(outputVector.getValue<int32_t>(1), -20);
+    ASSERT_EQ(outputVector.getValue<int32_t>(2), 123);
+    array.release(&array);
+    schema.release(&schema);
+}
+
+TEST(ArrowConverterTest, scansIntegerBackedSnowflakeDecimalMetadataIntoDecimalStorage) {
+    ArrowSchema schema{};
+    createSchema<int64_t>(&schema, "amount");
+    auto metadata =
+        serializeArrowMetadata({{"logicalType", "FIXED"}, {"precision", "7"}, {"scale", "2"}});
+    schema.metadata = metadata.data();
+
+    ArrowArray array{};
+    createInt64Array(&array, {120, 200, 50, 10000});
+    ValueVector outputVector{LogicalType::DECIMAL(7, 2)};
+
+    ArrowConverter::fromArrowArray(&schema, &array, outputVector);
+
+    ASSERT_EQ(outputVector.getValue<int32_t>(0), 120);
+    ASSERT_EQ(outputVector.getValue<int32_t>(1), 200);
+    ASSERT_EQ(outputVector.getValue<int32_t>(2), 50);
+    ASSERT_EQ(outputVector.getValue<int32_t>(3), 10000);
+    array.release(&array);
+    schema.release(&schema);
 }
 
 TEST_F(ArrowTest, resultToArrow) {

--- a/test/include/arrow_test_utils.h
+++ b/test/include/arrow_test_utils.h
@@ -51,6 +51,19 @@ inline void createSchema<double>(ArrowSchema* schema, const char* name) {
 }
 
 template<>
+inline void createSchema<float>(ArrowSchema* schema, const char* name) {
+    schema->format = "f"; // float
+    schema->name = name;
+    schema->metadata = nullptr;
+    schema->flags = ARROW_FLAG_NULLABLE;
+    schema->n_children = 0;
+    schema->children = nullptr;
+    schema->dictionary = nullptr;
+    schema->release = [](ArrowSchema* s) { s->release = nullptr; };
+    schema->private_data = nullptr;
+}
+
+template<>
 inline void createSchema<bool>(ArrowSchema* schema, const char* name) {
     schema->format = "b"; // boolean
     schema->name = name;
@@ -279,6 +292,54 @@ inline void createDoubleArray(ArrowArray* array, const std::vector<double>& data
     private_data->validity = nullptr; // No nulls
     private_data->data = malloc(data.size() * sizeof(double));
     memcpy(private_data->data, data.data(), data.size() * sizeof(double));
+
+    array->length = data.size();
+    array->null_count = 0;
+    array->offset = 0;
+    array->n_buffers = 2; // validity and data
+    array->n_children = 0;
+    array->buffers = static_cast<const void**>(malloc(sizeof(void*) * 2));
+    array->buffers[0] = nullptr; // validity buffer (no nulls)
+    array->buffers[1] = private_data->data;
+    array->children = nullptr;
+    array->dictionary = nullptr;
+    array->release = [](ArrowArray* a) {
+        if (a->private_data) {
+            auto* pd = static_cast<ArrayPrivateData*>(a->private_data);
+            free(pd->validity);
+            free(pd->data);
+            free(pd->offsets);
+            delete pd;
+        }
+        if (a->buffers) {
+            free(const_cast<void**>(a->buffers));
+        }
+        if (a->children) {
+            for (int64_t i = 0; i < a->n_children; i++) {
+                if (a->children[i]->release) {
+                    a->children[i]->release(a->children[i]);
+                }
+                free(a->children[i]);
+            }
+            free(a->children);
+        }
+        a->release = nullptr;
+    };
+    array->private_data = private_data;
+}
+
+// Helper to create a float array from vector
+inline void createFloatArray(ArrowArray* array, const std::vector<float>& data) {
+    struct ArrayPrivateData {
+        void* validity = nullptr;
+        void* data = nullptr;
+        int32_t* offsets = nullptr;
+    };
+
+    auto* private_data = new ArrayPrivateData();
+    private_data->validity = nullptr; // No nulls
+    private_data->data = malloc(data.size() * sizeof(float));
+    memcpy(private_data->data, data.data(), data.size() * sizeof(float));
 
     array->length = data.size();
     array->null_count = 0;


### PR DESCRIPTION
  ## Summary 
  ADBC exposes Arrow schemas and arrays, but some Snowflake types are not fully recoverable from the Arrow
  physical type alone. In particular, Snowflake NUMBER/DECIMAL columns may arrive with their semantics
  encoded in field metadata rather than standard Arrow decimal format.

  The Snowflake ADBC driver documents two relevant metadata channels:

  - query-result field metadata such as logicalType=FIXED, precision, and scale
  - table-schema metadata such as DATA_TYPE=NUMBER(p,s)

  Without interpreting those annotations, Ladybug can bind Snowflake decimals as plain numeric storage
  types.

  ## What changed

  - Added Snowflake-specific decoding for decimal types from:
      - logicalType=FIXED metadata on Arrow fields
      - DATA_TYPE=NUMBER(...), NUMERIC(...), and DECIMAL(...) metadata on Arrow fields

  - Added decimal scanning support for Snowflake FIXED values when the Arrow batch is:
      - integer-backed
      - float32-backed
      - float64-backed

  - Refactored Arrow metadata handling into separate decoder components:
      - shared metadata utilities
      - Snowflake decoder
      - generic metadata decoder
      - a single orchestrator entrypoint

  Design

  The refactor separates three concerns:

  - Arrow physical type parsing
  - logical type recovery from metadata
  - vendor-specific metadata decoding

  The rest of the Arrow pipeline still consumes normalized logical type information only. This keeps
  Snowflake-specific behavior out of the core binding and scan code paths except where the recovered
  logical type is applied.

  This structure is intended to make future support for other sources, such as Databricks/Spark-specific
  metadata, straightforward to add as separate decoders rather than as scattered conditionals.

https://arrow.apache.org/adbc/current/driver/snowflake.html

| Snowflake signal | Example metadata | Arrow physical storage | Ladybug result | Notes |
| --- | --- | --- | --- | --- |
| Raw Snowflake decimal type via `DATA_TYPE` | `DATA_TYPE=NUMBER(12,4)` | Any Arrow storage type | `DECIMAL(12,4)` | Parsed from Snowflake table-schema metadata. |
| Raw Snowflake decimal type via `DATA_TYPE` with implicit scale | `DATA_TYPE=NUMBER(18)` | Any Arrow storage type | `DECIMAL(18,0)` | Missing scale defaults to `0`. |
| Raw Snowflake decimal aliases via `DATA_TYPE` | `DATA_TYPE=NUMERIC(10,3)` or `DATA_TYPE=DECIMAL(10,3)` | Any Arrow storage type | `DECIMAL(10,3)` | Matching is case-insensitive and whitespace-tolerant. |
| Snowflake logical decimal metadata | `logicalType=FIXED`, `precision=7`, `scale=2` | Integer-backed Arrow (`INT8/16/32/64`, `UINT8/16/32/64`) | `DECIMAL(7,2)` | Used for query-result Arrow schemas. |
| Snowflake logical decimal metadata | `logicalType=FIXED`, `precision=9`, `scale=2` | Float-backed Arrow (`FLOAT`, `DOUBLE`) | `DECIMAL(9,2)` | Values are cast into decimal backing storage during scan. |
| Snowflake raw type fallback to logical metadata | malformed `DATA_TYPE` plus valid `logicalType=FIXED` metadata | Integer-backed or float-backed Arrow | `DECIMAL(p,s)` from `logicalType` metadata | If raw `DATA_TYPE` parsing fails, Snowflake `logicalType` parsing is tried next. |
| Snowflake metadata precedence over generic metadata | `DATA_TYPE=NUMBER(12,4)` plus generic `logicalType=DECIMAL`, `precision=9`, `scale=3` | Any Arrow storage type | `DECIMAL(12,4)` | Snowflake raw type metadata wins over generic metadata. |