### PR TITLE
fix: allow leading zeros in CAST(string AS INT64)

### DIFF
--- a/src/include/function/cast/functions/cast_string_non_nested_functions.h
+++ b/src/include/function/cast/functions/cast_string_non_nested_functions.h
@@ -233,10 +233,6 @@ inline bool tryIntegerCast(const char* input, uint64_t& len, IntegerCastData<T>&
         return integerCastLoop<T, true>(input, len, result);
     }
 
-    // not allow leading 0
-    if (len > 1 && *input == '0') {
-        return false;
-    }
     return integerCastLoop<T, false>(input, len, result);
 }
 


### PR DESCRIPTION
The tryIntegerCast function had an explicit check rejecting any non-negative integer string starting with '0' (beyond just 0). This caused CAST('000012' AS INT64) to fail with a conversion exception, even though leading zeros are valid in integer representations.

Removed the leading-zero restriction. The integerCastLoop digit parser handles leading zeros naturally.