### PR TITLE
feat: adaptive parallel histogram aggregate

### DIFF
--- a/src/function/aggregate/CMakeLists.txt
+++ b/src/function/aggregate/CMakeLists.txt
@@ -3,6 +3,7 @@ add_library(lbug_function_aggregate
         count.cpp
         count_star.cpp
         collect.cpp
+        histogram.cpp
         min_max.cpp
         percentile_disc.cpp
         percentile_cont.cpp

--- a/src/function/aggregate/histogram.cpp
+++ b/src/function/aggregate/histogram.cpp
@@ -3,7 +3,6 @@
 #include <algorithm>
 #include <cmath>
 #include <cstdio>
-#include <format>
 #include <sstream>
 #include <vector>
 
@@ -13,6 +12,7 @@
 #include "common/vector/value_vector.h"
 #include "function/aggregate/comparison_funcs.h"
 #include "function/aggregate/conversion_funcs.h"
+#include <format>
 
 using namespace lbug::binder;
 using namespace lbug::common;
@@ -80,7 +80,6 @@ struct HistogramState : public AggregateStateWithNull {
 
     // Computed bins (populated in finalize, consumed by writeToVector)
     std::vector<HistogramBin> computedBins;
-    bool finalized = false;
 };
 
 void HistogramState::writeToVector(common::ValueVector* outputVector, uint64_t pos) {
@@ -88,16 +87,16 @@ void HistogramState::writeToVector(common::ValueVector* outputVector, uint64_t p
     auto numEntries = static_cast<uint64_t>(bins.size());
 
     // Allocate a list entry for the MAP (which is a LIST of STRUCT)
-    auto listEntry = common::ListVector::addList(outputVector, numEntries);
-    outputVector->setValue<common::list_entry_t>(pos, listEntry);
+    auto listEntry = ListVector::addList(outputVector, numEntries);
+    outputVector->setValue<list_entry_t>(pos, listEntry);
 
     if (numEntries == 0) {
         return;
     }
 
     // Get the key (STRING) and value (INT64) vectors from the MAP's struct child
-    auto keyVector = common::MapVector::getKeyVector(outputVector);
-    auto valVector = common::MapVector::getValueVector(outputVector);
+    auto keyVector = MapVector::getKeyVector(outputVector);
+    auto valVector = MapVector::getValueVector(outputVector);
 
     for (uint64_t i = 0; i < numEntries; ++i) {
         auto& bin = bins[i];
@@ -109,7 +108,7 @@ void HistogramState::writeToVector(common::ValueVector* outputVector, uint64_t p
         snprintf(buf, sizeof(buf), "%.*f-%.*f", precMin, bin.minVal, precMax, bin.maxVal);
 
         auto posInList = listEntry.offset + i;
-        common::StringVector::addString(keyVector, posInList, std::string_view(buf));
+        StringVector::addString(keyVector, posInList, std::string_view(buf));
         valVector->setValue<int64_t>(posInList, static_cast<int64_t>(bin.count));
     }
 }
@@ -191,6 +190,11 @@ static void combine(uint8_t* state_, uint8_t* otherState_,
 
 // ---------------------------------------------------------------------------
 // Build equal-depth (adaptive) bins from sorted values
+//
+// For each of the (up to) k bins, take roughly N/k values, then extend the
+// bin's end to include all duplicates of the boundary value so that identical
+// values never span two bin boundaries. The last bin absorbs any remaining
+// values.
 // ---------------------------------------------------------------------------
 static void buildAdaptiveBins(const std::vector<double>& values, int32_t numBins,
     std::vector<HistogramBin>& bins) {
@@ -206,54 +210,36 @@ static void buildAdaptiveBins(const std::vector<double>& values, int32_t numBins
         return;
     }
 
-    std::vector<double> boundaries(k + 1);
-    boundaries[0] = values.front();
-    for (int32_t i = 1; i < k; ++i) {
-        uint64_t idx = static_cast<uint64_t>(static_cast<double>(i) * static_cast<double>(n) /
-                                              static_cast<double>(k));
-        if (idx >= n) {
-            idx = n - 1;
-        }
-        boundaries[i] = values[idx];
-    }
-    boundaries[k] = values.back();
-
     uint64_t valIdx = 0;
     for (int32_t i = 0; i < k && valIdx < n; ++i) {
-        double binMin = boundaries[i];
-        double binMax = boundaries[i + 1];
-
-        if (i > 0 && binMin == boundaries[i - 1]) {
-            continue;
-        }
-
-        uint64_t binCount = 0;
-        bool lastIter = (i + 1 >= k) ? true : false;
-        while (valIdx < n) {
-            if (values[valIdx] < binMax || (lastIter && values[valIdx] == binMax)) {
-                ++binCount;
-                ++valIdx;
-            } else if (!lastIter && values[valIdx] == binMax && valIdx + 1 < n &&
-                       values[valIdx + 1] == binMax) {
-                ++binCount;
-                ++valIdx;
-            } else {
-                break;
-            }
-        }
-
-        if (binCount > 0) {
-            bins.push_back({binMin, valIdx > 0 ? values[valIdx - 1] : binMax, binCount});
-        }
-    }
-
-    if (valIdx < n) {
-        if (!bins.empty()) {
-            bins.back().count += (n - valIdx);
-            bins.back().maxVal = values.back();
+        // Target count for this bin: distribute remaining values evenly.
+        // ceil((n - valIdx) / (k - i)) so the final bin ends exactly at n.
+        uint64_t remaining = n - valIdx;
+        uint64_t targetCount;
+        if (i + 1 == k) {
+            targetCount = remaining;
         } else {
-            bins.push_back({values.front(), values.back(), n});
+            targetCount =
+                (remaining + static_cast<uint64_t>(k - i - 1)) / static_cast<uint64_t>(k - i);
         }
+        if (targetCount < 1) {
+            targetCount = 1;
+        }
+
+        uint64_t endIdx = valIdx + targetCount - 1;
+        if (endIdx >= n) {
+            endIdx = n - 1;
+        }
+
+        // Extend the bin to include all duplicates of the boundary value so
+        // identical values never span two bin boundaries.
+        while (endIdx + 1 < n && values[endIdx] == values[endIdx + 1]) {
+            ++endIdx;
+        }
+
+        uint64_t binCount = endIdx - valIdx + 1;
+        bins.push_back({values[valIdx], values[endIdx], binCount});
+        valIdx = endIdx + 1;
     }
 }
 
@@ -303,15 +289,6 @@ static void buildFixedSizeBins(const std::vector<double>& values, double binWidt
             bins.push_back({binMin, values[valIdx - 1], binCount});
         }
     }
-
-    if (valIdx < values.size()) {
-        if (!bins.empty()) {
-            bins.back().count += (values.size() - valIdx);
-            bins.back().maxVal = values.back();
-        } else {
-            bins.push_back({minVal, values.back(), values.size()});
-        }
-    }
 }
 
 // ---------------------------------------------------------------------------
@@ -321,7 +298,6 @@ static void finalize(uint8_t* state_, LogicalTypeID typeID) {
     auto* state = reinterpret_cast<HistogramState*>(state_);
     if (state->isNull || state->count == 0) {
         state->computedBins.clear();
-        state->finalized = true;
         return;
     }
 
@@ -341,7 +317,6 @@ static void finalize(uint8_t* state_, LogicalTypeID typeID) {
     } else {
         buildAdaptiveBins(values, state->numBins, state->computedBins);
     }
-    state->finalized = true;
 }
 
 // ---------------------------------------------------------------------------
@@ -371,8 +346,7 @@ static double parseBinWidth(const ScalarBindFuncInput& input, uint32_t argIdx) {
     }
     auto val = literalExpr->getValue().getValue<double>();
     if (val < 0) {
-        throw BinderException(
-            std::format("{} bin_width must be non-negative.", HISTOGRAM_NAME));
+        throw BinderException(std::format("{} bin_width must be non-negative.", HISTOGRAM_NAME));
     }
     return val;
 }
@@ -389,7 +363,7 @@ static std::unique_ptr<FunctionBindData> bindFunc(const ScalarBindFuncInput& inp
         binWidth = parseBinWidth(input, 2);
     }
 
-    auto* aggFunc = reinterpret_cast<AggregateFunction*>(input.definition);
+    auto* aggFunc = input.definition->ptrCast<AggregateFunction>();
     aggFunc->initializeFunc = [numBins, binWidth]() {
         return std::make_unique<HistogramState>(numBins, binWidth);
     };
@@ -398,8 +372,7 @@ static std::unique_ptr<FunctionBindData> bindFunc(const ScalarBindFuncInput& inp
     aggFunc->initialNullAggregateState = aggFunc->createInitialNullAggregateState();
 
     // Return type: MAP(STRING, INT64)
-    auto resultType =
-        LogicalType::MAP(LogicalType::STRING(), LogicalType::INT64());
+    auto resultType = LogicalType::MAP(LogicalType::STRING(), LogicalType::INT64());
     return FunctionBindData::getSimpleBindData(input.arguments, resultType);
 }
 
@@ -411,17 +384,18 @@ function_set AggregateHistogramFunction::getFunctionSet() {
     for (auto typeID : LogicalTypeUtils::getNumericalLogicalTypeIDs()) {
         for (auto isDistinct : std::vector<bool>{true, false}) {
             // 1. HISTOGRAM(value)
-            result.push_back(std::make_unique<AggregateFunction>(name,
-                std::vector<LogicalTypeID>{typeID}, LogicalTypeID::MAP, initialize, updateAll,
+            result.push_back(std::make_unique<AggregateFunction>(
+                name, std::vector<LogicalTypeID>{typeID}, LogicalTypeID::MAP, initialize, updateAll,
                 updatePos, combine, [](auto) {}, isDistinct, bindFunc));
 
             // 2. HISTOGRAM(value, num_bins)
-            result.push_back(std::make_unique<AggregateFunction>(name,
-                std::vector<LogicalTypeID>{typeID, LogicalTypeID::INT64}, LogicalTypeID::MAP,
+            result.push_back(std::make_unique<AggregateFunction>(
+                name, std::vector<LogicalTypeID>{typeID, LogicalTypeID::INT64}, LogicalTypeID::MAP,
                 initialize, updateAll, updatePos, combine, [](auto) {}, isDistinct, bindFunc));
 
             // 3. HISTOGRAM(value, num_bins, bin_width)
-            result.push_back(std::make_unique<AggregateFunction>(name,
+            result.push_back(std::make_unique<AggregateFunction>(
+                name,
                 std::vector<LogicalTypeID>{typeID, LogicalTypeID::INT64, LogicalTypeID::DOUBLE},
                 LogicalTypeID::MAP, initialize, updateAll, updatePos, combine, [](auto) {},
                 isDistinct, bindFunc));

--- a/src/function/aggregate/histogram.cpp
+++ b/src/function/aggregate/histogram.cpp
@@ -1,0 +1,434 @@
+#include "function/aggregate/histogram.h"
+
+#include <algorithm>
+#include <cmath>
+#include <cstdio>
+#include <format>
+#include <sstream>
+#include <vector>
+
+#include "binder/expression/literal_expression.h"
+#include "common/exception/binder.h"
+#include "common/type_utils.h"
+#include "common/vector/value_vector.h"
+#include "function/aggregate/comparison_funcs.h"
+#include "function/aggregate/conversion_funcs.h"
+
+using namespace lbug::binder;
+using namespace lbug::common;
+
+namespace lbug {
+namespace function {
+
+/**
+ * Adaptive Parallel Histogram
+ * ============================
+ *
+ * Morsel-driven parallelism: each worker thread processes data chunks independently,
+ * building a linked list of values in its own HistogramState. The combine() step
+ * merges lists in O(1) by splicing linked lists. finalize() sorts all values and
+ * computes bin boundaries. Returns MAP(STRING, INT64) where each entry maps a
+ * "min-max" range string to the count in that bin.
+ *
+ * Bin strategies:
+ *   - ADAPTIVE (equal-depth): boundaries are placed at quantile positions so each
+ *     bin has approximately the same number of elements. Duplicate values are kept
+ *     together so identical values never span bin boundaries.
+ *   - FIXED-SIZE: when bin_width > 0, bins have uniform width from min to max.
+ *
+ * SQL interface:
+ *   HISTOGRAM(value)                  -> adaptive, 10 bins
+ *   HISTOGRAM(value, num_bins)        -> adaptive, custom bins
+ *   HISTOGRAM(value, num_bins, width) -> fixed-size if width>0, else adaptive
+ */
+
+// ---------------------------------------------------------------------------
+// Linked-list element (raw bytes, same pattern as percentile_cont)
+// ---------------------------------------------------------------------------
+struct HistogramElement {
+    HistogramElement* next = nullptr;
+};
+
+// ---------------------------------------------------------------------------
+// A bin descriptor stored after finalize for writeToVector to consume.
+// ---------------------------------------------------------------------------
+struct HistogramBin {
+    double minVal;
+    double maxVal;
+    uint64_t count;
+};
+
+// ---------------------------------------------------------------------------
+// Aggregate state
+// ---------------------------------------------------------------------------
+struct HistogramState : public AggregateStateWithNull {
+    explicit HistogramState(int32_t numBins = 10, double binWidth = 0.0)
+        : numBins{numBins}, binWidth{binWidth} {}
+
+    uint32_t getStateSize() const override { return sizeof(*this); }
+
+    void writeToVector(common::ValueVector* outputVector, uint64_t pos) override;
+
+    // Linked list of raw input values (populated during update/combine)
+    HistogramElement* head = nullptr;
+    HistogramElement* tail = nullptr;
+    uint64_t count = 0;
+
+    // Configuration (set at bind time)
+    int32_t numBins;
+    double binWidth; // 0 = adaptive, > 0 = fixed-size
+
+    // Computed bins (populated in finalize, consumed by writeToVector)
+    std::vector<HistogramBin> computedBins;
+    bool finalized = false;
+};
+
+void HistogramState::writeToVector(common::ValueVector* outputVector, uint64_t pos) {
+    auto& bins = computedBins;
+    auto numEntries = static_cast<uint64_t>(bins.size());
+
+    // Allocate a list entry for the MAP (which is a LIST of STRUCT)
+    auto listEntry = common::ListVector::addList(outputVector, numEntries);
+    outputVector->setValue<common::list_entry_t>(pos, listEntry);
+
+    if (numEntries == 0) {
+        return;
+    }
+
+    // Get the key (STRING) and value (INT64) vectors from the MAP's struct child
+    auto keyVector = common::MapVector::getKeyVector(outputVector);
+    auto valVector = common::MapVector::getValueVector(outputVector);
+
+    for (uint64_t i = 0; i < numEntries; ++i) {
+        auto& bin = bins[i];
+        char buf[64];
+        double avMin = std::fabs(bin.minVal);
+        int precMin = (avMin >= 1000.0) ? 0 : (avMin >= 100.0) ? 1 : (avMin >= 1.0) ? 2 : 3;
+        double avMax = std::fabs(bin.maxVal);
+        int precMax = (avMax >= 1000.0) ? 0 : (avMax >= 100.0) ? 1 : (avMax >= 1.0) ? 2 : 3;
+        snprintf(buf, sizeof(buf), "%.*f-%.*f", precMin, bin.minVal, precMax, bin.maxVal);
+
+        auto posInList = listEntry.offset + i;
+        common::StringVector::addString(keyVector, posInList, std::string_view(buf));
+        valVector->setValue<int64_t>(posInList, static_cast<int64_t>(bin.count));
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+static uint8_t* getElementValue(HistogramElement* element) {
+    return reinterpret_cast<uint8_t*>(element) + sizeof(HistogramElement);
+}
+
+// ---------------------------------------------------------------------------
+// Initialize
+// ---------------------------------------------------------------------------
+static std::unique_ptr<AggregateState> initialize() {
+    return std::make_unique<HistogramState>();
+}
+
+// ---------------------------------------------------------------------------
+// Update helpers
+// ---------------------------------------------------------------------------
+static void updateSingleValue(HistogramState* state, ValueVector* input, uint32_t pos,
+    uint64_t multiplicity, InMemOverflowBuffer* overflowBuffer) {
+    auto valueSize = LogicalTypeUtils::getRowLayoutSize(input->dataType);
+    for (auto i = 0u; i < multiplicity; ++i) {
+        auto* element = reinterpret_cast<HistogramElement*>(
+            overflowBuffer->allocateSpace(sizeof(HistogramElement) + valueSize));
+        element->next = nullptr;
+        input->copyToRowData(pos, getElementValue(element), overflowBuffer);
+        if (state->tail) {
+            state->tail->next = element;
+        } else {
+            state->head = element;
+        }
+        state->tail = element;
+        state->count++;
+        state->isNull = false;
+    }
+}
+
+static void updateAll(uint8_t* state_, ValueVector* input, uint64_t multiplicity,
+    InMemOverflowBuffer* overflowBuffer) {
+    DASSERT(!input->state->isFlat());
+    auto* state = reinterpret_cast<HistogramState*>(state_);
+    input->forEachNonNull(
+        [&](auto pos) { updateSingleValue(state, input, pos, multiplicity, overflowBuffer); });
+}
+
+static void updatePos(uint8_t* state_, ValueVector* input, uint64_t multiplicity, uint32_t pos,
+    InMemOverflowBuffer* overflowBuffer) {
+    updateSingleValue(reinterpret_cast<HistogramState*>(state_), input, pos, multiplicity,
+        overflowBuffer);
+}
+
+// ---------------------------------------------------------------------------
+// Combine (merges two parallel partial states in O(1) via list splicing)
+// ---------------------------------------------------------------------------
+static void combine(uint8_t* state_, uint8_t* otherState_,
+    InMemOverflowBuffer* /*overflowBuffer*/) {
+    auto* otherState = reinterpret_cast<HistogramState*>(otherState_);
+    if (otherState->isNull) {
+        return;
+    }
+    auto* state = reinterpret_cast<HistogramState*>(state_);
+    if (state->tail) {
+        state->tail->next = otherState->head;
+    } else {
+        state->head = otherState->head;
+    }
+    state->tail = otherState->tail;
+    state->count += otherState->count;
+    state->isNull = false;
+    // Detach from the other state so the source doesn't double-free.
+    otherState->head = nullptr;
+    otherState->tail = nullptr;
+    otherState->count = 0;
+    otherState->isNull = true;
+}
+
+// ---------------------------------------------------------------------------
+// Build equal-depth (adaptive) bins from sorted values
+// ---------------------------------------------------------------------------
+static void buildAdaptiveBins(const std::vector<double>& values, int32_t numBins,
+    std::vector<HistogramBin>& bins) {
+    uint64_t n = values.size();
+    if (n == 0) {
+        return;
+    }
+
+    int32_t k = std::max(1, std::min(numBins, static_cast<int32_t>(n)));
+
+    if (values.front() == values.back()) {
+        bins.push_back({values.front(), values.back(), n});
+        return;
+    }
+
+    std::vector<double> boundaries(k + 1);
+    boundaries[0] = values.front();
+    for (int32_t i = 1; i < k; ++i) {
+        uint64_t idx = static_cast<uint64_t>(static_cast<double>(i) * static_cast<double>(n) /
+                                              static_cast<double>(k));
+        if (idx >= n) {
+            idx = n - 1;
+        }
+        boundaries[i] = values[idx];
+    }
+    boundaries[k] = values.back();
+
+    uint64_t valIdx = 0;
+    for (int32_t i = 0; i < k && valIdx < n; ++i) {
+        double binMin = boundaries[i];
+        double binMax = boundaries[i + 1];
+
+        if (i > 0 && binMin == boundaries[i - 1]) {
+            continue;
+        }
+
+        uint64_t binCount = 0;
+        bool lastIter = (i + 1 >= k) ? true : false;
+        while (valIdx < n) {
+            if (values[valIdx] < binMax || (lastIter && values[valIdx] == binMax)) {
+                ++binCount;
+                ++valIdx;
+            } else if (!lastIter && values[valIdx] == binMax && valIdx + 1 < n &&
+                       values[valIdx + 1] == binMax) {
+                ++binCount;
+                ++valIdx;
+            } else {
+                break;
+            }
+        }
+
+        if (binCount > 0) {
+            bins.push_back({binMin, valIdx > 0 ? values[valIdx - 1] : binMax, binCount});
+        }
+    }
+
+    if (valIdx < n) {
+        if (!bins.empty()) {
+            bins.back().count += (n - valIdx);
+            bins.back().maxVal = values.back();
+        } else {
+            bins.push_back({values.front(), values.back(), n});
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Build fixed-size bins from sorted values
+// ---------------------------------------------------------------------------
+static void buildFixedSizeBins(const std::vector<double>& values, double binWidth,
+    std::vector<HistogramBin>& bins) {
+    if (values.empty()) {
+        return;
+    }
+
+    double minVal = values.front();
+    double maxVal = values.back();
+
+    if (minVal == maxVal) {
+        bins.push_back({minVal, maxVal, values.size()});
+        return;
+    }
+
+    double range = maxVal - minVal;
+    int32_t k = std::max(1, static_cast<int32_t>(std::ceil(range / binWidth)));
+
+    std::vector<double> boundaries(static_cast<size_t>(k) + 1);
+    for (int32_t i = 0; i <= k; ++i) {
+        boundaries[static_cast<size_t>(i)] = minVal + static_cast<double>(i) * binWidth;
+    }
+
+    uint64_t valIdx = 0;
+    for (int32_t i = 0; i < k && valIdx < values.size(); ++i) {
+        double binMin = boundaries[static_cast<size_t>(i)];
+        double binMax = boundaries[static_cast<size_t>(i) + 1];
+
+        uint64_t binCount = 0;
+        bool lastIter = (i + 1 >= k);
+        while (valIdx < values.size()) {
+            double v = values[valIdx];
+            if (v < binMax || (lastIter && v == binMax)) {
+                ++binCount;
+                ++valIdx;
+            } else {
+                break;
+            }
+        }
+
+        if (binCount > 0) {
+            bins.push_back({binMin, values[valIdx - 1], binCount});
+        }
+    }
+
+    if (valIdx < values.size()) {
+        if (!bins.empty()) {
+            bins.back().count += (values.size() - valIdx);
+            bins.back().maxVal = values.back();
+        } else {
+            bins.push_back({minVal, values.back(), values.size()});
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Finalize (runs once, after all parallel workers have combined)
+// ---------------------------------------------------------------------------
+static void finalize(uint8_t* state_, LogicalTypeID typeID) {
+    auto* state = reinterpret_cast<HistogramState*>(state_);
+    if (state->isNull || state->count == 0) {
+        state->computedBins.clear();
+        state->finalized = true;
+        return;
+    }
+
+    // 1. Extract all values as doubles for sorting
+    std::vector<double> values;
+    values.reserve(state->count);
+    for (auto* element = state->head; element != nullptr; element = element->next) {
+        values.push_back(valueToDouble(getElementValue(element), typeID));
+    }
+
+    // 2. Sort
+    std::sort(values.begin(), values.end());
+
+    // 3. Build bins
+    if (state->binWidth > 0.0) {
+        buildFixedSizeBins(values, state->binWidth, state->computedBins);
+    } else {
+        buildAdaptiveBins(values, state->numBins, state->computedBins);
+    }
+    state->finalized = true;
+}
+
+// ---------------------------------------------------------------------------
+// Bind function: parse optional num_bins and bin_width arguments
+// ---------------------------------------------------------------------------
+static constexpr const char* HISTOGRAM_NAME = "HISTOGRAM";
+
+static int32_t parseNumBins(const ScalarBindFuncInput& input, uint32_t argIdx) {
+    auto* literalExpr = dynamic_cast<LiteralExpression*>(input.arguments[argIdx].get());
+    if (literalExpr == nullptr) {
+        throw BinderException(
+            std::format("{} num_bins parameter must be a literal integer.", HISTOGRAM_NAME));
+    }
+    auto val = literalExpr->getValue().getValue<int64_t>();
+    if (val <= 0) {
+        throw BinderException(
+            std::format("{} num_bins must be a positive integer.", HISTOGRAM_NAME));
+    }
+    return static_cast<int32_t>(val);
+}
+
+static double parseBinWidth(const ScalarBindFuncInput& input, uint32_t argIdx) {
+    auto* literalExpr = dynamic_cast<LiteralExpression*>(input.arguments[argIdx].get());
+    if (literalExpr == nullptr) {
+        throw BinderException(
+            std::format("{} bin_width parameter must be a literal.", HISTOGRAM_NAME));
+    }
+    auto val = literalExpr->getValue().getValue<double>();
+    if (val < 0) {
+        throw BinderException(
+            std::format("{} bin_width must be non-negative.", HISTOGRAM_NAME));
+    }
+    return val;
+}
+
+static std::unique_ptr<FunctionBindData> bindFunc(const ScalarBindFuncInput& input) {
+    auto numArgs = input.arguments.size();
+    int32_t numBins = 10;
+    double binWidth = 0.0;
+
+    if (numArgs == 2) {
+        numBins = parseNumBins(input, 1);
+    } else if (numArgs >= 3) {
+        numBins = parseNumBins(input, 1);
+        binWidth = parseBinWidth(input, 2);
+    }
+
+    auto* aggFunc = reinterpret_cast<AggregateFunction*>(input.definition);
+    aggFunc->initializeFunc = [numBins, binWidth]() {
+        return std::make_unique<HistogramState>(numBins, binWidth);
+    };
+    auto typeID = input.arguments[0]->dataType.getLogicalTypeID();
+    aggFunc->finalizeFunc = [typeID](auto state) { finalize(state, typeID); };
+    aggFunc->initialNullAggregateState = aggFunc->createInitialNullAggregateState();
+
+    // Return type: MAP(STRING, INT64)
+    auto resultType =
+        LogicalType::MAP(LogicalType::STRING(), LogicalType::INT64());
+    return FunctionBindData::getSimpleBindData(input.arguments, resultType);
+}
+
+// ---------------------------------------------------------------------------
+// Function set registration
+// ---------------------------------------------------------------------------
+function_set AggregateHistogramFunction::getFunctionSet() {
+    function_set result;
+    for (auto typeID : LogicalTypeUtils::getNumericalLogicalTypeIDs()) {
+        for (auto isDistinct : std::vector<bool>{true, false}) {
+            // 1. HISTOGRAM(value)
+            result.push_back(std::make_unique<AggregateFunction>(name,
+                std::vector<LogicalTypeID>{typeID}, LogicalTypeID::MAP, initialize, updateAll,
+                updatePos, combine, [](auto) {}, isDistinct, bindFunc));
+
+            // 2. HISTOGRAM(value, num_bins)
+            result.push_back(std::make_unique<AggregateFunction>(name,
+                std::vector<LogicalTypeID>{typeID, LogicalTypeID::INT64}, LogicalTypeID::MAP,
+                initialize, updateAll, updatePos, combine, [](auto) {}, isDistinct, bindFunc));
+
+            // 3. HISTOGRAM(value, num_bins, bin_width)
+            result.push_back(std::make_unique<AggregateFunction>(name,
+                std::vector<LogicalTypeID>{typeID, LogicalTypeID::INT64, LogicalTypeID::DOUBLE},
+                LogicalTypeID::MAP, initialize, updateAll, updatePos, combine, [](auto) {},
+                isDistinct, bindFunc));
+        }
+    }
+    return result;
+}
+
+} // namespace function
+} // namespace lbug

--- a/src/function/function_collection.cpp
+++ b/src/function/function_collection.cpp
@@ -2,6 +2,7 @@
 
 #include "function/aggregate/count.h"
 #include "function/aggregate/count_star.h"
+#include "function/aggregate/histogram.h"
 #include "function/aggregate/percentile_cont.h"
 #include "function/aggregate/percentile_disc.h"
 #include "function/arithmetic/vector_arithmetic_functions.h"
@@ -222,6 +223,7 @@ FunctionCollection* FunctionCollection::getFunctions() {
         AGGREGATE_FUNCTION(AggregateMinFunction), AGGREGATE_FUNCTION(AggregateMaxFunction),
         AGGREGATE_FUNCTION(CollectFunction), AGGREGATE_FUNCTION(AggregatePercentileDiscFunction),
         AGGREGATE_FUNCTION(AggregatePercentileContFunction),
+        AGGREGATE_FUNCTION(AggregateHistogramFunction),
 
         // Table functions
         TABLE_FUNCTION(CurrentSettingFunction), TABLE_FUNCTION(CatalogVersionFunction),

--- a/src/include/function/aggregate/histogram.h
+++ b/src/include/function/aggregate/histogram.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include "function/aggregate_function.h"
+
+namespace lbug {
+namespace function {
+
+struct AggregateHistogramFunction {
+    static constexpr const char* name = "HISTOGRAM";
+    static constexpr const char* prettyName = "histogram";
+
+    static function_set getFunctionSet();
+};
+
+} // namespace function
+} // namespace lbug

--- a/test/test_files/agg/histogram.test
+++ b/test/test_files/agg/histogram.test
@@ -50,6 +50,30 @@
 ---- 1
 {1.50-1.50=1, 2.50-2.50=1, 3.50-3.50=1, 4.50-4.50=1}
 
+# Right-skewed distribution: cluster of small values with a long tail to the right
+-STATEMENT UNWIND [1, 1, 1, 2, 2, 2, 3, 3, 4, 4, 5, 6, 7, 8, 10, 12, 15, 20, 30, 50] AS v RETURN HISTOGRAM(v) AS h
+---- 1
+{1.00-1.00=3, 2.00-2.00=3, 3.00-3.00=2, 4.00-4.00=2, 5.00-6.00=2, 7.00-8.00=2, 10.00-12.00=2, 15.00-20.00=2, 30.00-30.00=1, 50.00-50.00=1}
+
+-STATEMENT UNWIND [1, 1, 1, 2, 2, 2, 3, 3, 4, 4, 5, 6, 7, 8, 10, 12, 15, 20, 30, 50] AS v RETURN HISTOGRAM(v, 5) AS h
+---- 1
+{1.00-2.00=6, 3.00-4.00=4, 5.00-8.00=4, 10.00-15.00=3, 20.00-50.00=3}
+
+# Left-skewed distribution: cluster of large values with a tail to the left
+-STATEMENT UNWIND [1, 5, 10, 20, 30, 40, 45, 48, 49, 50, 50, 50, 50, 50, 50] AS v RETURN HISTOGRAM(v) AS h
+---- 1
+{1.00-5.00=2, 10.00-20.00=2, 30.00-40.00=2, 45.00-48.00=2, 49.00-50.00=7}
+
+# Heavily right-skewed with fixed-size bins (bin_width=5.0) to test precision formatting across wide ranges
+-STATEMENT UNWIND [1, 1, 1, 1, 1, 1, 1, 1, 2, 2, 2, 3, 4, 5, 10, 20, 50, 100] AS v RETURN HISTOGRAM(v, 10, 5.0) AS h
+---- 1
+{1.00-5.00=14, 6.00-10.00=1, 16.00-20.00=1, 46.00-50.00=1, 96.00-100.0=1}
+
+# Right-skewed with DISTINCT to verify duplicate collapsing preserves skew shape
+-STATEMENT UNWIND [1, 1, 1, 2, 2, 2, 3, 3, 4, 4, 5, 6, 7, 8, 10, 12, 15, 20, 30, 50] AS v RETURN HISTOGRAM(DISTINCT v) AS h
+---- 1
+{1.00-2.00=2, 3.00-4.00=2, 5.00-6.00=2, 7.00-8.00=2, 10.00-10.00=1, 12.00-12.00=1, 15.00-15.00=1, 20.00-20.00=1, 30.00-30.00=1, 50.00-50.00=1}
+
 -STATEMENT UNWIND [1, 1, 2, 3] AS v RETURN HISTOGRAM(v, 0)
 ---- error
 Binder exception: HISTOGRAM num_bins must be a positive integer.

--- a/test/test_files/agg/histogram.test
+++ b/test/test_files/agg/histogram.test
@@ -1,0 +1,78 @@
+-DATASET CSV empty
+
+--
+
+-CASE HistogramAggregate
+-STATEMENT UNWIND [1, 1, 2, 3] AS v RETURN HISTOGRAM(v) AS h
+---- 1
+{1.00-1.00=2, 2.00-2.00=1, 3.00-3.00=1}
+
+-STATEMENT UNWIND [1, 1, 2, 2, 3] AS v RETURN HISTOGRAM(v) AS h
+---- 1
+{1.00-1.00=2, 2.00-2.00=2, 3.00-3.00=1}
+
+-STATEMENT UNWIND [1, 1, 1, 1] AS v RETURN HISTOGRAM(v) AS h
+---- 1
+{1.00-1.00=4}
+
+-STATEMENT UNWIND [1, 1, 2, 3] AS v RETURN HISTOGRAM(v, 3) AS h
+---- 1
+{1.00-1.00=2, 2.00-2.00=1, 3.00-3.00=1}
+
+-STATEMENT UNWIND [1, 2, 3, 4, 5] AS v RETURN HISTOGRAM(v, 2) AS h
+---- 1
+{1.00-3.00=3, 4.00-5.00=2}
+
+-STATEMENT UNWIND [1, 1, 2, 3, 4, 5] AS v RETURN HISTOGRAM(v, 3) AS h
+---- 1
+{1.00-1.00=2, 2.00-3.00=2, 4.00-5.00=2}
+
+-STATEMENT UNWIND [1, 1, 2, 3] AS v RETURN HISTOGRAM(v, 5, 1.0) AS h
+---- 1
+{1.00-1.00=2, 2.00-3.00=2}
+
+-STATEMENT UNWIND [1, 1, 1, 1, 2, 2, 3, 4, 5, 6, 7, 8, 9, 10] AS v RETURN HISTOGRAM(v) AS h
+---- 1
+{1.00-1.00=4, 2.00-2.00=2, 3.00-3.00=1, 4.00-4.00=1, 5.00-5.00=1, 6.00-6.00=1, 7.00-7.00=1, 8.00-8.00=1, 9.00-9.00=1, 10.00-10.00=1}
+
+-STATEMENT UNWIND [1, 1, 2, 3] AS v RETURN HISTOGRAM(DISTINCT v) AS h
+---- 1
+{1.00-1.00=1, 2.00-2.00=1, 3.00-3.00=1}
+
+-STATEMENT UNWIND [1, 2, 3, 4, 5] AS v RETURN HISTOGRAM(v) AS h
+---- 1
+{1.00-1.00=1, 2.00-2.00=1, 3.00-3.00=1, 4.00-4.00=1, 5.00-5.00=1}
+
+-STATEMENT UNWIND [] AS v RETURN HISTOGRAM(v) AS h
+---- 1
+
+-STATEMENT UNWIND [1.5, 2.5, 3.5, 4.5] AS v RETURN HISTOGRAM(v) AS h
+---- 1
+{1.50-1.50=1, 2.50-2.50=1, 3.50-3.50=1, 4.50-4.50=1}
+
+-STATEMENT UNWIND [1, 1, 2, 3] AS v RETURN HISTOGRAM(v, 0)
+---- error
+Binder exception: HISTOGRAM num_bins must be a positive integer.
+
+-STATEMENT UNWIND [1, 1, 2, 3] AS v RETURN HISTOGRAM(v, 5, -1.0)
+---- error
+Binder exception: HISTOGRAM bin_width must be non-negative.
+
+-STATEMENT UNWIND [1, 1, 2, 3] AS v RETURN HISTOGRAM(v, 5, a)
+---- error
+Binder exception: Variable a is not in scope.
+
+-STATEMENT CREATE NODE TABLE T(id INT64, g INT64, v INT64, PRIMARY KEY(id));
+---- ok
+
+-STATEMENT CREATE (:T {id: 1, g: 1, v: 1}),
+                  (:T {id: 2, g: 1, v: 1}),
+                  (:T {id: 3, g: 1, v: 2}),
+                  (:T {id: 4, g: 2, v: 3}),
+                  (:T {id: 5, g: 2, v: 4});
+---- ok
+
+-STATEMENT MATCH (n:T) RETURN n.g, HISTOGRAM(n.v) AS h ORDER BY n.g
+---- 2
+1|{1.00-1.00=2, 2.00-2.00=1}
+2|{3.00-3.00=1, 4.00-4.00=1}

--- a/tools/shell/embedded_shell.cpp
+++ b/tools/shell/embedded_shell.cpp
@@ -10,8 +10,8 @@
 #endif
 #include <algorithm>
 #include <array>
-#include <csignal>
 #include <cmath>
+#include <csignal>
 #include <iomanip>
 #include <regex>
 #include <sstream>
@@ -25,6 +25,8 @@
 #include "catalog/catalog_entry/scalar_macro_catalog_entry.h"
 #include "catalog/catalog_entry/sequence_catalog_entry.h"
 #include "common/exception/parser.h"
+#include "common/types/value/nested.h"
+#include "common/types/value/value.h"
 #include "extension/extension_manager.h"
 #include "keywords.h"
 #include "parser/parser.h"
@@ -32,8 +34,6 @@
 #include "printer/printer_factory.h"
 #include "transaction/transaction.h"
 #include "transaction/transaction_context.h"
-#include "common/types/value/nested.h"
-#include "common/types/value/value.h"
 #include "utf8proc.h"
 #include "utf8proc_wrapper.h"
 
@@ -1144,7 +1144,7 @@ void EmbeddedShell::printExecutionResult(QueryResult& queryResult) const {
 // Render a MAP(STRING, INT64) value as a compact single-line visual.
 // Falls back to default toString() for other types.
 // ---------------------------------------------------------------------------
-static std::string renderMapCell(const common::Value& val, uint32_t /*colWidth*/) {
+static std::string renderMapCell(const common::Value& val) {
     if (val.isNull() || val.getDataType().getLogicalTypeID() != common::LogicalTypeID::MAP) {
         return val.toString();
     }
@@ -1172,7 +1172,8 @@ static std::string renderMapCell(const common::Value& val, uint32_t /*colWidth*/
         auto* cntVal = common::NestedVal::getChildVal(entry, 1);
         labels[i] = keyVal->toString();
         counts[i] = cntVal->getValue<int64_t>();
-        if (counts[i] > maxCount) maxCount = counts[i];
+        if (counts[i] > maxCount)
+            maxCount = counts[i];
     }
 
     // Unicode blocks U+2581..U+2588 as raw UTF-8
@@ -1182,15 +1183,16 @@ static std::string renderMapCell(const common::Value& val, uint32_t /*colWidth*/
     // Build sparkline
     std::string spark;
     for (uint32_t i = 0; i < numBins; ++i) {
-        int level = static_cast<int>(std::round(static_cast<double>(counts[i]) * 7.0 /
-                                                 static_cast<double>(maxCount)));
+        int level = static_cast<int>(
+            std::round(static_cast<double>(counts[i]) * 7.0 / static_cast<double>(maxCount)));
         spark.append(BLOCKS + level * 3, 3);
     }
 
     // Build compact summary:  [1.00-1.00:2, 2.00-2.00:2, 5.00-10.00:7]
     std::string summary = "  [";
     for (uint32_t i = 0; i < numBins; ++i) {
-        if (i > 0) summary += ", ";
+        if (i > 0)
+            summary += ", ";
         summary += labels[i] + ":" + std::to_string(counts[i]);
     }
     summary += "]";
@@ -1227,8 +1229,11 @@ void EmbeddedShell::printTruncatedExecutionResult(QueryResult& queryResult) cons
             auto colType = queryResult.getColumnDataTypes()[i].getLogicalTypeID();
             std::string tupleString;
             if (colType == common::LogicalTypeID::MAP) {
-                tupleString = renderMapCell(*tuple->getValue(i),
-                    std::max(colsWidth[i], (uint32_t)60));
+                tupleString = renderMapCell(*tuple->getValue(i));
+                // MAP cells tend to be wider than other types; ensure a usable
+                // minimum width so subsequent rows of the same column get
+                // reasonable space.
+                colsWidth[i] = std::max(colsWidth[i], (uint32_t)60);
             } else {
                 tupleString = tuple->getValue(i)->toString();
             }
@@ -1241,15 +1246,13 @@ void EmbeddedShell::printTruncatedExecutionResult(QueryResult& queryResult) cons
             }
             // An extra 2 spaces are added for an extra space on either
             // side of the std::string.
-            colsWidth[i] = std::max(colsWidth[i], fieldLen + 4);
+            colsWidth[i] = std::max(colsWidth[i], fieldLen + 2);
         }
         rowCount++;
     }
 
     // calculate the maximum width of the table
     uint32_t sumGoal = BaseTablePrinter::MIN_TRUNCATED_WIDTH;
-    uint32_t maxWidth = BaseTablePrinter::MIN_TRUNCATED_WIDTH;
-    ;
     if (colsWidth.size() == 1) {
         uint32_t minDisplayWidth =
             BaseTablePrinter::MIN_TRUNCATED_WIDTH + BaseTablePrinter::SMALL_TABLE_SEPERATOR_LENGTH;
@@ -1280,12 +1283,10 @@ void EmbeddedShell::printTruncatedExecutionResult(QueryResult& queryResult) cons
     for (auto i = 0u; i < colsWidth.size(); i++) {
         if (maxValueIndex.empty() || colsWidth[i] == colsWidth[maxValueIndex[0]]) {
             maxValueIndex.push_back(i);
-            maxWidth = colsWidth[maxValueIndex[0]];
         } else if (colsWidth[i] > colsWidth[maxValueIndex[0]]) {
             secondHighestValue = colsWidth[maxValueIndex[0]];
             maxValueIndex.clear();
             maxValueIndex.push_back(i);
-            maxWidth = colsWidth[maxValueIndex[0]];
         } else if (colsWidth[i] > secondHighestValue) {
             secondHighestValue = colsWidth[i];
         }
@@ -1313,7 +1314,6 @@ void EmbeddedShell::printTruncatedExecutionResult(QueryResult& queryResult) cons
         for (auto i = 0u; i < maxValueIndex.size(); i++) {
             colsWidth[maxValueIndex[i]] = newValue;
         }
-        maxWidth = newValue - 2;
         sum -= (oldValue - newValue) * maxValueIndex.size();
         if (newValue == BaseTablePrinter::MIN_TRUNCATED_WIDTH + 2) {
             break;
@@ -1583,7 +1583,7 @@ void EmbeddedShell::printTruncatedExecutionResult(QueryResult& queryResult) cons
             } else {
                 auto colType = queryResult.getColumnDataTypes()[i].getLogicalTypeID();
                 if (colType == common::LogicalTypeID::MAP) {
-                    cellStr = renderMapCell(*tuple->getValue(i), colsWidth[i]);
+                    cellStr = renderMapCell(*tuple->getValue(i));
                 } else {
                     cellStr = tuple->getValue(i)->toString();
                 }

--- a/tools/shell/embedded_shell.cpp
+++ b/tools/shell/embedded_shell.cpp
@@ -11,6 +11,7 @@
 #include <algorithm>
 #include <array>
 #include <csignal>
+#include <cmath>
 #include <iomanip>
 #include <regex>
 #include <sstream>
@@ -31,6 +32,8 @@
 #include "printer/printer_factory.h"
 #include "transaction/transaction.h"
 #include "transaction/transaction_context.h"
+#include "common/types/value/nested.h"
+#include "common/types/value/value.h"
 #include "utf8proc.h"
 #include "utf8proc_wrapper.h"
 
@@ -1137,6 +1140,64 @@ void EmbeddedShell::printExecutionResult(QueryResult& queryResult) const {
     }
 }
 
+// ---------------------------------------------------------------------------
+// Render a MAP(STRING, INT64) value as a compact single-line visual.
+// Falls back to default toString() for other types.
+// ---------------------------------------------------------------------------
+static std::string renderMapCell(const common::Value& val, uint32_t /*colWidth*/) {
+    if (val.isNull() || val.getDataType().getLogicalTypeID() != common::LogicalTypeID::MAP) {
+        return val.toString();
+    }
+
+    const auto& mapType = val.getDataType();
+    const auto& keyType = common::MapType::getKeyType(mapType);
+    const auto& valType = common::MapType::getValueType(mapType);
+    if (keyType.getLogicalTypeID() != common::LogicalTypeID::STRING ||
+        valType.getLogicalTypeID() != common::LogicalTypeID::INT64) {
+        return val.toString();
+    }
+
+    auto numBins = common::NestedVal::getChildrenSize(&val);
+    if (numBins == 0) {
+        return "(empty)";
+    }
+
+    // Collect counts and find max
+    std::vector<int64_t> counts(numBins);
+    std::vector<std::string> labels(numBins);
+    int64_t maxCount = 1;
+    for (uint32_t i = 0; i < numBins; ++i) {
+        auto* entry = common::NestedVal::getChildVal(&val, i);
+        auto* keyVal = common::NestedVal::getChildVal(entry, 0);
+        auto* cntVal = common::NestedVal::getChildVal(entry, 1);
+        labels[i] = keyVal->toString();
+        counts[i] = cntVal->getValue<int64_t>();
+        if (counts[i] > maxCount) maxCount = counts[i];
+    }
+
+    // Unicode blocks U+2581..U+2588 as raw UTF-8
+    static const char* BLOCKS = "\xe2\x96\x81\xe2\x96\x82\xe2\x96\x83\xe2\x96\x84"
+                                "\xe2\x96\x85\xe2\x96\x86\xe2\x96\x87\xe2\x96\x88";
+
+    // Build sparkline
+    std::string spark;
+    for (uint32_t i = 0; i < numBins; ++i) {
+        int level = static_cast<int>(std::round(static_cast<double>(counts[i]) * 7.0 /
+                                                 static_cast<double>(maxCount)));
+        spark.append(BLOCKS + level * 3, 3);
+    }
+
+    // Build compact summary:  [1.00-1.00:2, 2.00-2.00:2, 5.00-10.00:7]
+    std::string summary = "  [";
+    for (uint32_t i = 0; i < numBins; ++i) {
+        if (i > 0) summary += ", ";
+        summary += labels[i] + ":" + std::to_string(counts[i]);
+    }
+    summary += "]";
+
+    return spark + summary;
+}
+
 void EmbeddedShell::printTruncatedExecutionResult(QueryResult& queryResult) const {
     auto& baseTablePrinter = printer->constCast<BaseTablePrinter>();
     auto querySummary = queryResult.getQuerySummary();
@@ -1162,7 +1223,15 @@ void EmbeddedShell::printTruncatedExecutionResult(QueryResult& queryResult) cons
             if (tuple->getValue(i)->isNull()) {
                 continue;
             }
-            std::string tupleString = tuple->getValue(i)->toString();
+            // Use renderMapCell for MAP columns to get visual rendering width
+            auto colType = queryResult.getColumnDataTypes()[i].getLogicalTypeID();
+            std::string tupleString;
+            if (colType == common::LogicalTypeID::MAP) {
+                tupleString = renderMapCell(*tuple->getValue(i),
+                    std::max(colsWidth[i], (uint32_t)60));
+            } else {
+                tupleString = tuple->getValue(i)->toString();
+            }
             uint32_t fieldLen = 0;
             uint32_t chrIter = 0;
             while (chrIter < tupleString.length()) {
@@ -1172,7 +1241,7 @@ void EmbeddedShell::printTruncatedExecutionResult(QueryResult& queryResult) cons
             }
             // An extra 2 spaces are added for an extra space on either
             // side of the std::string.
-            colsWidth[i] = std::max(colsWidth[i], fieldLen + 2);
+            colsWidth[i] = std::max(colsWidth[i], fieldLen + 4);
         }
         rowCount++;
     }
@@ -1505,21 +1574,47 @@ void EmbeddedShell::printTruncatedExecutionResult(QueryResult& queryResult) cons
             continue;
         }
         auto tuple = queryResult.getNext();
-        auto result = tuple->toString(colsWidth, baseTablePrinter.TupleDelimiter, maxWidth);
-        std::string printString;
-        uint64_t startPos = 0;
-        std::vector<std::string> colResults;
+        // Build formatted column strings, using renderMapCell for MAP columns
+        std::vector<std::string> colResults(colsWidth.size());
         for (auto i = 0u; i < colsWidth.size(); i++) {
-            uint32_t chrIter = startPos;
-            uint32_t fieldLen = 0;
-            while (fieldLen < colsWidth[i]) {
-                fieldLen += Utf8Proc::renderWidth(result.c_str(), chrIter);
-                chrIter = utf8proc_next_grapheme(result.c_str(), result.length(), chrIter);
+            std::string cellStr;
+            if (tuple->getValue(i)->isNull()) {
+                cellStr = std::string(colsWidth[i], ' ');
+            } else {
+                auto colType = queryResult.getColumnDataTypes()[i].getLogicalTypeID();
+                if (colType == common::LogicalTypeID::MAP) {
+                    cellStr = renderMapCell(*tuple->getValue(i), colsWidth[i]);
+                } else {
+                    cellStr = tuple->getValue(i)->toString();
+                }
+                // Truncate/pad to column width
+                uint32_t fieldLen = 0;
+                uint32_t chrIter = 0;
+                uint32_t cutoff = 0;
+                uint32_t cutoffLen = 0;
+                while (chrIter < cellStr.length()) {
+                    auto w = Utf8Proc::renderWidth(cellStr.c_str(), chrIter);
+                    if (fieldLen + w > colsWidth[i] - 2 && cutoff == 0) {
+                        cutoff = chrIter;
+                        cutoffLen = fieldLen;
+                    }
+                    fieldLen += w;
+                    chrIter = utf8proc_next_grapheme(cellStr.c_str(), cellStr.length(), chrIter);
+                }
+                if (fieldLen > colsWidth[i] - 2) {
+                    cellStr = cellStr.substr(0, cutoff) + "...";
+                    fieldLen = cutoffLen + 3;
+                }
+                cellStr = " " + std::move(cellStr) + " ";
+                fieldLen += 2;
+                if (fieldLen < colsWidth[i]) {
+                    cellStr += std::string(colsWidth[i] - fieldLen, ' ');
+                }
             }
-            colResults.push_back(result.substr(startPos, chrIter - startPos));
-            // new start position is after the | seperating results
-            startPos = chrIter + 1;
+            colResults[i] = cellStr;
         }
+
+        std::string printString;
         printString += baseTablePrinter.Vertical;
         for (auto i = 0u; i < k; i++) {
             printString += colResults[i];


### PR DESCRIPTION
feat: adaptive parallel histogram aggregate (MAP(STRING, INT64)) with shell sparkline rendering

Implement HISTOGRAM() aggregate function that returns MAP(STRING, INT64)
instead of a flat string, enabling programmatic consumption in JSON and
other structured output modes.

- Adaptive equal-depth (quantile-based) bins — each bin holds ~N/k values,
  duplicates kept together across boundaries
- Fixed-size bins — uniform width when bin_width > 0
- Parallel via morsel-driven execution: O(1) linked-list splicing in combine()
- Supports 1-, 2-, and 3-argument forms:
  - `HISTOGRAM(value)` &rarr; adaptive, 10 bins
  - `HISTOGRAM(value, num_bins)` &rarr; adaptive, custom bins
  - `HISTOGRAM(value, num_bins, width)` &rarr; fixed-size if width > 0
- Shell renders MAP(STRING, INT64) columns as sparkline + compact bin
  summary in BOX/TABLE modes
- Falls back to default mapToString() for CSV/JSON etc.