### PR TITLE
Pin npm upgrade to v11 instead of latest

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -419,6 +419,9 @@ jobs:
           node-version: "22"
           registry-url: "https://registry.npmjs.org"
 
+      - name: Upgrade npm
+        run: npm install -g npm@11
+
       - name: Package Node.js API (main + per-platform sub-packages)
         run: node package
         working-directory: tools/nodejs_api
@@ -520,6 +523,9 @@ jobs:
         with:
           node-version: "20"
           registry-url: "https://registry.npmjs.org"
+
+      - name: Upgrade npm
+        run: npm install -g npm@11
 
       - name: Show tarball contents
         run: tar -tvf lbug-wasm.tar.gz


### PR DESCRIPTION
npm@latest now resolves to version 12.0.0 (released 2026-07-08) which breaks 'npm publish --provenance' with MODULE_NOT_FOUND for 'sigstore'. Pin to npm@11 (the previous latest, currently 11.18.0) which was verified working in CI run #649.

The upgrade step is kept because the bundled npm 10.9.x in Node 22 was historically insufficient for trusted publishing support.