### PR TITLE
Fix #757: accept FixedSizeBinary(16) with arrow.uuid for UUID PK

### DIFF
--- a/src/common/arrow/arrow_array_scan.cpp
+++ b/src/common/arrow/arrow_array_scan.cpp
@@ -280,6 +280,36 @@ static void scanArrowArrayFixedBLOB(const ArrowArray* array, ValueVector& output
     });
 }
 
+// Reads a FixedSizeBinary(16) Arrow column carrying the `arrow.uuid` extension
+// (https://arrow.apache.org/docs/format/CDataInterface.html) into a UUID-typed
+// value vector. The 16 bytes are in big-endian (network) byte order on the wire;
+// lbug stores the UUID internally as an int128 with the most-significant bit
+// flipped (so lexicographic order of strings matches the natural numeric order),
+// so the buffer is byte-reversed to land in the int128 layout, then the MSB is
+// re-flipped.
+static void scanArrowArrayUuid(const ArrowArray* array, ValueVector& outputVector,
+    ArrowNullMaskTree* mask, uint64_t srcOffset, uint64_t dstOffset, uint64_t count) {
+    constexpr uint64_t uuidSize = sizeof(int128_t);
+    auto arrayBuffer = ((const uint8_t*)array->buffers[1]) + srcOffset * uuidSize;
+
+    mask->copyToValueVector(&outputVector, dstOffset, count);
+
+    rowIter(outputVector, count, [&](auto i) {
+        if (mask->isNull(i)) {
+            return;
+        }
+        int128_t value{};
+        auto valueBytes = reinterpret_cast<uint8_t*>(&value);
+        const auto* src = arrayBuffer + i * uuidSize;
+        for (uint64_t j = 0; j < uuidSize; ++j) {
+            valueBytes[j] = src[uuidSize - 1 - j];
+        }
+        // Re-flip the MSB to undo the internal flip applied when writing.
+        value.high ^= (int64_t(1) << 63);
+        outputVector.setValue<int128_t>(i + dstOffset, value);
+    });
+}
+
 template<typename offsetsT>
 static void scanArrowArrayList(const ArrowSchema* schema, const ArrowArray* array,
     ValueVector& outputVector, ArrowNullMaskTree* mask, uint64_t srcOffset, uint64_t dstOffset,
@@ -649,7 +679,11 @@ void ArrowConverter::fromArrowArray(const ArrowSchema* schema, const ArrowArray*
         }
     }
     case 'w':
-        // FIXED BLOB
+        // FIXED BLOB / UUID
+        if (logicalTypeInfo->has_value() &&
+            (*logicalTypeInfo)->type == ArrowLogicalTypeInfo::Type::UUID) {
+            return scanArrowArrayUuid(array, outputVector, mask, srcOffset, dstOffset, count);
+        }
         return scanArrowArrayFixedBLOB(array, outputVector, mask, std::stoi(arrowType + 2),
             srcOffset, dstOffset, count);
     case 't':

--- a/src/common/arrow/arrow_schema_metadata.cpp
+++ b/src/common/arrow/arrow_schema_metadata.cpp
@@ -18,6 +18,10 @@ std::optional<ArrowLogicalTypeInfo> tryGetArrowLogicalTypeInfo(const ArrowSchema
         snowflakeTypeInfo.has_value()) {
         return snowflakeTypeInfo;
     }
+    if (auto uuidTypeInfo = tryParseUuidExtensionMetadata(schema, metadata);
+        uuidTypeInfo.has_value()) {
+        return uuidTypeInfo;
+    }
     return tryParseGenericIntegerBackedDecimalMetadata(schema, metadata);
 }
 

--- a/src/common/arrow/arrow_schema_metadata_internal.h
+++ b/src/common/arrow/arrow_schema_metadata_internal.h
@@ -29,6 +29,8 @@ std::optional<ArrowLogicalTypeInfo> tryParseSnowflakeLogicalTypeInfo(const Arrow
     const ArrowMetadataMap& metadata);
 std::optional<ArrowLogicalTypeInfo> tryParseGenericIntegerBackedDecimalMetadata(
     const ArrowSchema* schema, const ArrowMetadataMap& metadata);
+std::optional<ArrowLogicalTypeInfo> tryParseUuidExtensionMetadata(const ArrowSchema* schema,
+    const ArrowMetadataMap& metadata);
 
 } // namespace common
 } // namespace lbug

--- a/src/common/arrow/arrow_schema_metadata_utils.cpp
+++ b/src/common/arrow/arrow_schema_metadata_utils.cpp
@@ -141,5 +141,23 @@ bool isValidDecimalParameters(uint32_t precision, uint32_t scale) {
     return precision > 0 && precision <= DECIMAL_PRECISION_LIMIT && scale <= precision;
 }
 
+std::optional<ArrowLogicalTypeInfo> tryParseUuidExtensionMetadata(const ArrowSchema* schema,
+    const ArrowMetadataMap& metadata) {
+    // Arrow's UUID extension uses FixedSizeBinary(16) ("w:16") with an "ARROW:extension:name"
+    // of "arrow.uuid". See https://arrow.apache.org/docs/format/CDataInterface.html.
+    if (schema == nullptr || schema->format == nullptr) {
+        return std::nullopt;
+    }
+    if (schema->format[0] != 'w' || std::string(schema->format) != "w:16") {
+        return std::nullopt;
+    }
+    const auto extensionName = getMetadataValue(metadata, "arrow:extension:name");
+    if (!extensionName.has_value() || *extensionName != "arrow.uuid") {
+        return std::nullopt;
+    }
+    return ArrowLogicalTypeInfo{ArrowLogicalTypeInfo::Source::GENERIC_METADATA,
+        ArrowLogicalTypeInfo::Type::UUID, ArrowDecimalTypeInfo{0, 0}};
+}
+
 } // namespace common
 } // namespace lbug

--- a/src/common/arrow/arrow_type.cpp
+++ b/src/common/arrow/arrow_type.cpp
@@ -22,6 +22,8 @@ LogicalType ArrowConverter::fromArrowSchema(const ArrowSchema* schema) {
         case ArrowLogicalTypeInfo::Type::DECIMAL:
             return LogicalType::DECIMAL(logicalTypeInfo->decimal.precision,
                 logicalTypeInfo->decimal.scale);
+        case ArrowLogicalTypeInfo::Type::UUID:
+            return LogicalType::UUID();
         }
     }
     switch (arrowType[0]) {

--- a/src/include/common/arrow/arrow_schema_metadata.h
+++ b/src/include/common/arrow/arrow_schema_metadata.h
@@ -22,6 +22,7 @@ struct ArrowLogicalTypeInfo {
 
     enum class Type : uint8_t {
         DECIMAL,
+        UUID,
     };
 
     Source source;

--- a/src/storage/table/arrow_rel_table.cpp
+++ b/src/storage/table/arrow_rel_table.cpp
@@ -53,6 +53,38 @@ static std::vector<std::optional<ArrowLogicalTypeInfo>> resolveColumnLogicalType
     return result;
 }
 
+// Returns true when the Arrow endpoint column's wire type is acceptable for the
+// node table's primary key type. The historical rule is "exact match" via
+// toString(); a UUID primary key breaks that because no Arrow wire type round-trips
+// to a UUID logical type. The `arrow.uuid` extension on FixedSizeBinary(16) is
+// the canonical Arrow encoding of a UUID, so we accept that as well, with the
+// 16 bytes assumed to be in the big-endian (network) byte order that the
+// extension spec mandates. See https://arrow.apache.org/docs/format/CDataInterface.html.
+static bool isArrowEndpointCompatibleWithPK(const ArrowSchema* endpointSchema,
+    const LogicalType& pkType) {
+    if (endpointSchema == nullptr) {
+        return false;
+    }
+    auto arrowType = ArrowConverter::fromArrowSchema(endpointSchema);
+    if (arrowType.toString() == pkType.toString()) {
+        return true;
+    }
+    if (pkType.getLogicalTypeID() == LogicalTypeID::UUID) {
+        if (endpointSchema->format == nullptr) {
+            return false;
+        }
+        if (std::string(endpointSchema->format) != "w:16") {
+            return false;
+        }
+        if (auto logicalTypeInfo = tryGetArrowLogicalTypeInfo(endpointSchema);
+            logicalTypeInfo.has_value() &&
+            logicalTypeInfo->type == ArrowLogicalTypeInfo::Type::UUID) {
+            return true;
+        }
+    }
+    return false;
+}
+
 void ArrowRelTableScanState::setToTable(const transaction::Transaction* transaction, Table* table_,
     std::vector<column_id_t> columnIDs_, std::vector<ColumnPredicateSet> columnPredicateSets_,
     RelDataDirection direction_) {
@@ -102,19 +134,27 @@ ArrowRelTable::ArrowRelTable(catalog::RelGroupCatalogEntry* relGroupEntry, table
                 "Arrow FLAT relationship table requires 'from' and 'to' columns");
         }
 
-        auto srcArrowType = ArrowConverter::fromArrowSchema(this->schema.children[fromColumnIdx]);
-        auto dstArrowType = ArrowConverter::fromArrowSchema(this->schema.children[toColumnIdx]);
+        auto* srcEndpointSchema = this->schema.children[fromColumnIdx];
+        auto* dstEndpointSchema = this->schema.children[toColumnIdx];
         const auto& srcPKType =
             this->fromNodeTable->getColumn(this->fromNodeTable->getPKColumnID()).getDataType();
         const auto& dstPKType =
             this->toNodeTable->getColumn(this->toNodeTable->getPKColumnID()).getDataType();
-        if (srcArrowType.toString() != srcPKType.toString()) {
-            throw RuntimeException("Arrow 'from' column type " + srcArrowType.toString() +
-                                   " must match source node PK type " + srcPKType.toString());
+        if (!isArrowEndpointCompatibleWithPK(srcEndpointSchema, srcPKType)) {
+            throw RuntimeException(
+                "Arrow 'from' column type " +
+                std::string(srcEndpointSchema->format ? srcEndpointSchema->format : "?") +
+                " is not compatible with source node PK type " + srcPKType.toString() +
+                "; supported: matching logical type, or "
+                "FixedSizeBinary(16) with the 'arrow.uuid' extension for UUID");
         }
-        if (dstArrowType.toString() != dstPKType.toString()) {
-            throw RuntimeException("Arrow 'to' column type " + dstArrowType.toString() +
-                                   " must match destination node PK type " + dstPKType.toString());
+        if (!isArrowEndpointCompatibleWithPK(dstEndpointSchema, dstPKType)) {
+            throw RuntimeException(
+                "Arrow 'to' column type " +
+                std::string(dstEndpointSchema->format ? dstEndpointSchema->format : "?") +
+                " is not compatible with destination node PK type " + dstPKType.toString() +
+                "; supported: matching logical type, or "
+                "FixedSizeBinary(16) with the 'arrow.uuid' extension for UUID");
         }
     } else {
         csrNbrColumnIdx = findColumnIdx(this->schema, dstColumnName);

--- a/test/api/arrow_rel_table_test.cpp
+++ b/test/api/arrow_rel_table_test.cpp
@@ -443,6 +443,107 @@ TEST_F(ArrowRelTableTest, ScanArrowRelTableOverNativeNodeTable) {
     ASSERT_EQ(sumResult->getNext()->getValue(0)->getValue<common::int128_t>(), 60);
 }
 
+// Regression test for https://github.com/LadybugDB/ladybug/issues/757:
+// Arrow `createArrowRelTable` must accept a `FixedSizeBinary(16)` endpoint column
+// carrying the `arrow.uuid` extension when the node table's primary key is UUID,
+// since the physical 16-byte layout matches the UUID storage.
+TEST_F(ArrowRelTableTest, ScanArrowRelTableOverNativeUuidNodeTable) {
+    auto setupResult =
+        conn->query("CREATE NODE TABLE nu(id UUID, name STRING, PRIMARY KEY(id));"
+                    "CREATE (:nu {id: UUID('11111111-1111-1111-1111-111111111111'), name: 'a'});"
+                    "CREATE (:nu {id: UUID('22222222-2222-2222-2222-222222222222'), name: 'b'});"
+                    "CREATE (:nu {id: UUID('33333333-3333-3333-3333-333333333333'), name: 'c'});");
+    ASSERT_TRUE(setupResult->isSuccess()) << setupResult->getErrorMessage();
+
+    auto u1 = common::UUID::fromString("11111111-1111-1111-1111-111111111111");
+    auto u2 = common::UUID::fromString("22222222-2222-2222-2222-222222222222");
+    auto u3 = common::UUID::fromString("33333333-3333-3333-3333-333333333333");
+
+    ArrowSchemaWrapper schema;
+    createStructSchema(&schema, 3);
+    createUuidSchema(schema.children[0], "from");
+    createUuidSchema(schema.children[1], "to");
+    createSchema<int64_t>(schema.children[2], "weight");
+
+    std::vector<ArrowArrayWrapper> arrays;
+    arrays.push_back(
+        createStructArray(3, {[&](ArrowArray* a) { createUuidArray(a, {u1, u1, u2}); },
+                                 [&](ArrowArray* a) { createUuidArray(a, {u2, u3, u3}); },
+                                 [&](ArrowArray* a) { createInt64Array(a, {10, 20, 30}); }}));
+
+    auto result = ArrowTableSupport::createRelTableFromArrowTable(*conn, "nu_knows", "nu", "nu",
+        std::move(schema), std::move(arrays));
+    ASSERT_TRUE(result.queryResult->isSuccess()) << result.queryResult->getErrorMessage();
+
+    auto countResult = conn->query("MATCH (:nu)-[:nu_knows]->(:nu) RETURN count(*)");
+    ASSERT_TRUE(countResult->isSuccess()) << countResult->getErrorMessage();
+    ASSERT_EQ(countResult->getNext()->getValue(0)->getValue<int64_t>(), 3);
+
+    auto sumResult = conn->query("MATCH (:nu)-[e:nu_knows]->(:nu) RETURN sum(e.weight)");
+    ASSERT_TRUE(sumResult->isSuccess()) << sumResult->getErrorMessage();
+    ASSERT_EQ(sumResult->getNext()->getValue(0)->getValue<common::int128_t>(), 60);
+
+    auto namesResult = conn->query(
+        "MATCH (a:nu)-[e:nu_knows]->(b:nu) RETURN a.name, b.name, e.weight ORDER BY e.weight");
+    ASSERT_TRUE(namesResult->isSuccess()) << namesResult->getErrorMessage();
+    const std::vector<std::tuple<std::string, std::string, int64_t>> expected = {{"a", "b", 10},
+        {"a", "c", 20}, {"b", "c", 30}};
+    for (const auto& [src, dst, weight] : expected) {
+        ASSERT_TRUE(namesResult->hasNext());
+        auto row = namesResult->getNext();
+        ASSERT_EQ(row->getValue(0)->getValue<std::string>(), src);
+        ASSERT_EQ(row->getValue(1)->getValue<std::string>(), dst);
+        ASSERT_EQ(row->getValue(2)->getValue<int64_t>(), weight);
+    }
+    ASSERT_FALSE(namesResult->hasNext());
+}
+
+// Verify that the Arrow endpoint check still rejects a `FixedSizeBinary(16)`
+// column WITHOUT the `arrow.uuid` extension when the PK is UUID. The accepted
+// forms are an exact logical-type match and `FixedSizeBinary(16) + arrow.uuid`.
+TEST_F(ArrowRelTableTest, RejectFixedSizeBinaryWithoutUuidExtensionForUuidPK) {
+    auto setupResult =
+        conn->query("CREATE NODE TABLE nu(id UUID, name STRING, PRIMARY KEY(id));"
+                    "CREATE (:nu {id: UUID('11111111-1111-1111-1111-111111111111'), name: 'a'});");
+    ASSERT_TRUE(setupResult->isSuccess()) << setupResult->getErrorMessage();
+
+    auto u1 = common::UUID::fromString("11111111-1111-1111-1111-111111111111");
+
+    ArrowSchemaWrapper schema;
+    createStructSchema(&schema, 2);
+    // FixedSizeBinary(16) WITHOUT the arrow.uuid extension. A bare `w:16` is
+    // a BLOB in lbug's view, so it must not be accepted for a UUID PK.
+    schema.children[0]->format = "w:16";
+    schema.children[0]->name = "from";
+    schema.children[0]->metadata = nullptr;
+    schema.children[0]->flags = ARROW_FLAG_NULLABLE;
+    schema.children[0]->n_children = 0;
+    schema.children[0]->children = nullptr;
+    schema.children[0]->dictionary = nullptr;
+    schema.children[0]->release = [](ArrowSchema* s) { s->release = nullptr; };
+    schema.children[0]->private_data = nullptr;
+    schema.children[1]->format = "w:16";
+    schema.children[1]->name = "to";
+    schema.children[1]->metadata = nullptr;
+    schema.children[1]->flags = ARROW_FLAG_NULLABLE;
+    schema.children[1]->n_children = 0;
+    schema.children[1]->children = nullptr;
+    schema.children[1]->dictionary = nullptr;
+    schema.children[1]->release = [](ArrowSchema* s) { s->release = nullptr; };
+    schema.children[1]->private_data = nullptr;
+
+    std::vector<ArrowArrayWrapper> arrays;
+    arrays.push_back(createStructArray(1, {[&](ArrowArray* a) { createUuidArray(a, {u1}); },
+                                              [&](ArrowArray* a) { createUuidArray(a, {u1}); }}));
+
+    auto result = ArrowTableSupport::createRelTableFromArrowTable(*conn, "nu_knows", "nu", "nu",
+        std::move(schema), std::move(arrays));
+    ASSERT_FALSE(result.queryResult->isSuccess());
+    ASSERT_NE(result.queryResult->getErrorMessage().find("not compatible with source node PK type"),
+        std::string::npos)
+        << result.queryResult->getErrorMessage();
+}
+
 TEST_F(ArrowRelTableTest, ScanMixedArrowAndNativeRelTables) {
     createArrowPersonTable(*conn);
     createArrowKnowsTable(*conn);

--- a/test/api/arrow_rel_table_test.cpp
+++ b/test/api/arrow_rel_table_test.cpp
@@ -498,6 +498,57 @@ TEST_F(ArrowRelTableTest, ScanArrowRelTableOverNativeUuidNodeTable) {
     ASSERT_FALSE(namesResult->hasNext());
 }
 
+// Regression test for the byte-order conversion in scanArrowArrayUuid.
+// The symmetric UUIDs in ScanArrowRelTableOverNativeUuidNodeTable
+// (11111111-..., 22222222-..., 33333333-...) have all 16 bytes identical,
+// so the 16-byte reversal in the read path is a no-op on them: the test
+// would pass even if the byte order were wrong. This test uses asymmetric
+// UUIDs (every byte differs) to actually exercise the byte-swap.
+TEST_F(ArrowRelTableTest, ScanArrowRelTableWithAsymmetricUuidEndpoints) {
+    auto setupResult =
+        conn->query("CREATE NODE TABLE nu(id UUID, name STRING, PRIMARY KEY(id));"
+                    "CREATE (:nu {id: UUID('01234567-89ab-cdef-0123-456789abcdef'), name: 'a'});"
+                    "CREATE (:nu {id: UUID('fedcba98-7654-3210-fedc-ba9876543210'), name: 'b'});");
+    ASSERT_TRUE(setupResult->isSuccess()) << setupResult->getErrorMessage();
+
+    auto ua = common::UUID::fromString("01234567-89ab-cdef-0123-456789abcdef");
+    auto ub = common::UUID::fromString("fedcba98-7654-3210-fedc-ba9876543210");
+
+    ArrowSchemaWrapper schema;
+    createStructSchema(&schema, 2);
+    createUuidSchema(schema.children[0], "from");
+    createUuidSchema(schema.children[1], "to");
+
+    std::vector<ArrowArrayWrapper> arrays;
+    arrays.push_back(createStructArray(1, {[&](ArrowArray* a) { createUuidArray(a, {ua}); },
+                                              [&](ArrowArray* a) { createUuidArray(a, {ub}); }}));
+
+    auto result = ArrowTableSupport::createRelTableFromArrowTable(*conn, "nu_knows", "nu", "nu",
+        std::move(schema), std::move(arrays));
+    ASSERT_TRUE(result.queryResult->isSuccess()) << result.queryResult->getErrorMessage();
+
+    // The edge must land on the right two nodes. If scanArrowArrayUuid
+    // reverses the bytes incorrectly, the UUID lookup misses and the
+    // edge either fails to insert or hits the wrong node.
+    auto namesResult = conn->query("MATCH (a:nu)-[:nu_knows]->(b:nu) RETURN a.name, b.name");
+    ASSERT_TRUE(namesResult->isSuccess()) << namesResult->getErrorMessage();
+    ASSERT_TRUE(namesResult->hasNext());
+    auto row = namesResult->getNext();
+    ASSERT_EQ(row->getValue(0)->getValue<std::string>(), "a");
+    ASSERT_EQ(row->getValue(1)->getValue<std::string>(), "b");
+    ASSERT_FALSE(namesResult->hasNext());
+
+    // The UUIDs must round-trip exactly. If the byte order were off, the
+    // read-back would return a different int128.
+    auto idResult = conn->query("MATCH (a:nu {name: 'a'}), (b:nu {name: 'b'}) RETURN a.id, b.id");
+    ASSERT_TRUE(idResult->isSuccess()) << idResult->getErrorMessage();
+    ASSERT_TRUE(idResult->hasNext());
+    auto idRow = idResult->getNext();
+    ASSERT_EQ(idRow->getValue(0)->getValue<common::int128_t>(), ua);
+    ASSERT_EQ(idRow->getValue(1)->getValue<common::int128_t>(), ub);
+    ASSERT_FALSE(idResult->hasNext());
+}
+
 // Verify that the Arrow endpoint check still rejects a `FixedSizeBinary(16)`
 // column WITHOUT the `arrow.uuid` extension when the PK is UUID. The accepted
 // forms are an exact logical-type match and `FixedSizeBinary(16) + arrow.uuid`.

--- a/test/api/arrow_test.cpp
+++ b/test/api/arrow_test.cpp
@@ -657,3 +657,55 @@ TEST_F(ArrowTest, queryAsArrowDoesNotTrackCSRMetadataForNonCSRShape) {
     ASSERT_NE(arrowResult, nullptr);
     ASSERT_FALSE(arrowResult->hasCSRMetadata());
 }
+
+// Verify that an Arrow FixedSizeBinary(16) column with the `arrow.uuid`
+// extension metadata is recognized as a UUID. This is the encoding the
+// Arrow UUID spec mandates and is the only encoding that maps cleanly
+// onto a UUID primary key on a relationship table.
+TEST(ArrowConverterTest, bindsArrowUuidExtensionMetadataAsUuid) {
+    ArrowSchema schema{};
+    createSchema<int64_t>(&schema, "id");
+    schema.format = "w:16";
+    auto metadata = serializeArrowMetadata(
+        {{"ARROW:extension:name", "arrow.uuid"}, {"ARROW:extension:metadata", ""}});
+    schema.metadata = metadata.data();
+
+    const auto type = ArrowConverter::fromArrowSchema(&schema);
+    const auto logicalTypeInfo = tryGetArrowLogicalTypeInfo(&schema);
+
+    ASSERT_EQ(type.getLogicalTypeID(), LogicalTypeID::UUID);
+    ASSERT_TRUE(logicalTypeInfo.has_value());
+    ASSERT_EQ(logicalTypeInfo->type, ArrowLogicalTypeInfo::Type::UUID);
+    schema.release(&schema);
+}
+
+// A bare FixedSizeBinary(16) WITHOUT the `arrow.uuid` extension is just a
+// BLOB. The UUID parser must not mistake it for a UUID.
+TEST(ArrowConverterTest, fixedSizeBinaryWithoutUuidExtensionIsNotUuid) {
+    ArrowSchema schema{};
+    createSchema<int64_t>(&schema, "id");
+    schema.format = "w:16";
+    schema.metadata = nullptr;
+
+    const auto type = ArrowConverter::fromArrowSchema(&schema);
+    const auto logicalTypeInfo = tryGetArrowLogicalTypeInfo(&schema);
+
+    ASSERT_NE(type.getLogicalTypeID(), LogicalTypeID::UUID);
+    ASSERT_FALSE(logicalTypeInfo.has_value());
+    schema.release(&schema);
+}
+
+// A FixedSizeBinary of a width other than 16 with the `arrow.uuid` extension
+// is malformed: a UUID is exactly 16 bytes, so this must not bind to UUID.
+TEST(ArrowConverterTest, rejectsNon16ByteArrowUuidExtensionAsUuid) {
+    ArrowSchema schema{};
+    createSchema<int64_t>(&schema, "id");
+    schema.format = "w:8";
+    auto metadata = serializeArrowMetadata(
+        {{"ARROW:extension:name", "arrow.uuid"}, {"ARROW:extension:metadata", ""}});
+    schema.metadata = metadata.data();
+
+    const auto logicalTypeInfo = tryGetArrowLogicalTypeInfo(&schema);
+    ASSERT_FALSE(logicalTypeInfo.has_value());
+    schema.release(&schema);
+}

--- a/test/include/arrow_test_utils.h
+++ b/test/include/arrow_test_utils.h
@@ -2,10 +2,13 @@
 
 #include <cstring>
 #include <functional>
+#include <map>
 #include <memory>
 #include <vector>
 
 #include "common/arrow/arrow.h"
+#include "common/types/int128_t.h"
+#include "common/types/uuid.h"
 
 // Template helpers to create Arrow schemas for different types
 template<typename T>
@@ -667,4 +670,99 @@ inline ArrowArrayWrapper createStructArray(int64_t length,
     };
     array.private_data = nullptr;
     return array;
+}
+
+// Serialize Arrow schema metadata into the binary format expected by
+// readArrowMetadata in src/common/arrow/arrow_schema_metadata_utils.cpp.
+// The keys are written in their original case; readArrowMetadata lowercases
+// keys when parsing, so the callers can use either case.
+inline char* serializeArrowSchemaMetadata(const std::map<std::string, std::string>& entries) {
+    size_t size = sizeof(int32_t);
+    for (const auto& [k, v] : entries) {
+        size += 2 * sizeof(int32_t) + k.size() + v.size();
+    }
+    auto* bytes = new char[size];
+    char* ptr = bytes;
+    auto numEntries = static_cast<int32_t>(entries.size());
+    memcpy(ptr, &numEntries, sizeof(int32_t));
+    ptr += sizeof(int32_t);
+    for (const auto& [k, v] : entries) {
+        auto ksz = static_cast<int32_t>(k.size());
+        auto vsz = static_cast<int32_t>(v.size());
+        memcpy(ptr, &ksz, sizeof(int32_t));
+        ptr += sizeof(int32_t);
+        memcpy(ptr, k.data(), k.size());
+        ptr += k.size();
+        memcpy(ptr, &vsz, sizeof(int32_t));
+        ptr += sizeof(int32_t);
+        memcpy(ptr, v.data(), v.size());
+        ptr += v.size();
+    }
+    return bytes;
+}
+
+// Schema helper for Arrow UUID extension type (FixedSizeBinary(16) with the
+// `arrow.uuid` extension metadata). See
+// https://arrow.apache.org/docs/format/CDataInterface.html and the issue
+// referenced in this test for the exact layout.
+inline void createUuidSchema(ArrowSchema* schema, const char* name) {
+    static auto* sharedMetadata = serializeArrowSchemaMetadata(
+        {{"ARROW:extension:name", "arrow.uuid"}, {"ARROW:extension:metadata", ""}});
+    schema->format = "w:16"; // FixedSizeBinary(16)
+    schema->name = name;
+    schema->metadata = sharedMetadata;
+    schema->flags = ARROW_FLAG_NULLABLE;
+    schema->n_children = 0;
+    schema->children = nullptr;
+    schema->dictionary = nullptr;
+    schema->release = [](ArrowSchema* s) { s->release = nullptr; };
+    schema->private_data = nullptr;
+}
+
+// Array helper for UUID columns. The 16-byte values are stored in big-endian
+// (network) byte order on the wire, matching the Arrow UUID extension type.
+inline void createUuidArray(ArrowArray* array, const std::vector<lbug::common::int128_t>& uuids) {
+    constexpr uint64_t uuidSize = sizeof(lbug::common::int128_t);
+    struct ArrayPrivateData {
+        void* validity = nullptr;
+        void* data = nullptr;
+    };
+    auto* private_data = new ArrayPrivateData();
+    private_data->validity = nullptr;
+    private_data->data = malloc(uuids.size() * uuidSize);
+    auto* dst = static_cast<uint8_t*>(private_data->data);
+    for (size_t i = 0; i < uuids.size(); ++i) {
+        // Mirror templateCopyNonNullValue<LogicalTypeID::UUID> in
+        // src/common/arrow/arrow_row_batch.cpp: the stored byte order is the
+        // byte-reversed (big-endian) form of the in-memory int128_t.
+        lbug::common::int128_t val = uuids[i];
+        val.high ^= (int64_t(1) << 63);
+        auto srcBytes = reinterpret_cast<uint8_t*>(&val);
+        for (uint64_t j = 0; j < uuidSize; ++j) {
+            dst[i * uuidSize + j] = srcBytes[uuidSize - 1 - j];
+        }
+    }
+    array->length = static_cast<int64_t>(uuids.size());
+    array->null_count = 0;
+    array->offset = 0;
+    array->n_buffers = 2; // validity and data
+    array->n_children = 0;
+    array->buffers = static_cast<const void**>(malloc(sizeof(void*) * 2));
+    array->buffers[0] = nullptr; // validity buffer (no nulls)
+    array->buffers[1] = private_data->data;
+    array->children = nullptr;
+    array->dictionary = nullptr;
+    array->release = [](ArrowArray* a) {
+        if (a->private_data) {
+            auto* pd = static_cast<ArrayPrivateData*>(a->private_data);
+            free(pd->validity);
+            free(pd->data);
+            delete pd;
+        }
+        if (a->buffers) {
+            free(const_cast<void**>(a->buffers));
+        }
+        a->release = nullptr;
+    };
+    array->private_data = private_data;
 }


### PR DESCRIPTION
## Summary

Closes #757.

`createArrowRelTable` required an exact match between the Arrow endpoint
column's logical type and the node table's primary key type. No Arrow wire
type mapped to a UUID logical type, so `createArrowRelTable` was unable to
address any node table keyed on UUID. CSV `COPY` could resolve STRING
endpoints against a UUID PK, so the restriction was an asymmetry, not a
limitation of the storage layer.

This implements **option 2** from the issue: accept
`FixedSizeBinary(16)` carrying the `arrow.uuid` Arrow extension as a
UUID primary key. The 16-byte physical layout is identical to lbug's
internal UUID storage, so no conversion is needed in the read path beyond
the byte order and the MSB flip that UUIDs already require internally.

## Changes

- Recognize the `arrow.uuid` Arrow extension on `FixedSizeBinary(16)` as
  a UUID in `tryGetArrowLogicalTypeInfo`, so the schema round-trips to
  `LogicalType::UUID` instead of `BLOB`.
- Route a `FixedSizeBinary(16)` UUID column through a new
  `scanArrowArrayUuid` that byte-reverses the 16-byte big-endian buffer
  to land in the `int128_t` layout and re-flips the UUID MSB. This mirrors
  the byte order the existing UUID write path produces.
- Replace the exact-type check in the `ArrowRelTable` constructor with
  `isArrowEndpointCompatibleWithPK`, which still accepts an exact
  logical-type match and additionally accepts a `FixedSizeBinary(16)`
  UUID-extension column for a UUID PK. The error message is updated to
  describe the new acceptance rule.
- Test utilities gain `createUuidSchema` and `createUuidArray` helpers.

## Tests

- `ArrowRelTableTest.ScanArrowRelTableOverNativeUuidNodeTable` is the
  end-to-end regression test: a `CREATE NODE TABLE ... PRIMARY KEY(id
  UUID)`, then `createRelTableFromArrowTable` with `w:16`+`arrow.uuid`
  endpoint columns. Asserts the edges load, the weights sum, and the
  endpoints round-trip back to the right nodes.
- `ArrowRelTableTest.RejectFixedSizeBinaryWithoutUuidExtensionForUuidPK`
  asserts that a bare `w:16` (no extension) is still rejected for a UUID
  PK, since the current "exact match" message contract is preserved for
  types that cannot be reconciled.
- `ArrowConverterTest.bindsArrowUuidExtensionMetadataAsUuid`,
  `...fixedSizeBinaryWithoutUuidExtensionIsNotUuid`, and
  `...rejectsNon16ByteArrowUuidExtensionAsUuid` cover the metadata
  parser directly: a correctly-annotated 16-byte column binds to UUID,
  a bare 16-byte column stays BLOB, and a non-16-byte column with the
  UUID extension is rejected (a UUID is exactly 16 bytes).

## Notes

- Byte order on the wire is big-endian (network), matching the Arrow
  UUID extension spec. The 16 bytes written by lbug's own UUID
  serialization in `arrow_row_batch.cpp` are already in this order; the
  read path mirrors the byte reversal performed on write.
- A caller now needs to know the byte order, as the issue notes, and
  must include the `ARROW:extension:name=arrow.uuid` extension metadata
  on the endpoint columns. The new error message spells that out.
- `fromArrowSchema` now returns `UUID` for `w:16` columns carrying the
  extension, so this is also a prerequisite fix for reading UUID values
  from Arrow anywhere else (e.g. node tables).