### PR TITLE
scan: init external rel table scan state before first scan()

### DIFF
--- a/src/processor/operator/scan/scan_rel_table.cpp
+++ b/src/processor/operator/scan/scan_rel_table.cpp
@@ -111,6 +111,21 @@ void ScanRelTable::initLocalStateInternal(ResultSet* resultSet, ExecutionContext
             boundNodeIDVector, outVectors, nbrNodeIDVector->state);
     }
     tableInfo.initScanState(*scanState, outVectors, clientContext);
+    // The native RelTable::initScanState reads from the bound-node
+    // nodeIDVector to pick a node group, so it must run after a child tuple
+    // is in flight (the existing call sites in fetchNextBoundNodeBatch and
+    // after pulling a child tuple handle that). External rel table backends
+    // (ForeignRelTable, ArrowRelTable, IceDiskRelTable, ...) only use
+    // initScanState to set up scan-function / shared / local state and
+    // source/nodeGroupIdx — they don't need a bound node — but the first
+    // scan() in this operator fires before any of those re-init call sites,
+    // so we'd dereference uninitialized state and crash. Detect "external"
+    // by checking the dynamic type isn't the native RelTable — this scales
+    // to any future external backend without enumerating each one here.
+    if (typeid(*tableInfo.table) != typeid(RelTable)) {
+        auto transaction = transaction::Transaction::Get(*clientContext);
+        tableInfo.table->initScanState(transaction, *scanState);
+    }
     if (sourceNodeScanMode) {
         sourceNodeOutVectors.clear();
         for (auto& pos : sourceNodeScanInfo.outVectorsPos) {


### PR DESCRIPTION
Fixes the regression introduced by the pg_client extension moving rel table registration to RelGroupCatalogEntry + ForeignRelTable: `MATCH (a:node_person)-[k:rel_knows]->(b:node_person)` was crashing with `tableFunc: sharedState is null` on the first scan.

**Root cause**

`ScanRelTable::initLocalStateInternal` creates the per-thread scan state but only calls `table->initScanState` in `fetchNextBoundNodeBatch()` and after pulling a new child tuple. The first `scan()` in `getNextTuplesInternal` therefore runs against an uninitialized scan state.

The native `RelTable::initScanState` reads from the bound-node `nodeIDVector` to pick a node group, so it must run after a child tuple is in flight. External rel table backends (`ForeignRelTable`, `ArrowRelTable`, `IceDiskRelTable`) only use `initScanState` to set up scan-function / shared / local state and `source`/`nodeGroupIdx` — they don't need a bound node — but the first `scan()` still fires before any re-init call site, so we'd dereference uninitialized state and crash.

**Fix**

Detect "external" via `typeid(*tableInfo.table) != typeid(RelTable)` and call `table->initScanState` once after creating the per-thread scan state, so the first `scan()` is well-defined. This scales to any future external backend (`XxxRelTable : RelTable`) without re-enumerating.

Native `RelTable` behavior is unchanged: first `scan()` still returns false (`source == NONE`), then `fetchNextBoundNodeBatch` re-inits with the child tuple in flight.

**Companion change**

The pg_client extension submodule was updated to restore `RelGroupCatalogEntry` registration for `rel_*` tables (so the planner has a real rel entry to anchor `MATCH` on) and to add a mutex around the morsel `currentOffset` in `tableFunc` (so parallel `HashJoinBuild` workers atomically claim rows). That lives in the `extensions` repo on the `pg_client` branch.

**Tests**

Verified with the pg_client extension's Python test suite (13/13 passing, including new `test_06b_match_rel_table` / `test_06c_match_rel_count_parallel`) and the e2e runner (new `MatchOnRelTable` case). The push-down optimizer (`ForeignJoinPushDownOptimizer`) correctly lowers `MATCH ... RETURN count(*)` to a single `COUNT_REL_TABLE` operator on `rel_knows`.