### PR TITLE
Fix #758: Clear ARROW_FLAG_NULLABLE on the entries struct of MAP columns

### DIFF
--- a/src/common/arrow/arrow_converter.cpp
+++ b/src/common/arrow/arrow_converter.cpp
@@ -265,6 +265,11 @@ void ArrowConverter::setArrowFormat(ArrowSchemaHolder& rootHolder, ArrowSchema& 
         child.children[0]->name = "entries";
         setArrowFormat(rootHolder, **child.children, ListType::getChildType(dataType),
             fallbackExtensionTypes);
+        // The Arrow columnar spec requires both the entries struct of a map and its
+        // key child to be non-nullable. See
+        // https://arrow.apache.org/docs/format/Columnar.html#map-layout
+        child.children[0]->flags &=
+            ~ARROW_FLAG_NULLABLE; // Map's entries struct must be non-nullable
         child.children[0]->children[0]->flags &=
             ~ARROW_FLAG_NULLABLE; // Map's keys must be non-nullable
     } break;

--- a/test/api/arrow_test.cpp
+++ b/test/api/arrow_test.cpp
@@ -501,6 +501,45 @@ TEST_F(ArrowTest, getArrowSchema) {
     schema->release(schema.get());
 }
 
+// The Arrow columnar map layout requires the entries struct of a map and the
+// key child of that struct to be non-nullable. Consumers (e.g. arrow-java's
+// MapVector) reject the schema when these flags are wrong, which makes every
+// query that returns a MAP column unreadable through the Arrow API.
+// See https://arrow.apache.org/docs/format/Columnar.html#map-layout
+TEST_F(ArrowTest, mapColumnArrowSchemaHasNonNullableEntriesAndKey) {
+    ASSERT_TRUE(conn->query("CREATE NODE TABLE MapT(id STRING, m MAP(STRING, STRING), "
+                            "PRIMARY KEY(id));")
+                    ->isSuccess());
+    ASSERT_TRUE(conn->query("CREATE (:MapT {id: 'r1', m: map(['k'], ['v'])});")->isSuccess());
+
+    auto result = conn->query("MATCH (n:MapT) RETURN n.m;");
+    ASSERT_TRUE(result->isSuccess());
+    auto schema = result->getArrowSchema();
+    ASSERT_NE(schema, nullptr);
+    ASSERT_EQ(schema->n_children, 1);
+
+    auto* mapColumn = schema->children[0];
+    ASSERT_STREQ(mapColumn->format, "+m");
+    // The map column itself may be null.
+    ASSERT_TRUE(mapColumn->flags & ARROW_FLAG_NULLABLE);
+    ASSERT_EQ(mapColumn->n_children, 1);
+
+    auto* entries = mapColumn->children[0];
+    ASSERT_STREQ(entries->name, "entries");
+    // Per the Arrow map layout, the entries struct must be non-nullable.
+    ASSERT_FALSE(entries->flags & ARROW_FLAG_NULLABLE);
+    ASSERT_EQ(entries->n_children, 2);
+
+    auto* key = entries->children[0];
+    auto* value = entries->children[1];
+    // Map keys are always non-nullable.
+    ASSERT_FALSE(key->flags & ARROW_FLAG_NULLABLE);
+    // Map values follow the value type's nullability.
+    ASSERT_TRUE(value->flags & ARROW_FLAG_NULLABLE);
+
+    schema->release(schema.get());
+}
+
 TEST_F(ArrowTest, queryAsArrowDirectCSRRowIDProjection) {
     ASSERT_TRUE(
         conn->query("CREATE NODE TABLE DirectPerson(id INT64, PRIMARY KEY(id));")->isSuccess());


### PR DESCRIPTION
Fixes #758.

## Problem

Any query returning a \`MAP\` column is unreadable through the Arrow result
API. Consumers (e.g. arrow-java's \`MapVector\`) reject the schema Ladybug
produces with:

\`\`\`
IllegalArgumentException: Map data should be a non-nullable struct type
\`\`\`

This also breaks \`RETURN n.*\` and \`RETURN n\`, since including a single
\`MAP\` column makes the whole Arrow read path unusable for that table.

## Root cause

\`ArrowConverter::setArrowFormat\`, \`LogicalTypeID::MAP\` case
(\`src/common/arrow/arrow_converter.cpp\`), only cleared
\`ARROW_FLAG_NULLABLE\` on the key child of the entries struct. The Arrow
columnar map layout requires **both** the entries struct and the key child
to be non-nullable:

> The entries struct itself must be non-nullable, as is its key child.
> — https://arrow.apache.org/docs/format/Columnar.html#map-layout

The fix is a single added line, applied immediately before the existing
key-child clear:

\`\`\`cpp
child.children[0]->flags &=
    ~ARROW_FLAG_NULLABLE; // Map's entries struct must be non-nullable
\`\`\`

## Test

Added \`ArrowTest.mapColumnArrowSchemaHasNonNullableEntriesAndKey\` in
\`test/api/arrow_test.cpp\`. The test creates a \`MAP(STRING, STRING)\` column,
exports the Arrow schema through \`getArrowSchema()\`, and asserts:

- the map column has format \`+m\` and is itself nullable,
- the entries struct is named \`entries\` and is non-nullable,
- the key child is non-nullable, and
- the value child is nullable (values follow the value type's nullability).

## Notes

- The C data interface does not treat child names as normative, so the
  upper-case \`KEY\`/\`VALUE\` naming mentioned in the issue is left for a
  separate change.
- A Java round trip with a locally patched \`liblbug\` cannot be verified
  end to end because the released \`com.ladybugdb:lbug\` artifact statically
  links its own engine build, but the flag is what \`arrow-java\`'s exception
  names, and it is now correct.