### PR TITLE
Fix recursive-rel node filter silently ignored in SHORTEST mode (#680)

### DIFF
--- a/src/function/gds/asp_destinations.cpp
+++ b/src/function/gds/asp_destinations.cpp
@@ -242,14 +242,20 @@ private:
 
 class ASPDestinationsEdgeCompute : public SPEdgeCompute {
 public:
-    ASPDestinationsEdgeCompute(SPFrontierPair* frontierPair, MultiplicitiesPair* multiplicitiesPair)
-        : SPEdgeCompute{frontierPair}, multiplicitiesPair{multiplicitiesPair} {};
+    ASPDestinationsEdgeCompute(SPFrontierPair* frontierPair, MultiplicitiesPair* multiplicitiesPair,
+        NodeOffsetMaskMap* pathNodeMask)
+        : SPEdgeCompute{frontierPair}, multiplicitiesPair{multiplicitiesPair},
+          pathNodeMask{pathNodeMask} {};
 
     std::vector<nodeID_t> edgeCompute(nodeID_t boundNodeID, NbrScanState::Chunk& resultChunk,
         bool) override {
         std::vector<nodeID_t> activeNodes;
         resultChunk.forEach([&](auto neighbors, auto, auto i) {
             auto nbrNodeID = neighbors[i];
+            // Skip nodes that fail the node predicate (if one is set).
+            if (pathNodeMask != nullptr && !pathNodeMask->valid(nbrNodeID)) {
+                return;
+            }
             auto nbrVal = frontierPair->getNextFrontierValue(nbrNodeID.offset);
             // We should update the nbrID's multiplicity in 2 cases: 1) if nbrID is being visited
             // for the first time, i.e., when its value in the pathLengths frontier is
@@ -272,11 +278,13 @@ public:
     }
 
     std::unique_ptr<EdgeCompute> copy() override {
-        return std::make_unique<ASPDestinationsEdgeCompute>(frontierPair, multiplicitiesPair);
+        return std::make_unique<ASPDestinationsEdgeCompute>(frontierPair, multiplicitiesPair,
+            pathNodeMask);
     }
 
 private:
     MultiplicitiesPair* multiplicitiesPair;
+    NodeOffsetMaskMap* pathNodeMask;
 };
 
 // All shortest path algorithm. Only destinations are tracked (reachability query).
@@ -306,7 +314,7 @@ private:
         auto frontier = DenseFrontier::getUnvisitedFrontier(context, graph);
         auto frontierPair = std::make_unique<SPFrontierPair>(std::move(frontier));
         auto edgeCompute = std::make_unique<ASPDestinationsEdgeCompute>(frontierPair.get(),
-            multiplicitiesPair.get());
+            multiplicitiesPair.get(), sharedState->getPathNodeMaskMap());
         auto auxiliaryState =
             std::make_unique<ASPDestinationsAuxiliaryState>(std::move(multiplicitiesPair));
         return std::make_unique<GDSComputeState>(std::move(frontierPair), std::move(edgeCompute),

--- a/src/function/gds/asp_paths.cpp
+++ b/src/function/gds/asp_paths.cpp
@@ -14,8 +14,10 @@ namespace function {
 
 class ASPPathsEdgeCompute : public SPEdgeCompute {
 public:
-    ASPPathsEdgeCompute(SPFrontierPair* frontiersPair, BFSGraphManager* bfsGraphManager)
-        : SPEdgeCompute{frontiersPair}, bfsGraphManager{bfsGraphManager} {
+    ASPPathsEdgeCompute(SPFrontierPair* frontiersPair, BFSGraphManager* bfsGraphManager,
+        NodeOffsetMaskMap* pathNodeMask)
+        : SPEdgeCompute{frontiersPair}, bfsGraphManager{bfsGraphManager},
+          pathNodeMask{pathNodeMask} {
         block = bfsGraphManager->getCurrentGraph()->addNewBlock();
     }
 
@@ -24,6 +26,10 @@ public:
         std::vector<nodeID_t> activeNodes;
         resultChunk.forEach([&](auto neighbors, auto propertyVectors, auto i) {
             auto nbrNodeID = neighbors[i];
+            // Skip nodes that fail the node predicate (if one is set).
+            if (pathNodeMask != nullptr && !pathNodeMask->valid(nbrNodeID)) {
+                return;
+            }
             auto iter = frontierPair->getNextFrontierValue(nbrNodeID.offset);
             // We should update in 2 cases: 1) if nbrID is being visited
             // for the first time, i.e., when its value in the pathLengths frontier is
@@ -47,12 +53,13 @@ public:
     }
 
     std::unique_ptr<EdgeCompute> copy() override {
-        return std::make_unique<ASPPathsEdgeCompute>(frontierPair, bfsGraphManager);
+        return std::make_unique<ASPPathsEdgeCompute>(frontierPair, bfsGraphManager, pathNodeMask);
     }
 
 private:
     BFSGraphManager* bfsGraphManager;
     ObjectBlock<ParentList>* block = nullptr;
+    NodeOffsetMaskMap* pathNodeMask;
 };
 
 // All shortest path algorithm. Paths are tracked.
@@ -87,8 +94,8 @@ private:
         auto frontierPair = std::make_unique<SPFrontierPair>(std::move(denseFrontier));
         auto bfsGraph = std::make_unique<BFSGraphManager>(
             sharedState->graph->getMaxOffsetMap(transaction::Transaction::Get(*clientContext)), mm);
-        auto edgeCompute =
-            std::make_unique<ASPPathsEdgeCompute>(frontierPair.get(), bfsGraph.get());
+        auto edgeCompute = std::make_unique<ASPPathsEdgeCompute>(frontierPair.get(), bfsGraph.get(),
+            sharedState->getPathNodeMaskMap());
         auto auxiliaryState = std::make_unique<PathAuxiliaryState>(std::move(bfsGraph));
         return std::make_unique<GDSComputeState>(std::move(frontierPair), std::move(edgeCompute),
             std::move(auxiliaryState));

--- a/src/function/gds/awsp_paths.cpp
+++ b/src/function/gds/awsp_paths.cpp
@@ -18,8 +18,8 @@ namespace function {
 template<typename T>
 class AWSPPathsEdgeCompute : public EdgeCompute {
 public:
-    explicit AWSPPathsEdgeCompute(BFSGraphManager* bfsGraphManager)
-        : bfsGraphManager{bfsGraphManager} {
+    explicit AWSPPathsEdgeCompute(BFSGraphManager* bfsGraphManager, NodeOffsetMaskMap* pathNodeMask)
+        : bfsGraphManager{bfsGraphManager}, pathNodeMask{pathNodeMask} {
         block = bfsGraphManager->getCurrentGraph()->addNewBlock();
     }
 
@@ -28,6 +28,10 @@ public:
         std::vector<nodeID_t> result;
         chunk.forEach([&](auto neighbors, auto propertyVectors, auto i) {
             auto nbrNodeID = neighbors[i];
+            // Skip nodes that fail the node predicate (if one is set).
+            if (pathNodeMask != nullptr && !pathNodeMask->valid(nbrNodeID)) {
+                return;
+            }
             auto edgeID = propertyVectors[0]->template getValue<relID_t>(i);
             auto weight = propertyVectors[1]->template getValue<T>(i);
             WeightUtils::checkWeight(AllWeightedSPPathsFunction::name, weight);
@@ -43,12 +47,13 @@ public:
     }
 
     std::unique_ptr<EdgeCompute> copy() override {
-        return std::make_unique<AWSPPathsEdgeCompute<T>>(bfsGraphManager);
+        return std::make_unique<AWSPPathsEdgeCompute<T>>(bfsGraphManager, pathNodeMask);
     }
 
 private:
     BFSGraphManager* bfsGraphManager;
     ObjectBlock<ParentList>* block = nullptr;
+    NodeOffsetMaskMap* pathNodeMask;
 };
 
 class AWSPPathsOutputWriter : public PathsOutputWriter {
@@ -156,7 +161,8 @@ private:
         std::unique_ptr<GDSComputeState> gdsState;
         WeightUtils::visit(AllWeightedSPPathsFunction::name,
             bindData.weightPropertyExpr->getDataType(), [&]<typename T>(T) {
-                auto edgeCompute = std::make_unique<AWSPPathsEdgeCompute<T>>(bfsGraph.get());
+                auto edgeCompute = std::make_unique<AWSPPathsEdgeCompute<T>>(bfsGraph.get(),
+                    sharedState->getPathNodeMaskMap());
                 auto auxiliaryState = std::make_unique<WSPPathsAuxiliaryState>(std::move(bfsGraph));
                 gdsState = std::make_unique<GDSComputeState>(std::move(frontierPair),
                     std::move(edgeCompute), std::move(auxiliaryState));

--- a/src/function/gds/ssp_destinations.cpp
+++ b/src/function/gds/ssp_destinations.cpp
@@ -60,15 +60,17 @@ private:
 
 class SSPDestinationsEdgeCompute : public SPEdgeCompute {
 public:
-    explicit SSPDestinationsEdgeCompute(SPFrontierPair* frontierPair)
-        : SPEdgeCompute{frontierPair} {};
+    explicit SSPDestinationsEdgeCompute(SPFrontierPair* frontierPair,
+        NodeOffsetMaskMap* pathNodeMask)
+        : SPEdgeCompute{frontierPair}, pathNodeMask{pathNodeMask} {};
 
     std::vector<nodeID_t> edgeCompute(nodeID_t, NbrScanState::Chunk& resultChunk, bool) override {
         std::vector<nodeID_t> activeNodes;
         resultChunk.forEach([&](auto neighbors, auto, auto i) {
             auto nbrNode = neighbors[i];
             auto iter = frontierPair->getNextFrontierValue(nbrNode.offset);
-            if (iter == FRONTIER_UNVISITED) {
+            if (iter == FRONTIER_UNVISITED &&
+                (pathNodeMask == nullptr || pathNodeMask->valid(nbrNode))) {
                 activeNodes.push_back(nbrNode);
             }
         });
@@ -76,8 +78,11 @@ public:
     }
 
     std::unique_ptr<EdgeCompute> copy() override {
-        return std::make_unique<SSPDestinationsEdgeCompute>(frontierPair);
+        return std::make_unique<SSPDestinationsEdgeCompute>(frontierPair, pathNodeMask);
     }
+
+private:
+    NodeOffsetMaskMap* pathNodeMask;
 };
 
 // Single shortest path algorithm. Only destinations are tracked (reachability query).
@@ -104,7 +109,8 @@ private:
         auto graph = sharedState->graph.get();
         auto denseFrontier = DenseFrontier::getUninitializedFrontier(context, graph);
         auto frontierPair = std::make_unique<SPFrontierPair>(std::move(denseFrontier));
-        auto edgeCompute = std::make_unique<SSPDestinationsEdgeCompute>(frontierPair.get());
+        auto edgeCompute = std::make_unique<SSPDestinationsEdgeCompute>(frontierPair.get(),
+            sharedState->getPathNodeMaskMap());
         auto auxiliaryState = std::make_unique<EmptyGDSAuxiliaryState>();
         return std::make_unique<GDSComputeState>(std::move(frontierPair), std::move(edgeCompute),
             std::move(auxiliaryState));

--- a/src/function/gds/ssp_paths.cpp
+++ b/src/function/gds/ssp_paths.cpp
@@ -15,8 +15,10 @@ namespace function {
 
 class SSPPathsEdgeCompute : public SPEdgeCompute {
 public:
-    SSPPathsEdgeCompute(SPFrontierPair* frontierPair, BFSGraphManager* bfsGraphManager)
-        : SPEdgeCompute{frontierPair}, bfsGraphManager{bfsGraphManager} {
+    SSPPathsEdgeCompute(SPFrontierPair* frontierPair, BFSGraphManager* bfsGraphManager,
+        NodeOffsetMaskMap* pathNodeMask)
+        : SPEdgeCompute{frontierPair}, bfsGraphManager{bfsGraphManager},
+          pathNodeMask{pathNodeMask} {
         block = bfsGraphManager->getCurrentGraph()->addNewBlock();
     }
 
@@ -25,6 +27,10 @@ public:
         std::vector<nodeID_t> activeNodes;
         resultChunk.forEach([&](auto neighbors, auto propertyVectors, auto i) {
             auto nbrNodeID = neighbors[i];
+            // Skip nodes that fail the node predicate (if one is set).
+            if (pathNodeMask != nullptr && !pathNodeMask->valid(nbrNodeID)) {
+                return;
+            }
             auto iter = frontierPair->getNextFrontierValue(nbrNodeID.offset);
             if (iter == FRONTIER_UNVISITED) {
                 if (!block->hasSpace()) {
@@ -40,12 +46,13 @@ public:
     }
 
     std::unique_ptr<EdgeCompute> copy() override {
-        return std::make_unique<SSPPathsEdgeCompute>(frontierPair, bfsGraphManager);
+        return std::make_unique<SSPPathsEdgeCompute>(frontierPair, bfsGraphManager, pathNodeMask);
     }
 
 private:
     BFSGraphManager* bfsGraphManager;
     ObjectBlock<ParentList>* block = nullptr;
+    NodeOffsetMaskMap* pathNodeMask;
 };
 
 // Single shortest path algorithm. Paths are tracked.
@@ -81,8 +88,8 @@ private:
         auto bfsGraph =
             std::make_unique<BFSGraphManager>(sharedState->graph->getMaxOffsetMap(transaction),
                 storage::MemoryManager::Get(*clientContext));
-        auto edgeCompute =
-            std::make_unique<SSPPathsEdgeCompute>(frontierPair.get(), bfsGraph.get());
+        auto edgeCompute = std::make_unique<SSPPathsEdgeCompute>(frontierPair.get(), bfsGraph.get(),
+            sharedState->getPathNodeMaskMap());
         auto auxiliaryState = std::make_unique<PathAuxiliaryState>(std::move(bfsGraph));
         return std::make_unique<GDSComputeState>(std::move(frontierPair), std::move(edgeCompute),
             std::move(auxiliaryState));

--- a/src/function/gds/wsp_destinations.cpp
+++ b/src/function/gds/wsp_destinations.cpp
@@ -183,13 +183,18 @@ private:
 template<typename T>
 class WSPDestinationsEdgeCompute : public EdgeCompute {
 public:
-    explicit WSPDestinationsEdgeCompute(CostsPair* costsPair) : costsPair{costsPair} {}
+    explicit WSPDestinationsEdgeCompute(CostsPair* costsPair, NodeOffsetMaskMap* pathNodeMask)
+        : costsPair{costsPair}, pathNodeMask{pathNodeMask} {}
 
     std::vector<nodeID_t> edgeCompute(nodeID_t boundNodeID, graph::NbrScanState::Chunk& chunk,
         bool) override {
         std::vector<nodeID_t> result;
         chunk.forEach([&](auto neighbors, auto propertyVectors, auto i) {
             auto nbrNodeID = neighbors[i];
+            // Skip nodes that fail the node predicate (if one is set).
+            if (pathNodeMask != nullptr && !pathNodeMask->valid(nbrNodeID)) {
+                return;
+            }
             auto weight = propertyVectors[0]->template getValue<T>(i);
             WeightUtils::checkWeight(WeightedSPDestinationsFunction::name, weight);
             if (costsPair->update(boundNodeID.offset, nbrNodeID.offset,
@@ -201,11 +206,12 @@ public:
     }
 
     std::unique_ptr<EdgeCompute> copy() override {
-        return std::make_unique<WSPDestinationsEdgeCompute<T>>(costsPair);
+        return std::make_unique<WSPDestinationsEdgeCompute<T>>(costsPair, pathNodeMask);
     }
 
 private:
     CostsPair* costsPair;
+    NodeOffsetMaskMap* pathNodeMask;
 };
 
 class WSPDestinationsAuxiliaryState : public GDSAuxiliaryState {
@@ -313,7 +319,8 @@ private:
         std::unique_ptr<GDSComputeState> gdsState;
         WeightUtils::visit(WeightedSPDestinationsFunction::name,
             bindData.weightPropertyExpr->getDataType(), [&]<typename T>(T) {
-                auto edgeCompute = std::make_unique<WSPDestinationsEdgeCompute<T>>(costPairPtr);
+                auto edgeCompute = std::make_unique<WSPDestinationsEdgeCompute<T>>(costPairPtr,
+                    sharedState->getPathNodeMaskMap());
                 gdsState = std::make_unique<GDSComputeState>(std::move(frontierPair),
                     std::move(edgeCompute), std::move(auxiliaryState));
             });

--- a/src/function/gds/wsp_paths.cpp
+++ b/src/function/gds/wsp_paths.cpp
@@ -17,8 +17,8 @@ namespace function {
 template<typename T>
 class WSPPathsEdgeCompute : public EdgeCompute {
 public:
-    explicit WSPPathsEdgeCompute(BFSGraphManager* bfsGraphManager)
-        : bfsGraphManager{bfsGraphManager} {
+    explicit WSPPathsEdgeCompute(BFSGraphManager* bfsGraphManager, NodeOffsetMaskMap* pathNodeMask)
+        : bfsGraphManager{bfsGraphManager}, pathNodeMask{pathNodeMask} {
         block = bfsGraphManager->getCurrentGraph()->addNewBlock();
     }
 
@@ -27,6 +27,10 @@ public:
         std::vector<nodeID_t> result;
         chunk.forEach([&](auto neighbors, auto propertyVectors, auto i) {
             auto nbrNodeID = neighbors[i];
+            // Skip nodes that fail the node predicate (if one is set).
+            if (pathNodeMask != nullptr && !pathNodeMask->valid(nbrNodeID)) {
+                return;
+            }
             auto edgeID = propertyVectors[0]->template getValue<relID_t>(i);
             auto weight = propertyVectors[1]->template getValue<T>(i);
             WeightUtils::checkWeight(WeightedSPPathsFunction::name, weight);
@@ -42,12 +46,13 @@ public:
     }
 
     std::unique_ptr<EdgeCompute> copy() override {
-        return std::make_unique<WSPPathsEdgeCompute<T>>(bfsGraphManager);
+        return std::make_unique<WSPPathsEdgeCompute<T>>(bfsGraphManager, pathNodeMask);
     }
 
 private:
     BFSGraphManager* bfsGraphManager;
     ObjectBlock<ParentList>* block = nullptr;
+    NodeOffsetMaskMap* pathNodeMask;
 };
 
 class WSPPathsOutputWriter : public PathsOutputWriter {
@@ -127,7 +132,8 @@ private:
         std::unique_ptr<GDSComputeState> gdsState;
         WeightUtils::visit(WeightedSPPathsFunction::name,
             bindData.weightPropertyExpr->getDataType(), [&]<typename T>(T) {
-                auto edgeCompute = std::make_unique<WSPPathsEdgeCompute<T>>(bfsGraph.get());
+                auto edgeCompute = std::make_unique<WSPPathsEdgeCompute<T>>(bfsGraph.get(),
+                    sharedState->getPathNodeMaskMap());
                 auto auxiliaryState = std::make_unique<WSPPathsAuxiliaryState>(std::move(bfsGraph));
                 gdsState = std::make_unique<GDSComputeState>(std::move(frontierPair),
                     std::move(edgeCompute), std::move(auxiliaryState));

--- a/test/test_files/shortest_path/shortest_path_node_filter.test
+++ b/test/test_files/shortest_path/shortest_path_node_filter.test
@@ -1,0 +1,73 @@
+-DATASET CSV empty
+
+--
+
+-CASE ShortestPathNodeFilter
+
+-LOG Issue680_SHORTEST_blocked
+# Regression test for issue #680: recursive-rel node filter silently ignored in SHORTEST mode.
+# Three persons in a chain. Person 2 has date=50 which fails the filter n.date >= 100,
+# so nothing should be reachable from person 1 in either SHORTEST or plain mode.
+-STATEMENT CREATE NODE TABLE Person(id INT64 PRIMARY KEY, date INT64);
+---- ok
+-STATEMENT CREATE REL TABLE Knows(FROM Person TO Person);
+---- ok
+-STATEMENT CREATE (:Person {id: 1, date: 100});
+---- ok
+-STATEMENT CREATE (:Person {id: 2, date: 50});
+---- ok
+-STATEMENT CREATE (:Person {id: 3, date: 200});
+---- ok
+-STATEMENT MATCH (a:Person {id: 1}), (b:Person {id: 2}) CREATE (a)-[:Knows]->(b);
+---- ok
+-STATEMENT MATCH (a:Person {id: 2}), (b:Person {id: 3}) CREATE (a)-[:Knows]->(b);
+---- ok
+-STATEMENT MATCH (p:Person {id: 1})-[e:Knows* SHORTEST 1..3 (r, n | WHERE n.date >= 100)]-(x:Person) WHERE x.id <> 1 AND x.date >= 100 RETURN x.id ORDER BY x.id;
+---- 0
+-STATEMENT MATCH (p:Person {id: 1})-[e:Knows*1..3 (r, n | WHERE n.date >= 100)]-(x:Person) WHERE x.id <> 1 AND x.date >= 100 RETURN x.id ORDER BY x.id;
+---- 0
+
+-LOG Issue680_SHORTEST_not_blocked
+# Sanity check: same structure but all nodes pass the filter -> results should be returned.
+-STATEMENT CREATE NODE TABLE Person2(id INT64 PRIMARY KEY, date INT64);
+---- ok
+-STATEMENT CREATE REL TABLE Knows2(FROM Person2 TO Person2);
+---- ok
+-STATEMENT CREATE (:Person2 {id: 1, date: 100});
+---- ok
+-STATEMENT CREATE (:Person2 {id: 2, date: 150});
+---- ok
+-STATEMENT CREATE (:Person2 {id: 3, date: 200});
+---- ok
+-STATEMENT MATCH (a:Person2 {id: 1}), (b:Person2 {id: 2}) CREATE (a)-[:Knows2]->(b);
+---- ok
+-STATEMENT MATCH (a:Person2 {id: 2}), (b:Person2 {id: 3}) CREATE (a)-[:Knows2]->(b);
+---- ok
+-STATEMENT MATCH (p:Person2 {id: 1})-[e:Knows2* SHORTEST 1..3 (r, n | WHERE n.date >= 100)]-(x:Person2) WHERE x.id <> 1 AND x.date >= 100 RETURN x.id ORDER BY x.id;
+---- 2
+2
+3
+
+-LOG Issue680_ALL_SHORTEST_blocked
+# Same as Issue680_SHORTEST_blocked but with ALL SHORTEST instead of SHORTEST
+-STATEMENT MATCH (p:Person {id: 1})-[e:Knows* ALL SHORTEST 1..3 (r, n | WHERE n.date >= 100)]-(x:Person) WHERE x.id <> 1 AND x.date >= 100 RETURN x.id ORDER BY x.id;
+---- 0
+
+-LOG Issue680_ALL_SHORTEST_not_blocked
+# Same as Issue680_SHORTEST_not_blocked but with ALL SHORTEST
+-STATEMENT MATCH (p:Person2 {id: 1})-[e:Knows2* ALL SHORTEST 1..3 (r, n | WHERE n.date >= 100)]-(x:Person2) WHERE x.id <> 1 AND x.date >= 100 RETURN x.id ORDER BY x.id;
+---- 2
+2
+3
+
+-LOG Issue680_directed_shortest_filtered
+# Directed shortest path with node filter blocking traversal through node 2
+-STATEMENT MATCH (p:Person {id: 1})-[e:Knows* SHORTEST 1..3 (r, n | WHERE n.date >= 100)]->(x:Person) WHERE x.id <> 1 AND x.date >= 100 RETURN x.id ORDER BY x.id;
+---- 0
+
+-LOG Issue680_directed_shortest_unfiltered
+# Directed shortest path without node filter — no predicate should still reach node 3
+-STATEMENT MATCH (p:Person {id: 1})-[e:Knows* SHORTEST 1..3]->(x:Person) WHERE x.id <> 1 RETURN x.id ORDER BY x.id;
+---- 2
+2
+3


### PR DESCRIPTION
Fixes: #680 

The node predicate on recursive relationships (e.g., `(r, n | WHERE ...)`) was being silently ignored when the recursive relationship uses SHORTEST mode (SHORTEST, ALL SHORTEST, WSHORTEST, ALL WSHORTEST). The filter was only checked during the output/path-reconstruction phase, not during the BFS traversal itself. This caused queries to return incorrect results that looked plausible.

Root cause: The `pathNodeMask` (pre-computed bitmap of nodes passing the predicate) was only used in `PathsOutputWriter::checkPathNodeMask()` during path construction, but was never checked in the `EdgeCompute` functions that drive the BFS traversal. As a result, nodes failing the predicate were still visited and used as intermediate hops, allowing the traversal to reach destinations through them.

Fix: Pass `pathNodeMask` from sharedState to all SHORTEST-mode EdgeCompute constructors and check the mask in each `edgeCompute()` call before adding a neighbor node to the next frontier (and before recording parent edges for path tracking).

Affected algorithms:
- SingleSP (destinations & paths)
- AllSP (destinations & paths)
- WeightedSP (destinations & paths)
- AllWeightedSP (paths)