### PR TITLE
fix: cleanup checkpoint intent/apply lock files after checkpoint

### DIFF
--- a/src/storage/checkpointer.cpp
+++ b/src/storage/checkpointer.cpp
@@ -140,6 +140,12 @@ void Checkpointer::acquireCheckpointLocks() {
 void Checkpointer::releaseCheckpointLocks() {
     checkpointApplyLockFile.reset();
     checkpointIntentLockFile.reset();
+    auto vfs = common::VirtualFileSystem::GetUnsafe(clientContext);
+    const auto databasePath = clientContext.getDatabasePath();
+    vfs->removeFileIfExists(StorageUtils::getCheckpointIntentLockFilePath(databasePath),
+        &clientContext);
+    vfs->removeFileIfExists(StorageUtils::getCheckpointApplyLockFilePath(databasePath),
+        &clientContext);
 }
 
 std::vector<Checkpointer::CheckpointTarget> Checkpointer::collectCheckpointTargets() const {


### PR DESCRIPTION
The intent/apply lock files (*.checkpoint.intent.lock and *.checkpoint.apply.lock) introduced for concurrent read-only access during checkpoint were never cleaned up after the checkpoint finished. releaseCheckpointLocks() only closed the file handles but didn't delete the files from disk.

Fix by calling removeFileIfExists() on both lock files after the FileInfo handles are released in releaseCheckpointLocks().