### PR TITLE
fix: convert timestamp to date math

### DIFF
--- a/src/common/types/interval_t.cpp
+++ b/src/common/types/interval_t.cpp
@@ -454,7 +454,10 @@ int32_t Interval::getIntervalPart(DatePartSpecifier specifier, interval_t interv
 }
 
 int64_t Interval::getMicro(const interval_t& val) {
-    return val.micros + val.months * MICROS_PER_MONTH + val.days * MICROS_PER_DAY;
+    int64_t years = val.months / MONTHS_PER_YEAR;
+    int64_t months = val.months % MONTHS_PER_YEAR;
+    return val.micros + years * DAYS_PER_YEAR * MICROS_PER_DAY +
+           months * DAYS_PER_MONTH * MICROS_PER_DAY + val.days * MICROS_PER_DAY;
 }
 
 int64_t Interval::getNanoseconds(const interval_t& val) {


### PR DESCRIPTION
Related: #694 

Interval::getMicro uses DAYS_PER_YEAR (365) for whole years instead of DAYS_PER_MONTH * 12 (360), matching the documented constants.