### PR TITLE
fix: use Interval::getMicro for Arrow interval export

### DIFF
--- a/src/common/arrow/arrow_row_batch.cpp
+++ b/src/common/arrow/arrow_row_batch.cpp
@@ -293,8 +293,7 @@ void ArrowRowBatch::templateCopyNonNullValue<LogicalTypeID::INTERVAL>(ArrowVecto
     const Value& value, std::int64_t pos, bool) {
     auto destAddr = (int64_t*)(vector->data.data() + pos * sizeof(std::int64_t));
     auto intervalVal = value.val.intervalVal;
-    *destAddr = intervalVal.micros + intervalVal.days * Interval::MICROS_PER_DAY +
-                intervalVal.months * Interval::MICROS_PER_MONTH;
+    *destAddr = Interval::getMicro(intervalVal);
 }
 
 template<>


### PR DESCRIPTION
ArrowRowBatch::templateCopyNonNullValue for INTERVAL was directly using months * MICROS_PER_MONTH (30 days/month) instead of Interval::getMicro which correctly uses DAYS_PER_YEAR (365) for whole years. This caused Arrow/numpy/pandas export to return wrong interval values.