### PR TITLE
fix: accept STANDALONE_TABLE_FUNCTION_ENTRY in bindInQueryCall (VECTOR extension fix)

### DIFF
--- a/src/binder/bind/read/bind_in_query_call.cpp
+++ b/src/binder/bind/read/bind_in_query_call.cpp
@@ -25,7 +25,8 @@ std::unique_ptr<BoundReadingClause> Binder::bindInQueryCall(const ReadingClause&
     auto transaction = transaction::Transaction::Get(*clientContext);
     auto entry = Catalog::Get(*clientContext)->getFunctionEntry(transaction, functionName);
     switch (entry->getType()) {
-    case CatalogEntryType::TABLE_FUNCTION_ENTRY: {
+    case CatalogEntryType::TABLE_FUNCTION_ENTRY:
+    case CatalogEntryType::STANDALONE_TABLE_FUNCTION_ENTRY: {
         auto boundTableFunction =
             bindTableFunc(functionName, *functionExpr, call.getYieldVariables());
         boundReadingClause =


### PR DESCRIPTION
## Summary

Fixes `CREATE_VECTOR_INDEX` returning `Binder exception: CREATE_VECTOR_INDEX is not a table or algorithm function` when called from the Node.js API.

## Bug

The VECTOR extension registers `CREATE_VECTOR_INDEX` as a `STANDALONE_TABLE_FUNCTION_ENTRY` (type 26). However, `bindInQueryCall()` in `bind_in_query_call.cpp` only matches `TABLE_FUNCTION_ENTRY` (type 23) — missing the standalone variant entirely.

This causes the error on ALL database types (`:memory:` and file-based) when calling `CREATE_VECTOR_INDEX` from Node.js. The CLI shell is unaffected because it goes through `standalone_call_rewriter.cpp`.

## Fix

One line: add `case CatalogEntryType::STANDALONE_TABLE_FUNCTION_ENTRY:` to the switch.

```diff
     switch (entry->getType()) {
     case CatalogEntryType::TABLE_FUNCTION_ENTRY:
+    case CatalogEntryType::STANDALONE_TABLE_FUNCTION_ENTRY: {
```

## Verification

- Windows 11 x64, MSVC 19.50, LadybugDB 0.18.3
- Node.js API: `CALL CREATE_VECTOR_INDEX(...)` → HNSW index created and queried successfully
- FTS and ALGO functions continue to work correctly (unaffected)