### PR TITLE
CI: exclude OpenSSL 3 from Python wheels

### DIFF
--- a/.github/workflows/python-wheel-workflow.yml
+++ b/.github/workflows/python-wheel-workflow.yml
@@ -109,6 +109,12 @@ jobs:
       CIBW_BEFORE_ALL_LINUX: "command -v dnf && dnf install -y ccache openssl3 openssl3-devel pkg-config && (ldconfig || true) && echo '-DOPENSSL_INCLUDE_DIR=/usr/include/openssl3 -DOPENSSL_CRYPTO_LIBRARY=/usr/lib64/libcrypto.so.3 -DOPENSSL_SSL_LIBRARY=/usr/lib64/libssl.so.3' > /tmp/lbug_openssl_cmake_flags || apk add --no-cache ccache openssl-dev pkgconfig"
       CIBW_ENVIRONMENT_LINUX: ${{ matrix.os == 'linux' && 'LBUG_API_PRECOMPILED_LIB_PATH=/project/precompiled-liblbug/liblbug.a CMAKE_C_COMPILER_LAUNCHER=ccache CMAKE_CXX_COMPILER_LAUNCHER=ccache CCACHE_DIR=/project/.ccache' || '' }}
 
+      # Exclude OpenSSL 3 from the repaired wheel on every platform
+      # so end users provide/update their own OpenSSL 3 runtime.
+      CIBW_REPAIR_WHEEL_COMMAND_LINUX: ${{ matrix.os == 'linux' && 'auditwheel repair --exclude libssl.so.3 --exclude libcrypto.so.3 -w {dest_dir} {wheel}' || '' }}
+      CIBW_REPAIR_WHEEL_COMMAND_MACOS: ${{ matrix.os == 'macos' && 'delocate-wheel --require-archs {delocate_arch} --exclude libssl.3.dylib --exclude libcrypto.3.dylib -w {dest_dir} {wheel}' || '' }}
+      CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: ${{ matrix.os == 'windows' && 'delvewheel repair -w {dest_dir} --exclude libssl-3-x64.dll --exclude libcrypto-3-x64.dll {wheel}' || '' }}
+
       # Set deployment target for macOS, and Windows MSVC setup
       CIBW_ENVIRONMENT_WINDOWS: ${{ matrix.os == 'windows' && format('DISTUTILS_USE_SDK=1 MSSdk=1 TMP={0} TEMP={0} LBUG_API_PRECOMPILED_LIB_PATH=$LBUG_API_PRECOMPILED_LIB_PATH', matrix.platform == 'arm64' && 'C:/t' || 'D:/t') || '' }}
       CIBW_ENVIRONMENT_MACOS: ${{ matrix.os == 'macos' && format('MACOSX_DEPLOYMENT_TARGET={0} LBUG_API_PRECOMPILED_LIB_PATH={1}/precompiled-liblbug/liblbug.a CMAKE_C_COMPILER_LAUNCHER=ccache CMAKE_CXX_COMPILER_LAUNCHER=ccache CCACHE_DIR={1}/.ccache', matrix.deployment-target, github.workspace) || '' }}


### PR DESCRIPTION
All three platform wheel-repair tools (auditwheel, delocate-wheel, delvewheel) were bundling OpenSSL 3 shared libraries into the wheel (`.libs/` / `.dylibs/`) because the native extension imports `libssl`/`libcrypto`.

This caused two problems:
1. The **Windows wheel** was broken — delvewheel mangled the DLL names with a hash suffix (e.g. `libssl-3-x64-<hash>.dll`), but the extension's import table was patched to the mangled name only partially, leaving stale plain-name references that the loader couldn't resolve.
2. Unnecessary bundling of security-sensitive libraries that end users want to manage/update independently.

**Fix**: Override `CIBW_REPAIR_WHEEL_COMMAND_{LINUX,MACOS,WINDOWS}` to pass `--exclude` for the OpenSSL 3 library names on each platform. The repair tools skip those libraries entirely — no copy, no mangle — and the extension's existing import table entries remain as-is, resolved from the system at runtime.

| Platform | Library names excluded |
|----------|-----------------------|
| Linux    | `libssl.so.3`, `libcrypto.so.3` |
| macOS    | `libssl.3.dylib`, `libcrypto.3.dylib` |
| Windows  | `libssl-3-x64.dll`, `libcrypto-3-x64.dll` |