### PR TITLE
fix: restore/save selection vector in QueryPrimaryKeyLookup

### DIFF
--- a/src/include/processor/operator/query_primary_key_lookup.h
+++ b/src/include/processor/operator/query_primary_key_lookup.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "expression_evaluator/expression_evaluator.h"
+#include "processor/operator/filtering_operator.h"
 #include "processor/operator/physical_operator.h"
 #include "processor/operator/scan/scan_node_table.h"
 
@@ -31,7 +32,7 @@ private:
           properties{other.properties} {}
 };
 
-class QueryPrimaryKeyLookup final : public PhysicalOperator {
+class QueryPrimaryKeyLookup final : public PhysicalOperator, SelVectorOverWriter {
     static constexpr PhysicalOperatorType type_ = PhysicalOperatorType::QUERY_PRIMARY_KEY_LOOKUP;
 
 public:

--- a/src/processor/operator/query_primary_key_lookup.cpp
+++ b/src/processor/operator/query_primary_key_lookup.cpp
@@ -35,14 +35,26 @@ void QueryPrimaryKeyLookup::initLocalStateInternal(ResultSet* resultSet,
 }
 
 bool QueryPrimaryKeyLookup::getNextTuplesInternal(ExecutionContext* context) {
-    while (children[0]->getNextTuple(context)) {
+    auto transaction = transaction::Transaction::Get(*context->clientContext);
+    sel_t outputSize = 0;
+    do {
+        // The node-id vector shares its DataChunkState with the child (the key expression lives
+        // in the same group). Restoring the saved selection vector hands control back to the
+        // child so it can advance, and saving afterwards swaps in a private selection vector we
+        // are free to rewrite. Without this restore/save dance, filtering the selection vector
+        // here would clobber the child's state (e.g. Flatten's currentSelVector) and leave it
+        // reporting an empty selection on the next call.
+        restoreSelVector(*nodeIDVector->state);
+        if (!children[0]->getNextTuple(context)) {
+            return false;
+        }
+        saveSelVector(*nodeIDVector->state);
         keyEvaluator->evaluate();
         auto* keyVector = keyEvaluator->resultVector.get();
-        auto& inputSelVector = keyVector->state->getSelVector();
+        const auto& inputSelVector = keyVector->state->getSelVector();
         auto& outputSelVector = nodeIDVector->state->getSelVectorUnsafe();
         outputSelVector.setToFiltered();
-        sel_t outputSize = 0;
-        auto transaction = transaction::Transaction::Get(*context->clientContext);
+        outputSize = 0;
         for (sel_t i = 0; i < inputSelVector.getSelSize(); ++i) {
             const auto pos = inputSelVector[i];
             if (keyVector->isNull(pos)) {
@@ -56,16 +68,12 @@ bool QueryPrimaryKeyLookup::getNextTuplesInternal(ExecutionContext* context) {
             outputSelVector[outputSize++] = pos;
         }
         outputSelVector.setSelSize(outputSize);
-        if (outputSize == 0) {
-            continue;
-        }
-        table->lookupMultiple(transaction, *scanState);
-        tableInfo.castColumns();
-        scanState->outState->setToUnflat();
-        metrics->numOutputTuple.increase(outputSize);
-        return true;
-    }
-    return false;
+    } while (outputSize == 0);
+    table->lookupMultiple(transaction, *scanState);
+    tableInfo.castColumns();
+    scanState->outState->setToUnflat();
+    metrics->numOutputTuple.increase(outputSize);
+    return true;
 }
 
 } // namespace processor

--- a/test/api/api_test.cpp
+++ b/test/api/api_test.cpp
@@ -217,6 +217,29 @@ TEST_F(ApiTest, UnwindQueryPrimaryKeyLookupFallsBackWithoutIndex) {
     ASSERT_EQ(TestHelper::convertResultToString(*result), std::vector<std::string>{"1"});
 }
 
+// Regression: when the first row(s) of an UNWIND-driven MATCH miss the primary-key index, the
+// row-driven lookup operator must not clobber the upstream selection vector (it had filtered the
+// shared state to size 0, starving every subsequent tuple). What remains must be exactly the rows
+// whose keys actually exist, in the same order as the UNWIND.
+TEST_F(ApiTest, UnwindQueryPrimaryKeyLookupLeadingMissThenHits) {
+    ASSERT_TRUE(conn->query("CREATE NODE TABLE LookupLeadingMiss(id INT64, v INT64, "
+                            "PRIMARY KEY(id));")
+                    ->isSuccess());
+    ASSERT_TRUE(conn->query("CREATE (:LookupLeadingMiss {id: 2, v: 20});"
+                            "CREATE (:LookupLeadingMiss {id: 3, v: 30});")
+                    ->isSuccess());
+
+    auto explain = conn->query("EXPLAIN UNWIND [0, 2, 3] AS x "
+                               "MATCH (t:LookupLeadingMiss {id: x}) RETURN t.v");
+    ASSERT_TRUE(explain->isSuccess());
+    EXPECT_NE(explain->toString().find("QUERY_PRIMARY_KEY_LOOKUP"), std::string::npos);
+
+    auto result = conn->query("UNWIND [0, 2, 3] AS x"
+                              " MATCH (t:LookupLeadingMiss {id: x}) RETURN t.v");
+    ASSERT_TRUE(result->isSuccess());
+    ASSERT_EQ(TestHelper::convertResultToString(*result), (std::vector<std::string>{"20", "30"}));
+}
+
 TEST_F(ApiTest, Profile) {
     auto result =
         conn->query("EXPLAIN MATCH (a:person) WHERE EXISTS { MATCH (a)-[:knows]->(b:person) WHERE "


### PR DESCRIPTION
Row-driven primary-key lookup (e92346c) filtered the node-id vector's shared DataChunkState directly. When an UNWIND row missed the PK index (e.g. UNWIND [0, 2, 3] ... MATCH ({id: x}) with x=0 absent), the selection size was driven to 0 and the upstream Flatten/Unwind operator kept seeing an empty selection, starving every subsequent tuple so only 0 rows were returned despite later keys (2, 3) existing.

Inherit SelVectorOverWriter (like Filter/NodeLabelFilter) and wrap each child pull with restore/save so we rewrite a private selection vector instead of clobbering the child's. Skip-empty now loops back to the child instead of terminating the pipeline.

Adds regression test UnwindQueryPrimaryKeyLookupLeadingMissThenHits.