### PR TITLE
fix(ci): generate dictionary-bug parquet fixtures before WASM kernel tests

### DIFF
--- a/.github/workflows/wasm-workflow.yml
+++ b/.github/workflows/wasm-workflow.yml
@@ -126,6 +126,10 @@ jobs:
           source /home/runner/emsdk/emsdk_env.sh
           make wasmtest-build
 
+      - name: Generate dictionary-bug fixtures
+        if: ${{ inputs.isNightly == true }}
+        run: uv run --with pyarrow python3 scripts/generate-dictionary-bug-fixture.py
+
       - name: Kernel test
         if: ${{ inputs.isNightly == true }}
         run: ctest --test-dir build/wasm/test/ --output-on-failure -j ${TEST_JOBS} --timeout 600 -E 'hash_leak\.LargeAggregateLeakTest|CopyTest\.GracefulBMExceptionHandlingManyThreads|lsqb_queries\.LSQBTest|lsqb_queries_parquet\.LSQBTestParquet'


### PR DESCRIPTION
## Problem

The WASM CI workflow was missing a step to generate the dictionary-bug parquet fixtures (A.parquet, B.parquet, A_TO_B.parquet) before running kernel tests. These files are `.gitignore`-d and auto-generated from the committed zlib payloads via `scripts/generate-dictionary-bug-fixture.py`.

This caused the following error in WASM kernel tests:

```
Binder exception: No file found that matches the pattern: .../orb383_relationship_projection_obfuscated_fixture/B.parquet
```

## Fix

Added a `Generate dictionary-bug fixtures` step between `Kernel build` and `Kernel test`, conditional on `isNightly == true`, matching the main CI workflow pattern.

Closes #...