### PR TITLE
ANY graph: surface real labels in _LABEL for RETURN n / RETURN e

### DIFF
--- a/src/binder/bind/bind_graph_pattern.cpp
+++ b/src/binder/bind/bind_graph_pattern.cpp
@@ -311,8 +311,15 @@ std::shared_ptr<RelExpression> Binder::createNonRecursiveQueryRel(const std::str
         queryRel->setDirectionExpr(expressionBinder.createVariableExpression(LogicalType::BOOL(),
             queryRel->getUniqueName() + InternalKeyword::DIRECTION));
     }
-    auto input = function::RewriteFunctionBindInput(clientContext, &expressionBinder, {queryRel});
-    queryRel->setLabelExpression(function::LabelFunction::rewriteFunc(input));
+    // In an ANY graph a rel's type is stored in the scalar `label` STRING column, so surface
+    // that as _LABEL instead of the internal `_edges` table name (type stays STRING).
+    if (isAnyGraphNodeOrRel(*queryRel, clientContext) && queryRel->hasPropertyExpression("label")) {
+        queryRel->setLabelExpression(queryRel->getPropertyExpression("label"));
+    } else {
+        auto input =
+            function::RewriteFunctionBindInput(clientContext, &expressionBinder, {queryRel});
+        queryRel->setLabelExpression(function::LabelFunction::rewriteFunc(input));
+    }
     // Store original labels for ANY graphs
     if (!originalLabels.empty()) {
         queryRel->setOriginalLabels(originalLabels);
@@ -647,8 +654,24 @@ std::shared_ptr<NodeExpression> Binder::createQueryNode(const std::string& parse
     // Bind internal expressions
     queryNode->setInternalID(
         construct(LogicalType::INTERNAL_ID(), InternalKeyword::ID, *queryNode));
-    auto input = function::RewriteFunctionBindInput(clientContext, &expressionBinder, {queryNode});
-    queryNode->setLabelExpression(function::LabelFunction::rewriteFunc(input));
+    // In an ANY graph a node carries a *set* of labels, stored in the `label` STRING[] column.
+    // Surface that column as _LABEL (typed STRING[]) rather than the internal `_nodes` table
+    // name. Structured graphs keep the single-label STRING form via the rewrite.
+    if (isAnyGraphNodeOrRel(*queryNode, clientContext) &&
+        queryNode->hasPropertyExpression("label")) {
+        std::vector<StructField> fields;
+        fields.emplace_back(InternalKeyword::ID, LogicalType::INTERNAL_ID());
+        fields.emplace_back(InternalKeyword::LABEL, LogicalType::LIST(LogicalType::STRING()));
+        for (auto& property : propertyExpressions) {
+            fields.emplace_back(property->getPropertyName(), property->getDataType().copy());
+        }
+        queryNode->setDataType(LogicalType::NODE(std::move(fields)));
+        queryNode->setLabelExpression(queryNode->getPropertyExpression("label"));
+    } else {
+        auto input =
+            function::RewriteFunctionBindInput(clientContext, &expressionBinder, {queryNode});
+        queryNode->setLabelExpression(function::LabelFunction::rewriteFunc(input));
+    }
     return queryNode;
 }
 

--- a/test/test_files/graph/any.test
+++ b/test/test_files/graph/any.test
@@ -162,3 +162,30 @@ WorksAt
 ---- ok
 -STATEMENT DROP GRAPH g
 ---- ok
+
+-CASE AnyGraphWholeObjectLabel
+-SKIP_FSM_LEAK_CHECK
+
+-LOG CreateAnyGraph
+-STATEMENT CREATE GRAPH g ANY
+---- ok
+-STATEMENT USE GRAPH g
+---- ok
+-STATEMENT CREATE (:Person:Employee {name: 'Alice'})-[:WorksAt {since: 2020}]->(:Org {name: 'Acme'})
+---- ok
+
+-LOG WholeNodeLabelIsRealLabelSet
+-STATEMENT MATCH (n:Person:Employee) RETURN n
+---- 1
+{_ID: 0:0, _LABEL: [Person,Employee], id: 0, label: [Person,Employee], data: {"name":"Alice"}}
+
+-LOG WholeRelLabelIsRealType
+-STATEMENT MATCH ()-[e:WorksAt]->() RETURN e
+---- 1
+(0:0)-{_LABEL: WorksAt, _id: 1:0, label: WorksAt, data: {"since":2020}}->(0:1)
+
+-LOG Cleanup
+-STATEMENT USE GRAPH main
+---- ok
+-STATEMENT DROP GRAPH g
+---- ok


### PR DESCRIPTION
## Description

Part of #712 — implements **Option A** (the direction you confirmed). On an ANY graph, whole-object `RETURN n` / `RETURN e` now surface the node's real label *set* / the rel's real type in `_LABEL`, instead of the internal `_nodes` / `_edges` table name.

Before → after:
```
RETURN n :  {_ID:…, _LABEL: '_nodes',  …}   ->   {_ID:…, _LABEL: ['Person','Employee'], …}
RETURN e :  {… _LABEL: '_edges',  …}         ->   {… _LABEL: 'WorksAt', …}
```

### Approach
`_LABEL`'s value/type comes from the precompute-path `LabelFunction::rewriteFunc`, which returns the table name on ANY graphs. In `createQueryNode` / `createNonRecursiveQueryRel`, when the node/rel is ANY (reusing `isAnyGraphNodeOrRel` from #709), I point `_LABEL` at the per-row `label` column instead of the table name:

- **nodes**: a node carries a *set* of labels, so `_LABEL` is promoted to `STRING[]` (matching the `label` column type).
- **rels**: a rel has a single type, so `_LABEL` stays scalar `STRING`.

Structured graphs are untouched — the change is gated on ANY detection, and the else-branch is the original rewrite.

### Scope — and the North Star follow-on
This is **Option A only**: `_LABEL` is now correct. The internal `id` / `label` / `data` columns still appear in whole-object output. Hiding those and surfacing the user's real properties as top-level fields — so ANY output is *identical to a strongly typed subgraph* (your second comment) — is the larger follow-on. I'd like to take that on next; flagging it here so this PR reads as a deliberate first step rather than a partial one.

### Tests
Added `AnyGraphWholeObjectLabel` to `test/test_files/graph/any.test` asserting `RETURN n` / `RETURN e` `_LABEL`. The full e2e suite is green locally; structured-graph label tests are unaffected.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] I have changed storage version if on disk format has changed. — N/A, no on-disk format change
- [x] I have requested a review from a maintainer.
- [ ] I have updated the documentation (if needed). — ANY graphs still undocumented; separate docs PR.
