### PR TITLE
fix(test): open .test files in binary mode to fix Windows e2e_test runner

### DIFF
--- a/test/include/test_runner/test_parser.h
+++ b/test/include/test_runner/test_parser.h
@@ -149,7 +149,14 @@ private:
 
     bool nextLine() {
         previousFilePosition = fileStream.tellg();
-        return static_cast<bool>(getline(fileStream, line));
+        bool result = static_cast<bool>(getline(fileStream, line));
+        // Strip trailing '\r' (CRLF line endings). When the file is opened in
+        // binary mode, getline keeps '\r'; this keeps both LF and CRLF test
+        // files parseable identically on all platforms.
+        if (result && !line.empty() && line.back() == '\r') {
+            line.pop_back();
+        }
+        return result;
     }
 
     void checkMinimumParams(uint64_t minimumParams) const {

--- a/test/test_runner/test_parser.cpp
+++ b/test/test_runner/test_parser.cpp
@@ -698,7 +698,12 @@ void TestParser::openFile() {
     if (access(path.c_str(), 0) != 0) {
         throw TestException("Test file not exists [" + path + "].");
     }
-    fileStream.open(path);
+    // Open in binary mode so tellg/seekg offsets match byte positions on all
+    // platforms. In MSVC text mode, getline over LF-only files advances the
+    // stream position one extra byte per line, which makes
+    // setCursorToPreviousLine() re-read from a wrong offset (Windows-only
+    // test runner bug). CRLF is handled in nextLine() by stripping '\r'.
+    fileStream.open(path, std::ios::binary);
 }
 
 static std::vector<std::string> extractToken(std::string& line) {


### PR DESCRIPTION
Rebased commit history. Original commit: #773 

In MSVC text mode, getline() over LF-only files advances the stream position one extra byte per line (treating \n as \r\n internally). This makes setCursorToPreviousLine() re-read from a wrong offset, causing subsequent statements to be parsed as garbage (e.g. ";" or other single characters from wrong file positions).

The fix opens the file in binary mode so tellg/seekg offsets match actual byte positions. CRLF line endings are handled by stripping trailing '\r' in nextLine() (separate change in test_parser.h).

When files are opened in binary mode (to fix Windows tellg/seekg offset issues), getline preserves the \\r from CRLF line endings. This adds a simple strip of trailing \\r in nextLine() so both LF and CRLF test files are parsed identically on all platforms.

Companion to the binary mode fix in test_parser.cpp.

Verified on Windows 11 x64 MSVC with upstream louvain (6 tests), page_rank (1 test), and new Leiden (4 tests) — all 11 pass.
