### PR TITLE
fix(attach): don't shadow main catalog when attaching lbug database

### DIFF
--- a/src/binder/bind/bind_graph_pattern.cpp
+++ b/src/binder/bind/bind_graph_pattern.cpp
@@ -827,14 +827,17 @@ std::vector<TableCatalogEntry*> Binder::bindRelGroupEntries(
         for (auto entry : catalog->getRelGroupEntries(transaction, useInternal)) {
             entrySet.insert(entry);
         }
-        for (auto attachedDB : dbManager->getAttachedDatabases()) {
-            auto attachedCatalog = attachedDB->getCatalog();
-            for (auto entry : attachedCatalog->getRelGroupEntries(transaction, useInternal)) {
-                entrySet.insert(entry);
-            }
-        }
+        // Stop-gap: skip attached rel groups; physical routing for rel patterns
+        // over attached databases is not yet implemented. Unlabeled ()-[r]->()
+        // would otherwise crash or silently read the wrong table on ID overlap.
+        // TODO: implement full dbName plumbing for rel patterns (BUG 6).
     } else {
         for (auto& name : tableNames) {
+            // Check for qualified rel name (db.table) — not yet supported.
+            if (name.find('.') != std::string::npos) {
+                throw BinderException(
+                    "Qualified relationship patterns (e.g. -[r:db.rel]->) are not supported yet.");
+            }
             if (catalog->containsTable(transaction, name)) {
                 auto entry = catalog->getTableCatalogEntry(transaction, name, useInternal);
                 if (entry->getType() != CatalogEntryType::REL_GROUP_ENTRY) {

--- a/src/include/main/database_manager.h
+++ b/src/include/main/database_manager.h
@@ -44,6 +44,13 @@ public:
 
     LBUG_API void invalidateCache();
 
+    // Given a table ID, find the database that contains it and return its
+    // catalog and storage manager. Returns (main catalog, main storage manager)
+    // if the table is in the main database. If dbName is non-empty, use that
+    // database directly.
+    static std::pair<catalog::Catalog*, storage::StorageManager*> resolveTableStorage(
+        const ClientContext& context, common::table_id_t tableID, const std::string& dbName = {});
+
     LBUG_API static DatabaseManager* Get(const ClientContext& context);
 
 private:

--- a/src/include/optimizer/filter_push_down_optimizer.h
+++ b/src/include/optimizer/filter_push_down_optimizer.h
@@ -93,9 +93,6 @@ private:
     std::shared_ptr<planner::LogicalOperator> appendFiltersStatsAware(
         binder::expression_vector predicates, std::shared_ptr<planner::LogicalOperator> child);
 
-    std::shared_ptr<planner::LogicalOperator> appendScanNodeTable(
-        std::shared_ptr<binder::Expression> nodeID, std::vector<common::table_id_t> nodeTableIDs,
-        binder::expression_vector properties, std::shared_ptr<planner::LogicalOperator> child);
     std::shared_ptr<planner::LogicalOperator> appendFilter(
         std::shared_ptr<binder::Expression> predicate,
         std::shared_ptr<planner::LogicalOperator> child);

--- a/src/include/planner/operator/scan/logical_scan_node_table.h
+++ b/src/include/planner/operator/scan/logical_scan_node_table.h
@@ -102,6 +102,12 @@ public:
 
     std::shared_ptr<binder::Expression> getNodeID() const { return nodeID; }
     std::vector<common::table_id_t> getTableIDs() const { return nodeTableIDs; }
+    const std::unordered_map<common::table_id_t, std::string>& getTableDBMap() const {
+        return tableDBMap;
+    }
+    void setTableDBMap(std::unordered_map<common::table_id_t, std::string> map) {
+        tableDBMap = std::move(map);
+    }
 
     binder::expression_vector getProperties() const { return properties; }
     void addProperty(std::shared_ptr<binder::Expression> expr) {
@@ -128,6 +134,7 @@ private:
     LogicalScanNodeTableType scanType;
     std::shared_ptr<binder::Expression> nodeID;
     std::vector<common::table_id_t> nodeTableIDs;
+    std::unordered_map<common::table_id_t, std::string> tableDBMap;
     binder::expression_vector properties;
     std::vector<storage::ColumnPredicateSet> propertyPredicates;
     std::unique_ptr<ExtraScanNodeTableInfo> extraInfo;

--- a/src/include/planner/planner.h
+++ b/src/include/planner/planner.h
@@ -237,7 +237,7 @@ public:
     void appendExpressionsScan(const binder::expression_vector& expressions, LogicalPlan& plan);
     void appendScanNodeTable(std::shared_ptr<binder::Expression> nodeID,
         std::vector<common::table_id_t> tableIDs, const binder::expression_vector& properties,
-        LogicalPlan& plan);
+        LogicalPlan& plan, const binder::NodeOrRelExpression* nodeOrRel = nullptr);
     bool tryPlanQueryPrimaryKeyLookup(const binder::QueryGraphCollection& queryGraphCollection,
         const binder::expression_vector& predicates, LogicalPlan& plan);
 

--- a/src/include/storage/storage_manager.h
+++ b/src/include/storage/storage_manager.h
@@ -41,6 +41,7 @@ public:
     ~StorageManager();
 
     Table* getTable(common::table_id_t tableID);
+    bool containsTable(common::table_id_t tableID) const;
 
     static void recover(main::ClientContext& clientContext, bool throwOnWalReplayFailure,
         bool enableChecksums);

--- a/src/main/attached_database.cpp
+++ b/src/main/attached_database.cpp
@@ -65,8 +65,9 @@ AttachedLbugDatabase::AttachedLbugDatabase(std::string dbPath, std::string dbNam
     }
     catalog = std::make_unique<catalog::Catalog>();
     validateEmptyWAL(path, clientContext);
-    storageManager = std::make_unique<storage::StorageManager>(path, true /* isReadOnly */,
-        clientContext->getDBConfig()->enableChecksums, *storage::MemoryManager::Get(*clientContext),
+    storageManager = std::make_unique<storage::StorageManager>(path,
+        clientContext->getDBConfig()->readOnly, clientContext->getDBConfig()->enableChecksums,
+        *storage::MemoryManager::Get(*clientContext),
         clientContext->getDBConfig()->enableCompression,
         clientContext->getDBConfig()->enableDefaultHashIndex, vfs);
     transactionManager =

--- a/src/main/database_manager.cpp
+++ b/src/main/database_manager.cpp
@@ -397,5 +397,35 @@ std::vector<catalog::Catalog*> DatabaseManager::getGraphs() const {
     return result;
 }
 
+std::pair<catalog::Catalog*, storage::StorageManager*> DatabaseManager::resolveTableStorage(
+    const ClientContext& context, common::table_id_t tableID, const std::string& dbName) {
+    if (!dbName.empty()) {
+        auto* attachedDB = DatabaseManager::Get(context)->getAttachedDatabase(dbName);
+        if (attachedDB->getDBType() == common::ATTACHED_LBUG_DB_TYPE) {
+            auto* attachedLbug = static_cast<main::AttachedLbugDatabase*>(attachedDB);
+            if (attachedLbug->getStorageManager()->containsTable(tableID)) {
+                return {attachedDB->getCatalog(), attachedLbug->getStorageManager()};
+            }
+        }
+        throw common::RuntimeException(
+            std::format("Table with ID {} not found in database {}.", tableID, dbName));
+    }
+    auto* mainSM = storage::StorageManager::Get(context);
+    if (mainSM->containsTable(tableID)) {
+        return {catalog::Catalog::Get(context), mainSM};
+    }
+    auto* dbManager = DatabaseManager::Get(context);
+    for (auto* attachedDB : dbManager->getAttachedDatabases()) {
+        if (attachedDB->getDBType() == common::ATTACHED_LBUG_DB_TYPE) {
+            auto* attachedLbug = static_cast<main::AttachedLbugDatabase*>(attachedDB);
+            if (attachedLbug->getStorageManager()->containsTable(tableID)) {
+                return {attachedDB->getCatalog(), attachedLbug->getStorageManager()};
+            }
+        }
+    }
+    throw common::RuntimeException(
+        std::format("Table with ID {} not found in any attached database.", tableID));
+}
+
 } // namespace main
 } // namespace lbug

--- a/src/optimizer/filter_push_down_optimizer.cpp
+++ b/src/optimizer/filter_push_down_optimizer.cpp
@@ -13,7 +13,9 @@
 #include "catalog/catalog_entry/index_catalog_entry.h"
 #include "catalog/catalog_entry/table_catalog_entry.h"
 #include "common/string_utils.h"
+#include "main/attached_database.h"
 #include "main/client_context.h"
+#include "main/database_manager.h"
 #include "planner/join_order/cardinality_estimator.h"
 #include "planner/operator/extend/logical_extend.h"
 #include "planner/operator/logical_empty_result.h"
@@ -208,11 +210,11 @@ static bool isNodeProperty(const Expression& expression, const Expression& nodeI
 
 static std::optional<std::pair<std::shared_ptr<Expression>, std::string>>
 popSecondaryARTEqualityComparison(PredicateSet& predicateSet, const Expression& nodeID,
-    table_id_t tableID, main::ClientContext* context) {
-    auto catalog = Catalog::Get(*context);
+    table_id_t tableID, main::ClientContext* context, const std::string& dbName = {}) {
+    auto [cat, sm] = main::DatabaseManager::resolveTableStorage(*context, tableID, dbName);
     auto transaction = transaction::Transaction::Get(*context);
-    auto tableEntry = catalog->getTableCatalogEntry(transaction, tableID);
-    auto* table = StorageManager::Get(*context)->getTable(tableID)->ptrCast<NodeTable>();
+    auto tableEntry = cat->getTableCatalogEntry(transaction, tableID);
+    auto* table = sm->getTable(tableID)->ptrCast<NodeTable>();
     for (auto i = 0u; i < predicateSet.equalityPredicates.size(); ++i) {
         auto predicate = predicateSet.equalityPredicates[i];
         auto lhs = predicate->getChild(0);
@@ -228,7 +230,7 @@ popSecondaryARTEqualityComparison(PredicateSet& predicateSet, const Expression& 
             continue;
         }
         const auto propertyID = tableEntry->getPropertyID(property.getPropertyName());
-        for (auto* indexEntry : catalog->getIndexEntries(transaction, tableID)) {
+        for (auto* indexEntry : cat->getIndexEntries(transaction, tableID)) {
             if (!indexEntry->containsPropertyID(propertyID) ||
                 !StringUtils::caseInsensitiveEquals(indexEntry->getIndexType(),
                     ArtPrimaryKeyIndex::getIndexType().typeName)) {
@@ -257,12 +259,18 @@ std::shared_ptr<LogicalOperator> FilterPushDownOptimizer::visitScanNodeTableRepl
     // Apply index scan
     auto tableIDs = scan.getTableIDs();
     std::shared_ptr<Expression> primaryKeyEqualityComparison = nullptr;
+    auto& dbMap = scan.getTableDBMap();
+    auto getResolvedTable = [&](table_id_t id) -> storage::NodeTable* {
+        auto dbIt = dbMap.find(id);
+        auto dbName = dbIt != dbMap.end() ? dbIt->second : std::string{};
+        auto [cat, sm] = main::DatabaseManager::resolveTableStorage(*context, id, dbName);
+        return sm->getTable(id)->ptrCast<storage::NodeTable>();
+    };
     if (tableIDs.size() == 1) {
         primaryKeyEqualityComparison = predicateSet.popNodePKEqualityComparison(*nodeID);
     }
     if (primaryKeyEqualityComparison != nullptr) { // Try rewrite index scan
-        auto* table =
-            StorageManager::Get(*context)->getTable(tableIDs[0])->ptrCast<storage::NodeTable>();
+        auto* table = getResolvedTable(tableIDs[0]);
         auto rhs = primaryKeyEqualityComparison->getChild(1);
         if (table->tryGetPrimaryKeyIndex() != nullptr && isConstantExpression(rhs)) {
             auto extraInfo = std::make_unique<PrimaryKeyScanInfo>(rhs);
@@ -274,8 +282,7 @@ std::shared_ptr<LogicalOperator> FilterPushDownOptimizer::visitScanNodeTableRepl
             predicateSet.addPredicate(primaryKeyEqualityComparison);
         }
     } else if (tableIDs.size() == 1) {
-        auto* table =
-            StorageManager::Get(*context)->getTable(tableIDs[0])->ptrCast<storage::NodeTable>();
+        auto* table = getResolvedTable(tableIDs[0]);
         auto* pkIndex = table->tryGetPrimaryKeyIndex();
         if (pkIndex != nullptr && pkIndex->getIndexInfo().indexType ==
                                       storage::ArtPrimaryKeyIndex::getIndexType().typeName) {
@@ -291,8 +298,10 @@ std::shared_ptr<LogicalOperator> FilterPushDownOptimizer::visitScanNodeTableRepl
         }
     }
     if (scan.getScanType() == LogicalScanNodeTableType::SCAN && tableIDs.size() == 1) {
+        auto dbIt = dbMap.find(tableIDs[0]);
+        auto dbName = dbIt != dbMap.end() ? dbIt->second : std::string{};
         auto secondaryIndexComparison =
-            popSecondaryARTEqualityComparison(predicateSet, *nodeID, tableIDs[0], context);
+            popSecondaryARTEqualityComparison(predicateSet, *nodeID, tableIDs[0], context, dbName);
         if (secondaryIndexComparison.has_value()) {
             scan.setScanType(LogicalScanNodeTableType::SECONDARY_INDEX_SCAN);
             scan.setExtraInfo(std::make_unique<SecondaryIndexScanInfo>(
@@ -358,19 +367,6 @@ std::shared_ptr<LogicalOperator> FilterPushDownOptimizer::finishPushDown(
     auto root = appendFiltersStatsAware(std::move(predicates), op);
     predicateSet.clear();
     return root;
-}
-
-std::shared_ptr<LogicalOperator> FilterPushDownOptimizer::appendScanNodeTable(
-    std::shared_ptr<binder::Expression> nodeID, std::vector<common::table_id_t> nodeTableIDs,
-    binder::expression_vector properties, std::shared_ptr<planner::LogicalOperator> child) {
-    if (properties.empty()) {
-        return child;
-    }
-    auto printInfo = std::make_unique<OPPrintInfo>();
-    auto scanNodeTable = std::make_shared<LogicalScanNodeTable>(std::move(nodeID),
-        std::move(nodeTableIDs), std::move(properties));
-    scanNodeTable->computeFlatSchema();
-    return scanNodeTable;
 }
 
 std::shared_ptr<LogicalOperator> FilterPushDownOptimizer::appendFilters(

--- a/src/planner/join_order/cardinality_estimator.cpp
+++ b/src/planner/join_order/cardinality_estimator.cpp
@@ -6,6 +6,7 @@
 #include "catalog/catalog_entry/table_catalog_entry.h"
 #include "common/enums/extend_direction_util.h"
 #include "main/client_context.h"
+#include "main/database_manager.h"
 #include "planner/join_order/join_order_util.h"
 #include "planner/operator/logical_aggregate.h"
 #include "planner/operator/logical_hash_join.h"
@@ -26,8 +27,8 @@ static cardinality_t atLeastOne(uint64_t x) {
 }
 
 static PlannerTableStats getPlannerStats(main::ClientContext* context,
-    storage::StorageManager& storageManager, catalog::TableCatalogEntry& tableEntry,
-    table_id_t physicalTableID = INVALID_TABLE_ID) {
+    storage::StorageManager& storageManager, catalog::Catalog& catalog,
+    catalog::TableCatalogEntry& tableEntry, table_id_t physicalTableID = INVALID_TABLE_ID) {
     const auto tableID =
         physicalTableID == INVALID_TABLE_ID ? tableEntry.getTableID() : physicalTableID;
     auto* table = storageManager.getTable(tableID);
@@ -35,7 +36,7 @@ static PlannerTableStats getPlannerStats(main::ClientContext* context,
         cachedStats.has_value() && cachedStats->tableChangeEpoch == table->getChangeEpoch()) {
         return std::move(cachedStats.value());
     }
-    return storage::buildPlannerTableStats(storageManager, *catalog::Catalog::Get(*context),
+    return storage::buildPlannerTableStats(storageManager, catalog,
         transaction::Transaction::Get(*context), tableEntry, physicalTableID,
         storage::PlannerStatsMode::SCHEMA_ONLY);
 }
@@ -58,14 +59,25 @@ void CardinalityEstimator::init(const QueryGraph& queryGraph) {
 void CardinalityEstimator::init(const NodeExpression& node) {
     auto key = node.getInternalID()->getUniqueName();
     cardinality_t numNodes = 0u;
-    auto storageManager = storage::StorageManager::Get(*context);
     for (auto entry : node.getEntries()) {
         // Skip foreign tables - they don't have storage in the local database
         if (entry->getType() == catalog::CatalogEntryType::FOREIGN_TABLE_ENTRY) {
             continue;
         }
         auto tableID = entry->getTableID();
-        auto stats = getPlannerStats(context, *storageManager, *entry);
+        auto dbName = node.getDbName(entry);
+        storage::StorageManager* storageManager;
+        catalog::Catalog* cat;
+        if (!dbName.empty()) {
+            auto* attachedDB = main::DatabaseManager::Get(*context)->getAttachedDatabase(dbName);
+            auto* attachedLbugDB = static_cast<main::AttachedLbugDatabase*>(attachedDB);
+            storageManager = attachedLbugDB->getStorageManager();
+            cat = attachedDB->getCatalog();
+        } else {
+            storageManager = storage::StorageManager::Get(*context);
+            cat = catalog::Catalog::Get(*context);
+        }
+        auto stats = getPlannerStats(context, *storageManager, *cat, *entry);
         DASSERT(stats.storageStats.has_value());
         numNodes += stats.storageStats->getTableCard();
         if (!tableStats.contains(tableID)) {
@@ -78,10 +90,21 @@ void CardinalityEstimator::init(const NodeExpression& node) {
 }
 
 void CardinalityEstimator::init(const RelExpression& rel) {
-    auto storageManager = storage::StorageManager::Get(*context);
     for (auto entry : rel.getEntries()) {
         if (entry->getType() == catalog::CatalogEntryType::FOREIGN_TABLE_ENTRY) {
             continue;
+        }
+        auto dbName = rel.getDbName(entry);
+        storage::StorageManager* storageManager;
+        catalog::Catalog* cat;
+        if (!dbName.empty()) {
+            auto* attachedDB = main::DatabaseManager::Get(*context)->getAttachedDatabase(dbName);
+            auto* attachedLbugDB = static_cast<main::AttachedLbugDatabase*>(attachedDB);
+            storageManager = attachedLbugDB->getStorageManager();
+            cat = attachedDB->getCatalog();
+        } else {
+            storageManager = storage::StorageManager::Get(*context);
+            cat = catalog::Catalog::Get(*context);
         }
         auto& relGroupEntry = entry->cast<catalog::RelGroupCatalogEntry>();
         for (const auto& relInfo : relGroupEntry.getRelEntryInfos()) {
@@ -90,7 +113,7 @@ void CardinalityEstimator::init(const RelExpression& rel) {
                 continue;
             }
             tableStats.insert(
-                {tableID, getPlannerStats(context, *storageManager, *entry, tableID)});
+                {tableID, getPlannerStats(context, *storageManager, *cat, *entry, tableID)});
         }
     }
 }
@@ -219,8 +242,8 @@ static std::optional<cardinality_t> getTableStatsIfPossible(main::ClientContext*
         if (tableStats.contains(tableID) && tableStats.at(tableID).storageStats.has_value() &&
             propertyExpr.hasProperty(tableID)) {
             auto transaction = Transaction::Get(*context);
-            auto entry =
-                catalog::Catalog::Get(*context)->getTableCatalogEntry(transaction, tableID);
+            auto [cat, sm] = main::DatabaseManager::resolveTableStorage(*context, tableID);
+            auto entry = cat->getTableCatalogEntry(transaction, tableID);
             if (!entry->containsProperty(propertyExpr.getPropertyName())) {
                 return {};
             }
@@ -266,12 +289,17 @@ uint64_t CardinalityEstimator::getNumNodes(const Transaction*,
     return atLeastOne(numNodes);
 }
 
+static storage::Table* getTableFromAnyStorageManager(main::ClientContext* context,
+    common::table_id_t tableID) {
+    auto [cat, sm] = main::DatabaseManager::resolveTableStorage(*context, tableID);
+    return sm->getTable(tableID);
+}
+
 uint64_t CardinalityEstimator::getNumRels(const Transaction* transaction,
     const std::vector<table_id_t>& tableIDs) const {
     cardinality_t numRels = 0u;
     for (auto tableID : tableIDs) {
-        numRels +=
-            storage::StorageManager::Get(*context)->getTable(tableID)->getNumTotalRows(transaction);
+        numRels += getTableFromAnyStorageManager(context, tableID)->getNumTotalRows(transaction);
     }
     return atLeastOne(numRels);
 }

--- a/src/planner/join_order/join_plan_solver.cpp
+++ b/src/planner/join_order/join_plan_solver.cpp
@@ -59,7 +59,7 @@ LogicalPlan JoinPlanSolver::solveNodeScanTreeNode(const JoinTreeNode& treeNode) 
     auto boundNode = std::static_pointer_cast<NodeExpression>(nodeInfo.nodeOrRel);
     auto plan = LogicalPlan();
     planner->appendScanNodeTable(boundNode->getInternalID(), boundNode->getTableIDs(),
-        nodeInfo.properties, plan);
+        nodeInfo.properties, plan, boundNode.get());
     planner->appendFilters(nodeInfo.predicates, plan);
     for (auto& relInfo : extraInfo.relInfos) {
         auto rel = std::static_pointer_cast<RelExpression>(relInfo.nodeOrRel);
@@ -101,7 +101,7 @@ LogicalPlan JoinPlanSolver::solveRelScanTreeNode(const JoinTreeNode& treeNode,
     auto direction = getExtendDirection(*rel, *boundNode);
     auto plan = LogicalPlan();
     planner->appendScanNodeTable(boundNode->getInternalID(), boundNode->getTableIDs(),
-        expression_vector{}, plan);
+        expression_vector{}, plan, boundNode.get());
     planner->appendExtend(boundNode, nbrNode, rel, direction, relInfo.properties, plan);
     planner->appendFilters(relInfo.predicates, plan);
     return plan;

--- a/src/planner/operator/scan/logical_scan_node_table.cpp
+++ b/src/planner/operator/scan/logical_scan_node_table.cpp
@@ -5,7 +5,7 @@ namespace planner {
 
 LogicalScanNodeTable::LogicalScanNodeTable(const LogicalScanNodeTable& other)
     : LogicalOperator{type_}, scanType{other.scanType}, nodeID{other.nodeID},
-      nodeTableIDs{other.nodeTableIDs}, properties{other.properties},
+      nodeTableIDs{other.nodeTableIDs}, tableDBMap{other.tableDBMap}, properties{other.properties},
       propertyPredicates{copyVector(other.propertyPredicates)} {
     if (other.extraInfo != nullptr) {
         setExtraInfo(other.extraInfo->copy());

--- a/src/planner/plan/append_extend.cpp
+++ b/src/planner/plan/append_extend.cpp
@@ -194,14 +194,15 @@ void Planner::appendRecursiveExtend(const std::shared_ptr<NodeExpression>& bound
 
 void Planner::createPathNodePropertyScanPlan(const std::shared_ptr<NodeExpression>& node,
     const expression_vector& properties, LogicalPlan& plan) {
-    appendScanNodeTable(node->getInternalID(), node->getTableIDs(), properties, plan);
+    appendScanNodeTable(node->getInternalID(), node->getTableIDs(), properties, plan, node.get());
 }
 
 void Planner::createPathRelPropertyScanPlan(const std::shared_ptr<NodeExpression>& boundNode,
     const std::shared_ptr<NodeExpression>& nbrNode, const std::shared_ptr<RelExpression>& rel,
     ExtendDirection direction, bool extendFromSource, const expression_vector& properties,
     LogicalPlan& plan) {
-    appendScanNodeTable(boundNode->getInternalID(), boundNode->getTableIDs(), {}, plan);
+    appendScanNodeTable(boundNode->getInternalID(), boundNode->getTableIDs(), {}, plan,
+        boundNode.get());
     appendNonRecursiveExtend(boundNode, nbrNode, rel, direction, extendFromSource, properties,
         plan);
     appendProjection(properties, plan);

--- a/src/planner/plan/append_scan_node_table.cpp
+++ b/src/planner/plan/append_scan_node_table.cpp
@@ -26,13 +26,22 @@ void Planner::appendScanNodeTable(std::shared_ptr<Expression> nodeID,
     auto propertiesToScan_ = removeInternalIDProperty(properties);
     auto scan = make_shared<LogicalScanNodeTable>(std::move(nodeID), std::move(tableIDs),
         propertiesToScan_);
-    // Build tableDBMap from node/rel expression if available
+    // Build tableDBMap from node/rel expression if available.
+    // When entries from different databases share a table ID (both number from 0),
+    // erase the key to mark it ambiguous. The physical mapper will then fall back
+    // to the property-match heuristic to resolve the correct database.
     if (nodeOrRel) {
         std::unordered_map<common::table_id_t, std::string> dbMap;
         for (auto* entry : nodeOrRel->getEntries()) {
             auto dbName = nodeOrRel->getDbName(entry);
             if (!dbName.empty()) {
-                dbMap[entry->getTableID()] = dbName;
+                auto tid = entry->getTableID();
+                auto [it, inserted] = dbMap.try_emplace(tid, dbName);
+                if (!inserted && it->second != dbName) {
+                    // Collision: different databases have the same table ID.
+                    // Remove so the mapper's property-based fallback handles it.
+                    dbMap.erase(it);
+                }
             }
         }
         scan->setTableDBMap(std::move(dbMap));

--- a/src/planner/plan/append_scan_node_table.cpp
+++ b/src/planner/plan/append_scan_node_table.cpp
@@ -1,3 +1,4 @@
+#include "binder/expression/node_rel_expression.h"
 #include "binder/expression/property_expression.h"
 #include "planner/operator/scan/logical_scan_node_table.h"
 #include "planner/planner.h"
@@ -20,10 +21,22 @@ static expression_vector removeInternalIDProperty(const expression_vector& expre
 }
 
 void Planner::appendScanNodeTable(std::shared_ptr<Expression> nodeID,
-    std::vector<table_id_t> tableIDs, const expression_vector& properties, LogicalPlan& plan) {
+    std::vector<table_id_t> tableIDs, const expression_vector& properties, LogicalPlan& plan,
+    const NodeOrRelExpression* nodeOrRel) {
     auto propertiesToScan_ = removeInternalIDProperty(properties);
     auto scan = make_shared<LogicalScanNodeTable>(std::move(nodeID), std::move(tableIDs),
         propertiesToScan_);
+    // Build tableDBMap from node/rel expression if available
+    if (nodeOrRel) {
+        std::unordered_map<common::table_id_t, std::string> dbMap;
+        for (auto* entry : nodeOrRel->getEntries()) {
+            auto dbName = nodeOrRel->getDbName(entry);
+            if (!dbName.empty()) {
+                dbMap[entry->getTableID()] = dbName;
+            }
+        }
+        scan->setTableDBMap(std::move(dbMap));
+    }
     scan->computeFactorizedSchema();
     scan->setCardinality(cardinalityEstimator.estimateScanNode(*scan));
     plan.setLastOperator(std::move(scan));

--- a/src/planner/plan/plan_join_order.cpp
+++ b/src/planner/plan/plan_join_order.cpp
@@ -305,10 +305,12 @@ void Planner::planNodeScan(uint32_t nodePos) {
             // Use table function call for entries that supply a scan function
             appendTableFunctionCall(*boundScanInfo, plan);
         } else {
-            appendScanNodeTable(node->getInternalID(), node->getTableIDs(), properties, plan);
+            appendScanNodeTable(node->getInternalID(), node->getTableIDs(), properties, plan,
+                node.get());
         }
     } else {
-        appendScanNodeTable(node->getInternalID(), node->getTableIDs(), properties, plan);
+        appendScanNodeTable(node->getInternalID(), node->getTableIDs(), properties, plan,
+            node.get());
     }
     auto predicates = getNewlyMatchedExprs(context.getEmptySubqueryGraph(), newSubgraph,
         context.getWhereExpressions());
@@ -321,7 +323,7 @@ void Planner::planNodeIDScan(uint32_t nodePos) {
     auto newSubgraph = context.getEmptySubqueryGraph();
     newSubgraph.addQueryNode(nodePos);
     auto plan = LogicalPlan();
-    appendScanNodeTable(node->getInternalID(), node->getTableIDs(), {}, plan);
+    appendScanNodeTable(node->getInternalID(), node->getTableIDs(), {}, plan, node.get());
     context.addPlan(newSubgraph, std::move(plan));
 }
 
@@ -367,7 +369,8 @@ void Planner::planRelScan(uint32_t relPos, const QueryGraphPlanningInfo& info) {
             auto nbrNode = srcCorrelated ? dstNode : srcNode;
             auto plan = LogicalPlan();
             const auto extendDirection = getExtendDirection(*rel, *boundNode);
-            appendScanNodeTable(boundNode->getInternalID(), boundNode->getTableIDs(), {}, plan);
+            appendScanNodeTable(boundNode->getInternalID(), boundNode->getTableIDs(), {}, plan,
+                boundNode.get());
             // Use PackedExtend for eligible single-rel seeds so the bound node group stays unflat.
             // tryPlanPackedINLJoin depends on this when attaching a second rel as a sibling.
             if (clientContext->getClientConfig()->enablePackedPathExtend &&
@@ -388,7 +391,8 @@ void Planner::planRelScan(uint32_t relPos, const QueryGraphPlanningInfo& info) {
         auto plan = LogicalPlan();
         auto [boundNode, nbrNode] = getBoundAndNbrNodes(*rel, direction);
         const auto extendDirection = getExtendDirection(*rel, *boundNode);
-        appendScanNodeTable(boundNode->getInternalID(), boundNode->getTableIDs(), {}, plan);
+        appendScanNodeTable(boundNode->getInternalID(), boundNode->getTableIDs(), {}, plan,
+            boundNode.get());
         // Use PackedExtend for eligible single-rel seeds so the bound node group stays unflat.
         // tryPlanPackedINLJoin depends on this when attaching a second rel as a sibling.
         if (clientContext->getClientConfig()->enablePackedPathExtend &&

--- a/src/planner/plan/plan_node_scan.cpp
+++ b/src/planner/plan/plan_node_scan.cpp
@@ -11,7 +11,7 @@ LogicalPlan Planner::getNodePropertyScanPlan(const NodeExpression& node) {
     if (properties.empty()) {
         return scanPlan;
     }
-    appendScanNodeTable(node.getInternalID(), node.getTableIDs(), properties, scanPlan);
+    appendScanNodeTable(node.getInternalID(), node.getTableIDs(), properties, scanPlan, &node);
     return scanPlan;
 }
 

--- a/src/planner/plan/plan_node_semi_mask.cpp
+++ b/src/planner/plan/plan_node_semi_mask.cpp
@@ -36,7 +36,7 @@ LogicalPlan Planner::getNodeSemiMaskPlan(SemiMaskTargetType targetType, const No
         auto& propExpr = expr->constCast<PropertyExpression>();
         propertyExprCollection.addProperties(propExpr.getVariableName(), expr);
     }
-    appendScanNodeTable(node.getInternalID(), node.getTableIDs(), getProperties(node), plan);
+    appendScanNodeTable(node.getInternalID(), node.getTableIDs(), getProperties(node), plan, &node);
     appendFilter(nodePredicate, plan);
     exitPropertyExprCollection(std::move(prevCollection));
     appendNodeSemiMask(targetType, node, plan);

--- a/src/processor/map/map_scan_node_table.cpp
+++ b/src/processor/map/map_scan_node_table.cpp
@@ -3,6 +3,8 @@
 #include "binder/expression_binder.h"
 #include "catalog/catalog.h"
 #include "common/mask.h"
+#include "main/attached_database.h"
+#include "main/database_manager.h"
 #include "planner/operator/scan/logical_scan_node_table.h"
 #include "processor/expression_mapper.h"
 #include "processor/operator/scan/primary_key_scan_node_table.h"
@@ -19,8 +21,6 @@ namespace processor {
 
 std::unique_ptr<PhysicalOperator> PlanMapper::mapScanNodeTable(
     const LogicalOperator* logicalOperator) {
-    auto storageManager = storage::StorageManager::Get(*clientContext);
-    auto catalog = catalog::Catalog::Get(*clientContext);
     auto transaction = transaction::Transaction::Get(*clientContext);
     auto& scan = logicalOperator->constCast<LogicalScanNodeTable>();
     const auto outSchema = scan.getSchema();
@@ -36,9 +36,59 @@ std::unique_ptr<PhysicalOperator> PlanMapper::mapScanNodeTable(
     auto binder = Binder(clientContext);
     auto expressionBinder = ExpressionBinder(&binder, clientContext);
     for (const auto& tableID : tableIDs) {
-        auto tableEntry = catalog->getTableCatalogEntry(transaction, tableID);
+        // Look up database name from the scan's tableDBMap (set during planning
+        // when the node expression carries dbNames for attached databases).
+        auto& dbMap = scan.getTableDBMap();
+        auto it = dbMap.find(tableID);
+        auto dbName = it != dbMap.end() ? it->second : std::string{};
+        auto [cat, sm] =
+            main::DatabaseManager::resolveTableStorage(*clientContext, tableID, dbName);
+        auto tableEntry = cat->getTableCatalogEntry(transaction, tableID);
+        // Fallback: if the resolved entry doesn't have any of the scanned
+        // properties, try attached databases (IDs overlap between databases).
+        if (dbName.empty() && !scan.getProperties().empty()) {
+            bool hasAnyProperty = false;
+            for (auto& expr : scan.getProperties()) {
+                auto& prop = expr->constCast<PropertyExpression>();
+                if (prop.hasProperty(tableEntry->getTableID()) &&
+                    tableEntry->containsProperty(prop.getPropertyName())) {
+                    hasAnyProperty = true;
+                    break;
+                }
+            }
+            if (!hasAnyProperty) {
+                // Try attached databases
+                auto* dbManager = main::DatabaseManager::Get(*clientContext);
+                for (auto* attachedDB : dbManager->getAttachedDatabases()) {
+                    if (attachedDB->getDBType() == common::ATTACHED_LBUG_DB_TYPE) {
+                        auto* attachedLbug = static_cast<main::AttachedLbugDatabase*>(attachedDB);
+                        if (attachedLbug->getStorageManager()->containsTable(tableID)) {
+                            auto* attachedCat = attachedDB->getCatalog();
+                            auto* attachedEntry =
+                                attachedCat->getTableCatalogEntry(transaction, tableID);
+                            // Verify this database has the expected properties
+                            bool found = false;
+                            for (auto& expr : scan.getProperties()) {
+                                auto& prop = expr->constCast<PropertyExpression>();
+                                if (prop.hasProperty(attachedEntry->getTableID()) &&
+                                    attachedEntry->containsProperty(prop.getPropertyName())) {
+                                    found = true;
+                                    break;
+                                }
+                            }
+                            if (found) {
+                                cat = attachedCat;
+                                sm = attachedLbug->getStorageManager();
+                                tableEntry = attachedEntry;
+                                break;
+                            }
+                        }
+                    }
+                }
+            }
+        }
         tableNames.push_back(tableEntry->getName());
-        auto table = storageManager->getTable(tableID)->ptrCast<storage::NodeTable>();
+        auto table = sm->getTable(tableID)->ptrCast<storage::NodeTable>();
         auto tableInfo = ScanNodeTableInfo(table, copyVector(scan.getPropertyPredicates()));
         for (auto& expr : scan.getProperties()) {
             auto& property = expr->constCast<PropertyExpression>();
@@ -70,7 +120,12 @@ std::unique_ptr<PhysicalOperator> PlanMapper::mapScanNodeTable(
     }
     std::vector<std::shared_ptr<ScanNodeTableSharedState>> sharedStates;
     for (auto& tableID : tableIDs) {
-        auto table = storageManager->getTable(tableID)->ptrCast<storage::NodeTable>();
+        auto& dbMap = scan.getTableDBMap();
+        auto it = dbMap.find(tableID);
+        auto dbName = it != dbMap.end() ? it->second : std::string{};
+        auto [cat, sm] =
+            main::DatabaseManager::resolveTableStorage(*clientContext, tableID, dbName);
+        auto table = sm->getTable(tableID)->ptrCast<storage::NodeTable>();
         auto semiMask = SemiMaskUtil::createMask(table->getNumTotalRows(transaction));
         sharedStates.push_back(std::make_shared<ScanNodeTableSharedState>(std::move(semiMask)));
     }

--- a/src/processor/map/map_scan_node_table.cpp
+++ b/src/processor/map/map_scan_node_table.cpp
@@ -31,78 +31,90 @@ std::unique_ptr<PhysicalOperator> PlanMapper::mapScanNodeTable(
     }
     auto scanInfo = ScanOpInfo(nodeIDPos, outVectorsPos);
     const auto tableIDs = scan.getTableIDs();
-    std::vector<std::string> tableNames;
-    std::vector<ScanNodeTableInfo> tableInfos;
-    auto binder = Binder(clientContext);
-    auto expressionBinder = ExpressionBinder(&binder, clientContext);
-    for (const auto& tableID : tableIDs) {
-        // Look up database name from the scan's tableDBMap (set during planning
-        // when the node expression carries dbNames for attached databases).
+    // Resolve (catalog, storage, entry) for each table ID once, with property-match
+    // fallback when dbName is empty (handles ID overlap between databases).
+    struct ResolvedTable {
+        catalog::Catalog* cat;
+        storage::StorageManager* sm;
+        catalog::TableCatalogEntry* entry;
+    };
+    std::vector<ResolvedTable> resolved;
+    {
         auto& dbMap = scan.getTableDBMap();
-        auto it = dbMap.find(tableID);
-        auto dbName = it != dbMap.end() ? it->second : std::string{};
-        auto [cat, sm] =
-            main::DatabaseManager::resolveTableStorage(*clientContext, tableID, dbName);
-        auto tableEntry = cat->getTableCatalogEntry(transaction, tableID);
-        // Fallback: if the resolved entry doesn't have any of the scanned
-        // properties, try attached databases (IDs overlap between databases).
-        if (dbName.empty() && !scan.getProperties().empty()) {
-            bool hasAnyProperty = false;
-            for (auto& expr : scan.getProperties()) {
-                auto& prop = expr->constCast<PropertyExpression>();
-                if (prop.hasProperty(tableEntry->getTableID()) &&
-                    tableEntry->containsProperty(prop.getPropertyName())) {
-                    hasAnyProperty = true;
-                    break;
+        for (const auto& tableID : tableIDs) {
+            auto it = dbMap.find(tableID);
+            auto dbName = it != dbMap.end() ? it->second : std::string{};
+            auto [cat, sm] =
+                main::DatabaseManager::resolveTableStorage(*clientContext, tableID, dbName);
+            auto tableEntry = cat->getTableCatalogEntry(transaction, tableID);
+            // Fallback: if dbName is empty and the entry lacks any scanned
+            // property, try attached databases (IDs overlap between databases).
+            if (dbName.empty() && !scan.getProperties().empty()) {
+                bool hasAnyProperty = false;
+                for (auto& expr : scan.getProperties()) {
+                    auto& prop = expr->constCast<PropertyExpression>();
+                    if (prop.hasProperty(tableEntry->getTableID()) &&
+                        tableEntry->containsProperty(prop.getPropertyName())) {
+                        hasAnyProperty = true;
+                        break;
+                    }
                 }
-            }
-            if (!hasAnyProperty) {
-                // Try attached databases
-                auto* dbManager = main::DatabaseManager::Get(*clientContext);
-                for (auto* attachedDB : dbManager->getAttachedDatabases()) {
-                    if (attachedDB->getDBType() == common::ATTACHED_LBUG_DB_TYPE) {
-                        auto* attachedLbug = static_cast<main::AttachedLbugDatabase*>(attachedDB);
-                        if (attachedLbug->getStorageManager()->containsTable(tableID)) {
-                            auto* attachedCat = attachedDB->getCatalog();
-                            auto* attachedEntry =
-                                attachedCat->getTableCatalogEntry(transaction, tableID);
-                            // Verify this database has the expected properties
-                            bool found = false;
-                            for (auto& expr : scan.getProperties()) {
-                                auto& prop = expr->constCast<PropertyExpression>();
-                                if (prop.hasProperty(attachedEntry->getTableID()) &&
-                                    attachedEntry->containsProperty(prop.getPropertyName())) {
-                                    found = true;
+                if (!hasAnyProperty) {
+                    auto* dbManager = main::DatabaseManager::Get(*clientContext);
+                    for (auto* attachedDB : dbManager->getAttachedDatabases()) {
+                        if (attachedDB->getDBType() == common::ATTACHED_LBUG_DB_TYPE) {
+                            auto* attachedLbug =
+                                static_cast<main::AttachedLbugDatabase*>(attachedDB);
+                            if (attachedLbug->getStorageManager()->containsTable(tableID)) {
+                                auto* attachedCat = attachedDB->getCatalog();
+                                auto* attachedEntry =
+                                    attachedCat->getTableCatalogEntry(transaction, tableID);
+                                bool found = false;
+                                for (auto& expr : scan.getProperties()) {
+                                    auto& prop = expr->constCast<PropertyExpression>();
+                                    if (prop.hasProperty(attachedEntry->getTableID()) &&
+                                        attachedEntry->containsProperty(prop.getPropertyName())) {
+                                        found = true;
+                                        break;
+                                    }
+                                }
+                                if (found) {
+                                    cat = attachedCat;
+                                    sm = attachedLbug->getStorageManager();
+                                    tableEntry = attachedEntry;
                                     break;
                                 }
-                            }
-                            if (found) {
-                                cat = attachedCat;
-                                sm = attachedLbug->getStorageManager();
-                                tableEntry = attachedEntry;
-                                break;
                             }
                         }
                     }
                 }
             }
+            resolved.push_back({cat, sm, tableEntry});
         }
-        tableNames.push_back(tableEntry->getName());
-        auto table = sm->getTable(tableID)->ptrCast<storage::NodeTable>();
+    }
+    // Build tableInfos and sharedStates from the single resolution.
+    std::vector<std::string> tableNames;
+    std::vector<ScanNodeTableInfo> tableInfos;
+    std::vector<std::shared_ptr<ScanNodeTableSharedState>> sharedStates;
+    auto binder = Binder(clientContext);
+    auto expressionBinder = ExpressionBinder(&binder, clientContext);
+    for (size_t i = 0; i < tableIDs.size(); ++i) {
+        auto& r = resolved[i];
+        auto table = r.sm->getTable(tableIDs[i])->ptrCast<storage::NodeTable>();
+        tableNames.push_back(r.entry->getName());
+        // Build tableInfo
         auto tableInfo = ScanNodeTableInfo(table, copyVector(scan.getPropertyPredicates()));
         for (auto& expr : scan.getProperties()) {
             auto& property = expr->constCast<PropertyExpression>();
-            if (property.hasProperty(tableEntry->getTableID())) {
+            if (property.hasProperty(r.entry->getTableID())) {
                 auto propertyName = property.getPropertyName();
-                if (!tableEntry->containsProperty(propertyName) &&
-                    tableEntry->containsProperty("data")) {
+                if (!r.entry->containsProperty(propertyName) && r.entry->containsProperty("data")) {
                     auto columnCaster = ColumnCaster(LogicalType::JSON());
                     columnCaster.setJSONExtract(propertyName);
-                    tableInfo.addColumnInfo(tableEntry->getColumnID("data"),
-                        std::move(columnCaster));
+                    tableInfo.addColumnInfo(r.entry->getColumnID("data"), std::move(columnCaster));
                     continue;
                 }
-                auto& columnType = tableEntry->getProperty(propertyName).getType();
+                auto& columnType = r.entry->getProperty(propertyName).getType();
                 auto columnCaster = ColumnCaster(columnType.copy());
                 if (property.getDataType() != columnType) {
                     auto columnExpr = std::make_shared<PropertyExpression>(property);
@@ -110,22 +122,14 @@ std::unique_ptr<PhysicalOperator> PlanMapper::mapScanNodeTable(
                     columnCaster.setCastExpr(
                         expressionBinder.forceCast(columnExpr, property.getDataType()));
                 }
-                tableInfo.addColumnInfo(tableEntry->getColumnID(propertyName),
+                tableInfo.addColumnInfo(r.entry->getColumnID(propertyName),
                     std::move(columnCaster));
             } else {
                 tableInfo.addColumnInfo(INVALID_COLUMN_ID, ColumnCaster(LogicalType::ANY()));
             }
         }
         tableInfos.push_back(std::move(tableInfo));
-    }
-    std::vector<std::shared_ptr<ScanNodeTableSharedState>> sharedStates;
-    for (auto& tableID : tableIDs) {
-        auto& dbMap = scan.getTableDBMap();
-        auto it = dbMap.find(tableID);
-        auto dbName = it != dbMap.end() ? it->second : std::string{};
-        auto [cat, sm] =
-            main::DatabaseManager::resolveTableStorage(*clientContext, tableID, dbName);
-        auto table = sm->getTable(tableID)->ptrCast<storage::NodeTable>();
+        // Build sharedState
         auto semiMask = SemiMaskUtil::createMask(table->getNumTotalRows(transaction));
         sharedStates.push_back(std::make_shared<ScanNodeTableSharedState>(std::move(semiMask)));
     }

--- a/src/processor/operator/simple/attach_database.cpp
+++ b/src/processor/operator/simple/attach_database.cpp
@@ -35,7 +35,6 @@ void AttachDatabase::executeInternal(ExecutionContext* context) {
     if (common::StringUtils::getUpper(attachInfo.dbType) == common::ATTACHED_LBUG_DB_TYPE) {
         auto db = std::make_unique<main::AttachedLbugDatabase>(attachInfo.dbPath,
             attachInfo.dbAlias, common::ATTACHED_LBUG_DB_TYPE, client);
-        client->setDefaultDatabase(db.get());
         databaseManager->registerAttachedDatabase(std::move(db));
         client->addDBDirToFileSearchPath(attachInfo.dbPath);
         appendMessage(attachMessage(), memoryManager);

--- a/src/processor/operator/simple/detach_database.cpp
+++ b/src/processor/operator/simple/detach_database.cpp
@@ -16,10 +16,6 @@ std::string DetatchDatabasePrintInfo::toString() const {
 void DetachDatabase::executeInternal(ExecutionContext* context) {
     auto clientContext = context->clientContext;
     auto dbManager = main::DatabaseManager::Get(*clientContext);
-    if (dbManager->hasAttachedDatabase(dbName) &&
-        dbManager->getAttachedDatabase(dbName)->getDBType() == common::ATTACHED_LBUG_DB_TYPE) {
-        clientContext->setDefaultDatabase(nullptr /* defaultDatabase */);
-    }
     dbManager->detachDatabase(dbName);
     appendMessage("Detached database successfully.", storage::MemoryManager::Get(*clientContext));
 }

--- a/src/storage/storage_manager.cpp
+++ b/src/storage/storage_manager.cpp
@@ -100,6 +100,11 @@ Table* StorageManager::getTable(table_id_t tableID) {
     return tables.at(tableID).get();
 }
 
+bool StorageManager::containsTable(table_id_t tableID) const {
+    std::shared_lock lck{mtx};
+    return tables.contains(tableID);
+}
+
 std::optional<PlannerTableStats> StorageManager::getCachedPlannerTableStats(
     table_id_t tableID) const {
     std::shared_lock lck{plannerStatsMtx};


### PR DESCRIPTION
When attaching a lbug database, stop calling setDefaultDatabase() which set remoteDatabase on the client context. This caused Catalog::Get() and StorageManager::Get() to return the attached database's catalog/storage, making all main database tables invisible. Foreign database extensions (Postgres, DuckDB) never called setDefaultDatabase, so the behavior is now consistent.

Key changes:
- Attach: remove client->setDefaultDatabase() so remoteDatabase stays null
- AttachedLbugDatabase: use clientContext->getDBConfig()->readOnly instead of hardcoded true, so attached db inherits the same read/write mode
- DatabaseManager: add resolveTableStorage() centralized resolver for looking up (Catalog*, StorageManager*) by table ID (+ optional dbName)
- StorageManager: add containsTable() method
- CardinalityEstimator: use per-entry dbName from node/rel expressions to route to the correct catalog and storage manager
- LogicalScanNodeTable: add tableDBMap (table_id -> db_name) carrying database context from planner to physical plan mapper
- mapScanNodeTable: use resolveTableStorage with fallback; when table IDs overlap between databases (both start at 0), verify properties match the resolved entry and try attached databases as needed
- Detach: remove corresponding setDefaultDatabase(nullptr) cleanup