### PR TITLE
optimize the trivial "RETURN $i" query

### DIFF
--- a/src/expression_evaluator/literal_evaluator.cpp
+++ b/src/expression_evaluator/literal_evaluator.cpp
@@ -1,5 +1,6 @@
 #include "expression_evaluator/literal_evaluator.h"
 
+#include "binder/expression/parameter_expression.h"
 #include "common/types/value/value.h"
 
 using namespace lbug::common;
@@ -32,10 +33,16 @@ void LiteralExpressionEvaluator::resolveResultVector(const processor::ResultSet&
     flatState = DataChunkState::getSingleValueDataChunkState();
     unFlatState = std::make_shared<DataChunkState>();
     resultVector->setState(flatState);
-    if (value.isNull()) {
+    // If the expression is a bound parameter, read the fresh value from the expression
+    // rather than the frozen copy captured at plan-build time. This enables the cached
+    // physical-plan path to pick up changed parameter values between executions.
+    const auto& srcValue = expression->expressionType == common::ExpressionType::PARAMETER ?
+                               expression->constCast<binder::ParameterExpression>().getValue() :
+                               value;
+    if (srcValue.isNull()) {
         resultVector->setNull(0 /* pos */, true);
     } else {
-        resultVector->copyFromValue(resultVector->state->getSelVector()[0], value);
+        resultVector->copyFromValue(resultVector->state->getSelVector()[0], srcValue);
     }
 }
 

--- a/src/include/function/table/table_function.h
+++ b/src/include/function/table/table_function.h
@@ -46,6 +46,7 @@ struct LBUG_API TableFuncSharedState {
     explicit TableFuncSharedState(common::row_idx_t numRows) : numRows{numRows} {}
     virtual ~TableFuncSharedState() = default;
     virtual uint64_t getNumRows() const { return numRows; }
+    virtual void resetState() {}
 
     common::table_id_map_t<common::SemiMask*> getSemiMasks() const { return semiMasks.getMasks(); }
 

--- a/src/include/main/client_context.h
+++ b/src/include/main/client_context.h
@@ -224,7 +224,8 @@ private:
 
     std::unique_ptr<QueryResult> executeNoLock(PreparedStatement* preparedStatement,
         CachedPreparedStatement* cachedPreparedStatement,
-        std::optional<uint64_t> queryID = std::nullopt, QueryConfig config = {});
+        std::optional<uint64_t> queryID = std::nullopt, QueryConfig config = {},
+        bool cachePhysicalPlan = false);
     std::unique_ptr<QueryResult> queryNoLock(std::string_view query,
         std::optional<uint64_t> queryID = std::nullopt, QueryConfig config = {});
 

--- a/src/include/main/prepared_statement.h
+++ b/src/include/main/prepared_statement.h
@@ -12,6 +12,7 @@
 namespace lbug {
 namespace processor {
 class PhysicalPlan;
+class ResultSet;
 struct ResultSetDescriptor;
 } // namespace processor
 } // namespace lbug
@@ -47,6 +48,13 @@ struct CachedPreparedStatement {
     // Cached result-set descriptor. copy() does not propagate the descriptor from an
     // operator tree, so we store it here separately and re-attach it on the cloned sink.
     std::unique_ptr<processor::ResultSetDescriptor> resultSetDescriptor;
+    // Cached ResultSet (DataChunks + ValueVectors + value buffers) reused
+    // across executions of this prepared statement. Without this, every
+    // execution allocates a fresh ResultSet via Sink::getResultSet(), paying
+    // a calloc() per ValueVector's value buffer and a fresh nullMask. The
+    // ResultSet outlives any single PhysicalPlan clone, so we hold it here
+    // and attach it to the cloned sink before each execution.
+    std::shared_ptr<processor::ResultSet> resultSetCache;
 
     CachedPreparedStatement();
     ~CachedPreparedStatement();

--- a/src/include/main/prepared_statement.h
+++ b/src/include/main/prepared_statement.h
@@ -12,7 +12,6 @@
 namespace lbug {
 namespace processor {
 class PhysicalPlan;
-class ResultSet;
 struct ResultSetDescriptor;
 } // namespace processor
 } // namespace lbug
@@ -48,13 +47,6 @@ struct CachedPreparedStatement {
     // Cached result-set descriptor. copy() does not propagate the descriptor from an
     // operator tree, so we store it here separately and re-attach it on the cloned sink.
     std::unique_ptr<processor::ResultSetDescriptor> resultSetDescriptor;
-    // Cached ResultSet (DataChunks + ValueVectors + value buffers) reused
-    // across executions of this prepared statement. Without this, every
-    // execution allocates a fresh ResultSet via Sink::getResultSet(), paying
-    // a calloc() per ValueVector's value buffer and a fresh nullMask. The
-    // ResultSet outlives any single PhysicalPlan clone, so we hold it here
-    // and attach it to the cloned sink before each execution.
-    std::shared_ptr<processor::ResultSet> resultSetCache;
 
     CachedPreparedStatement();
     ~CachedPreparedStatement();

--- a/src/include/main/prepared_statement.h
+++ b/src/include/main/prepared_statement.h
@@ -10,6 +10,13 @@
 #include "query_summary.h"
 
 namespace lbug {
+namespace processor {
+class PhysicalPlan;
+struct ResultSetDescriptor;
+} // namespace processor
+} // namespace lbug
+
+namespace lbug {
 namespace common {
 class LogicalType;
 }
@@ -32,6 +39,14 @@ struct CachedPreparedStatement {
     std::unique_ptr<planner::LogicalPlan> logicalPlan;
     std::vector<std::shared_ptr<binder::Expression>> columns;
     std::vector<std::string> columnNames;
+
+    // Cached physical plan for fast re-execution. When canReuseCachedPlanWith returns true,
+    // this operator-tree template is cloned and its sink state is refreshed for each call,
+    // avoiding the PlanMapper::mapOperator recursion entirely.
+    std::unique_ptr<processor::PhysicalPlan> physicalPlanCache;
+    // Cached result-set descriptor. copy() does not propagate the descriptor from an
+    // operator tree, so we store it here separately and re-attach it on the cloned sink.
+    std::unique_ptr<processor::ResultSetDescriptor> resultSetDescriptor;
 
     CachedPreparedStatement();
     ~CachedPreparedStatement();

--- a/src/include/processor/execution_context.h
+++ b/src/include/processor/execution_context.h
@@ -7,18 +7,11 @@ namespace main {
 class ClientContext;
 }
 namespace processor {
-class ResultSet;
 
 struct LBUG_API ExecutionContext {
     uint64_t queryID;
     common::Profiler* profiler;
     main::ClientContext* clientContext;
-    // Optional pre-attached ResultSet (non-owning). When set, the processor
-    // reuses this ResultSet instead of allocating a new one via
-    // Sink::getResultSet(). Used by the cached physical-plan path to skip
-    // per-execution DataChunk/ValueVector allocation. The pointee is owned
-    // by the CachedPreparedStatement and outlives this ExecutionContext.
-    ResultSet* sharedResultSet = nullptr;
 
     ExecutionContext(common::Profiler* profiler, main::ClientContext* clientContext,
         uint64_t queryID)

--- a/src/include/processor/execution_context.h
+++ b/src/include/processor/execution_context.h
@@ -7,11 +7,18 @@ namespace main {
 class ClientContext;
 }
 namespace processor {
+class ResultSet;
 
 struct LBUG_API ExecutionContext {
     uint64_t queryID;
     common::Profiler* profiler;
     main::ClientContext* clientContext;
+    // Optional pre-attached ResultSet (non-owning). When set, the processor
+    // reuses this ResultSet instead of allocating a new one via
+    // Sink::getResultSet(). Used by the cached physical-plan path to skip
+    // per-execution DataChunk/ValueVector allocation. The pointee is owned
+    // by the CachedPreparedStatement and outlives this ExecutionContext.
+    ResultSet* sharedResultSet = nullptr;
 
     ExecutionContext(common::Profiler* profiler, main::ClientContext* clientContext,
         uint64_t queryID)

--- a/src/include/processor/operator/physical_operator.h
+++ b/src/include/processor/operator/physical_operator.h
@@ -8,6 +8,9 @@ class Profiler;
 class NumericMetric;
 class TimeMetric;
 } // namespace lbug::common
+namespace lbug::storage {
+class MemoryManager;
+} // namespace lbug::storage
 namespace lbug {
 namespace processor {
 struct ExecutionContext;
@@ -169,6 +172,15 @@ public:
     bool getNextTuple(ExecutionContext* context);
 
     virtual void finalize(ExecutionContext* context);
+
+    // Prepare the operator tree for reuse across executions. Replaces mutable shared state
+    // (e.g., accumulating result tables) with fresh instances so the tree can be executed
+    // again without leaking data between iterations.
+    virtual void prepareForReuse(storage::MemoryManager* memoryManager) {
+        for (auto& child : children) {
+            child->prepareForReuse(memoryManager);
+        }
+    }
 
     std::unordered_map<std::string, std::string> getProfilerKeyValAttributes(
         common::Profiler& profiler) const;

--- a/src/include/processor/operator/result_collector.h
+++ b/src/include/processor/operator/result_collector.h
@@ -77,6 +77,8 @@ public:
 
     void finalizeInternal(ExecutionContext* context) override;
 
+    void prepareForReuse(storage::MemoryManager* memoryManager) override;
+
     std::shared_ptr<FactorizedTable> getResultFTable() const override {
         return sharedState->getTable();
     }

--- a/src/include/processor/operator/sink.h
+++ b/src/include/processor/operator/sink.h
@@ -27,6 +27,7 @@ public:
         DASSERT(resultSetDescriptor == nullptr);
         resultSetDescriptor = std::move(descriptor);
     }
+    ResultSetDescriptor* getDescriptor() const { return resultSetDescriptor.get(); }
     std::unique_ptr<ResultSet> getResultSet(storage::MemoryManager* memoryManager);
 
     void execute(ResultSet* resultSet, ExecutionContext* context) {

--- a/src/include/processor/operator/table_function_call.h
+++ b/src/include/processor/operator/table_function_call.h
@@ -64,6 +64,13 @@ public:
 
     void finalizeInternal(ExecutionContext* context) override;
 
+    void prepareForReuse(storage::MemoryManager* memoryManager) override {
+        if (sharedState) {
+            sharedState->resetState();
+        }
+        PhysicalOperator::prepareForReuse(memoryManager);
+    }
+
     double getProgress(ExecutionContext* context) const override;
 
     std::unique_ptr<PhysicalOperator> copy() override {

--- a/src/include/processor/result/factorized_table.h
+++ b/src/include/processor/result/factorized_table.h
@@ -71,6 +71,17 @@ public:
     DataBlock* getBlock(ft_block_idx_t blockIdx) { return blocks[blockIdx].get(); }
     DataBlock* getLastBlock() { return blocks.back().get(); }
 
+    // Truncates the collection to at most one block, dropping the rest so that
+    // getBlockIdxAndTupleIdxInBlock(tupleIdx) = tupleIdx / numTuplesPerBlock
+    // keeps mapping tuple 0 to block 0 across a clear/reuse cycle. The caller
+    // is responsible for zeroing the surviving block (if any) before calling
+    // this.
+    void keepFirstBlock() {
+        if (blocks.size() > 1) {
+            blocks.resize(1);
+        }
+    }
+
     void merge(DataBlockCollection& other);
     void preventDestruction() const {
         for (auto& block : blocks) {

--- a/src/include/processor/result/result_set.h
+++ b/src/include/processor/result/result_set.h
@@ -15,6 +15,13 @@ public:
     explicit ResultSet(common::idx_t numDataChunks) : multiplicity{1}, dataChunks(numDataChunks) {}
     ResultSet(ResultSetDescriptor* resultSetDescriptor, storage::MemoryManager* memoryManager);
 
+    // Reset per-execution mutable state so the ResultSet can be reused across
+    // multiple executions of the same prepared statement without re-allocating
+    // DataChunks / ValueVectors / value buffers. Operators overwrite the values
+    // and null bits on every execution; this just clears stale state for the
+    // pieces the operators don't explicitly reset.
+    void resetForReuse();
+
     void insert(common::idx_t pos, std::shared_ptr<common::DataChunk> dataChunk) {
         DASSERT(dataChunks.size() > pos);
         dataChunks[pos] = std::move(dataChunk);

--- a/src/include/processor/result/result_set_descriptor.h
+++ b/src/include/processor/result/result_set_descriptor.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <atomic>
+
 #include "common/types/types.h"
 
 namespace lbug {
@@ -24,12 +26,20 @@ struct DataChunkDescriptor {
 };
 
 struct LBUG_API ResultSetDescriptor {
+    // Monotonically increasing identity that survives pointer reuse (ABA
+    // prevention).  Thread-local ResultSet caching in ProcessorTask::run()
+    // compares this ID instead of the raw pointer so that a descriptor
+    // allocated at the same address as a freed one is never confused with it.
+    static inline std::atomic<uint64_t> nextID{0};
+    uint64_t id;
+
     std::vector<std::unique_ptr<DataChunkDescriptor>> dataChunkDescriptors;
 
-    ResultSetDescriptor() = default;
+    ResultSetDescriptor() : id{nextID.fetch_add(1, std::memory_order_relaxed)} {}
     explicit ResultSetDescriptor(
         std::vector<std::unique_ptr<DataChunkDescriptor>> dataChunkDescriptors)
-        : dataChunkDescriptors{std::move(dataChunkDescriptors)} {}
+        : id{nextID.fetch_add(1, std::memory_order_relaxed)},
+          dataChunkDescriptors{std::move(dataChunkDescriptors)} {}
     explicit ResultSetDescriptor(planner::Schema* schema);
     DELETE_BOTH_COPY(ResultSetDescriptor);
 

--- a/src/main/client_context.cpp
+++ b/src/main/client_context.cpp
@@ -579,7 +579,7 @@ std::unique_ptr<QueryResult> ClientContext::executeNoLock(PreparedStatement* pre
                     queryID = localDatabase->getNextQueryID();
                 }
                 setActiveQueryID(queryID.value());
-                const auto executionContext =
+                auto executionContext =
                     std::make_unique<ExecutionContext>(profiler.get(), this, *queryID);
                 std::unique_ptr<PhysicalPlan> physicalPlan;
                 if (cachePhysicalPlan && cachedStatement->physicalPlanCache) {
@@ -606,8 +606,32 @@ std::unique_ptr<QueryResult> ClientContext::executeNoLock(PreparedStatement* pre
                         auto* sink = physicalPlan->lastOperator->ptrCast<Sink>();
                         if (sink->getDescriptor()) {
                             cachedStatement->resultSetDescriptor = sink->getDescriptor()->copy();
+                            // Build the cached ResultSet once (first execution
+                            // only) and borrow it into the ExecutionContext so
+                            // ProcessorTask::run reuses the DataChunks /
+                            // ValueVectors / value buffers instead of
+                            // allocating fresh ones every call. The ResultSet
+                            // is owned by CachedPreparedStatement and outlives
+                            // the cloned PhysicalPlan.
+                            cachedStatement->resultSetCache = std::make_shared<ResultSet>(
+                                sink->getDescriptor(), storage::MemoryManager::Get(*this));
                         }
                     }
+                }
+                // Expose the cached ResultSet (if any) to the processor via the
+                // ExecutionContext. ProcessorTask::run will prefer this over
+                // allocating a new ResultSet. Doing it here -- instead of
+                // stashing the pointer on the sink -- avoids a data race with
+                // the multi-threaded ProcessorTask that calls Sink::getResultSet
+                // concurrently.
+                if (cachePhysicalPlan && cachedStatement->resultSetCache) {
+                    executionContext->sharedResultSet = cachedStatement->resultSetCache.get();
+                    // Clear per-execution state (null mask, aux buffers,
+                    // multiplicity) so operators start from a clean slate.
+                    // Operators overwrite values themselves; this covers the
+                    // bits they don't reset (e.g. setValue<T> doesn't clear
+                    // the null bit).
+                    cachedStatement->resultSetCache->resetForReuse();
                 }
                 if (isTransactionStatement) {
                     result = localDatabase->queryProcessor->execute(physicalPlan.get(),

--- a/src/main/client_context.cpp
+++ b/src/main/client_context.cpp
@@ -390,14 +390,14 @@ std::unique_ptr<QueryResult> ClientContext::executeWithParams(PreparedStatement*
     // LCOV_EXCL_STOP
     auto cachedStatement = cachedPreparedStatementManager.getCachedStatement(name);
     if (useCachedPlan) {
-        return executeNoLock(preparedStatement, cachedStatement, queryID);
+        return executeNoLock(preparedStatement, cachedStatement, queryID, {}, true);
     }
     // rebind
     auto [newPreparedStatement, newCachedStatement] =
         prepareNoLock(cachedStatement->parsedStatement, false /*shouldCommitNewTransaction*/,
             preparedStatement->parameterMap);
     useInternalCatalogEntry_ = false;
-    return executeNoLock(newPreparedStatement.get(), newCachedStatement.get(), queryID);
+    return executeNoLock(newPreparedStatement.get(), newCachedStatement.get(), queryID, {}, true);
 }
 
 std::unique_ptr<QueryResult> ClientContext::query(std::string_view query,
@@ -421,7 +421,7 @@ std::unique_ptr<QueryResult> ClientContext::queryNoLock(std::string_view query,
         auto [preparedStatement, cachedStatement] =
             prepareNoLock(statement, false /*shouldCommitNewTransaction*/);
         auto currentQueryResult =
-            executeNoLock(preparedStatement.get(), cachedStatement.get(), queryID, config);
+            executeNoLock(preparedStatement.get(), cachedStatement.get(), queryID, config, false);
         if (!currentQueryResult->isSuccess()) {
             if (!lastResult) {
                 queryResult = std::move(currentQueryResult);
@@ -554,7 +554,7 @@ ClientContext::PrepareResult ClientContext::prepareNoLock(
 
 std::unique_ptr<QueryResult> ClientContext::executeNoLock(PreparedStatement* preparedStatement,
     CachedPreparedStatement* cachedStatement, std::optional<uint64_t> queryID,
-    QueryConfig queryConfig) {
+    QueryConfig queryConfig, bool cachePhysicalPlan) {
     if (!preparedStatement->isSuccess()) {
         return QueryResult::getQueryResultWithError(preparedStatement->errMsg);
     }
@@ -581,9 +581,34 @@ std::unique_ptr<QueryResult> ClientContext::executeNoLock(PreparedStatement* pre
                 setActiveQueryID(queryID.value());
                 const auto executionContext =
                     std::make_unique<ExecutionContext>(profiler.get(), this, *queryID);
-                auto mapper = PlanMapper(executionContext.get());
-                const auto physicalPlan = mapper.getPhysicalPlan(cachedStatement->logicalPlan.get(),
-                    cachedStatement->columns, queryConfig.resultType, queryConfig.arrowConfig);
+                std::unique_ptr<PhysicalPlan> physicalPlan;
+                if (cachePhysicalPlan && cachedStatement->physicalPlanCache) {
+                    // Fast path: clone cached operator tree and refresh sink state.
+                    // Avoids the PlanMapper::mapOperator recursion entirely.
+                    physicalPlan = std::make_unique<PhysicalPlan>(
+                        cachedStatement->physicalPlanCache->lastOperator->copy());
+                    physicalPlan->lastOperator->prepareForReuse(storage::MemoryManager::Get(*this));
+                    // Re-attach the ResultSetDescriptor (not propagated by copy()).
+                    if (cachedStatement->resultSetDescriptor) {
+                        auto* sink = physicalPlan->lastOperator->ptrCast<Sink>();
+                        sink->setDescriptor(cachedStatement->resultSetDescriptor->copy());
+                    }
+                } else {
+                    auto mapper = PlanMapper(executionContext.get());
+                    physicalPlan = mapper.getPhysicalPlan(cachedStatement->logicalPlan.get(),
+                        cachedStatement->columns, queryConfig.resultType, queryConfig.arrowConfig);
+                    if (cachePhysicalPlan) {
+                        // Cache the operator tree template for future reuse.
+                        cachedStatement->physicalPlanCache =
+                            std::make_unique<PhysicalPlan>(physicalPlan->lastOperator->copy());
+                        // Also save the ResultSetDescriptor separately (copy() doesn't
+                        // propagate it, and the cloned sink needs it for getResultSet).
+                        auto* sink = physicalPlan->lastOperator->ptrCast<Sink>();
+                        if (sink->getDescriptor()) {
+                            cachedStatement->resultSetDescriptor = sink->getDescriptor()->copy();
+                        }
+                    }
+                }
                 if (isTransactionStatement) {
                     result = localDatabase->queryProcessor->execute(physicalPlan.get(),
                         executionContext.get());

--- a/src/main/client_context.cpp
+++ b/src/main/client_context.cpp
@@ -606,32 +606,8 @@ std::unique_ptr<QueryResult> ClientContext::executeNoLock(PreparedStatement* pre
                         auto* sink = physicalPlan->lastOperator->ptrCast<Sink>();
                         if (sink->getDescriptor()) {
                             cachedStatement->resultSetDescriptor = sink->getDescriptor()->copy();
-                            // Build the cached ResultSet once (first execution
-                            // only) and borrow it into the ExecutionContext so
-                            // ProcessorTask::run reuses the DataChunks /
-                            // ValueVectors / value buffers instead of
-                            // allocating fresh ones every call. The ResultSet
-                            // is owned by CachedPreparedStatement and outlives
-                            // the cloned PhysicalPlan.
-                            cachedStatement->resultSetCache = std::make_shared<ResultSet>(
-                                sink->getDescriptor(), storage::MemoryManager::Get(*this));
                         }
                     }
-                }
-                // Expose the cached ResultSet (if any) to the processor via the
-                // ExecutionContext. ProcessorTask::run will prefer this over
-                // allocating a new ResultSet. Doing it here -- instead of
-                // stashing the pointer on the sink -- avoids a data race with
-                // the multi-threaded ProcessorTask that calls Sink::getResultSet
-                // concurrently.
-                if (cachePhysicalPlan && cachedStatement->resultSetCache) {
-                    executionContext->sharedResultSet = cachedStatement->resultSetCache.get();
-                    // Clear per-execution state (null mask, aux buffers,
-                    // multiplicity) so operators start from a clean slate.
-                    // Operators overwrite values themselves; this covers the
-                    // bits they don't reset (e.g. setValue<T> doesn't clear
-                    // the null bit).
-                    cachedStatement->resultSetCache->resetForReuse();
                 }
                 if (isTransactionStatement) {
                     result = localDatabase->queryProcessor->execute(physicalPlan.get(),

--- a/src/main/prepared_statement.cpp
+++ b/src/main/prepared_statement.cpp
@@ -4,6 +4,7 @@
 #include "common/exception/binder.h"
 #include "common/types/value/value.h"
 #include "planner/operator/logical_plan.h" // IWYU pragma: keep
+#include "processor/physical_plan.h"       // IWYU pragma: keep
 #include <format>
 
 using namespace lbug::common;

--- a/src/processor/operator/result_collector.cpp
+++ b/src/processor/operator/result_collector.cpp
@@ -58,8 +58,9 @@ void ResultCollector::executeInternal(ExecutionContext* context) {
 }
 
 void ResultCollector::prepareForReuse(storage::MemoryManager* memoryManager) {
-    sharedState = std::make_shared<ResultCollectorSharedState>(
-        std::make_shared<FactorizedTable>(memoryManager, info.tableSchema.copy()));
+    // Clear the existing result table instead of freeing + re-allocating.
+    // This keeps the DataBlocks alive so the next execution reuses them.
+    sharedState->getTable()->clear();
     PhysicalOperator::prepareForReuse(memoryManager);
 }
 

--- a/src/processor/operator/result_collector.cpp
+++ b/src/processor/operator/result_collector.cpp
@@ -57,6 +57,12 @@ void ResultCollector::executeInternal(ExecutionContext* context) {
     }
 }
 
+void ResultCollector::prepareForReuse(storage::MemoryManager* memoryManager) {
+    sharedState = std::make_shared<ResultCollectorSharedState>(
+        std::make_shared<FactorizedTable>(memoryManager, info.tableSchema.copy()));
+    PhysicalOperator::prepareForReuse(memoryManager);
+}
+
 void ResultCollector::finalizeInternal(ExecutionContext* context) {
     switch (info.accumulateType) {
     case AccumulateType::OPTIONAL_: {

--- a/src/processor/operator/table_scan/ftable_scan_function.cpp
+++ b/src/processor/operator/table_scan/ftable_scan_function.cpp
@@ -18,6 +18,8 @@ struct FTableScanSharedState final : public SimpleTableFuncSharedState {
         : SimpleTableFuncSharedState{table->getNumTuples()}, table{std::move(table)},
           morselSize{morselSize}, nextTupleIdx{0} {}
 
+    void resetState() override { nextTupleIdx = 0; }
+
     TableFuncMorsel getMorsel() override {
         std::unique_lock lck{mtx};
         auto numTuplesToScan = std::min(morselSize, table->getNumTuples() - nextTupleIdx);

--- a/src/processor/processor_task.cpp
+++ b/src/processor/processor_task.cpp
@@ -4,6 +4,7 @@
 #include "main/client_context.h"
 #include "main/settings.h"
 #include "processor/execution_context.h"
+#include "processor/result/result_set.h"
 #include "storage/buffer_manager/memory_manager.h"
 
 using namespace lbug::common;
@@ -26,21 +27,38 @@ void ProcessorTask::run() {
     }
     auto taskRoot = sink->copy();
     lck.unlock();
-    // Pick the ResultSet to hand to the cloned sink. We prefer the cached
-    // one from the ExecutionContext (set up by the cached physical-plan
-    // path) to skip per-execution DataChunk/ValueVector allocation, but
-    // only when this task is single-threaded: a shared ResultSet would
-    // race between worker threads writing to the same ValueVectors
-    // concurrently. The old code created a fresh ResultSet per call, so
-    // each thread had its own. We restore that behaviour for multi-
-    // threaded tasks; the single-threaded path (the hot one for trivial
-    // queries) keeps the allocation savings.
+    // Reuse the DataChunk / ValueVector / value-buffer allocations across
+    // executions of the same prepared statement. The old code allocated a
+    // fresh ResultSet per ProcessorTask::run() call; for a loop like
+    //     for i in range(n): conn.execute("RETURN $i", {"i": i})
+    // that's a 16KB+ calloc on every iteration.
+    //
+    // We instead keep a thread-local shared_ptr<ResultSet> whose descriptor
+    // matches this sink's, so each thread of a multi-threaded task gets
+    // its own allocation-free slot. The thread owns the ResultSet outright
+    // (no aliasing), so the lifetime is straightforward: dropped when the
+    // thread exits, or when a different prepared statement runs on this
+    // thread and the descriptor pointer no longer matches.
     ResultSet* resultSetPtr = nullptr;
     std::unique_ptr<ResultSet> ownedResultSet;
-    if (maxNumThreads == 1) {
-        resultSetPtr = executionContext->sharedResultSet;
-    }
-    if (resultSetPtr == nullptr) {
+    if (auto* desc = sink->getDescriptor()) {
+        thread_local processor::ResultSetDescriptor* cachedDesc = nullptr;
+        thread_local std::shared_ptr<processor::ResultSet> cachedResultSet;
+        if (cachedDesc == desc && cachedResultSet) {
+            // Same prepared statement on this thread: reuse the allocation.
+            cachedResultSet->resetForReuse();
+            resultSetPtr = cachedResultSet.get();
+        } else {
+            // First time on this thread, or a different prepared statement:
+            // allocate fresh. Owning shared_ptr; lifetime ends with the
+            // thread (or when the descriptor changes).
+            cachedResultSet = std::make_shared<processor::ResultSet>(desc,
+                storage::MemoryManager::Get(*executionContext->clientContext));
+            cachedDesc = desc;
+            resultSetPtr = cachedResultSet.get();
+        }
+    } else {
+        // No descriptor (e.g. OrderByMerge): fall back to per-call allocation.
         ownedResultSet =
             sink->getResultSet(storage::MemoryManager::Get(*executionContext->clientContext));
         resultSetPtr = ownedResultSet.get();

--- a/src/processor/processor_task.cpp
+++ b/src/processor/processor_task.cpp
@@ -26,9 +26,26 @@ void ProcessorTask::run() {
     }
     auto taskRoot = sink->copy();
     lck.unlock();
-    auto resultSet =
-        sink->getResultSet(storage::MemoryManager::Get(*executionContext->clientContext));
-    taskRoot->ptrCast<Sink>()->execute(resultSet.get(), executionContext);
+    // Pick the ResultSet to hand to the cloned sink. We prefer the cached
+    // one from the ExecutionContext (set up by the cached physical-plan
+    // path) to skip per-execution DataChunk/ValueVector allocation, but
+    // only when this task is single-threaded: a shared ResultSet would
+    // race between worker threads writing to the same ValueVectors
+    // concurrently. The old code created a fresh ResultSet per call, so
+    // each thread had its own. We restore that behaviour for multi-
+    // threaded tasks; the single-threaded path (the hot one for trivial
+    // queries) keeps the allocation savings.
+    ResultSet* resultSetPtr = nullptr;
+    std::unique_ptr<ResultSet> ownedResultSet;
+    if (maxNumThreads == 1) {
+        resultSetPtr = executionContext->sharedResultSet;
+    }
+    if (resultSetPtr == nullptr) {
+        ownedResultSet =
+            sink->getResultSet(storage::MemoryManager::Get(*executionContext->clientContext));
+        resultSetPtr = ownedResultSet.get();
+    }
+    taskRoot->ptrCast<Sink>()->execute(resultSetPtr, executionContext);
 }
 
 void ProcessorTask::finalize() {

--- a/src/processor/processor_task.cpp
+++ b/src/processor/processor_task.cpp
@@ -42,9 +42,9 @@ void ProcessorTask::run() {
     ResultSet* resultSetPtr = nullptr;
     std::unique_ptr<ResultSet> ownedResultSet;
     if (auto* desc = sink->getDescriptor()) {
-        thread_local processor::ResultSetDescriptor* cachedDesc = nullptr;
+        thread_local uint64_t cachedDescID = UINT64_MAX;
         thread_local std::shared_ptr<processor::ResultSet> cachedResultSet;
-        if (cachedDesc == desc && cachedResultSet) {
+        if (cachedDescID == desc->id && cachedResultSet) {
             // Same prepared statement on this thread: reuse the allocation.
             cachedResultSet->resetForReuse();
             resultSetPtr = cachedResultSet.get();
@@ -54,7 +54,7 @@ void ProcessorTask::run() {
             // thread (or when the descriptor changes).
             cachedResultSet = std::make_shared<processor::ResultSet>(desc,
                 storage::MemoryManager::Get(*executionContext->clientContext));
-            cachedDesc = desc;
+            cachedDescID = desc->id;
             resultSetPtr = cachedResultSet.get();
         }
     } else {

--- a/src/processor/result/factorized_table.cpp
+++ b/src/processor/result/factorized_table.cpp
@@ -334,8 +334,20 @@ void FactorizedTable::setNonOverflowColNull(uint8_t* nullBuffer, ft_col_idx_t co
 
 void FactorizedTable::clear() {
     numTuples = 0;
-    flatTupleBlockCollection = std::make_unique<DataBlockCollection>(
-        tableSchema.getNumBytesPerTuple(), numFlatTuplesPerBlock);
+    // Reuse the first DataBlock (zeroed) and drop the rest. This skips the
+    // 256KB malloc on the next append while preserving the dense-packing
+    // invariant that getBlockIdxAndTupleIdxInBlock(tupleIdx) =
+    // tupleIdx / numFlatTuplesPerBlock relies on: the "next" block to write
+    // to must live at index 0. Once it fills, allocateFlatTupleBlocks
+    // appends new blocks at the tail, so block 1, 2, ... keep the formula
+    // correct.
+    if (!flatTupleBlockCollection->isEmpty()) {
+        auto& firstBlock = flatTupleBlockCollection->getBlocks().front();
+        firstBlock->resetToZero();
+        firstBlock->freeSize = firstBlock->getSizedData().size();
+        firstBlock->numTuples = 0;
+        flatTupleBlockCollection->keepFirstBlock();
+    }
     unFlatTupleBlockCollection = std::make_unique<DataBlockCollection>();
     inMemOverflowBuffer->resetBuffer();
 }

--- a/src/processor/result/result_set.cpp
+++ b/src/processor/result/result_set.cpp
@@ -36,5 +36,28 @@ uint64_t ResultSet::getNumTuplesWithoutMultiplicity(
     return numTuples;
 }
 
+void ResultSet::resetForReuse() {
+    // multiplicity is overwritten by Projection / MultiplicityReducer each
+    // execution, but if neither runs (e.g. trivial ``RETURN $i``) the cached
+    // value from the previous run would leak into the next. Reset to 1 so
+    // downstream operators that multiply it start from a clean slate.
+    multiplicity = 1;
+    for (auto& dataChunk : dataChunks) {
+        if (dataChunk == nullptr) {
+            continue;
+        }
+        for (auto& valueVector : dataChunk->valueVectors) {
+            // setAllNonNull() clears any null bits the previous run may have
+            // set (operators that only call setValue<T>() don't touch the null
+            // mask, so the stale bit would otherwise persist across runs).
+            // resetAuxiliaryBuffer() drops the in-memory overflow buffer for
+            // strings / lists / arrays / structs so variable-length state from
+            // a prior run doesn't survive.
+            valueVector->setAllNonNull();
+            valueVector->resetAuxiliaryBuffer();
+        }
+    }
+}
+
 } // namespace processor
 } // namespace lbug

--- a/src/processor/result/result_set_descriptor.cpp
+++ b/src/processor/result/result_set_descriptor.cpp
@@ -5,7 +5,8 @@
 namespace lbug {
 namespace processor {
 
-ResultSetDescriptor::ResultSetDescriptor(planner::Schema* schema) {
+ResultSetDescriptor::ResultSetDescriptor(planner::Schema* schema)
+    : id{nextID.fetch_add(1, std::memory_order_relaxed)} {
     for (auto i = 0u; i < schema->getNumGroups(); ++i) {
         auto group = schema->getGroup(i);
         auto dataChunkDescriptor = std::make_unique<DataChunkDescriptor>(group->isSingleState());


### PR DESCRIPTION
Profiling the following trivial query:

```
    for i in range(n):
        conn.execute("RETURN $i", {"i": i})
```

revealed many optimization opportunities.

- Reuse physical plan in the prepared statement
- Avoid unnecessary allocations
       