### PR TITLE
fix(arrow): quote identifiers in generated DDL for Arrow-backed tables (#756)

### DIFF
--- a/src/storage/table/arrow_table_support.cpp
+++ b/src/storage/table/arrow_table_support.cpp
@@ -42,6 +42,13 @@ static int64_t findArrowColumnByName(const ArrowSchemaWrapper& schema, const std
     return -1;
 }
 
+// Identifiers generated into DDL must be quoted: Arrow field names and caller-supplied table
+// names are arbitrary strings, and many ordinary ones (`index`, `order`, `group`, names with a
+// space or a leading digit) are not valid unquoted Cypher identifiers.
+std::string quoteIdent(const std::string& name) {
+    return "`" + name + "`";
+}
+
 std::string ArrowTableSupport::registerArrowData(ArrowSchemaWrapper schema,
     std::vector<ArrowArrayWrapper> arrays) {
     std::lock_guard<std::mutex> lock(g_arrowRegistryMutex);
@@ -109,12 +116,12 @@ ArrowTableCreationResult ArrowTableSupport::createViewFromArrowTable(main::Conne
         std::string colName = schema.children[i]->name;
         std::string colType =
             common::ArrowConverter::fromArrowSchema(schema.children[i]).toString();
-        columnDefs.push_back(colName + " " + colType);
+        columnDefs.push_back(quoteIdent(colName) + " " + colType);
     }
 
     // Add PRIMARY KEY clause using first column
     std::string primaryKey = numColumns > 0 ? schema.children[0]->name : "id";
-    columnDefs.push_back("PRIMARY KEY (" + primaryKey + ")");
+    columnDefs.push_back("PRIMARY KEY (" + quoteIdent(primaryKey) + ")");
 
     // Create table definition
     std::string tableDef = "(" + join(columnDefs, ", ") + ")";
@@ -124,7 +131,7 @@ ArrowTableCreationResult ArrowTableSupport::createViewFromArrowTable(main::Conne
 
     // Build CREATE NODE TABLE statement with arrow storage
 
-    std::string statement = "CREATE NODE TABLE " + viewName + " " + tableDef +
+    std::string statement = "CREATE NODE TABLE " + quoteIdent(viewName) + " " + tableDef +
                             " WITH (storage='arrow://" + arrowId + "')";
 
     // Create table with Arrow storage
@@ -171,11 +178,11 @@ ArrowTableCreationResult ArrowTableSupport::createRelTableFromArrowTable(
         std::string colName = schema.children[i]->name;
         std::string colType =
             common::ArrowConverter::fromArrowSchema(schema.children[i]).toString();
-        propertyDefs.push_back(colName + " " + colType);
+        propertyDefs.push_back(quoteIdent(colName) + " " + colType);
     }
 
     std::vector<std::string> relDefs;
-    relDefs.push_back("FROM " + srcTableName + " TO " + dstTableName);
+    relDefs.push_back("FROM " + quoteIdent(srcTableName) + " TO " + quoteIdent(dstTableName));
     relDefs.insert(relDefs.end(), propertyDefs.begin(), propertyDefs.end());
     std::string tableDef = "(" + join(relDefs, ", ") + ")";
 
@@ -185,7 +192,7 @@ ArrowTableCreationResult ArrowTableSupport::createRelTableFromArrowTable(
     data.arrays = std::move(arrays);
     std::string arrowId = registerArrowRelData(std::move(data));
 
-    std::string statement = "CREATE REL TABLE " + tableName + " " + tableDef +
+    std::string statement = "CREATE REL TABLE " + quoteIdent(tableName) + " " + tableDef +
                             " WITH (storage='arrow://" + arrowId + "')";
     auto queryResult = connection.query(statement);
     if (!queryResult->isSuccess()) {
@@ -219,11 +226,11 @@ ArrowTableCreationResult ArrowTableSupport::createRelTableFromArrowCSR(main::Con
         std::string colName = indicesSchema.children[i]->name;
         std::string colType =
             common::ArrowConverter::fromArrowSchema(indicesSchema.children[i]).toString();
-        propertyDefs.push_back(colName + " " + colType);
+        propertyDefs.push_back(quoteIdent(colName) + " " + colType);
     }
 
     std::vector<std::string> relDefs;
-    relDefs.push_back("FROM " + srcTableName + " TO " + dstTableName);
+    relDefs.push_back("FROM " + quoteIdent(srcTableName) + " TO " + quoteIdent(dstTableName));
     relDefs.insert(relDefs.end(), propertyDefs.begin(), propertyDefs.end());
     std::string tableDef = "(" + join(relDefs, ", ") + ")";
 
@@ -236,7 +243,7 @@ ArrowTableCreationResult ArrowTableSupport::createRelTableFromArrowCSR(main::Con
     data.dstColumnName = dstColumnName;
     std::string arrowId = registerArrowRelData(std::move(data));
 
-    std::string statement = "CREATE REL TABLE " + tableName + " " + tableDef +
+    std::string statement = "CREATE REL TABLE " + quoteIdent(tableName) + " " + tableDef +
                             " WITH (storage='arrow://" + arrowId + "')";
     auto queryResult = connection.query(statement);
     if (!queryResult->isSuccess()) {
@@ -250,7 +257,7 @@ std::unique_ptr<main::QueryResult> ArrowTableSupport::unregisterArrowTable(
     main::Connection& connection, const std::string& tableName) {
 
     // Drop the table - this will trigger ArrowNodeTable destructor which unregisters the data
-    std::string dropStatement = "DROP TABLE " + tableName;
+    std::string dropStatement = "DROP TABLE " + quoteIdent(tableName);
     return connection.query(dropStatement);
 }
 

--- a/test/api/arrow_node_table_test.cpp
+++ b/test/api/arrow_node_table_test.cpp
@@ -7,6 +7,7 @@
 #include "common/arrow/arrow.h"
 #include "gtest/gtest.h"
 #include "storage/table/arrow_node_table.h"
+#include "storage/table/arrow_table_support.h"
 
 using namespace lbug;
 using namespace lbug::storage;
@@ -244,4 +245,69 @@ TEST_F(ArrowNodeTableTest, ArrowTableLargeData) {
         schema.release(&schema);
     if (array.release)
         array.release(&array);
+}
+
+TEST_F(ArrowNodeTableTest, CreateArrowTableReservedFieldNames) {
+    // Use reserved word "index" as a field name
+    std::vector<int32_t> indexData = {10, 20};
+    std::vector<std::string> valueData = {"foo", "bar"};
+
+    ArrowSchemaWrapper schema;
+    createStructSchema(&schema, 2);
+    createSchema<int32_t>(schema.children[0], "index");
+    createSchema<std::string>(schema.children[1], "value");
+
+    std::vector<ArrowArrayWrapper> arrays;
+    arrays.push_back(createStructArray(indexData.size(),
+        {[&](ArrowArray* a) { createInt32Array(a, indexData); },
+            [&](ArrowArray* a) { createStringArray(a, valueData); }}));
+
+    auto result = ArrowTableSupport::createViewFromArrowTable(*conn, "t1", std::move(schema),
+        std::move(arrays));
+    ASSERT_TRUE(result.queryResult->isSuccess()) << result.queryResult->getErrorMessage();
+
+    // Query back to confirm data was ingested
+    auto queryResult = conn->query("MATCH (n:t1) RETURN n.`index`, n.value ORDER BY n.`index`");
+    ASSERT_TRUE(queryResult->isSuccess()) << queryResult->getErrorMessage();
+    ASSERT_TRUE(queryResult->hasNext());
+    auto row = queryResult->getNext();
+    ASSERT_EQ(row->getValue(0)->getValue<int32_t>(), 10);
+    ASSERT_EQ(row->getValue(1)->getValue<std::string>(), "foo");
+    ASSERT_TRUE(queryResult->hasNext());
+    row = queryResult->getNext();
+    ASSERT_EQ(row->getValue(0)->getValue<int32_t>(), 20);
+    ASSERT_EQ(row->getValue(1)->getValue<std::string>(), "bar");
+}
+
+TEST_F(ArrowNodeTableTest, CreateArrowTableIrregularFieldNames) {
+    // Use field names with a space and a leading digit
+    std::vector<int32_t> col1Data = {1, 2};
+    std::vector<std::string> col2Data = {"x", "y"};
+
+    ArrowSchemaWrapper schema;
+    createStructSchema(&schema, 2);
+    createSchema<int32_t>(schema.children[0], "my column");
+    createSchema<std::string>(schema.children[1], "2nd");
+
+    std::vector<ArrowArrayWrapper> arrays;
+    arrays.push_back(createStructArray(col1Data.size(),
+        {[&](ArrowArray* a) { createInt32Array(a, col1Data); },
+            [&](ArrowArray* a) { createStringArray(a, col2Data); }}));
+
+    auto result = ArrowTableSupport::createViewFromArrowTable(*conn, "t2", std::move(schema),
+        std::move(arrays));
+    ASSERT_TRUE(result.queryResult->isSuccess()) << result.queryResult->getErrorMessage();
+
+    // Query back to confirm data was ingested
+    auto queryResult =
+        conn->query("MATCH (n:t2) RETURN n.`my column`, n.`2nd` ORDER BY n.`my column`");
+    ASSERT_TRUE(queryResult->isSuccess()) << queryResult->getErrorMessage();
+    ASSERT_TRUE(queryResult->hasNext());
+    auto row = queryResult->getNext();
+    ASSERT_EQ(row->getValue(0)->getValue<int32_t>(), 1);
+    ASSERT_EQ(row->getValue(1)->getValue<std::string>(), "x");
+    ASSERT_TRUE(queryResult->hasNext());
+    row = queryResult->getNext();
+    ASSERT_EQ(row->getValue(0)->getValue<int32_t>(), 2);
+    ASSERT_EQ(row->getValue(1)->getValue<std::string>(), "y");
 }

--- a/test/api/arrow_rel_table_test.cpp
+++ b/test/api/arrow_rel_table_test.cpp
@@ -579,6 +579,42 @@ TEST_F(ArrowRelTableTest, LargeBatchArrowRelTable) {
     ASSERT_EQ(sumResult->getNext()->getValue(0)->getValue<common::int128_t>(), 2098176);
 }
 
+TEST_F(ArrowRelTableTest, CreateArrowRelTableReservedTableName) {
+    // Use a reserved word as the relationship table name
+    createArrowPersonTable(*conn);
+
+    std::vector<int64_t> from = {1, 1, 2};
+    std::vector<int64_t> to = {2, 3, 3};
+    std::vector<int64_t> weight = {10, 20, 30};
+
+    ArrowSchemaWrapper schema;
+    createStructSchema(&schema, 3);
+    createSchema<int64_t>(schema.children[0], "from");
+    createSchema<int64_t>(schema.children[1], "to");
+    createSchema<int64_t>(schema.children[2], "weight");
+
+    std::vector<ArrowArrayWrapper> arrays;
+    arrays.push_back(
+        createStructArray(from.size(), {[&](ArrowArray* a) { createInt64Array(a, from); },
+                                           [&](ArrowArray* a) { createInt64Array(a, to); },
+                                           [&](ArrowArray* a) { createInt64Array(a, weight); }}));
+
+    // "index" is a reserved word
+    auto result = ArrowTableSupport::createRelTableFromArrowTable(*conn, "index",
+        "arrow_rel_person", "arrow_rel_person", std::move(schema), std::move(arrays));
+    ASSERT_TRUE(result.queryResult->isSuccess()) << result.queryResult->getErrorMessage();
+
+    auto countResult =
+        conn->query("MATCH (:arrow_rel_person)-[`index`]->(:arrow_rel_person) RETURN count(*)");
+    ASSERT_TRUE(countResult->isSuccess()) << countResult->getErrorMessage();
+    ASSERT_EQ(countResult->getNext()->getValue(0)->getValue<int64_t>(), 3);
+
+    auto sumResult = conn->query(
+        "MATCH (:arrow_rel_person)-[e:`index`]->(:arrow_rel_person) RETURN sum(e.weight)");
+    ASSERT_TRUE(sumResult->isSuccess()) << sumResult->getErrorMessage();
+    ASSERT_EQ(sumResult->getNext()->getValue(0)->getValue<common::int128_t>(), 60);
+}
+
 class ArrowRelTableComplexTypesTest : public lbug::testing::EmptyDBTest {
 protected:
     void SetUp() override {


### PR DESCRIPTION
Fixes #756

`ArrowTableSupport::createViewFromArrowTable`, `createRelTableFromArrowTable`, and `createRelTableFromArrowCSR` built their `CREATE NODE TABLE` / `CREATE REL TABLE` statements by string concatenation, never quoting the Arrow field names or the caller-supplied table names. Many ordinary names (`index`, `order`, `group`, `end`, `default`, names with a space, names with a leading digit) are not valid unquoted Cypher identifiers and were rejected by the parser.

**Change** (`src/storage/table/arrow_table_support.cpp`):

- New `quoteIdent` helper (file-scoped in the `lbug` namespace, matching the existing `join` and `findArrowColumnByName` helpers): wraps an identifier in backticks.
- All identifier interpolations in the three `CREATE ... TABLE` builders are now wrapped in `quoteIdent(...)`: column names, table name, primary-key column, and the `FROM`/`TO` endpoint table names in the rel-table builders.
- **Bonus fix** (same bug pattern): `unregisterArrowTable` builds a `DROP TABLE` statement with the same unquoted identifier. Without fixing it, a table created via this PR with a reserved name would have been un-droppable. Now also quoted.

**Tests added** (3, all pass):

- `ArrowNodeTableTest.CreateArrowTableReservedFieldNames` — columns named `index` and `value`
- `ArrowNodeTableTest.CreateArrowTableIrregularFieldNames` — columns named `my column` and `2nd` (the harder cases)
- `ArrowRelTableTest.CreateArrowRelTableReservedTableName` — rel table itself named `index`

All 50 arrow tests continue to pass; 14 pre-existing skips, 0 regressions.

**Release note:** callers that previously worked around this bug by pre-quoting Arrow field names with backticks (so the generated DDL happened to be correct) will now get double-quoted identifiers (`` `\`index\`` ``) and fail. Those backticks should be removed from the Arrow field names.

**Out of scope** (per the issue author):

- `LogicalType::toString()` for `STRUCT` member names is a design call left for a separate look; `STRUCT` member quoting still fails after this change.
- Backtick-escaping inside `Transformer::transformSymbolicName` is a separate parser issue; not addressed here.