### PR TITLE
Remove global npm upgrade from deploy-nodejs/deploy-wasm jobs

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -419,9 +419,6 @@ jobs:
           node-version: "22"
           registry-url: "https://registry.npmjs.org"
 
-      - name: Upgrade npm
-        run: npm install -g npm@latest
-
       - name: Package Node.js API (main + per-platform sub-packages)
         run: node package
         working-directory: tools/nodejs_api
@@ -523,9 +520,6 @@ jobs:
         with:
           node-version: "20"
           registry-url: "https://registry.npmjs.org"
-
-      - name: Upgrade npm
-        run: npm install -g npm@latest
 
       - name: Show tarball contents
         run: tar -tvf lbug-wasm.tar.gz

--- a/src/extension/extension_installer.cpp
+++ b/src/extension/extension_installer.cpp
@@ -28,7 +28,9 @@ void configureSSLCerts(httplib::Client& client, const ExtensionRepoInfo& repoInf
         return;
     }
     if (auto caCertPath = ExtensionUtils::getCaCertPath()) {
+#ifdef CPPHTTPLIB_OPENSSL_SUPPORT
         client.set_ca_cert_path(caCertPath->caCertFilePath, caCertPath->caCertDirPath);
+#endif
     }
 }
 


### PR DESCRIPTION
The 'npm install -g npm@latest' step causes MODULE_NOT_FOUND errors for the 'sigstore' module needed by --provenance during npm publish. This is a known issue where npm 11's in-place global upgrade on GitHub hosted runners fails to properly lay down its restructured dependency tree (sigstore is missing from node_modules).

The bundled npm 10.9.x in both Node 20 and Node 22 already supports --provenance (added in npm 9.5.0), so the upgrade is unnecessary.