### PR TITLE
fix: use binary mode for test CSV on Windows to prevent CRLF corruption

### DIFF
--- a/test/copy/copy_test.cpp
+++ b/test/copy/copy_test.cpp
@@ -128,7 +128,7 @@ public:
         std::replace(filePath.begin(), filePath.end(), '\\', '/');
 #endif
         std::filesystem::create_directories(tempDir);
-        std::ofstream file(filePath);
+        std::ofstream file(filePath, std::ios::binary);
         for (const auto& row : rows) {
             file << row << "\n";
         }


### PR DESCRIPTION
https://github.com/LadybugDB/ladybug/actions/runs/28755126469