### PR TITLE
fix: bound filtered string scans to the current segment

### DIFF
--- a/src/include/storage/table/string_column.h
+++ b/src/include/storage/table/string_column.h
@@ -44,7 +44,8 @@ protected:
         common::offset_t numValuesToRead, common::ValueVector* resultVector,
         common::sel_t startPosInVector = 0) const;
     void scanFiltered(const SegmentState& state, common::offset_t startOffsetInChunk,
-        common::ValueVector* resultVector, common::sel_t startPosInVector) const;
+        common::row_idx_t numValuesToScan, common::ValueVector* resultVector,
+        common::sel_t startPosInVector) const;
 
     void lookupInternal(const SegmentState& state, common::offset_t nodeOffset,
         common::ValueVector* resultVector, uint32_t posInVector) const override;

--- a/src/storage/table/string_column.cpp
+++ b/src/storage/table/string_column.cpp
@@ -132,7 +132,7 @@ void StringColumn::scanSegment(const SegmentState& state, offset_t startOffsetIn
     if (!resultVector->state || resultVector->state->getSelVector().isUnfiltered()) {
         scanUnfiltered(state, startOffsetInChunk, numValuesToScan, resultVector, offsetInResult);
     } else {
-        scanFiltered(state, startOffsetInChunk, resultVector, offsetInResult);
+        scanFiltered(state, startOffsetInChunk, numValuesToScan, resultVector, offsetInResult);
     }
 }
 
@@ -249,17 +249,17 @@ void StringColumn::scanUnfiltered(const SegmentState& state, offset_t startOffse
 }
 
 void StringColumn::scanFiltered(const SegmentState& state, offset_t startOffsetInChunk,
-    ValueVector* resultVector, offset_t offsetInResult) const {
+    row_idx_t numValuesToScan, ValueVector* resultVector, offset_t offsetInResult) const {
     std::vector<std::pair<string_index_t, uint64_t>> offsetsToScan;
     for (sel_t i = 0; i < resultVector->state->getSelVector().getSelSize(); i++) {
         const auto pos = resultVector->state->getSelVector()[i];
-        if (pos >= offsetInResult && startOffsetInChunk + pos < state.metadata.numValues &&
+        if (pos >= offsetInResult && pos < offsetInResult + numValuesToScan &&
             !resultVector->isNull(pos)) {
             // TODO(bmwinger): optimize index scans by grouping them when adjacent
-            const auto offsetInGroup = startOffsetInChunk + pos - offsetInResult;
+            const auto offsetInSegment = startOffsetInChunk + pos - offsetInResult;
             string_index_t index = 0;
-            indexColumn->scanSegment(getChildState(state, ChildStateIndex::INDEX), offsetInGroup, 1,
-                reinterpret_cast<uint8_t*>(&index));
+            indexColumn->scanSegment(getChildState(state, ChildStateIndex::INDEX), offsetInSegment,
+                1, reinterpret_cast<uint8_t*>(&index));
             offsetsToScan.emplace_back(index, pos);
         }
     }

--- a/test/storage/string_chunk_scan_test.cpp
+++ b/test/storage/string_chunk_scan_test.cpp
@@ -374,5 +374,39 @@ TEST_F(StringChunkScanTest, ValueVectorPartialScansRemainCorrectWhenDictionaryOf
     EXPECT_EQ(scanned, expectedRange(values, 1, 3));
 }
 
+TEST_F(StringChunkScanTest, FilteredValueVectorScanUsesResultCoordinatesAcrossSegments) {
+    auto* memoryManager = getMemoryManager(*database);
+    auto* storageManager = getStorageManager(*database);
+    PageManager pageManager{storageManager->getDataFH()};
+    StringColumn column{"scan_value", LogicalType::STRING(), storageManager->getDataFH(),
+        memoryManager, &storageManager->getShadowFile(), true /*enableCompression*/};
+
+    const std::vector<MaybeString> firstValues = {value("ROW_ZERO"), value("ROW_ONE")};
+    const std::vector<MaybeString> secondValues = {value("ROW_TWO"), value("ROW_THREE")};
+    auto firstPersisted =
+        buildPersistedStringChunk(*memoryManager, pageManager, column, firstValues);
+    auto secondPersisted =
+        buildPersistedStringChunk(*memoryManager, pageManager, column, secondValues);
+    ChunkState scanState;
+    scanState.column = &column;
+    scanState.segmentStates.push_back(std::move(firstPersisted.state.segmentStates[0]));
+    scanState.segmentStates.push_back(std::move(secondPersisted.state.segmentStates[0]));
+
+    auto outputState = std::make_shared<DataChunkState>();
+    ValueVector outputVector{LogicalType::STRING(), memoryManager, outputState};
+    StringVector::addString(&outputVector, 2, "SENTINEL_TWO");
+    StringVector::addString(&outputVector, 3, "SENTINEL_THREE");
+    auto& selection = outputVector.state->getSelVectorUnsafe();
+    auto selectedPositions = selection.getMutableBuffer();
+    selectedPositions[0] = 2;
+    selectedPositions[1] = 3;
+    selection.setToFiltered(2);
+
+    column.scan(scanState, 0 /*startRow*/, 4 /*numRows*/, &outputVector, 0 /*offsetInVector*/);
+
+    EXPECT_EQ(outputVector.getValue<string_t>(2).getAsString(), "ROW_TWO");
+    EXPECT_EQ(outputVector.getValue<string_t>(3).getAsString(), "ROW_THREE");
+}
+
 } // namespace testing
 } // namespace lbug


### PR DESCRIPTION
## Description

Addresses the non-concurrent string scan corruption reported in #678.

`StringColumn::scanFiltered` receives selection positions in result-vector
coordinates. For a scan spanning multiple persisted segments, it checked the
lower result offset but did not bound selected positions to the current
segment's result range. A position belonging to a later segment could therefore
be read from the current segment using the wrong local offset.

Pass the current segment's scan length into `scanFiltered`, restrict selected
positions to `[offsetInResult, offsetInResult + numValuesToScan)`, and derive
the index-column offset from the segment-local coordinate.

The regression test constructs two persisted string segments and selects only
result positions owned by the second segment. It verifies that the first
segment does not consume those positions and that the second segment returns
the expected strings.

This changes only scan bounds and does not change the on-disk format.

## Validation

- `build/release/test/storage/string_chunk_scan_test --gtest_color=no`
- `ctest --test-dir build/release/test --output-on-failure -j 4`
- `python3 scripts/run-clang-format.py --clang-format-executable clang-format-18 ...`

## Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation Update

## Checklist

- [x] I have changed storage version if on disk format has changed. — N/A; no on-disk format change.
- [ ] I have requested a review from a maintainer.
- [x] I have updated the documentation (if needed). — N/A; no user-facing API or configuration change.
