### PR TITLE
profiler: add wall clock time to PROFILE output

### DIFF
--- a/src/common/profiler.cpp
+++ b/src/common/profiler.cpp
@@ -3,6 +3,17 @@
 namespace lbug {
 namespace common {
 
+void Profiler::startQueryTimer() {
+    std::lock_guard<std::mutex> lck(mtx);
+    queryTimer.start();
+    queryTimerStarted = true;
+}
+
+double Profiler::getQueryElapsedTimeMS() const {
+    std::lock_guard<std::mutex> lck(mtx);
+    return queryTimerStarted ? queryTimer.getElapsedTimeMS() : 0.0;
+}
+
 TimeMetric* Profiler::registerTimeMetric(const std::string& key) {
     auto timeMetric = std::make_unique<TimeMetric>(enabled);
     auto metricPtr = timeMetric.get();

--- a/src/include/common/profiler.h
+++ b/src/include/common/profiler.h
@@ -13,6 +13,10 @@ namespace common {
 class Profiler {
 
 public:
+    void startQueryTimer();
+
+    double getQueryElapsedTimeMS() const;
+
     TimeMetric* registerTimeMetric(const std::string& key);
 
     NumericMetric* registerNumericMetric(const std::string& key);
@@ -25,7 +29,9 @@ private:
     void addMetric(const std::string& key, std::unique_ptr<Metric> metric);
 
 public:
-    std::mutex mtx;
+    Timer queryTimer;
+    bool queryTimerStarted = false;
+    mutable std::mutex mtx;
     bool enabled = false;
     std::unordered_map<std::string, std::vector<std::unique_ptr<Metric>>> metrics;
 };

--- a/src/include/common/timer.h
+++ b/src/include/common/timer.h
@@ -38,6 +38,12 @@ public:
         return count;
     }
 
+    double getElapsedTimeMS() const {
+        auto now = std::chrono::high_resolution_clock::now();
+        auto duration = now - startTime;
+        return std::chrono::duration_cast<std::chrono::microseconds>(duration).count() / 1000.0;
+    }
+
 private:
     std::chrono::time_point<std::chrono::high_resolution_clock> startTime;
     std::chrono::time_point<std::chrono::high_resolution_clock> stopTime;

--- a/src/main/client_context.cpp
+++ b/src/main/client_context.cpp
@@ -572,6 +572,9 @@ std::unique_ptr<QueryResult> ClientContext::executeNoLock(PreparedStatement* pre
             [&]() -> void {
                 const auto profiler = std::make_unique<Profiler>();
                 profiler->enabled = cachedStatement->logicalPlan->isProfile();
+                if (profiler->enabled) {
+                    profiler->startQueryTimer();
+                }
                 if (!queryID) {
                     queryID = localDatabase->getNextQueryID();
                 }

--- a/src/processor/operator/physical_operator.cpp
+++ b/src/processor/operator/physical_operator.cpp
@@ -255,6 +255,14 @@ uint64_t PhysicalOperator::getNumOutputTuples(Profiler& profiler) const {
 std::unordered_map<std::string, std::string> PhysicalOperator::getProfilerKeyValAttributes(
     Profiler& profiler) const {
     std::unordered_map<std::string, std::string> result;
+    if (operatorType == PhysicalOperatorType::PROFILE) {
+        // Real wall-clock time for the entire query (includes plan mapping).
+        result.insert({"WallClockTime", std::to_string(profiler.getQueryElapsedTimeMS())});
+    }
+    // Total CPU time in this operator's subtree, accumulated across all threads.
+    // For parallel operators this may exceed real wall-clock time.
+    result.insert(
+        {"TotalTime", std::to_string(profiler.sumAllTimeMetricsWithKey(getTimeMetricKey()))});
     result.insert({"ExecutionTime", std::to_string(getExecutionTime(profiler))});
     result.insert({"NumOutputTuples", std::to_string(getNumOutputTuples(profiler))});
     return result;

--- a/test/api/api_test.cpp
+++ b/test/api/api_test.cpp
@@ -152,6 +152,21 @@ TEST_F(ApiTest, Profile) {
     ASSERT_TRUE(result->isSuccess());
 }
 
+TEST_F(ApiTest, ProfileReportsWallClockTime) {
+    auto result = conn->query("PROFILE MATCH (a:person) RETURN a.ID");
+    ASSERT_TRUE(result->isSuccess());
+    auto profile = result->toString();
+    // WallClockTime (real wall clock) appears only on the PROFILE operator.
+    EXPECT_NE(profile.find("WallClockTime:"), std::string::npos);
+    // TotalTime (accumulated CPU across threads) appears on every operator.
+    auto totalCount = 0u;
+    for (auto pos = profile.find("TotalTime:"); pos != std::string::npos;
+         pos = profile.find("TotalTime:", pos + 1)) {
+        totalCount++;
+    }
+    EXPECT_GT(totalCount, 1);
+}
+
 TEST_F(ApiTest, TimeOut) {
     conn->setQueryTimeOut(1000 /* timeoutInMS */);
     auto result = conn->query(


### PR DESCRIPTION
The new PROFILE output exposes three timing metrics per operator:

- **WallClockTime** (PROFILE operator only): real elapsed wall clock time
  for the entire query, including plan mapping and execution overhead.
  Measured by a dedicated query timer started before plan mapping.

- **TotalTime** (every operator): total CPU time accumulated across all
  threads in this operator's subtree (the raw TimeMetric value).
  For single-threaded operators this is equivalent to wall clock time;
  for parallel operators (hash join build, intersect build, etc.) it
  is the sum of CPU time across all worker threads and may exceed the
  real wall clock duration.

- **ExecutionTime** (every operator, unchanged): self CPU time, exclusive
  of children (only children[0] is subtracted for multi-child ops).

### Motivation

The existing profiler only tracked per-operator ExecutionTime (self CPU
time).  Users had no way to see:
- The real wall clock cost of a query (plan mapping + execution overhead)
- How much CPU time each subtree consumed (TotalTime), which reveals
  CPU-hot subtrees even when they parallelize well
- Whether a subquery's TotalTime is dominated by execution time or by
  children

### Key design decisions

- **WallClockTime** uses a dedicated query-level timer (started before
  plan mapping), not the per-operator TimeMetric, so it captures
  planning overhead and is a true wall clock measurement.
- **TotalTime** uses the existing per-operator accumulated TimeMetric.
  For parallel operators this is the sum across threads, so it can
  exceed WallClockTime — this is intentional and informative (the gap
  reveals the degree of parallelism).
- Both new methods lock the existing `mtx` (made mutable) for thread
  safety when operators execute concurrently over the same Profiler
  instance.

### Changes

- `Timer::getElapsedTimeMS()` — new const accessor with microsecond
  precision for wall-clock queries.
- `Profiler::startQueryTimer() / getQueryElapsedTimeMS()` — stateful
  query-level timer, started in `ClientContext::executeNoLock`.
- `PhysicalOperator::getProfilerKeyValAttributes()` — emits
  WallClockTime (PROFILE only) and TotalTime (all operators).
- Test: `ProfileReportsWallClockTime` asserts WallClockTime on the
  PROFILE operator and TotalTime on all sub-operators.