### PR TITLE
Fix labels()/label() returning _nodes/_edges on ANY graphs

### DIFF
--- a/src/binder/bind_expression/bind_function_expression.cpp
+++ b/src/binder/bind_expression/bind_function_expression.cpp
@@ -142,7 +142,7 @@ std::shared_ptr<Expression> ExpressionBinder::bindRewriteFunctionExpression(
         entry->ptrCast<FunctionCatalogEntry>());
     auto function = match->constPtrCast<RewriteFunction>();
     DASSERT(function->rewriteFunc != nullptr);
-    auto input = RewriteFunctionBindInput(context, this, children);
+    auto input = RewriteFunctionBindInput(context, this, children, functionName);
     return function->rewriteFunc(input);
 }
 

--- a/src/binder/bind_expression/bind_property_expression.cpp
+++ b/src/binder/bind_expression/bind_property_expression.cpp
@@ -34,8 +34,7 @@ static bool isStructPattern(const Expression& expression) {
            logicalTypeID == LogicalTypeID::STRUCT;
 }
 
-static bool isAnyGraphNodeOrRel(const NodeOrRelExpression& nodeOrRel,
-    main::ClientContext* context) {
+bool isAnyGraphNodeOrRel(const NodeOrRelExpression& nodeOrRel, main::ClientContext* context) {
     auto transaction = transaction::Transaction::Get(*context);
     auto useInternal = context->useInternalCatalogEntry();
     auto dbManager = main::DatabaseManager::Get(*context);

--- a/src/function/pattern/label_function.cpp
+++ b/src/function/pattern/label_function.cpp
@@ -7,6 +7,7 @@
 #include "catalog/catalog_entry/table_catalog_entry.h"
 #include "function/binary_function_executor.h"
 #include "function/list/functions/list_extract_function.h"
+#include "function/list/vector_list_functions.h"
 #include "function/rewrite_function.h"
 #include "function/scalar_function.h"
 #include "function/schema/vector_node_rel_functions.h"
@@ -102,6 +103,22 @@ std::shared_ptr<Expression> LabelFunction::rewriteFunc(const RewriteFunctionBind
             if (node.isEmpty()) {
                 return expressionBinder->createLiteralExpression("");
             }
+            // ANY graph: the node's single catalog entry is the internal `_nodes` table, whose
+            // name is not the user's label. Read the per-row `label` STRING[] column instead
+            // (the same column `n.*` exposes). functionName is empty on the precompute path,
+            // which preserves legacy behavior; only query-level label()/labels() get here.
+            if (!input.functionName.empty() && isAnyGraphNodeOrRel(node, input.context) &&
+                node.hasPropertyExpression("label")) {
+                auto labelProp = node.getPropertyExpression("label");
+                if (input.functionName == LabelsFunction::name) {
+                    return labelProp->copy(); // labels(n) -> STRING[]
+                }
+                // label(n) -> labels(n)[0] (list_extract is 1-based)
+                return expressionBinder->bindScalarFunctionExpression(
+                    expression_vector{labelProp,
+                        expressionBinder->createLiteralExpression(Value((int64_t)1))},
+                    ListExtractFunction::name);
+            }
             if (!node.isMultiLabeled()) {
                 auto label = node.getEntry(0)->getName();
                 return expressionBinder->createLiteralExpression(label);
@@ -115,6 +132,18 @@ std::shared_ptr<Expression> LabelFunction::rewriteFunc(const RewriteFunctionBind
         if (!disableLiteralRewrite) {
             if (rel.isEmpty()) {
                 return expressionBinder->createLiteralExpression("");
+            }
+            // ANY graph: the rel is backed by the internal `_edges` table, whose `label` is a
+            // scalar STRING (a rel has one type). label(e) returns it directly; labels(e) wraps
+            // it into a 1-element list for parity with node labels().
+            if (!input.functionName.empty() && isAnyGraphNodeOrRel(rel, input.context) &&
+                rel.hasPropertyExpression("label")) {
+                auto labelProp = rel.getPropertyExpression("label");
+                if (input.functionName == LabelsFunction::name) {
+                    return expressionBinder->bindScalarFunctionExpression(
+                        expression_vector{labelProp}, ListCreationFunction::name);
+                }
+                return labelProp->copy(); // label(e) -> scalar STRING
             }
             if (!rel.isMultiLabeled()) {
                 auto label = rel.getEntry(0)->getName();

--- a/src/include/binder/expression/node_rel_expression.h
+++ b/src/include/binder/expression/node_rel_expression.h
@@ -10,6 +10,9 @@ namespace lbug {
 namespace catalog {
 class TableCatalogEntry;
 }
+namespace main {
+class ClientContext;
+}
 namespace binder {
 
 class LBUG_API NodeOrRelExpression : public Expression {
@@ -109,6 +112,9 @@ protected:
     // Original labels from the node/rel pattern (for ANY graphs)
     std::vector<std::string> originalLabels;
 };
+
+// True when the node/rel is backed by an ANY graph's internal `_nodes`/`_edges` table.
+bool isAnyGraphNodeOrRel(const NodeOrRelExpression& nodeOrRel, main::ClientContext* context);
 
 } // namespace binder
 } // namespace lbug

--- a/src/include/function/rewrite_function.h
+++ b/src/include/function/rewrite_function.h
@@ -12,10 +12,16 @@ struct RewriteFunctionBindInput {
     main::ClientContext* context;
     binder::ExpressionBinder* expressionBinder;
     binder::expression_vector arguments;
+    // The as-invoked, normalized (upper-case) function name, e.g. "LABEL" vs "LABELS".
+    // Empty when a rewrite is precomputed directly (bypassing the binder); callers use the
+    // empty form to request the legacy/full-list behavior.
+    std::string functionName;
 
     RewriteFunctionBindInput(main::ClientContext* context,
-        binder::ExpressionBinder* expressionBinder, binder::expression_vector arguments)
-        : context{context}, expressionBinder{expressionBinder}, arguments{std::move(arguments)} {}
+        binder::ExpressionBinder* expressionBinder, binder::expression_vector arguments,
+        std::string functionName = "")
+        : context{context}, expressionBinder{expressionBinder}, arguments{std::move(arguments)},
+          functionName{std::move(functionName)} {}
 };
 
 // Rewrite function to a different expression, e.g. id(n) -> n._id.

--- a/test/test_files/graph/any.test
+++ b/test/test_files/graph/any.test
@@ -125,3 +125,40 @@ Binder exception: Create node a with multiple node labels is not supported.
 ---- ok
 -STATEMENT DROP TABLE Person
 ---- ok
+
+-CASE AnyGraphLabelsFunctions
+-SKIP_FSM_LEAK_CHECK
+
+-LOG CreateAnyGraph
+-STATEMENT CREATE GRAPH g ANY
+---- ok
+-STATEMENT USE GRAPH g
+---- ok
+-STATEMENT CREATE (:Person:Employee {name: 'Alice'})-[:WorksAt {since: 2020}]->(:Org {name: 'Acme'})
+---- ok
+
+-LOG NodeLabelsReturnsFullList
+-STATEMENT MATCH (n:Person:Employee) RETURN labels(n)
+---- 1
+[Person,Employee]
+
+-LOG NodeLabelSingularReturnsFirst
+-STATEMENT MATCH (n:Person:Employee) RETURN label(n)
+---- 1
+Person
+
+-LOG RelLabelsReturnsList
+-STATEMENT MATCH (:Person)-[e:WorksAt]->(:Org) RETURN labels(e)
+---- 1
+[WorksAt]
+
+-LOG RelLabelSingularReturnsScalar
+-STATEMENT MATCH (:Person)-[e:WorksAt]->(:Org) RETURN label(e)
+---- 1
+WorksAt
+
+-LOG Cleanup
+-STATEMENT USE GRAPH main
+---- ok
+-STATEMENT DROP GRAPH g
+---- ok


### PR DESCRIPTION
## Description

Fixes #708. On an ANY ("open type") graph, `labels(n)`/`label(n)` returned the internal `_nodes` table name (and `label(e)`/`labels(e)` returned `_edges`) instead of the node/rel's actual labels. The data was already correct — `RETURN n.*` returns the real list — only these functions read the wrong source: an ANY node/rel has a single catalog entry (the `_nodes`/`_edges` table), so `isMultiLabeled()` is false and `LabelFunction::rewriteFunc` returned the table name.

Per your guidance on the issue:
- `labels(x)` → the full `STRING[]` list; `label(x)` → `labels(x)[0]` (first label, scalar), not throw.
- Fixed for **both node and rel**.

### Approach
`label()` and `labels()` alias through the same `LabelFunction::rewriteFunc`, and the resolved function name is `"LABEL"` for both — only the catalog-lookup name (`bindRewriteFunctionExpression`, already computed) distinguishes them. I thread that name into `RewriteFunctionBindInput` as a defaulted field so the shared rewrite can branch on singular vs plural. On an ANY graph it returns the per-row `label` column (the same one `n.*` reads) instead of the table name:

- node `label STRING[]`: `labels(n)` → the list; `label(n)` → `list_extract(label, 1)`.
- rel `label STRING` (scalar): `label(e)` → the scalar; `labels(e)` → wrapped into a 1-element list.

The **empty-name default** keeps the two precompute sites (`createQueryNode` / `createNonRecursiveQueryRel`, which materialize the `_LABEL` struct field) on their existing path, so `RETURN n` / `RETURN e` are unchanged, and structured graphs are fully unaffected — the new branch is gated on a non-empty name **plus** `isAnyGraphNodeOrRel(...)`.

### Tests
Added `AnyGraphLabelsFunctions` to `test/test_files/graph/any.test` covering node + rel, singular + plural. Existing `function/label.test` (structured `tinysnb`) and the rest of `graph/any.test` still pass locally (`e2e_test`, RelWithDebInfo).

### Known follow-up (out of scope, flagging so it reads as deliberate)
`RETURN n` / `RETURN e` whole-object materialization still shows `_nodes`/`_edges` in the `_LABEL` position — that struct field is typed `STRING`, and changing it touches scan/materialization. Happy to address separately if you'd like.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] I have changed storage version if on disk format has changed. — N/A, no on-disk format change
- [x] I have requested a review from a maintainer.
- [ ] I have updated the documentation (if needed). — ANY graphs appear undocumented today; happy to add docs in a separate PR.
