### PR TITLE
fix(extension): name the missing dependency when Windows load fails

### DIFF
--- a/src/extension/extension.cpp
+++ b/src/extension/extension.cpp
@@ -369,13 +369,38 @@ void ExtensionUtils::registerIndexType(main::Database& database, storage::IndexT
     database.getStorageManager()->registerIndexType(std::move(type));
 }
 
+#ifdef _WIN32
+// Windows reports a dependency it cannot find as ERROR_MOD_NOT_FOUND against the library we asked
+// for, so the message names the extension while the file actually missing is something the
+// extension links against. Say so, rather than leaving users to guess which module is meant.
+static std::string dlMissingDependencyHint(const std::string& path) {
+    // Capture the code before touching the filesystem, which would overwrite it -- the caller still
+    // needs GetLastError() intact for dlErrMessage().
+    const auto errorCode = GetLastError();
+    const auto extensionExists = std::filesystem::exists(path);
+    SetLastError(errorCode);
+    if (errorCode != ERROR_MOD_NOT_FOUND || !extensionExists) {
+        return "";
+    }
+    return "\nThe extension itself was found, so a library it depends on is the one that could not "
+           "be located. Extensions link against OpenSSL 3 (libssl-3-x64.dll and "
+           "libcrypto-3-x64.dll), which is not distributed with them.";
+}
+#else
+static std::string dlMissingDependencyHint(const std::string&) {
+    return "";
+}
+#endif
+
 ExtensionLibLoader::ExtensionLibLoader(const std::string& extensionName, const std::string& path)
     : extensionName{extensionName} {
     libHdl = dlopen(path.c_str(), RTLD_NOW | RTLD_LOCAL);
     if (libHdl == nullptr) {
+        // Read before dlErrMessage(), which is also driven by GetLastError().
+        const auto hint = dlMissingDependencyHint(path);
         throw common::IOException(
-            std::format("Failed to load library: {} which is needed by extension: {}.\nError: {}.",
-                path, extensionName, common::dlErrMessage()));
+            std::format("Failed to load library: {} which is needed by extension: {}.\nError: {}.{}",
+                path, extensionName, common::dlErrMessage(), hint));
     }
 }
 

--- a/src/extension/extension.cpp
+++ b/src/extension/extension.cpp
@@ -398,9 +398,9 @@ ExtensionLibLoader::ExtensionLibLoader(const std::string& extensionName, const s
     if (libHdl == nullptr) {
         // Read before dlErrMessage(), which is also driven by GetLastError().
         const auto hint = dlMissingDependencyHint(path);
-        throw common::IOException(
-            std::format("Failed to load library: {} which is needed by extension: {}.\nError: {}.{}",
-                path, extensionName, common::dlErrMessage(), hint));
+        throw common::IOException(std::format(
+            "Failed to load library: {} which is needed by extension: {}.\nError: {}.{}", path,
+            extensionName, common::dlErrMessage(), hint));
     }
 }
 


### PR DESCRIPTION
Windows reports a missing transitive dependency as `ERROR_MOD_NOT_FOUND` against the library passed to `LoadLibraryW`, so `LOAD EXTENSION fts` on a machine without OpenSSL 3 fails with "the specified module could not be found" — naming the extension, which is present. Users are left guessing which module is actually meant (#685).

When the extension file itself exists, this adds a line saying the missing module is something the extension links against, and names the OpenSSL 3 DLLs.

**Scope:** this only improves the message. It does not fix #685 — @adsharma confirmed the core links OpenSSL dynamically, which means the core has already loaded `libssl-3-x64.dll` before any extension loads, so the fix for the underlying packaging problem belongs elsewhere.

**Testing:** compiles clean on MSVC 14.44 (VS 2022 Build Tools, Windows SDK 10.0.26100), full static Release build links. I could not exercise the message at runtime — `lbug_shell.exe` built here crashes with `0xC0000409` on database open, which I confirmed is pre-existing by reproducing it with this change reverted.