### PR TITLE
fix: Skip disconnected correlated-only query graphs

### DIFF
--- a/src/planner/plan/plan_join_order.cpp
+++ b/src/planner/plan/plan_join_order.cpp
@@ -52,9 +52,39 @@ LogicalPlan Planner::planQueryGraphCollection(const QueryGraphCollection& queryG
         // product.
         queryGraphIdxToPlanExpressionsScan = getConnectedQueryGraphIdx(queryGraphCollection, info);
     }
+    // First pass: determine which disconnected graphs contain only correlated nodes.
+    // These patterns reference already-bound variables without adding new constraints
+    // (e.g. `(n3)` in OPTIONAL MATCH where n3 is from the outer plan). Skipping them
+    // avoids a full node-table scan that would artificially multiply cardinality (#697).
+    std::vector<bool> skipGraph(queryGraphCollection.getNumQueryGraphs(), false);
+    bool anyNonSkipped = false;
+    for (auto i = 0u; i < queryGraphCollection.getNumQueryGraphs(); ++i) {
+        auto queryGraph = queryGraphCollection.getQueryGraph(i);
+        if (queryGraph->getNumQueryRels() == 0 && info.subqueryType != SubqueryPlanningType::NONE) {
+            bool allNodesCorrelated = true;
+            for (auto& node : queryGraph->getQueryNodes()) {
+                if (!info.containsCorrExpr(*node->getInternalID())) {
+                    allNodesCorrelated = false;
+                    break;
+                }
+            }
+            skipGraph[i] = allNodesCorrelated;
+        }
+        if (!skipGraph[i]) {
+            anyNonSkipped = true;
+        }
+    }
+    // If every graph would be skipped, preserve the first one to keep the plan valid.
+    if (!anyNonSkipped && queryGraphCollection.getNumQueryGraphs() > 0) {
+        skipGraph[0] = false;
+    }
+
     std::unordered_set<uint32_t> evaluatedPredicatesIndices;
     std::vector<LogicalPlan> planPerQueryGraph;
     for (auto i = 0u; i < queryGraphCollection.getNumQueryGraphs(); ++i) {
+        if (skipGraph[i]) {
+            continue;
+        }
         auto queryGraph = queryGraphCollection.getQueryGraph(i);
         // Extract predicates for current query graph
         std::unordered_set<uint32_t> predicateToEvaluateIndices;

--- a/test/test_files/issue/issue697.test
+++ b/test/test_files/issue/issue697.test
@@ -1,0 +1,40 @@
+-DATASET CSV empty
+
+--
+
+-CASE Issue697OptionalMatchBoundNode
+# Reproduction for github issue #697:
+# Repeating a bound node in a comma-separated OPTIONAL MATCH doubles the
+# result cardinality.
+#
+# Bug: Adding (n3) to OPTIONAL MATCH when n3 is already bound from the
+# outer MATCH changes count(*) from 2 to 4 because n3 gets re-scanned.
+
+-STATEMENT CREATE NODE TABLE L1(id INT64, k11 INT64, PRIMARY KEY(id));
+---- ok
+-STATEMENT CREATE NODE TABLE X(id INT64, PRIMARY KEY(id));
+---- ok
+-STATEMENT CREATE REL TABLE T1(FROM X TO L1);
+---- ok
+
+-STATEMENT CREATE (:L1 {id: 1, k11: 1});
+---- ok
+-STATEMENT CREATE (:X {id: 2});
+---- ok
+-STATEMENT MATCH (a:X), (b:L1) CREATE (a)-[:T1]->(b);
+---- ok
+
+# Query A: OPTIONAL MATCH without the redundant (n3) - should return 2
+-STATEMENT MATCH (n0:L1), (n3) OPTIONAL MATCH (n6)-[:T1]->(n0) WHERE n0.k11 = 1 RETURN count(*) AS c;
+---- 1
+2
+
+# Query B: OPTIONAL MATCH with redundant (n3) - was returning 4, github issue #697
+-STATEMENT MATCH (n0:L1), (n3) OPTIONAL MATCH (n6)-[:T1]->(n0), (n3) WHERE n0.k11 = 1 RETURN count(*) AS c;
+---- 1
+2
+
+# Verify the base MATCH produces 2 rows
+-STATEMENT MATCH (n0:L1), (n3) RETURN count(*) AS c;
+---- 1
+2


### PR DESCRIPTION
When a comma-separated pattern in OPTIONAL MATCH references an already-bound variable without adding new constraints (e.g., bare (n3) in OPTIONAL MATCH), the binder creates a disconnected query graph. This graph was planned as a full node-table scan, producing extra rows that doubled the cardinality.

Fix: in planQueryGraphCollection, skip query graphs that have no relationships and whose nodes are all correlated (already bound in the outer plan). Their correlated expressions are already captured via join conditions.

Fixes #697.