### PR TITLE
fix: default throwOnWalReplayFailure to false so torn WAL tails don't refuse the database

### DIFF
--- a/src/include/main/database.h
+++ b/src/include/main/database.h
@@ -65,6 +65,8 @@ struct LBUG_API SystemConfig {
      * @param throwOnWalReplayFailure If true, any WAL replaying failure when loading the database
      * will throw an error. Otherwise, Lbug will silently ignore the failure and replay up to where
      * the error occured.
+     * Default is false: on a torn tail (e.g. after a crash), the database opens with all data
+     * up to the last checkpoint, discarding only the unreplayable tail.
      * @param enableChecksums If true, the database will use checksums to detect corruption in the
      * WAL file.
      * @param enableMultiWrites If true, multiple concurrent write transactions are allowed.
@@ -75,7 +77,7 @@ struct LBUG_API SystemConfig {
     explicit SystemConfig(uint64_t bufferPoolSize = -1u, uint64_t maxNumThreads = 0,
         bool enableCompression = true, bool readOnly = false, uint64_t maxDBSize = -1u,
         bool autoCheckpoint = true, uint64_t checkpointThreshold = 16777216 /* 16MB */,
-        bool forceCheckpointOnClose = true, bool throwOnWalReplayFailure = true,
+        bool forceCheckpointOnClose = true, bool throwOnWalReplayFailure = false,
         bool enableChecksums = true, bool enableMultiWrites = false,
         bool enableDefaultHashIndex = true
 #if defined(__APPLE__)

--- a/src/storage/wal/wal_replayer.cpp
+++ b/src/storage/wal/wal_replayer.cpp
@@ -1,5 +1,7 @@
 #include "storage/wal/wal_replayer.h"
 
+#include <string>
+
 #include "common/exception/io.h"
 #include "common/exception/runtime.h"
 #include "common/file_system/file_info.h"
@@ -330,12 +332,23 @@ void WALReplayer::replayWALRecord(WALRecord& walRecord) const {
         replayLoadExtensionRecord(walRecord);
     } break;
     case WALRecordType::CHECKPOINT_RECORD: {
-        // This record should not be replayed. It is only used to indicate that the previous records
-        // had been replayed and shadow files are created.
-        UNREACHABLE_CODE;
+        // This record should not be replayed during individual record replay.
+        // CHECKPOINT records are handled by the frozen/active WAL recovery path
+        // that replays shadow pages as a batch. If we reach here, the WAL file has
+        // been corrupted (or checksums are disabled and a torn write happened to
+        // produce type byte 254). Throw a descriptive error instead of asserting
+        // so that the database can still be opened with throwOnWalReplayFailure=false.
+        throw common::RuntimeException(std::format(
+            "WAL replay encountered a CHECKPOINT record outside the expected recovery "
+            "path. This is caused by a corrupted WAL tail. "
+            "Set throwOnWalReplayFailure=false to discard the tail and open the database."));
     }
     default:
-        UNREACHABLE_CODE;
+        throw common::RuntimeException(std::format(
+            "WAL replay encountered an unknown record type ({}). "
+            "The WAL file is corrupted. "
+            "Set throwOnWalReplayFailure=false to discard the tail and open the database.",
+            static_cast<int>(walRecord.type)));
     }
 }
 


### PR DESCRIPTION
Fixes #714

## Problem

When the WAL contains any single record larger than ~2 KB and the process is hard-terminated (crash, kill, power loss) before the next checkpoint, the WAL is unreplayable on next open: recovery fails and the engine **refuses to open the database file entirely** — including all data folded into the main file long before the death.

Two distinct defects:
1. **Recovery converts a torn journal tail into total loss** — the correct worst outcome is "discard the unreplayable tail, open with everything up to the last checkpoint".
2. **`UNREACHABLE_CODE` assertion in `replayWALRecord`** — on one production corpse, recovery hit an internal assertion during startup replay. If corrupted data (without checksums) happens to decode as `CHECKPOINT_RECORD` or an unknown type, `UNREACHABLE_CODE` crashes the process.

## Root Cause

`throwOnWalReplayFailure` defaulted to `true`. A journal's purpose is surviving dirty deaths — a torn tail after hard termination is its design-basis event, not an edge case. Losing the torn tail is expected; losing the entire database is not.

The existing test suite already documents the correct behavior: `WalTest::SetUp()` explicitly sets `throwOnWalReplayFailure = false` before every test, and tests that want strict validation explicitly opt in with `throwOnWalReplayFailure = true`.

## Changes

1. **`src/include/main/database.h`** — Changed default `throwOnWalReplayFailure` from `true` to `false`.

2. **`src/storage/wal/wal_replayer.cpp`** — Replaced `UNREACHABLE_CODE` assertions in `replayWALRecord` with descriptive `RuntimeException` throws that include recovery guidance.

## Testing

- All 27 previously-passing WAL tests continue to pass (verified before and after the change).
- 2 tests (`WalTest.WALFileLeftoverFromPreviousDBNewDBCOPYWithoutCheckpoint` and `...ReadOnly`) are **pre-existing failures** — confirmed identical before and after the change. They fail on an `ASSERT_FALSE` checking WAL file existence after close, unrelated to this fix.
- Full release build compiles cleanly (no new warnings).