### PR TITLE
Fix concurrent INSTALL/LOAD extension race on cold cache

### DIFF
--- a/src/common/file_system/local_file_system.cpp
+++ b/src/common/file_system/local_file_system.cpp
@@ -255,11 +255,6 @@ void LocalFileSystem::copyFile(const std::string& from, const std::string& to) {
 
 void LocalFileSystem::createDir(const std::string& dir) const {
     try {
-        if (std::filesystem::exists(dir)) {
-            // LCOV_EXCL_START
-            throw IOException(std::format("Directory {} already exists.", dir));
-            // LCOV_EXCL_STOP
-        }
         auto directoryToCreate = dir;
         if (directoryToCreate.ends_with('/')
 #if defined(_WIN32)
@@ -272,13 +267,7 @@ void LocalFileSystem::createDir(const std::string& dir) const {
             directoryToCreate = directoryToCreate.substr(0, directoryToCreate.size() - 1);
         }
         std::error_code errCode;
-        if (!std::filesystem::create_directories(directoryToCreate, errCode)) {
-            // LCOV_EXCL_START
-            throw IOException(
-                std::format("Directory {} cannot be created. Check if it exists and remove it.",
-                    directoryToCreate));
-            // LCOV_EXCL_STOP
-        }
+        std::filesystem::create_directories(directoryToCreate, errCode);
         if (errCode) {
             // LCOV_EXCL_START
             throw IOException(std::format("Failed to create directory: {}, error message: {}.", dir,

--- a/src/extension/extension_installer.cpp
+++ b/src/extension/extension_installer.cpp
@@ -1,5 +1,8 @@
 #include "extension/extension_installer.h"
 
+#include <atomic>
+#include <thread>
+
 #include "common/exception/io.h"
 #include "common/file_system/virtual_file_system.h"
 #include "httplib.h"
@@ -62,13 +65,36 @@ void ExtensionInstaller::tryDownloadExtensionFile(const ExtensionRepoInfo& repoI
         }
     }
 
+    // Download to a temp file, then atomically rename into place so that concurrent
+    // readers (e.g. dlopen) never see a truncated or partially-written file.
     auto vfs = common::VirtualFileSystem::GetUnsafe(context);
-    auto fileInfo = vfs->openFile(localFilePath,
+    static std::atomic<uint64_t> tempCounter{0};
+    std::hash<std::thread::id> threadHasher;
+    auto tempPath = localFilePath + ".tmp." +
+                    std::to_string(threadHasher(std::this_thread::get_id())) + "." +
+                    std::to_string(tempCounter.fetch_add(1, std::memory_order_relaxed));
+
+    auto fileInfo = vfs->openFile(tempPath,
         common::FileOpenFlags(common::FileFlags::WRITE | common::FileFlags::READ_ONLY |
                               common::FileFlags::CREATE_AND_TRUNCATE_IF_EXISTS));
-    fileInfo->writeFile(reinterpret_cast<const uint8_t*>(res->body.c_str()), res->body.size(),
-        0 /* offset */);
-    fileInfo->syncFile();
+    try {
+        fileInfo->writeFile(reinterpret_cast<const uint8_t*>(res->body.c_str()), res->body.size(),
+            0 /* offset */);
+        fileInfo->syncFile();
+    } catch (...) {
+        // Clean up the temp file on write failure before rethrowing.
+        fileInfo.reset();
+        vfs->removeFileIfExists(tempPath);
+        throw;
+    }
+    fileInfo.reset(); // Ensure the file handle is closed before rename.
+    try {
+        vfs->renameFile(tempPath, localFilePath);
+    } catch (...) {
+        // Clean up the temp file on rename failure (e.g. cross-filesystem edge case).
+        vfs->removeFileIfExists(tempPath);
+        throw;
+    }
 }
 
 bool ExtensionInstaller::install() {
@@ -99,6 +125,12 @@ bool ExtensionInstaller::installExtension() {
     auto localDirForSharedLib = extension::ExtensionUtils::getLocalPathForSharedLib(&context);
     if (!vfs->fileOrPathExists(localDirForSharedLib)) {
         vfs->createDir(localDirForSharedLib);
+    }
+    // Re-check after creating dirs: another process may have installed it while we
+    // were working.  Without this, both processes would download and rename, wasting
+    // bandwidth (though atomic rename prevents data races in dlopen).
+    if (vfs->fileOrPathExists(localLibFilePath) && !info.forceInstall) {
+        return false;
     }
     auto libFileRepoInfo = extension::ExtensionUtils::getExtensionLibRepoInfo(info.name, info.repo);
 


### PR DESCRIPTION
## Summary

Fixes #710. Makes extension installation process-safe on a cold cache by eliminating three TOCTOU races.

## Races fixed

### 1. `createDir` race
`LocalFileSystem::createDir` did an `exists()` pre-check before calling `create_directories()`, creating a TOCTOU window. Two concurrent callers both passed the check and one threw "Directory already exists".

**Fix**: Removed the `exists()` check. `std::filesystem::create_directories` already returns `false` (without setting `errCode`) when the directory already exists — we only throw on actual filesystem errors (`errCode` set).

### 2. File mutation under `dlopen` (SIGBUS/SIGSEGV)
`tryDownloadExtensionFile` opened the destination with `CREATE_AND_TRUNCATE_IF_EXISTS` and wrote in-place. If another connection had `dlopen`d the same path (across threads or processes), the truncation or partial write caused the dynamic loader to fault on mutated mmap content → **SIGBUS** (truncated past EOF) or **SIGSEGV** (hash-walk over partial content).

**Fix**: Download to a unique temp file (`{path}.tmp.{thread_hash}.{counter}`), then `rename()` into place. POSIX `rename()` is atomic on the same filesystem:
- Readers holding the old inode via `dlopen` keep a consistent view of the old file.
- New opens always see the complete new file.

Temp files are cleaned up on both write failure and rename failure.

### 3. Wasted download race
Two processes both passed the `fileOrPathExists` check before the first finished writing. Added a re-check after the dir-creation section so the second process skips the download.

## Testing
- All 4 extension tests pass (`extension~extension.*`)
- All 13 graph tests pass (including `AnyGraphLabelsFunctions`)
- `createDir` change passes all existing tests (pre-existing failures in `copy_to_csv`, `copy_to_parquet`, `copy_to_big_results` also fail on `main`)
- Build clean (lbug_extension, lbug_file_system)