### PR TITLE
fix: use 'python' instead of 'python3' in Windows CI dataset step

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -267,7 +267,7 @@ jobs:
           LBUG_SHELL="$(find build -path '*/src/lbug_shell.exe' -print -quit)"
           test -n "$LBUG_SHELL"
           bash scripts/generate_binary_demo.sh --lbug-shell "$LBUG_SHELL"
-          uv run --with pyarrow python3 scripts/generate-dictionary-bug-fixture.py
+          uv run --with pyarrow python scripts/generate-dictionary-bug-fixture.py
 
       - name: Test
         shell: bash


### PR DESCRIPTION
On Windows runners the Python executable is python.exe, not python3.exe. Using python3 causes uv to run the script with a different interpreter that doesn't see the pyarrow package installed in uv's ephemeral environment.

https://github.com/LadybugDB/ladybug/actions/runs/29169077041
