### PR TITLE
Implement percentileCont aggregate function

### DIFF
--- a/src/function/aggregate/CMakeLists.txt
+++ b/src/function/aggregate/CMakeLists.txt
@@ -5,6 +5,7 @@ add_library(lbug_function_aggregate
         collect.cpp
         min_max.cpp
         percentile_disc.cpp
+        percentile_cont.cpp
         sum.cpp
         avg.cpp)
 

--- a/src/function/aggregate/percentile_cont.cpp
+++ b/src/function/aggregate/percentile_cont.cpp
@@ -7,6 +7,8 @@
 #include "binder/expression/literal_expression.h"
 #include "common/exception/binder.h"
 #include "common/type_utils.h"
+#include "function/aggregate/comparison_funcs.h"
+#include "function/aggregate/conversion_funcs.h"
 
 using namespace lbug::binder;
 using namespace lbug::common;
@@ -36,71 +38,6 @@ struct PercentileContState : public AggregateStateWithNull {
 
 static uint8_t* getElementValue(PercentileContElement* element) {
     return reinterpret_cast<uint8_t*>(element) + sizeof(PercentileContElement);
-}
-
-static bool valueLess(const uint8_t* left, const uint8_t* right, LogicalTypeID typeID) {
-    switch (typeID) {
-    case LogicalTypeID::INT8:
-        return *reinterpret_cast<const int8_t*>(left) < *reinterpret_cast<const int8_t*>(right);
-    case LogicalTypeID::INT16:
-        return *reinterpret_cast<const int16_t*>(left) < *reinterpret_cast<const int16_t*>(right);
-    case LogicalTypeID::INT32:
-        return *reinterpret_cast<const int32_t*>(left) < *reinterpret_cast<const int32_t*>(right);
-    case LogicalTypeID::INT64:
-    case LogicalTypeID::SERIAL:
-        return *reinterpret_cast<const int64_t*>(left) < *reinterpret_cast<const int64_t*>(right);
-    case LogicalTypeID::UINT8:
-        return *reinterpret_cast<const uint8_t*>(left) < *reinterpret_cast<const uint8_t*>(right);
-    case LogicalTypeID::UINT16:
-        return *reinterpret_cast<const uint16_t*>(left) < *reinterpret_cast<const uint16_t*>(right);
-    case LogicalTypeID::UINT32:
-        return *reinterpret_cast<const uint32_t*>(left) < *reinterpret_cast<const uint32_t*>(right);
-    case LogicalTypeID::UINT64:
-        return *reinterpret_cast<const uint64_t*>(left) < *reinterpret_cast<const uint64_t*>(right);
-    case LogicalTypeID::FLOAT:
-        return *reinterpret_cast<const float*>(left) < *reinterpret_cast<const float*>(right);
-    case LogicalTypeID::DOUBLE:
-        return *reinterpret_cast<const double*>(left) < *reinterpret_cast<const double*>(right);
-    case LogicalTypeID::INT128:
-        return *reinterpret_cast<const int128_t*>(left) < *reinterpret_cast<const int128_t*>(right);
-    case LogicalTypeID::UINT128:
-        return *reinterpret_cast<const uint128_t*>(left) <
-               *reinterpret_cast<const uint128_t*>(right);
-    default:
-        UNREACHABLE_CODE;
-    }
-}
-
-static double getValueAsDouble(const uint8_t* data, LogicalTypeID typeID) {
-    switch (typeID) {
-    case LogicalTypeID::INT8:
-        return static_cast<double>(*reinterpret_cast<const int8_t*>(data));
-    case LogicalTypeID::INT16:
-        return static_cast<double>(*reinterpret_cast<const int16_t*>(data));
-    case LogicalTypeID::INT32:
-        return static_cast<double>(*reinterpret_cast<const int32_t*>(data));
-    case LogicalTypeID::INT64:
-    case LogicalTypeID::SERIAL:
-        return static_cast<double>(*reinterpret_cast<const int64_t*>(data));
-    case LogicalTypeID::UINT8:
-        return static_cast<double>(*reinterpret_cast<const uint8_t*>(data));
-    case LogicalTypeID::UINT16:
-        return static_cast<double>(*reinterpret_cast<const uint16_t*>(data));
-    case LogicalTypeID::UINT32:
-        return static_cast<double>(*reinterpret_cast<const uint32_t*>(data));
-    case LogicalTypeID::UINT64:
-        return static_cast<double>(*reinterpret_cast<const uint64_t*>(data));
-    case LogicalTypeID::FLOAT:
-        return static_cast<double>(*reinterpret_cast<const float*>(data));
-    case LogicalTypeID::DOUBLE:
-        return *reinterpret_cast<const double*>(data);
-    case LogicalTypeID::INT128:
-        return static_cast<double>(*reinterpret_cast<const int128_t*>(data));
-    case LogicalTypeID::UINT128:
-        return static_cast<double>(*reinterpret_cast<const uint128_t*>(data));
-    default:
-        UNREACHABLE_CODE;
-    }
 }
 
 static std::unique_ptr<AggregateState> initialize() {
@@ -177,8 +114,8 @@ static void finalize(uint8_t* state_, LogicalTypeID typeID) {
     uint64_t lowIdx = static_cast<uint64_t>(std::floor(idx));
     uint64_t highIdx = static_cast<uint64_t>(std::ceil(idx));
     auto fraction = idx - static_cast<double>(lowIdx);
-    double lowVal = getValueAsDouble(values[lowIdx], typeID);
-    double highVal = getValueAsDouble(values[highIdx], typeID);
+    double lowVal = valueToDouble(values[lowIdx], typeID);
+    double highVal = valueToDouble(values[highIdx], typeID);
     state->result = lowVal + fraction * (highVal - lowVal);
 }
 

--- a/src/function/aggregate/percentile_cont.cpp
+++ b/src/function/aggregate/percentile_cont.cpp
@@ -1,0 +1,227 @@
+#include "function/aggregate/percentile_cont.h"
+
+#include <algorithm>
+#include <cmath>
+#include <vector>
+
+#include "binder/expression/literal_expression.h"
+#include "common/exception/binder.h"
+#include "common/type_utils.h"
+
+using namespace lbug::binder;
+using namespace lbug::common;
+
+namespace lbug {
+namespace function {
+
+struct PercentileContElement {
+    PercentileContElement* next = nullptr;
+};
+
+struct PercentileContState : public AggregateStateWithNull {
+    explicit PercentileContState(double percentile = 0) : percentile{percentile} {}
+
+    uint32_t getStateSize() const override { return sizeof(*this); }
+
+    void writeToVector(common::ValueVector* outputVector, uint64_t pos) override {
+        outputVector->setValue(pos, result);
+    }
+
+    PercentileContElement* head = nullptr;
+    PercentileContElement* tail = nullptr;
+    uint64_t count = 0;
+    double percentile;
+    double result = 0;
+};
+
+static uint8_t* getElementValue(PercentileContElement* element) {
+    return reinterpret_cast<uint8_t*>(element) + sizeof(PercentileContElement);
+}
+
+static bool valueLess(const uint8_t* left, const uint8_t* right, LogicalTypeID typeID) {
+    switch (typeID) {
+    case LogicalTypeID::INT8:
+        return *reinterpret_cast<const int8_t*>(left) < *reinterpret_cast<const int8_t*>(right);
+    case LogicalTypeID::INT16:
+        return *reinterpret_cast<const int16_t*>(left) < *reinterpret_cast<const int16_t*>(right);
+    case LogicalTypeID::INT32:
+        return *reinterpret_cast<const int32_t*>(left) < *reinterpret_cast<const int32_t*>(right);
+    case LogicalTypeID::INT64:
+    case LogicalTypeID::SERIAL:
+        return *reinterpret_cast<const int64_t*>(left) < *reinterpret_cast<const int64_t*>(right);
+    case LogicalTypeID::UINT8:
+        return *reinterpret_cast<const uint8_t*>(left) < *reinterpret_cast<const uint8_t*>(right);
+    case LogicalTypeID::UINT16:
+        return *reinterpret_cast<const uint16_t*>(left) < *reinterpret_cast<const uint16_t*>(right);
+    case LogicalTypeID::UINT32:
+        return *reinterpret_cast<const uint32_t*>(left) < *reinterpret_cast<const uint32_t*>(right);
+    case LogicalTypeID::UINT64:
+        return *reinterpret_cast<const uint64_t*>(left) < *reinterpret_cast<const uint64_t*>(right);
+    case LogicalTypeID::FLOAT:
+        return *reinterpret_cast<const float*>(left) < *reinterpret_cast<const float*>(right);
+    case LogicalTypeID::DOUBLE:
+        return *reinterpret_cast<const double*>(left) < *reinterpret_cast<const double*>(right);
+    case LogicalTypeID::INT128:
+        return *reinterpret_cast<const int128_t*>(left) < *reinterpret_cast<const int128_t*>(right);
+    case LogicalTypeID::UINT128:
+        return *reinterpret_cast<const uint128_t*>(left) <
+               *reinterpret_cast<const uint128_t*>(right);
+    default:
+        UNREACHABLE_CODE;
+    }
+}
+
+static double getValueAsDouble(const uint8_t* data, LogicalTypeID typeID) {
+    switch (typeID) {
+    case LogicalTypeID::INT8:
+        return static_cast<double>(*reinterpret_cast<const int8_t*>(data));
+    case LogicalTypeID::INT16:
+        return static_cast<double>(*reinterpret_cast<const int16_t*>(data));
+    case LogicalTypeID::INT32:
+        return static_cast<double>(*reinterpret_cast<const int32_t*>(data));
+    case LogicalTypeID::INT64:
+    case LogicalTypeID::SERIAL:
+        return static_cast<double>(*reinterpret_cast<const int64_t*>(data));
+    case LogicalTypeID::UINT8:
+        return static_cast<double>(*reinterpret_cast<const uint8_t*>(data));
+    case LogicalTypeID::UINT16:
+        return static_cast<double>(*reinterpret_cast<const uint16_t*>(data));
+    case LogicalTypeID::UINT32:
+        return static_cast<double>(*reinterpret_cast<const uint32_t*>(data));
+    case LogicalTypeID::UINT64:
+        return static_cast<double>(*reinterpret_cast<const uint64_t*>(data));
+    case LogicalTypeID::FLOAT:
+        return static_cast<double>(*reinterpret_cast<const float*>(data));
+    case LogicalTypeID::DOUBLE:
+        return *reinterpret_cast<const double*>(data);
+    case LogicalTypeID::INT128:
+        return static_cast<double>(*reinterpret_cast<const int128_t*>(data));
+    case LogicalTypeID::UINT128:
+        return static_cast<double>(*reinterpret_cast<const uint128_t*>(data));
+    default:
+        UNREACHABLE_CODE;
+    }
+}
+
+static std::unique_ptr<AggregateState> initialize() {
+    return std::make_unique<PercentileContState>();
+}
+
+static void updateSingleValue(PercentileContState* state, common::ValueVector* input, uint32_t pos,
+    uint64_t multiplicity, common::InMemOverflowBuffer* overflowBuffer) {
+    auto valueSize = LogicalTypeUtils::getRowLayoutSize(input->dataType);
+    for (auto i = 0u; i < multiplicity; ++i) {
+        auto* element = reinterpret_cast<PercentileContElement*>(
+            overflowBuffer->allocateSpace(sizeof(PercentileContElement) + valueSize));
+        element->next = nullptr;
+        input->copyToRowData(pos, getElementValue(element), overflowBuffer);
+        if (state->tail) {
+            state->tail->next = element;
+        } else {
+            state->head = element;
+        }
+        state->tail = element;
+        state->count++;
+        state->isNull = false;
+    }
+}
+
+static void updateAll(uint8_t* state_, common::ValueVector* input, uint64_t multiplicity,
+    common::InMemOverflowBuffer* overflowBuffer) {
+    DASSERT(!input->state->isFlat());
+    auto* state = reinterpret_cast<PercentileContState*>(state_);
+    input->forEachNonNull(
+        [&](auto pos) { updateSingleValue(state, input, pos, multiplicity, overflowBuffer); });
+}
+
+static void updatePos(uint8_t* state_, common::ValueVector* input, uint64_t multiplicity,
+    uint32_t pos, common::InMemOverflowBuffer* overflowBuffer) {
+    updateSingleValue(reinterpret_cast<PercentileContState*>(state_), input, pos, multiplicity,
+        overflowBuffer);
+}
+
+static void combine(uint8_t* state_, uint8_t* otherState_,
+    common::InMemOverflowBuffer* /*overflowBuffer*/) {
+    auto* otherState = reinterpret_cast<PercentileContState*>(otherState_);
+    if (otherState->isNull) {
+        return;
+    }
+    auto* state = reinterpret_cast<PercentileContState*>(state_);
+    if (state->tail) {
+        state->tail->next = otherState->head;
+    } else {
+        state->head = otherState->head;
+    }
+    state->tail = otherState->tail;
+    state->count += otherState->count;
+    state->isNull = false;
+    otherState->head = nullptr;
+    otherState->tail = nullptr;
+    otherState->count = 0;
+    otherState->isNull = true;
+}
+
+static void finalize(uint8_t* state_, LogicalTypeID typeID) {
+    auto* state = reinterpret_cast<PercentileContState*>(state_);
+    if (state->isNull) {
+        return;
+    }
+    std::vector<uint8_t*> values;
+    values.reserve(state->count);
+    for (auto* element = state->head; element != nullptr; element = element->next) {
+        values.push_back(getElementValue(element));
+    }
+    std::sort(values.begin(), values.end(),
+        [typeID](auto left, auto right) { return valueLess(left, right, typeID); });
+    auto idx = state->percentile * static_cast<double>(values.size() - 1);
+    uint64_t lowIdx = static_cast<uint64_t>(std::floor(idx));
+    uint64_t highIdx = static_cast<uint64_t>(std::ceil(idx));
+    auto fraction = idx - static_cast<double>(lowIdx);
+    double lowVal = getValueAsDouble(values[lowIdx], typeID);
+    double highVal = getValueAsDouble(values[highIdx], typeID);
+    state->result = lowVal + fraction * (highVal - lowVal);
+}
+
+static double bindPercentile(const ScalarBindFuncInput& input) {
+    if (input.arguments.size() != 2) {
+        throw BinderException("percentileCont requires exactly two arguments.");
+    }
+    auto literalExpr = dynamic_cast<LiteralExpression*>(input.arguments[1].get());
+    if (literalExpr == nullptr) {
+        throw BinderException("Second parameter of percentileCont must be a literal.");
+    }
+    auto percentile = literalExpr->getValue().getValue<double>();
+    if (percentile < 0 || percentile > 1) {
+        throw BinderException("percentileCont percentile must be between 0.0 and 1.0.");
+    }
+    return percentile;
+}
+
+static std::unique_ptr<FunctionBindData> bindFunc(const ScalarBindFuncInput& input) {
+    auto percentile = bindPercentile(input);
+    auto typeID = input.arguments[0]->dataType.getLogicalTypeID();
+    auto* aggregateFunction = input.definition->ptrCast<AggregateFunction>();
+    aggregateFunction->initializeFunc = [percentile]() {
+        return std::make_unique<PercentileContState>(percentile);
+    };
+    aggregateFunction->finalizeFunc = [typeID](auto state) { finalize(state, typeID); };
+    aggregateFunction->initialNullAggregateState =
+        aggregateFunction->createInitialNullAggregateState();
+    return FunctionBindData::getSimpleBindData(input.arguments, LogicalType::DOUBLE());
+}
+
+function_set AggregatePercentileContFunction::getFunctionSet() {
+    function_set result;
+    for (auto typeID : LogicalTypeUtils::getNumericalLogicalTypeIDs()) {
+        for (auto isDistinct : std::vector<bool>{true, false}) {
+            result.push_back(std::make_unique<AggregateFunction>(
+                name, std::vector<LogicalTypeID>{typeID, LogicalTypeID::DOUBLE},
+                LogicalTypeID::DOUBLE, initialize, updateAll, updatePos, combine, [](auto) {},
+                isDistinct, bindFunc));
+        }
+    }
+    return result;
+}
+
+} // namespace function
+} // namespace lbug

--- a/src/function/aggregate/percentile_disc.cpp
+++ b/src/function/aggregate/percentile_disc.cpp
@@ -7,6 +7,7 @@
 #include "binder/expression/literal_expression.h"
 #include "common/exception/binder.h"
 #include "common/type_utils.h"
+#include "function/aggregate/comparison_funcs.h"
 
 using namespace lbug::binder;
 using namespace lbug::common;
@@ -37,39 +38,6 @@ struct PercentileDiscState : public AggregateStateWithNull {
 
 static uint8_t* getElementValue(PercentileDiscElement* element) {
     return reinterpret_cast<uint8_t*>(element) + sizeof(PercentileDiscElement);
-}
-
-static bool valueLess(const uint8_t* left, const uint8_t* right, LogicalTypeID typeID) {
-    switch (typeID) {
-    case LogicalTypeID::INT8:
-        return *reinterpret_cast<const int8_t*>(left) < *reinterpret_cast<const int8_t*>(right);
-    case LogicalTypeID::INT16:
-        return *reinterpret_cast<const int16_t*>(left) < *reinterpret_cast<const int16_t*>(right);
-    case LogicalTypeID::INT32:
-        return *reinterpret_cast<const int32_t*>(left) < *reinterpret_cast<const int32_t*>(right);
-    case LogicalTypeID::INT64:
-    case LogicalTypeID::SERIAL:
-        return *reinterpret_cast<const int64_t*>(left) < *reinterpret_cast<const int64_t*>(right);
-    case LogicalTypeID::UINT8:
-        return *reinterpret_cast<const uint8_t*>(left) < *reinterpret_cast<const uint8_t*>(right);
-    case LogicalTypeID::UINT16:
-        return *reinterpret_cast<const uint16_t*>(left) < *reinterpret_cast<const uint16_t*>(right);
-    case LogicalTypeID::UINT32:
-        return *reinterpret_cast<const uint32_t*>(left) < *reinterpret_cast<const uint32_t*>(right);
-    case LogicalTypeID::UINT64:
-        return *reinterpret_cast<const uint64_t*>(left) < *reinterpret_cast<const uint64_t*>(right);
-    case LogicalTypeID::FLOAT:
-        return *reinterpret_cast<const float*>(left) < *reinterpret_cast<const float*>(right);
-    case LogicalTypeID::DOUBLE:
-        return *reinterpret_cast<const double*>(left) < *reinterpret_cast<const double*>(right);
-    case LogicalTypeID::INT128:
-        return *reinterpret_cast<const int128_t*>(left) < *reinterpret_cast<const int128_t*>(right);
-    case LogicalTypeID::UINT128:
-        return *reinterpret_cast<const uint128_t*>(left) <
-               *reinterpret_cast<const uint128_t*>(right);
-    default:
-        UNREACHABLE_CODE;
-    }
 }
 
 static std::unique_ptr<AggregateState> initialize() {

--- a/src/function/function_collection.cpp
+++ b/src/function/function_collection.cpp
@@ -2,6 +2,7 @@
 
 #include "function/aggregate/count.h"
 #include "function/aggregate/count_star.h"
+#include "function/aggregate/percentile_cont.h"
 #include "function/aggregate/percentile_disc.h"
 #include "function/arithmetic/vector_arithmetic_functions.h"
 #include "function/array/vector_array_functions.h"
@@ -220,6 +221,7 @@ FunctionCollection* FunctionCollection::getFunctions() {
         AGGREGATE_FUNCTION(AggregateSumFunction), AGGREGATE_FUNCTION(AggregateAvgFunction),
         AGGREGATE_FUNCTION(AggregateMinFunction), AGGREGATE_FUNCTION(AggregateMaxFunction),
         AGGREGATE_FUNCTION(CollectFunction), AGGREGATE_FUNCTION(AggregatePercentileDiscFunction),
+        AGGREGATE_FUNCTION(AggregatePercentileContFunction),
 
         // Table functions
         TABLE_FUNCTION(CurrentSettingFunction), TABLE_FUNCTION(CatalogVersionFunction),

--- a/src/include/function/aggregate/comparison_funcs.h
+++ b/src/include/function/aggregate/comparison_funcs.h
@@ -1,0 +1,45 @@
+#pragma once
+
+#include "common/types/int128_t.h"
+#include "common/types/types.h"
+#include "common/types/uint128_t.h"
+
+namespace lbug {
+namespace function {
+
+inline bool valueLess(const uint8_t* left, const uint8_t* right, common::LogicalTypeID typeID) {
+    switch (typeID) {
+    case common::LogicalTypeID::INT8:
+        return *reinterpret_cast<const int8_t*>(left) < *reinterpret_cast<const int8_t*>(right);
+    case common::LogicalTypeID::INT16:
+        return *reinterpret_cast<const int16_t*>(left) < *reinterpret_cast<const int16_t*>(right);
+    case common::LogicalTypeID::INT32:
+        return *reinterpret_cast<const int32_t*>(left) < *reinterpret_cast<const int32_t*>(right);
+    case common::LogicalTypeID::INT64:
+    case common::LogicalTypeID::SERIAL:
+        return *reinterpret_cast<const int64_t*>(left) < *reinterpret_cast<const int64_t*>(right);
+    case common::LogicalTypeID::UINT8:
+        return *reinterpret_cast<const uint8_t*>(left) < *reinterpret_cast<const uint8_t*>(right);
+    case common::LogicalTypeID::UINT16:
+        return *reinterpret_cast<const uint16_t*>(left) < *reinterpret_cast<const uint16_t*>(right);
+    case common::LogicalTypeID::UINT32:
+        return *reinterpret_cast<const uint32_t*>(left) < *reinterpret_cast<const uint32_t*>(right);
+    case common::LogicalTypeID::UINT64:
+        return *reinterpret_cast<const uint64_t*>(left) < *reinterpret_cast<const uint64_t*>(right);
+    case common::LogicalTypeID::FLOAT:
+        return *reinterpret_cast<const float*>(left) < *reinterpret_cast<const float*>(right);
+    case common::LogicalTypeID::DOUBLE:
+        return *reinterpret_cast<const double*>(left) < *reinterpret_cast<const double*>(right);
+    case common::LogicalTypeID::INT128:
+        return *reinterpret_cast<const common::int128_t*>(left) <
+               *reinterpret_cast<const common::int128_t*>(right);
+    case common::LogicalTypeID::UINT128:
+        return *reinterpret_cast<const common::uint128_t*>(left) <
+               *reinterpret_cast<const common::uint128_t*>(right);
+    default:
+        UNREACHABLE_CODE;
+    }
+}
+
+} // namespace function
+} // namespace lbug

--- a/src/include/function/aggregate/conversion_funcs.h
+++ b/src/include/function/aggregate/conversion_funcs.h
@@ -1,0 +1,43 @@
+#pragma once
+
+#include "common/types/int128_t.h"
+#include "common/types/types.h"
+#include "common/types/uint128_t.h"
+
+namespace lbug {
+namespace function {
+
+inline double valueToDouble(const uint8_t* data, common::LogicalTypeID typeID) {
+    switch (typeID) {
+    case common::LogicalTypeID::INT8:
+        return static_cast<double>(*reinterpret_cast<const int8_t*>(data));
+    case common::LogicalTypeID::INT16:
+        return static_cast<double>(*reinterpret_cast<const int16_t*>(data));
+    case common::LogicalTypeID::INT32:
+        return static_cast<double>(*reinterpret_cast<const int32_t*>(data));
+    case common::LogicalTypeID::INT64:
+    case common::LogicalTypeID::SERIAL:
+        return static_cast<double>(*reinterpret_cast<const int64_t*>(data));
+    case common::LogicalTypeID::UINT8:
+        return static_cast<double>(*reinterpret_cast<const uint8_t*>(data));
+    case common::LogicalTypeID::UINT16:
+        return static_cast<double>(*reinterpret_cast<const uint16_t*>(data));
+    case common::LogicalTypeID::UINT32:
+        return static_cast<double>(*reinterpret_cast<const uint32_t*>(data));
+    case common::LogicalTypeID::UINT64:
+        return static_cast<double>(*reinterpret_cast<const uint64_t*>(data));
+    case common::LogicalTypeID::FLOAT:
+        return static_cast<double>(*reinterpret_cast<const float*>(data));
+    case common::LogicalTypeID::DOUBLE:
+        return *reinterpret_cast<const double*>(data);
+    case common::LogicalTypeID::INT128:
+        return static_cast<double>(*reinterpret_cast<const common::int128_t*>(data));
+    case common::LogicalTypeID::UINT128:
+        return static_cast<double>(*reinterpret_cast<const common::uint128_t*>(data));
+    default:
+        UNREACHABLE_CODE;
+    }
+}
+
+} // namespace function
+} // namespace lbug

--- a/src/include/function/aggregate/percentile_cont.h
+++ b/src/include/function/aggregate/percentile_cont.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include "function/aggregate_function.h"
+
+namespace lbug {
+namespace function {
+
+struct AggregatePercentileContFunction {
+    static constexpr const char* name = "PERCENTILECONT";
+    static constexpr const char* prettyName = "percentileCont";
+
+    static function_set getFunctionSet();
+};
+
+} // namespace function
+} // namespace lbug

--- a/test/test_files/agg/percentile_cont.test
+++ b/test/test_files/agg/percentile_cont.test
@@ -1,0 +1,64 @@
+-DATASET CSV empty
+
+--
+
+-CASE PercentileContAggregate
+-STATEMENT UNWIND [10.0, 20.0, 30.0, 40.0] AS v
+           RETURN percentileCont(v, 0.0), percentileCont(v, 0.5),
+                  percentileCont(v, 0.75), percentileCont(v, 1.0)
+---- 1
+10.000000|25.000000|32.500000|40.000000
+
+-STATEMENT UNWIND [1, 2, 3, 4, 5] AS v
+           RETURN percentileCont(v, 0.5)
+---- 1
+3.000000
+
+-STATEMENT UNWIND [1, 2, 3, 4] AS v
+           RETURN percentileCont(v, 0.5)
+---- 1
+2.500000
+
+-STATEMENT CREATE NODE TABLE T(id INT64, g INT64, v INT64, PRIMARY KEY(id));
+---- ok
+
+-STATEMENT CREATE (:T {id: 1, g: 1, v: 10}),
+                  (:T {id: 2, g: 1, v: 20}),
+                  (:T {id: 3, g: 1, v: 30}),
+                  (:T {id: 4, g: 2, v: 5}),
+                  (:T {id: 5, g: 2, v: 15});
+---- ok
+
+-STATEMENT MATCH (n:T)
+           RETURN n.g, percentileCont(n.v, 0.5)
+           ORDER BY n.g
+---- 2
+1|20.000000
+2|10.000000
+
+-STATEMENT MATCH (n:T)
+           RETURN percentileCont(DISTINCT n.g, 1.0)
+---- 1
+2.000000
+
+-STATEMENT MATCH (n:T)
+           WHERE n.id > 100
+           RETURN percentileCont(n.v, 0.5)
+---- 1
+
+-STATEMENT UNWIND [1.5, 2.5, 3.5] AS v
+           RETURN percentileCont(v, 0.5)
+---- 1
+2.500000
+
+-STATEMENT UNWIND [100, 200] AS v
+           RETURN percentileCont(v, 0.25)
+---- 1
+125.000000
+
+-STATEMENT UNWIND [1, 2, 3, 4, 5, 6] AS v
+           RETURN percentileCont(v, 0.0), percentileCont(v, 0.25),
+                  percentileCont(v, 0.5), percentileCont(v, 0.75),
+                  percentileCont(v, 1.0)
+---- 1
+1.000000|2.250000|3.500000|4.750000|6.000000


### PR DESCRIPTION
Fixes: #748 

Add continuous percentile (interpolated) function alongside the existing discrete percentileDisc. Key differences:
- percentileCont returns DOUBLE regardless of input type
- Uses p * (N-1) formula with linear interpolation between adjacent values (vs ceil(p * N) - 1 nearest-rank for percentileDisc)

