### PR TITLE
Fix buffer manager causing huge core dumps and hung processes on SIGSEGV

### DIFF
--- a/src/storage/buffer_manager/vm_region.cpp
+++ b/src/storage/buffer_manager/vm_region.cpp
@@ -65,6 +65,14 @@ VMRegion::VMRegion(PageSizeClass pageSizeClass, uint64_t maxRegionSize) : numFra
         throw BufferManagerException(
             "Mmap for size " + std::to_string(getMaxRegionSize()) + " failed.");
     }
+#ifdef MADV_DONTDUMP
+    // Tell the kernel not to include this virtual reservation in core dumps.
+    // Without this, the kernel walks the entire (potentially multi-TB) sparse
+    // reservation during crash dump generation, turning every SIGSEGV into an
+    // unkillable process stuck at 100% CPU in the dump path for minutes.
+    // MADV_DONTDUMP is available on Linux >= 3.4; macOS has no equivalent.
+    madvise(region, getMaxRegionSize(), MADV_DONTDUMP);
+#endif
 #endif
 }
 


### PR DESCRIPTION
Fixes: #664 

Call madvise(..., MADV_DONTDUMP) on the buffer pool's virtual address reservation right after mmap, so the kernel skips this sparse multi-TB range during core dump generation.

Without this, when a ladybug process crashes with coredumps enabled (the default on many distros via systemd-coredump/apport), the kernel walks the entire reservation in the dump path, turning every SIGSEGV into an unkillable process stuck at 100% CPU for 10+ minutes.

MADV_DONTDUMP is available on Linux >= 3.4. macOS has no equivalent, so the call is guarded by #ifdef MADV_DONTDUMP.