### PR TITLE
fix: stop creating checkpoint lock files in StorageManager constructor

### DIFF
--- a/src/storage/storage_manager.cpp
+++ b/src/storage/storage_manager.cpp
@@ -48,14 +48,11 @@ StorageManager::StorageManager(const std::string& databasePath, bool readOnly, b
     shadowFile =
         std::make_unique<ShadowFile>(*memoryManager.getBufferManager(), vfs, this->databasePath);
     inMemory = main::DBConfig::isDBPathInMemory(databasePath);
-    if (!readOnly && !inMemory) {
-        vfs->openFile(StorageUtils::getCheckpointIntentLockFilePath(databasePath),
-            FileOpenFlags(
-                FileFlags::READ_ONLY | FileFlags::WRITE | FileFlags::CREATE_IF_NOT_EXISTS));
-        vfs->openFile(StorageUtils::getCheckpointApplyLockFilePath(databasePath),
-            FileOpenFlags(
-                FileFlags::READ_ONLY | FileFlags::WRITE | FileFlags::CREATE_IF_NOT_EXISTS));
-    }
+    // Checkpoint intent/apply lock files (*.checkpoint.intent.lock and
+    // *.checkpoint.apply.lock) are NOT created here.  All access, including subgraph
+    // access, goes through the main database path returned by
+    // clientContext.getDatabasePath().  The Checkpointer creates these files on demand
+    // (with CREATE_IF_NOT_EXISTS) when a checkpoint starts via acquireCheckpointLocks().
     registerIndexType(PrimaryKeyIndex::getIndexType());
     registerIndexType(ArtPrimaryKeyIndex::getIndexType());
 }


### PR DESCRIPTION
The checkpoint intent/apply lock files (*.checkpoint.intent.lock and *.checkpoint.apply.lock) were being created as empty placeholders by every StorageManager constructor, including for subgraph databases (e.g. test.mygraph1.db).  These files are unnecessary because all access (including subgraph access) goes through the main database path via clientContext.getDatabasePath().

The files are already created on demand by Checkpointer:: acquireCheckpointLocks() (with CREATE_IF_NOT_EXISTS) when a checkpoint actually starts, and cleaned up by releaseCheckpointLocks() after the checkpoint completes.  Pre-creating them in the StorageManager constructor was redundant and caused stale files to leak on disk for subgraph databases that are checkpointed via collectCheckpointTargets() but never have their own locks acquired or released.