### PR TITLE
fix(ci): route fork artifacts to current repository

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -101,6 +101,9 @@ jobs:
       - name: Check extension files for std::assert
         run: ./scripts/check-no-std-assert.sh extension
 
+      - name: Test precompiled artifact download routing
+        run: ./scripts/test-download-liblbug.sh
+
       - name: Ensure generated grammar files are up to date
         run: |
           python3 scripts/antlr4/hash.py src/antlr4/keywords.txt src/antlr4/Cypher.g4 > tmphashfile

--- a/scripts/download-liblbug.sh
+++ b/scripts/download-liblbug.sh
@@ -4,9 +4,14 @@ set -euo pipefail
 
 LIB_KIND="${LBUG_LIB_KIND:-shared}"
 LINUX_VARIANT="${LBUG_LINUX_VARIANT:-compat}"
-REPOSITORY="${LBUG_GITHUB_REPOSITORY:-LadybugDB/ladybug}"
 RUN_ID="${LBUG_PRECOMPILED_RUN_ID:-}"
 VERSION_OVERRIDE="${LBUG_VERSION:-}"
+
+if [ -n "$RUN_ID" ]; then
+  REPOSITORY="${LBUG_GITHUB_REPOSITORY:-${GITHUB_REPOSITORY:-LadybugDB/ladybug}}"
+else
+  REPOSITORY="${LBUG_GITHUB_REPOSITORY:-LadybugDB/ladybug}"
+fi
 
 if [ "$LIB_KIND" != "shared" ] && [ "$LIB_KIND" != "static" ]; then
   echo "Unsupported LBUG_LIB_KIND: $LIB_KIND (expected 'shared' or 'static')" >&2

--- a/scripts/test-download-liblbug.sh
+++ b/scripts/test-download-liblbug.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root_dir="$(cd "$(dirname "$0")/.." && pwd)"
+test_dir="$(mktemp -d)"
+trap 'rm -rf "$test_dir"' EXIT
+
+bin_dir="$test_dir/bin"
+mkdir -p "$bin_dir"
+
+cat > "$bin_dir/uname" <<'EOF'
+#!/usr/bin/env bash
+case "${1:-}" in
+  -s) printf 'Linux\n' ;;
+  -m) printf 'x86_64\n' ;;
+  *) exit 1 ;;
+esac
+EOF
+
+cat > "$bin_dir/gh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+printf '%s\n' "$@" > "$TEST_GH_ARGS"
+artifact_dir=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --dir)
+      artifact_dir="$2"
+      shift 2
+      ;;
+    *)
+      shift
+      ;;
+  esac
+done
+
+mkdir -p "$artifact_dir" "$TEST_PAYLOAD_DIR"
+printf 'fixture\n' > "$TEST_PAYLOAD_DIR/liblbug.a"
+tar czf "$artifact_dir/liblbug-static-linux-x86_64-compat.tar.gz" \
+  -C "$TEST_PAYLOAD_DIR" liblbug.a
+EOF
+
+cat > "$bin_dir/curl" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+printf '%s\n' "$@" > "$TEST_CURL_ARGS"
+output=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -o)
+      output="$2"
+      shift 2
+      ;;
+    *)
+      shift
+      ;;
+  esac
+done
+
+mkdir -p "$(dirname "$output")" "$TEST_PAYLOAD_DIR"
+printf 'fixture\n' > "$TEST_PAYLOAD_DIR/liblbug.a"
+tar czf "$output" -C "$TEST_PAYLOAD_DIR" liblbug.a
+EOF
+
+chmod +x "$bin_dir/uname" "$bin_dir/gh" "$bin_dir/curl"
+
+export PATH="$bin_dir:$PATH"
+export TEST_GH_ARGS="$test_dir/gh-args"
+export TEST_CURL_ARGS="$test_dir/curl-args"
+export TEST_PAYLOAD_DIR="$test_dir/payload"
+export GITHUB_REPOSITORY="fork-owner/ladybug"
+export LBUG_LIB_KIND="static"
+export LBUG_PRECOMPILED_RUN_ID="12345"
+
+export LBUG_TARGET_DIR="$test_dir/current-repository"
+"$root_dir/scripts/download-liblbug.sh"
+test -s "$LBUG_TARGET_DIR/liblbug.a"
+test "$(awk '$0 == "--repo" { getline; print; exit }' "$TEST_GH_ARGS")" = \
+  "fork-owner/ladybug"
+
+export LBUG_GITHUB_REPOSITORY="override-owner/ladybug"
+export LBUG_TARGET_DIR="$test_dir/explicit-override"
+"$root_dir/scripts/download-liblbug.sh"
+test -s "$LBUG_TARGET_DIR/liblbug.a"
+test "$(awk '$0 == "--repo" { getline; print; exit }' "$TEST_GH_ARGS")" = \
+  "override-owner/ladybug"
+
+unset LBUG_GITHUB_REPOSITORY LBUG_PRECOMPILED_RUN_ID
+export LBUG_VERSION="0.18.1"
+export LBUG_TARGET_DIR="$test_dir/release"
+"$root_dir/scripts/download-liblbug.sh"
+test -s "$LBUG_TARGET_DIR/liblbug.a"
+grep -Fx \
+  "https://github.com/LadybugDB/ladybug/releases/download/v0.18.1/liblbug-static-linux-x86_64-compat.tar.gz" \
+  "$TEST_CURL_ARGS"


### PR DESCRIPTION
## Summary

- route workflow artifact downloads to the current GitHub repository when a
  precompiled run ID is provided
- preserve `LBUG_GITHUB_REPOSITORY` as the highest-priority explicit override
- preserve `LadybugDB/ladybug` as the default for release downloads
- add a subprocess regression test to the existing sanity job

## Root cause

GitHub Actions run IDs are repository-scoped, but
`scripts/download-liblbug.sh` always defaulted to `LadybugDB/ladybug`.
Dispatching the reusable language workflows in a fork therefore queried the
upstream repository with a fork run ID and returned HTTP 404.

Fixes #683.

## Validation

- observed the original test fail on the current upstream script
- `scripts/test-download-liblbug.sh`
- `bash -n scripts/download-liblbug.sh scripts/test-download-liblbug.sh`
- `shellcheck scripts/download-liblbug.sh scripts/test-download-liblbug.sh`
- parsed `.github/workflows/ci-workflow.yml` with Ruby YAML
- downloaded a real fork artifact from run `29227829393` with only
  `GITHUB_REPOSITORY=100yenadmin/ladybug`
- `git diff --check`

No package publication or deployment is requested.
