### PR TITLE
Hide ANY graph internal columns from whole-object output

### DIFF
--- a/src/binder/bind/bind_graph_pattern.cpp
+++ b/src/binder/bind/bind_graph_pattern.cpp
@@ -282,22 +282,22 @@ std::shared_ptr<RelExpression> Binder::createNonRecursiveQueryRel(const std::str
     std::shared_ptr<NodeExpression> dstNode, RelDirectionType directionType,
     const std::vector<std::string>& originalLabels) {
     auto uniqueName = getUniqueExpressionName(parsedName);
-    // Bind properties
+    // Bind properties. As with createQueryNode, defer the struct type until we know whether this
+    // is an ANY graph, so start from the base fields and set the full struct type afterwards.
     auto structFields = getBaseRelStructFields();
     std::vector<std::shared_ptr<PropertyExpression>> propertyExpressions;
-    if (entries.empty()) {
-        structFields.emplace_back(InternalKeyword::ID, LogicalType::INTERNAL_ID());
-    } else {
+    if (!entries.empty()) {
         for (auto& propertyName : getPropertyNames(entries)) {
-            auto property = createPropertyExpression(propertyName, uniqueName, parsedName, entries);
-            structFields.emplace_back(property->getPropertyName(), property->getDataType().copy());
-            propertyExpressions.push_back(std::move(property));
+            propertyExpressions.push_back(
+                createPropertyExpression(propertyName, uniqueName, parsedName, entries));
         }
     }
-    auto queryRel = std::make_shared<RelExpression>(LogicalType::REL(std::move(structFields)),
+    auto queryRel = std::make_shared<RelExpression>(LogicalType::REL(getBaseRelStructFields()),
         uniqueName, parsedName, entries, std::move(srcNode), std::move(dstNode), directionType,
         QueryRelType::NON_RECURSIVE);
     queryRel->setAlias(parsedName);
+    // Keep every property bound (the insert path looks columns up by name); internal columns are
+    // hidden from projection below, not dropped here.
     if (entries.empty()) {
         queryRel->addPropertyExpression(
             construct(LogicalType::INTERNAL_ID(), InternalKeyword::ID, *queryRel));
@@ -306,14 +306,25 @@ std::shared_ptr<RelExpression> Binder::createNonRecursiveQueryRel(const std::str
             queryRel->addPropertyExpression(property);
         }
     }
+    // In an ANY graph, rels are backed by the internal `_edges` table whose `label` column is
+    // surfaced as _LABEL (see DatabaseManager::createGraph). Hide the redundant `label` column
+    // from whole-object (`RETURN e`) and `.*` output, keeping `_id` and the `data` property bag.
+    const bool isAny = !entries.empty() && isAnyGraphNodeOrRel(*queryRel, clientContext);
+    if (isAny) {
+        queryRel->setHiddenPropertyNames({"label"});
+    }
+    for (auto& property : queryRel->getProjectedPropertyExpressions()) {
+        structFields.emplace_back(property->getPropertyName(), property->getDataType().copy());
+    }
+    queryRel->setDataType(LogicalType::REL(std::move(structFields)));
     // Bind internal expressions.
     if (directionType == RelDirectionType::BOTH) {
         queryRel->setDirectionExpr(expressionBinder.createVariableExpression(LogicalType::BOOL(),
             queryRel->getUniqueName() + InternalKeyword::DIRECTION));
     }
-    // In an ANY graph a rel's type is stored in the scalar `label` STRING column, so surface
-    // that as _LABEL instead of the internal `_edges` table name (type stays STRING).
-    if (isAnyGraphNodeOrRel(*queryRel, clientContext) && queryRel->hasPropertyExpression("label")) {
+    // In an ANY graph a rel's type is stored in the scalar `label` STRING column (kept above),
+    // so surface it as _LABEL instead of the internal `_edges` table name (type stays STRING).
+    if (isAny && queryRel->hasPropertyExpression("label")) {
         queryRel->setLabelExpression(queryRel->getPropertyExpression("label"));
     } else {
         auto input =
@@ -630,17 +641,19 @@ std::shared_ptr<NodeExpression> Binder::createQueryNode(const std::string& parse
     const std::unordered_map<TableCatalogEntry*, std::string>& dbNames,
     const std::vector<std::string>& originalLabels) {
     auto uniqueName = getUniqueExpressionName(parsedName);
-    // Bind properties.
-    auto structFields = getBaseNodeStructFields();
+    // Bind properties. The struct type is finalized below, once we know whether this is an ANY
+    // graph (whose internal columns are hidden from projection), so start the node from just the
+    // base fields and set the full struct type afterwards.
     std::vector<std::shared_ptr<PropertyExpression>> propertyExpressions;
     for (auto& propertyName : getPropertyNames(entries)) {
-        auto property = createPropertyExpression(propertyName, uniqueName, parsedName, entries);
-        structFields.emplace_back(property->getPropertyName(), property->getDataType().copy());
-        propertyExpressions.push_back(std::move(property));
+        propertyExpressions.push_back(
+            createPropertyExpression(propertyName, uniqueName, parsedName, entries));
     }
-    auto queryNode = std::make_shared<NodeExpression>(LogicalType::NODE(std::move(structFields)),
+    auto queryNode = std::make_shared<NodeExpression>(LogicalType::NODE(getBaseNodeStructFields()),
         uniqueName, parsedName, entries);
     queryNode->setAlias(parsedName);
+    // Keep every property bound: the insert path and explicit `n.prop` access rely on the full
+    // set. Internal columns are hidden from projection (below), not dropped here.
     for (auto& property : propertyExpressions) {
         queryNode->addPropertyExpression(property);
     }
@@ -654,18 +667,24 @@ std::shared_ptr<NodeExpression> Binder::createQueryNode(const std::string& parse
     // Bind internal expressions
     queryNode->setInternalID(
         construct(LogicalType::INTERNAL_ID(), InternalKeyword::ID, *queryNode));
-    // In an ANY graph a node carries a *set* of labels, stored in the `label` STRING[] column.
-    // Surface that column as _LABEL (typed STRING[]) rather than the internal `_nodes` table
-    // name. Structured graphs keep the single-label STRING form via the rewrite.
-    if (isAnyGraphNodeOrRel(*queryNode, clientContext) &&
-        queryNode->hasPropertyExpression("label")) {
-        std::vector<StructField> fields;
-        fields.emplace_back(InternalKeyword::ID, LogicalType::INTERNAL_ID());
-        fields.emplace_back(InternalKeyword::LABEL, LogicalType::LIST(LogicalType::STRING()));
-        for (auto& property : propertyExpressions) {
-            fields.emplace_back(property->getPropertyName(), property->getDataType().copy());
-        }
-        queryNode->setDataType(LogicalType::NODE(std::move(fields)));
+    // In an ANY graph, nodes are backed by the internal `_nodes` table whose `id`/`label`/`data`
+    // columns are implementation detail (see DatabaseManager::createGraph): `id` duplicates _ID,
+    // `label` is surfaced as _LABEL (a label *set*, so STRING[]), and `data` is the JSON property
+    // bag. Hide `id`/`label` from whole-object (`RETURN n`) and `.*` output, keeping the real
+    // user-facing column(s). Structured graphs keep every column and the scalar-STRING _LABEL.
+    const bool isAny = isAnyGraphNodeOrRel(*queryNode, clientContext);
+    if (isAny) {
+        queryNode->setHiddenPropertyNames({"id", "label"});
+    }
+    std::vector<StructField> structFields;
+    structFields.emplace_back(InternalKeyword::ID, LogicalType::INTERNAL_ID());
+    structFields.emplace_back(InternalKeyword::LABEL,
+        isAny ? LogicalType::LIST(LogicalType::STRING()) : LogicalType::STRING());
+    for (auto& property : queryNode->getProjectedPropertyExpressions()) {
+        structFields.emplace_back(property->getPropertyName(), property->getDataType().copy());
+    }
+    queryNode->setDataType(LogicalType::NODE(std::move(structFields)));
+    if (isAny && queryNode->hasPropertyExpression("label")) {
         queryNode->setLabelExpression(queryNode->getPropertyExpression("label"));
     } else {
         auto input =

--- a/src/binder/bind/bind_graph_pattern.cpp
+++ b/src/binder/bind/bind_graph_pattern.cpp
@@ -261,6 +261,28 @@ static std::vector<StructField> getBaseRelStructFields() {
     return fields;
 }
 
+// Full node/rel struct type: the base fields followed by the properties surfaced in whole-object
+// (`RETURN n`) and `.*` output. Properties hidden from projection are excluded here so the struct
+// fields stay aligned with the child expressions built in ExpressionMapper.
+static std::vector<StructField> getNodeStructFields(const NodeExpression& node,
+    LogicalType labelType) {
+    std::vector<StructField> fields;
+    fields.emplace_back(InternalKeyword::ID, LogicalType::INTERNAL_ID());
+    fields.emplace_back(InternalKeyword::LABEL, std::move(labelType));
+    for (auto& property : node.getProjectedPropertyExpressions()) {
+        fields.emplace_back(property->getPropertyName(), property->getDataType().copy());
+    }
+    return fields;
+}
+
+static std::vector<StructField> getRelStructFields(const RelExpression& rel) {
+    auto fields = getBaseRelStructFields();
+    for (auto& property : rel.getProjectedPropertyExpressions()) {
+        fields.emplace_back(property->getPropertyName(), property->getDataType().copy());
+    }
+    return fields;
+}
+
 static std::shared_ptr<PropertyExpression> construct(LogicalType type,
     const std::string& propertyName, const Expression& child) {
     DASSERT(child.expressionType == ExpressionType::PATTERN);
@@ -284,7 +306,6 @@ std::shared_ptr<RelExpression> Binder::createNonRecursiveQueryRel(const std::str
     auto uniqueName = getUniqueExpressionName(parsedName);
     // Bind properties. As with createQueryNode, defer the struct type until we know whether this
     // is an ANY graph, so start from the base fields and set the full struct type afterwards.
-    auto structFields = getBaseRelStructFields();
     std::vector<std::shared_ptr<PropertyExpression>> propertyExpressions;
     if (!entries.empty()) {
         for (auto& propertyName : getPropertyNames(entries)) {
@@ -306,27 +327,23 @@ std::shared_ptr<RelExpression> Binder::createNonRecursiveQueryRel(const std::str
             queryRel->addPropertyExpression(property);
         }
     }
-    // In an ANY graph, rels are backed by the internal `_edges` table whose `label` column is
-    // surfaced as _LABEL (see DatabaseManager::createGraph). Hide the redundant `label` column
-    // from whole-object (`RETURN e`) and `.*` output, keeping `_id` and the `data` property bag.
-    const bool isAny = !entries.empty() && isAnyGraphNodeOrRel(*queryRel, clientContext);
-    if (isAny) {
-        queryRel->setHiddenPropertyNames({"label"});
-    }
-    for (auto& property : queryRel->getProjectedPropertyExpressions()) {
-        structFields.emplace_back(property->getPropertyName(), property->getDataType().copy());
-    }
-    queryRel->setDataType(LogicalType::REL(std::move(structFields)));
     // Bind internal expressions.
     if (directionType == RelDirectionType::BOTH) {
         queryRel->setDirectionExpr(expressionBinder.createVariableExpression(LogicalType::BOOL(),
             queryRel->getUniqueName() + InternalKeyword::DIRECTION));
     }
-    // In an ANY graph a rel's type is stored in the scalar `label` STRING column (kept above),
-    // so surface it as _LABEL instead of the internal `_edges` table name (type stays STRING).
-    if (isAny && queryRel->hasPropertyExpression("label")) {
+    if (!entries.empty() && isAnyGraphNodeOrRel(*queryRel, clientContext) &&
+        queryRel->hasPropertyExpression("label")) {
+        // ANY graph. Rels are backed by the internal `_edges` table, whose `label` column is
+        // surfaced as _LABEL (see DatabaseManager::createGraph), so hide the redundant column from
+        // projection. A rel has a single type, so _LABEL stays scalar STRING. `_id` and `data`
+        // (the JSON property bag) stay.
+        queryRel->setHiddenPropertyNames({"label"});
+        queryRel->setDataType(LogicalType::REL(getRelStructFields(*queryRel)));
         queryRel->setLabelExpression(queryRel->getPropertyExpression("label"));
     } else {
+        // Structured graph. Every column is user-facing, and _LABEL is resolved by the rewrite.
+        queryRel->setDataType(LogicalType::REL(getRelStructFields(*queryRel)));
         auto input =
             function::RewriteFunctionBindInput(clientContext, &expressionBinder, {queryRel});
         queryRel->setLabelExpression(function::LabelFunction::rewriteFunc(input));
@@ -667,26 +684,21 @@ std::shared_ptr<NodeExpression> Binder::createQueryNode(const std::string& parse
     // Bind internal expressions
     queryNode->setInternalID(
         construct(LogicalType::INTERNAL_ID(), InternalKeyword::ID, *queryNode));
-    // In an ANY graph, nodes are backed by the internal `_nodes` table whose `id`/`label`/`data`
-    // columns are implementation detail (see DatabaseManager::createGraph): `id` duplicates _ID,
-    // `label` is surfaced as _LABEL (a label *set*, so STRING[]), and `data` is the JSON property
-    // bag. Hide `id`/`label` from whole-object (`RETURN n`) and `.*` output, keeping the real
-    // user-facing column(s). Structured graphs keep every column and the scalar-STRING _LABEL.
-    const bool isAny = isAnyGraphNodeOrRel(*queryNode, clientContext);
-    if (isAny) {
+    if (isAnyGraphNodeOrRel(*queryNode, clientContext) &&
+        queryNode->hasPropertyExpression("label")) {
+        // ANY graph. Nodes are backed by the internal `_nodes` table whose `id`/`label`/`data`
+        // columns are implementation detail (see DatabaseManager::createGraph): `id` duplicates
+        // _ID and `label` is surfaced as _LABEL, so hide both from projection. A node carries a
+        // *set* of labels, hence STRING[]. `data` (the JSON property bag) stays.
         queryNode->setHiddenPropertyNames({"id", "label"});
-    }
-    std::vector<StructField> structFields;
-    structFields.emplace_back(InternalKeyword::ID, LogicalType::INTERNAL_ID());
-    structFields.emplace_back(InternalKeyword::LABEL,
-        isAny ? LogicalType::LIST(LogicalType::STRING()) : LogicalType::STRING());
-    for (auto& property : queryNode->getProjectedPropertyExpressions()) {
-        structFields.emplace_back(property->getPropertyName(), property->getDataType().copy());
-    }
-    queryNode->setDataType(LogicalType::NODE(std::move(structFields)));
-    if (isAny && queryNode->hasPropertyExpression("label")) {
+        queryNode->setDataType(LogicalType::NODE(
+            getNodeStructFields(*queryNode, LogicalType::LIST(LogicalType::STRING()))));
         queryNode->setLabelExpression(queryNode->getPropertyExpression("label"));
     } else {
+        // Structured graph. Every column is user-facing, and _LABEL is the single table name
+        // resolved by the rewrite (scalar STRING).
+        queryNode->setDataType(
+            LogicalType::NODE(getNodeStructFields(*queryNode, LogicalType::STRING())));
         auto input =
             function::RewriteFunctionBindInput(clientContext, &expressionBinder, {queryNode});
         queryNode->setLabelExpression(function::LabelFunction::rewriteFunc(input));

--- a/src/binder/bind/bind_graph_pattern.cpp
+++ b/src/binder/bind/bind_graph_pattern.cpp
@@ -262,8 +262,8 @@ static std::vector<StructField> getBaseRelStructFields() {
 }
 
 // Full node/rel struct type: the base fields followed by the properties surfaced in whole-object
-// (`RETURN n`) and `.*` output. Properties hidden from projection are excluded here so the struct
-// fields stay aligned with the child expressions built in ExpressionMapper.
+// (`RETURN n`) output. Properties hidden from the struct are excluded here so the struct fields
+// stay aligned with the child expressions built in ExpressionMapper.
 static std::vector<StructField> getNodeStructFields(const NodeExpression& node,
     LogicalType labelType) {
     std::vector<StructField> fields;

--- a/src/binder/bind_expression/bind_property_expression.cpp
+++ b/src/binder/bind_expression/bind_property_expression.cpp
@@ -73,9 +73,7 @@ expression_vector ExpressionBinder::bindPropertyStarExpression(
 expression_vector ExpressionBinder::bindNodeOrRelPropertyStarExpression(const Expression& child) {
     expression_vector result;
     auto& nodeOrRel = child.constCast<NodeOrRelExpression>();
-    // Projected properties exclude columns hidden from output (e.g. an ANY graph's internal
-    // `id`/`label`), matching whole-object `RETURN n` behaviour.
-    for (auto& property : nodeOrRel.getProjectedPropertyExpressions()) {
+    for (auto& property : nodeOrRel.getPropertyExpressions()) {
         if (Binder::reservedInPropertyLookup(property->getPropertyName())) {
             continue;
         }

--- a/src/binder/bind_expression/bind_property_expression.cpp
+++ b/src/binder/bind_expression/bind_property_expression.cpp
@@ -73,7 +73,9 @@ expression_vector ExpressionBinder::bindPropertyStarExpression(
 expression_vector ExpressionBinder::bindNodeOrRelPropertyStarExpression(const Expression& child) {
     expression_vector result;
     auto& nodeOrRel = child.constCast<NodeOrRelExpression>();
-    for (auto& property : nodeOrRel.getPropertyExpressions()) {
+    // Projected properties exclude columns hidden from output (e.g. an ANY graph's internal
+    // `id`/`label`), matching whole-object `RETURN n` behaviour.
+    for (auto& property : nodeOrRel.getProjectedPropertyExpressions()) {
         if (Binder::reservedInPropertyLookup(property->getPropertyName())) {
             continue;
         }

--- a/src/include/binder/expression/node_rel_expression.h
+++ b/src/include/binder/expression/node_rel_expression.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <unordered_map>
+#include <unordered_set>
 
 #include "common/case_insensitive_map.h"
 #include "expression.h"
@@ -50,6 +51,24 @@ public:
     }
     std::vector<std::shared_ptr<PropertyExpression>> getPropertyExpressions() const {
         return propertyExprs;
+    }
+    // Property expressions surfaced in whole-object (`RETURN n`) and `.*` output. Equal to
+    // getPropertyExpressions() unless some are hidden (e.g. an ANY graph's internal `id`/`label`
+    // columns), which stay bound for writes and explicit access but are excluded from projection.
+    std::vector<std::shared_ptr<PropertyExpression>> getProjectedPropertyExpressions() const {
+        if (hiddenPropertyNames.empty()) {
+            return propertyExprs;
+        }
+        std::vector<std::shared_ptr<PropertyExpression>> result;
+        for (auto& property : propertyExprs) {
+            if (!hiddenPropertyNames.contains(property->getPropertyName())) {
+                result.push_back(property);
+            }
+        }
+        return result;
+    }
+    void setHiddenPropertyNames(std::unordered_set<std::string> names) {
+        hiddenPropertyNames = std::move(names);
     }
     std::shared_ptr<PropertyExpression> getPropertyExpression(
         const std::string& propertyName) const {
@@ -111,6 +130,8 @@ protected:
     std::unordered_map<catalog::TableCatalogEntry*, std::string> dbNames;
     // Original labels from the node/rel pattern (for ANY graphs)
     std::vector<std::string> originalLabels;
+    // Property names hidden from whole-object / `.*` projection (e.g. ANY internal `id`/`label`).
+    std::unordered_set<std::string> hiddenPropertyNames;
 };
 
 // True when the node/rel is backed by an ANY graph's internal `_nodes`/`_edges` table.

--- a/src/include/binder/expression/node_rel_expression.h
+++ b/src/include/binder/expression/node_rel_expression.h
@@ -52,9 +52,10 @@ public:
     std::vector<std::shared_ptr<PropertyExpression>> getPropertyExpressions() const {
         return propertyExprs;
     }
-    // Property expressions surfaced in whole-object (`RETURN n`) and `.*` output. Equal to
+    // Property expressions surfaced in whole-object (`RETURN n`) output. Equal to
     // getPropertyExpressions() unless some are hidden (e.g. an ANY graph's internal `id`/`label`
-    // columns), which stay bound for writes and explicit access but are excluded from projection.
+    // columns, which the whole-object struct already exposes as _ID/_LABEL). Hidden properties
+    // stay bound for writes, explicit access, and `.*`; only the whole-object struct omits them.
     std::vector<std::shared_ptr<PropertyExpression>> getProjectedPropertyExpressions() const {
         if (hiddenPropertyNames.empty()) {
             return propertyExprs;
@@ -130,7 +131,7 @@ protected:
     std::unordered_map<catalog::TableCatalogEntry*, std::string> dbNames;
     // Original labels from the node/rel pattern (for ANY graphs)
     std::vector<std::string> originalLabels;
-    // Property names hidden from whole-object / `.*` projection (e.g. ANY internal `id`/`label`).
+    // Property names hidden from the whole-object struct (e.g. ANY internal `id`/`label`).
     std::unordered_set<std::string> hiddenPropertyNames;
 };
 

--- a/src/processor/map/expression_mapper.cpp
+++ b/src/processor/map/expression_mapper.cpp
@@ -167,7 +167,9 @@ std::unique_ptr<ExpressionEvaluator> ExpressionMapper::getNodeEvaluator(
     expression_vector children;
     children.push_back(node->getInternalID());
     children.push_back(node->getLabelExpression());
-    for (auto& property : node->getPropertyExpressions()) {
+    // Projected (not full) properties: internal columns hidden from output must stay out of the
+    // whole-object struct's children to keep them aligned with its (also-filtered) field list.
+    for (auto& property : node->getProjectedPropertyExpressions()) {
         children.push_back(property);
     }
     auto childrenEvaluators = getEvaluators(children);
@@ -182,7 +184,7 @@ std::unique_ptr<ExpressionEvaluator> ExpressionMapper::getRelEvaluator(
     children.push_back(rel->getSrcNode()->getInternalID());
     children.push_back(rel->getDstNode()->getInternalID());
     children.push_back(rel->getLabelExpression());
-    for (auto& property : rel->getPropertyExpressions()) {
+    for (auto& property : rel->getProjectedPropertyExpressions()) {
         children.push_back(property);
     }
     auto childrenEvaluators = getEvaluators(children);

--- a/test/test_files/graph/any.test
+++ b/test/test_files/graph/any.test
@@ -25,8 +25,8 @@
 -LOG QueryAllNodes
 -STATEMENT MATCH (a) RETURN a.*
 ---- 2
-0|[User]|{"age":30,"name":"Alice"}
-1|[City]|{"population":8000000,"name":"New York"}
+{"age":30,"name":"Alice"}
+{"population":8000000,"name":"New York"}
 
 -LOG QueryDynamicProperties
 -STATEMENT MATCH (u:User)-[:LivesIn]->(c:City) RETURN u.name, c.name
@@ -46,7 +46,7 @@ Alice|30
 -LOG QueryDynamicNodePropertyInWhereFilter
 -STATEMENT MATCH (u:User) WHERE u.age = 30 RETURN u.*
 ---- 1
-0|[User]|{"age":30,"name":"Alice"}
+{"age":30,"name":"Alice"}
 
 -LOG QueryDynamicStringNodePropertyInWhereFilter
 -STATEMENT MATCH (u:User) WHERE u.name = 'Alice' RETURN u.name, u.age
@@ -98,7 +98,7 @@ Alice|30
 -LOG MatchConjunctiveLabelsReturnNodeStar
 -STATEMENT MATCH (n:Person:Employee) RETURN n.*
 ---- 1
-0|[Person,Employee]|{"name":"Alice"}
+{"name":"Alice"}
 
 -LOG Cleanup
 -STATEMENT USE GRAPH main
@@ -177,12 +177,12 @@ WorksAt
 -LOG WholeNodeLabelIsRealLabelSet
 -STATEMENT MATCH (n:Person:Employee) RETURN n
 ---- 1
-{_ID: 0:0, _LABEL: [Person,Employee], id: 0, label: [Person,Employee], data: {"name":"Alice"}}
+{_ID: 0:0, _LABEL: [Person,Employee], data: {"name":"Alice"}}
 
 -LOG WholeRelLabelIsRealType
 -STATEMENT MATCH ()-[e:WorksAt]->() RETURN e
 ---- 1
-(0:0)-{_LABEL: WorksAt, _id: 1:0, label: WorksAt, data: {"since":2020}}->(0:1)
+(0:0)-{_LABEL: WorksAt, _id: 1:0, data: {"since":2020}}->(0:1)
 
 -LOG Cleanup
 -STATEMENT USE GRAPH main

--- a/test/test_files/graph/any.test
+++ b/test/test_files/graph/any.test
@@ -25,8 +25,8 @@
 -LOG QueryAllNodes
 -STATEMENT MATCH (a) RETURN a.*
 ---- 2
-{"age":30,"name":"Alice"}
-{"population":8000000,"name":"New York"}
+0|[User]|{"age":30,"name":"Alice"}
+1|[City]|{"population":8000000,"name":"New York"}
 
 -LOG QueryDynamicProperties
 -STATEMENT MATCH (u:User)-[:LivesIn]->(c:City) RETURN u.name, c.name
@@ -46,7 +46,7 @@ Alice|30
 -LOG QueryDynamicNodePropertyInWhereFilter
 -STATEMENT MATCH (u:User) WHERE u.age = 30 RETURN u.*
 ---- 1
-{"age":30,"name":"Alice"}
+0|[User]|{"age":30,"name":"Alice"}
 
 -LOG QueryDynamicStringNodePropertyInWhereFilter
 -STATEMENT MATCH (u:User) WHERE u.name = 'Alice' RETURN u.name, u.age
@@ -98,7 +98,7 @@ Alice|30
 -LOG MatchConjunctiveLabelsReturnNodeStar
 -STATEMENT MATCH (n:Person:Employee) RETURN n.*
 ---- 1
-{"name":"Alice"}
+0|[Person,Employee]|{"name":"Alice"}
 
 -LOG Cleanup
 -STATEMENT USE GRAPH main


### PR DESCRIPTION
## Description

Part of #712, and a follow-on to #715. On an ANY graph, whole-object `RETURN n` / `RETURN e` leaked the internal `_nodes`/`_edges` columns as if they were user properties — even though the struct already exposes the same information as `_ID` / `_LABEL`. This removes that redundancy as a deliberate first step toward the North Star (output identical to a strongly-typed subgraph).

Before → after (ANY graph only):
```
RETURN n :  {_ID, _LABEL, id, label, data}          ->  {_ID, _LABEL, data}
RETURN e :  {_SRC,_DST,_LABEL, _id, label, data}    ->  {_SRC,_DST,_LABEL, _id, data}
```

`id` duplicates `_ID`; `label` duplicates `_LABEL` (surfaced in #715). `data` — the JSON property bag — is kept; promoting it to top-level typed fields is the larger follow-on, which I've written up as a design question on #712 (it needs a property registry + a type policy that's really a maintainer call).

### Approach
The internal columns must stay **bound** — the insert path (`bindInsertNode`/`bindInsertRel`) looks them up by name, and explicit `n.id` access resolves through them — so they aren't dropped. Instead `NodeOrRelExpression` gains a `hiddenPropertyNames` set and a `getProjectedPropertyExpressions()` accessor (full list minus hidden). The whole-object struct type is built from that projected list, and `ExpressionMapper::getNodeEvaluator` / `getRelEvaluator` consume the same list so the struct fields stay positionally aligned with the child expressions that fill them.

In `createQueryNode` / `createNonRecursiveQueryRel` the ANY and structured paths are separate branches of a single if/else, with the shared struct assembly factored into `getNodeStructFields(node, labelType)` / `getRelStructFields(rel)`:
- **ANY**: mark the internal columns hidden (`{id, label}` for nodes, `{label}` for rels), build the struct, point `_LABEL` at the real `label` column.
- **structured**: build the struct, resolve `_LABEL` via the rewrite.

Structured graphs — which may legitimately have user columns named `id`/`label`/`data` — are completely untouched (empty hidden set ⇒ projected list == full list).

### Scope
Deliberately narrow — this only changes whole-object output:
- **`.*` is unchanged.** Hiding `label` there would remove the only per-row type signal, since star expansion has no `_LABEL` to fall back on and an ANY result can mix labels. `a.*` still returns `id | label | data`.
- **`show_tables()` is unchanged.** The other half of "hide `_nodes`/`_edges` in public APIs" is a genuine API-design choice (name-filter vs `isInternal=true` catalog entries, plus consistent behaviour when a graph's backing file is opened directly), which I raised on #712. Happy to follow up once the direction is set.

### Tests
Updated the two whole-object cases in `test/test_files/graph/any.test`. Structured-graph tests (`typed_subgraph.test`, `label.test`) and the path / recursive-join suites are unaffected — proving the ANY gate.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] I have changed storage version if on disk format has changed. — N/A, no on-disk format change
- [x] I have requested a review from a maintainer.
- [ ] I have updated the documentation (if needed). — ANY graphs still undocumented; separate docs PR.
