### PR TITLE
fix(nodejs): resolve OpenSSL through macOS rpaths

### DIFF
--- a/.github/workflows/nodejs-workflow.yml
+++ b/.github/workflows/nodejs-workflow.yml
@@ -313,6 +313,14 @@ jobs:
         working-directory: tools/nodejs_api
         run: npm test
 
+      - name: Make macOS OpenSSL lookup package-manager independent
+        if: ${{ matrix.platform == 'darwin' }}
+        working-directory: tools/nodejs_api
+        run: |
+          ../../scripts/relocate-macos-openssl.sh build/lbugjs.node
+          ../../scripts/verify-macos-openssl-rpaths.sh build/lbugjs.node
+          node -e "require('./build/lbugjs.node')"
+
       - name: Move Node.js native module (Linux)
         if: ${{ matrix.platform == 'linux' }}
         working-directory: tools/nodejs_api

--- a/scripts/relocate-macos-openssl.sh
+++ b/scripts/relocate-macos-openssl.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "$#" -ne 1 ]; then
+    echo "usage: $0 <mach-o-binary>" >&2
+    exit 2
+fi
+
+binary="$1"
+if [ ! -f "$binary" ]; then
+    echo "Mach-O binary not found: $binary" >&2
+    exit 1
+fi
+
+dependency_for() {
+    local library="$1"
+    otool -L "$binary" | awk -v library="$library" \
+        'index($1, library) && substr($1, length($1) - length(library) + 1) == library { print $1; exit }'
+}
+
+for library in libssl.3.dylib libcrypto.3.dylib; do
+    dependency="$(dependency_for "$library")"
+    if [ -z "$dependency" ]; then
+        echo "OpenSSL dependency $library not found in $binary" >&2
+        exit 1
+    fi
+    if [ "$dependency" != "@rpath/$library" ]; then
+        install_name_tool -change "$dependency" "@rpath/$library" "$binary"
+    fi
+done
+
+for rpath in \
+    /opt/homebrew/opt/openssl@3/lib \
+    /usr/local/opt/openssl@3/lib \
+    /opt/local/lib; do
+    existing_rpaths="$(otool -l "$binary" | awk '/cmd LC_RPATH/{getline; getline; print $2}')"
+    if ! grep -Fxq "$rpath" <<<"$existing_rpaths"; then
+        install_name_tool -add_rpath "$rpath" "$binary"
+    fi
+done
+
+# install_name_tool invalidates the existing signature.
+codesign --force --sign - "$binary"

--- a/scripts/relocate-macos-openssl.sh
+++ b/scripts/relocate-macos-openssl.sh
@@ -40,4 +40,7 @@ for rpath in \
 done
 
 # install_name_tool invalidates the existing signature.
+# Ad-hoc signing ("-") is sufficient for development and CI. If this binary is
+# distributed to end-users (e.g., via npm), a proper Developer ID certificate
+# should be used instead for notarization compatibility.
 codesign --force --sign - "$binary"

--- a/scripts/verify-macos-openssl-rpaths.sh
+++ b/scripts/verify-macos-openssl-rpaths.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "$#" -ne 1 ]; then
+    echo "usage: $0 <mach-o-binary>" >&2
+    exit 2
+fi
+
+binary="$1"
+dependencies="$(otool -L "$binary")"
+
+for library in libssl.3.dylib libcrypto.3.dylib; do
+    if ! grep -Fq "@rpath/$library" <<<"$dependencies"; then
+        echo "missing @rpath dependency for $library in $binary" >&2
+        exit 1
+    fi
+done
+
+if grep -Eq '^[[:space:]]+/(opt/homebrew|usr/local|opt/local)/.*lib(ssl|crypto)\.3\.dylib' \
+    <<<"$dependencies"; then
+    echo "package-manager-specific OpenSSL dependency remains in $binary" >&2
+    exit 1
+fi
+
+rpaths="$(otool -l "$binary" | awk '/cmd LC_RPATH/{getline; getline; print $2}')"
+for required in \
+    /opt/homebrew/opt/openssl@3/lib \
+    /usr/local/opt/openssl@3/lib \
+    /opt/local/lib; do
+    if ! grep -Fxq "$required" <<<"$rpaths"; then
+        echo "missing OpenSSL rpath $required in $binary" >&2
+        exit 1
+    fi
+done

--- a/scripts/verify-macos-openssl-rpaths.sh
+++ b/scripts/verify-macos-openssl-rpaths.sh
@@ -7,6 +7,11 @@ if [ "$#" -ne 1 ]; then
 fi
 
 binary="$1"
+if [ ! -f "$binary" ]; then
+    echo "Mach-O binary not found: $binary" >&2
+    exit 1
+fi
+
 dependencies="$(otool -L "$binary")"
 
 for library in libssl.3.dylib libcrypto.3.dylib; do
@@ -16,6 +21,8 @@ for library in libssl.3.dylib libcrypto.3.dylib; do
     fi
 done
 
+# The leading '/' is matched by the '^[[:space:]]+/' portion of the regex, so the
+# alternatives within the group omit it: 'opt/homebrew', 'usr/local', 'opt/local'.
 if grep -Eq '^[[:space:]]+/(opt/homebrew|usr/local|opt/local)/.*lib(ssl|crypto)\.3\.dylib' \
     <<<"$dependencies"; then
     echo "package-manager-specific OpenSSL dependency remains in $binary" >&2


### PR DESCRIPTION
## Summary

- rewrite macOS Node addon OpenSSL dependencies to `@rpath`
- search the standard Homebrew ARM, Homebrew Intel, and MacPorts OpenSSL roots
- verify the packaged Mach-O dependencies and load the relocated addon in CI

## Root cause

The published macOS Node addons inherit absolute install names from the OpenSSL
dylibs available on the build runner. Current artifacts therefore reference
`/opt/homebrew/opt/openssl@3/...` directly and fail to load for MacPorts users
even when a maintained OpenSSL 3 installation is present at `/opt/local/lib`.

## Security and packaging

This does not bundle or statically link OpenSSL. Consumers still provide a
separately maintained OpenSSL 3 installation. The packaging step replaces the
build-machine-specific dependency names with `@rpath` and embeds only these
search roots:

- `/opt/homebrew/opt/openssl@3/lib`
- `/usr/local/opt/openssl@3/lib`
- `/opt/local/lib`

The modified addon is ad-hoc signed after `install_name_tool` changes it.

## Validation

- verifier failed against the published 0.18.1 addon before relocation
- relocation and verification pass on a fresh copy of that addon
- relocation is idempotent when run twice
- the relocated addon loads successfully through Node.js
- `bash -n` and ShellCheck pass for both scripts
- `git diff --check` passes
- the workflow runs relocation, Mach-O verification, and addon loading on both
  macOS matrix entries before artifact upload

Full macOS ARM and Intel build proof remains delegated to this PR's remote CI.

Closes #681
