### PR TITLE
fix(copy): defer COPY's per-worker chunk buffers to the first append

### DIFF
--- a/src/processor/operator/persistent/node_batch_insert.cpp
+++ b/src/processor/operator/persistent/node_batch_insert.cpp
@@ -519,9 +519,6 @@ void NodeBatchInsert::initLocalStateInternal(ResultSet* resultSet, ExecutionCont
         evaluator->init(*resultSet, context->clientContext);
         nodeLocalState->columnVectors[i] = evaluator->resultVector.get();
     }
-    nodeLocalState->chunkedGroup =
-        std::make_unique<InMemChunkedNodeGroup>(*MemoryManager::Get(*context->clientContext),
-            nodeInfo->columnTypes, info->compressionEnabled, StorageConfig::NODE_GROUP_SIZE, 0);
     DASSERT(resultSet->dataChunks[0]);
     nodeLocalState->columnState = resultSet->dataChunks[0]->state;
 }
@@ -544,7 +541,7 @@ void NodeBatchInsert::executeInternal(ExecutionContext* context) {
         copyToNodeGroup(transaction, MemoryManager::Get(*clientContext)),
             nodeLocalState->columnState->setSelVector(originalSelVector);
     }
-    if (nodeLocalState->chunkedGroup->getNumRows() > 0) {
+    if (nodeLocalState->chunkedGroup && nodeLocalState->chunkedGroup->getNumRows() > 0) {
         appendIncompleteNodeGroup(transaction, std::move(nodeLocalState->chunkedGroup),
             nodeLocalState->localIndexBuilder, MemoryManager::Get(*context->clientContext));
     }
@@ -593,6 +590,15 @@ void NodeBatchInsert::copyToNodeGroup(transaction::Transaction* transaction,
     const auto nodeLocalState = dynamic_cast_checked<NodeBatchInsertLocalState*>(localState.get());
     const auto numTuplesToAppend = nodeLocalState->columnState->getSelVector().getSelSize();
     while (numAppendedTuples < numTuplesToAppend) {
+        if (!nodeLocalState->chunkedGroup) {
+            // Allocate on the first append rather than in initLocalStateInternal so that a worker
+            // that receives no rows allocates nothing. Eager allocation reserves NODE_GROUP_SIZE
+            // rows of every column for every worker before the scan produces a row, which sets
+            // the COPY memory floor to columns x workers regardless of the input size.
+            const auto nodeInfo = info->ptrCast<NodeBatchInsertInfo>();
+            nodeLocalState->chunkedGroup = std::make_unique<InMemChunkedNodeGroup>(*mm,
+                nodeInfo->columnTypes, info->compressionEnabled, StorageConfig::NODE_GROUP_SIZE, 0);
+        }
         const auto numAppendedTuplesInNodeGroup =
             nodeLocalState->chunkedGroup->append(nodeLocalState->columnVectors, numAppendedTuples,
                 numTuplesToAppend - numAppendedTuples);

--- a/test/copy/copy_test.cpp
+++ b/test/copy/copy_test.cpp
@@ -889,5 +889,56 @@ TEST_F(CopyTest, OutOfMemoryRecoveryDropTable) {
         ASSERT_EQ(result->getNext()->getValue(0)->getValue<int64_t>(), 2420766);
     }
 }
+
+TEST_F(CopyTest, CopySmallInputIntoWideTableUnderSmallBufferPool) {
+    if (inMemMode ||
+        common::StorageConfig::NODE_GROUP_SIZE_LOG2 != TestParser::STANDARD_NODE_GROUP_SIZE_LOG_2) {
+        GTEST_SKIP();
+    }
+    // A worker allocates its column buffers only once it receives rows, so the buffer pool a
+    // COPY needs scales with the input size rather than with columns x workers. With the
+    // standard node group size an eager allocation would cost about 1 MiB per INT64 column per
+    // worker, which the pool below cannot hold for 64 columns at 16 workers.
+    static constexpr auto numColumns = 64;
+    systemConfig->maxNumThreads = 16;
+    resetDB(192 * 1024 * 1024 + TestHelper::HASH_INDEX_MEM);
+    std::string header = "id";
+    std::string createQuery = "CREATE NODE TABLE wide(id INT64";
+    for (auto i = 1; i <= numColumns; i++) {
+        header += std::format(",c{}", i);
+        createQuery += std::format(", c{} INT64", i);
+    }
+    createQuery += ", PRIMARY KEY(id))";
+    auto result = conn->query(createQuery);
+    ASSERT_TRUE(result->isSuccess()) << result->toString();
+    // A zero-row input reaches no worker, so it must not allocate any worker column buffers.
+    auto emptyCsvPath = writeCSV("wide_empty.csv", {header});
+    result = conn->query(std::format("COPY wide FROM '{}' (HEADER=true)", emptyCsvPath));
+    ASSERT_TRUE(result->isSuccess()) << result->toString();
+    result = conn->query("MATCH (w:wide) RETURN COUNT(w.id)");
+    ASSERT_TRUE(result->isSuccess()) << result->toString();
+    ASSERT_TRUE(result->hasNext());
+    ASSERT_EQ(result->getNext()->getValue(0)->getValue<int64_t>(), 0);
+    // A small input only allocates in the workers that receive rows.
+    std::vector<std::string> rows = {header};
+    for (auto r = 0; r < 100; r++) {
+        auto row = std::to_string(r);
+        for (auto i = 1; i <= numColumns; i++) {
+            row += std::format(",{}", r + i);
+        }
+        rows.push_back(row);
+    }
+    auto smallCsvPath = writeCSV("wide_small.csv", rows);
+    result = conn->query(std::format("COPY wide FROM '{}' (HEADER=true)", smallCsvPath));
+    ASSERT_TRUE(result->isSuccess()) << result->toString();
+    result = conn->query("MATCH (w:wide) RETURN COUNT(w.id)");
+    ASSERT_TRUE(result->isSuccess()) << result->toString();
+    ASSERT_TRUE(result->hasNext());
+    ASSERT_EQ(result->getNext()->getValue(0)->getValue<int64_t>(), 100);
+    result = conn->query("MATCH (w:wide) WHERE w.id = 42 RETURN w.c17");
+    ASSERT_TRUE(result->isSuccess()) << result->toString();
+    ASSERT_TRUE(result->hasNext());
+    ASSERT_EQ(result->getNext()->getValue(0)->getValue<int64_t>(), 59);
+}
 } // namespace testing
 } // namespace lbug


### PR DESCRIPTION
Fixes #760. A node table `COPY` now allocates each worker's column chunk buffers at the first appended row instead of at worker start. The buffer pool floor and the fixed CPU cost of a `COPY` follow the input, not columns times workers. Every number below was measured on `main` at `554c1e711` (v0.19.1), `relwithdebinfo`, with the unpatched and the patched build rebuilt in one session on the same host.

## Every worker builds every column buffer before the first row

`initLocalStateInternal` (`src/processor/operator/persistent/node_batch_insert.cpp:499`) gives every worker an `InMemChunkedNodeGroup` at `:522-524`. The group's constructor loops over every column type (`src/storage/table/chunked_node_group.cpp:76-86`). Each `ColumnChunk` builds a `ColumnChunkData` at full capacity (`src/storage/table/column_chunk.cpp:40-46`), and that chunk reserves `getBufferSize(capacity)` from the `MemoryManager` (`src/storage/table/column_chunk_data.cpp:128-135`). The capacity is `StorageConfig::NODE_GROUP_SIZE` (`cmake/templates/system_config.h.in:47-48`), 131072 rows by default and a build option (`CMakeLists.txt:158`). A worker therefore pays about 1 MiB per `INT64` column before the reader produces a row, whatever the input holds. On a zero-row input at 16 threads, gdb counts 2848 calls of `ColumnChunkData::initializeBuffer`: 89 columns times two, one data chunk and one null chunk, times 16 workers.

## The allocation moves to the first append

The patch moves the allocation into `copyToNodeGroup`, where it runs on the first appended row, and adds a null check to the one later read of the pointer:

```diff
--- a/src/processor/operator/persistent/node_batch_insert.cpp
+++ b/src/processor/operator/persistent/node_batch_insert.cpp
@@ -517,13 +517,10 @@ void NodeBatchInsert::initLocalStateInternal(ResultSet* resultSet, ExecutionCont
     for (auto i = 0u; i < numColumns; ++i) {
         auto& evaluator = nodeInfo->columnEvaluators[i];
         evaluator->init(*resultSet, context->clientContext);
         nodeLocalState->columnVectors[i] = evaluator->resultVector.get();
     }
-    nodeLocalState->chunkedGroup =
-        std::make_unique<InMemChunkedNodeGroup>(*MemoryManager::Get(*context->clientContext),
-            nodeInfo->columnTypes, info->compressionEnabled, StorageConfig::NODE_GROUP_SIZE, 0);
     DASSERT(resultSet->dataChunks[0]);
     nodeLocalState->columnState = resultSet->dataChunks[0]->state;
 }
 
 void NodeBatchInsert::executeInternal(ExecutionContext* context) {
@@ -542,11 +539,11 @@ void NodeBatchInsert::executeInternal(ExecutionContext* context) {
         const auto numTuples = nodeLocalState->columnState->getSelVector().getSelSize();
         evaluateExpressions(numTuples);
         copyToNodeGroup(transaction, MemoryManager::Get(*clientContext)),
             nodeLocalState->columnState->setSelVector(originalSelVector);
     }
-    if (nodeLocalState->chunkedGroup->getNumRows() > 0) {
+    if (nodeLocalState->chunkedGroup && nodeLocalState->chunkedGroup->getNumRows() > 0) {
         appendIncompleteNodeGroup(transaction, std::move(nodeLocalState->chunkedGroup),
             nodeLocalState->localIndexBuilder, MemoryManager::Get(*context->clientContext));
     }
     if (nodeLocalState->localIndexBuilder) {
         DASSERT(token);
@@ -591,10 +588,19 @@ void NodeBatchInsert::copyToNodeGroup(transaction::Transaction* transaction,
     MemoryManager* mm) const {
     auto numAppendedTuples = 0ul;
     const auto nodeLocalState = dynamic_cast_checked<NodeBatchInsertLocalState*>(localState.get());
     const auto numTuplesToAppend = nodeLocalState->columnState->getSelVector().getSelSize();
     while (numAppendedTuples < numTuplesToAppend) {
+        if (!nodeLocalState->chunkedGroup) {
+            // Allocate on the first append rather than in initLocalStateInternal so that a worker
+            // that receives no rows allocates nothing. Eager allocation reserves NODE_GROUP_SIZE
+            // rows of every column for every worker before the scan produces a row, which sets
+            // the COPY memory floor to columns x workers regardless of the input size.
+            const auto nodeInfo = info->ptrCast<NodeBatchInsertInfo>();
+            nodeLocalState->chunkedGroup = std::make_unique<InMemChunkedNodeGroup>(*mm,
+                nodeInfo->columnTypes, info->compressionEnabled, StorageConfig::NODE_GROUP_SIZE, 0);
+        }
         const auto numAppendedTuplesInNodeGroup =
             nodeLocalState->chunkedGroup->append(nodeLocalState->columnVectors, numAppendedTuples,
                 numTuplesToAppend - numAppendedTuples);
         numAppendedTuples += numAppendedTuplesInNodeGroup;
         if (nodeLocalState->chunkedGroup->isFull()) {
```

A worker that receives no rows allocates nothing. A worker that receives rows allocates once, as before. The only other read of the pointer is the `getNumRows()` test one line above the move, which the patch guards. `finalize` already tests `sharedNodeGroup` for null (`src/processor/operator/persistent/node_batch_insert.cpp:748`), and `sharedNodeGroup` is only ever set from a local group that holds rows (`:723-726`).

## Before and after

Buffer pool floor, `bp_bisect.c`, one 89-column table, 100 rows, bisected to 8 MB:

| `max_num_threads` | before | after |
|---:|---|---|
| 1 | 96 MB | 96 MB |
| 2 | 184 MB | 184 MB |
| 4 | 272 MB | 256 MB |
| 8 | 456 MB | 296 MB |
| 16 | 888 MB | 296 MB |

At one and two threads one or two workers receive all 100 rows, and an active worker still allocates its full-capacity group, so the floor does not move there. From four threads on, the floor stops tracking the thread count. At eight threads and above the patched floor wanders in a 250 to 300 MB band between runs, because the number of workers that receive data depends on the scan's morsel split.

Floor against the row count, `bp_rows.c` at 16 threads:

| rows | before | after |
|---:|---|---|
| 0 | 1 GB | 64 MB |
| 100 | 1 GB | 256 MB |
| 1000 | 1 GB | 1 GB |
| 10000 | 1 GB | 1 GB |
| 100000 | 2 GB | 2 GB |

Where the input spans most workers the floor is unchanged: each worker that receives rows still allocates a full-capacity group. The patch removes the allocation from the workers that receive nothing. Scaling the worker count, or the group capacity, to the input size (question 2 in the issue) is the complementary fix for that remainder.

One zero-row `COPY` into an 89-column table, `one_copy.c 89 0 20`, twenty statements divided by twenty:

| `max_num_threads` | metric | before | after |
|---:|---|---|---|
| 1 | wall per `COPY` | 15.78 ms | 10.77 ms |
| 1 | CPU per `COPY` | 15.74 ms | 10.76 ms |
| 16 | wall per `COPY` | 61.8 ms, 69.2 ms | 16.7 ms, 17.0 ms |
| 16 | CPU per `COPY` | 563 ms, 624 ms | 71 ms, 75 ms |
| 16 | minor faults | 741k, 1281k | 276k, 300k |

Two runs at 16 threads. The remaining cost sits in per-worker constructions this patch does not touch, broken down under "Four smaller instances of the pattern remain".

Breakpoint hit counts, zero-row input at 16 threads:

| breakpoint | before | after |
|---|---:|---:|
| `NodeBatchInsert::initLocalStateInternal` | 16 | 16 |
| `ColumnChunkData::initializeBuffer` | 2848 | 0 |

## Four smaller instances of the pattern remain

Ranked by yield against the work, with what I believe each one needs:

1. **The `IndexBuilder` clone.** A profile of the patched zero-row `COPY` puts 46% of the CPU under `initLocalStateInternal` → `IndexBuilder::IndexBuilder` → `IndexBuilderLocalBuffers::IndexBuilderLocalBuffers`, which builds about 4 MiB of zeroed buffer arrays per worker (`src/include/storage/index/in_mem_hash_index.h:20-22`), plus a matching share of page faults. The deferral can target the buffers alone: they hold the entire allocation (`src/processor/operator/persistent/index_builder.cpp:105-112`), while the `IndexBuilder` itself is a `shared_ptr` copy, so producer registration and its `isDone` wait (`:171-178`) stay exactly as today. Ready for a follow-up patch; I can offer one.
2. **The rel path's CSR header.** `RelBatchInsert` builds an `InMemChunkedCSRNodeGroup` per worker (`src/processor/operator/persistent/rel_batch_insert.cpp:36-38`). Its column buffers hold capacity 0, but its CSR header is sized `NODE_GROUP_SIZE` (`src/include/storage/table/csr_chunked_node_group.h:180-183`), about 2 MB of buffer pool per worker. The same lazy treatment applies, with the construction moved to the first partition. Ready for a follow-up patch; I can offer it as a second patch, alone or folded into the first.
3. **The worker count.** The profile puts 60% of the patched zero-row `COPY`'s CPU under `TaskScheduler::runWorkerThread`, so scaling the worker count to the input size (question 2 in the issue) is the only change that removes the worker-side remainder. The input size is knowable per source, though: a CSV file can be `stat`ed, an Arrow source knows its row count, and a `COPY FROM (MATCH ...)` subquery knows nothing. That heuristic and its scheduler changes deserve a discussion before a patch, in a dedicated issue if that is useful.
4. **The group capacity.** An active worker still allocates a full `NODE_GROUP_SIZE` group for its first row. `ColumnChunkData::resize` already grows a buffer on demand (`src/storage/table/column_chunk_data.cpp:486`), and `InMemChunkedNodeGroup::resizeChunks` resizes every chunk through it (`src/storage/table/chunked_node_group.cpp:659-667`), so sizing the initial buffer to the input is possible. The growth policy and its interaction with write-and-reset frequency reach more capacity assumptions than this patch, and the change overlaps what the worker count would buy. This one too deserves a discussion before a patch, in a dedicated issue if that is useful.

This patch stays at one mechanism so the review stays small. The choice of what follows is yours; the ordering above is the one the measurements support.

## What I did not verify

- The rel `COPY` path: unchanged and not measured.
- The profile covers the zero-row residual only. I did not profile a `COPY` with input.
- No language binding was exercised, since no binding-level surface changes.

## Tests

Added `CopySmallInputIntoWideTableUnderSmallBufferPool` to the existing `test/copy/copy_test.cpp`. The test sets 16 threads and a 192 MB buffer pool, then copies a zero-row CSV and a 100-row CSV into a 64-column node table and checks the row counts. On the unpatched tree the first `COPY` fails, which is the negative control:

```
Buffer manager exception: Unable to allocate memory! The buffer pool is full and no memory could be freed!
```

`make test NUM_THREADS=14 TEST_JOBS=8` on the patched tree gives 2892 passed and 3 failed. The same three fail on the unpatched tree in the same session: two extension tests that download from `extension.ladybugdb.com`, and `dictionary_bug~orb383_relationship_projection_obfuscated.AnonymousParquetDeleteReload`, which needs gitignored Parquet fixtures.

## Notes

Tree `main` at `554c1e711` (v0.19.1), branch `fix/760-lazy-copy-worker-buffers`. Build `make relwithdebinfo NUM_THREADS=14` with gcc 14.2.0. Timings are `clock_gettime` and `getrusage` over twenty `COPY`s divided by twenty; the allocation counts are gdb breakpoint hit counts; the residual-cost attribution is `perf record -g --call-graph dwarf` on the otherwise idle machine. Machine: 16 core (8 physical) AMD Ryzen 7 7840U, 64 GB RAM, Linux 7.1.3.

<details>
<summary>bp_bisect.c</summary>

```c
/* bp_bisect.c - the COPY buffer pool floor, bisected to 8 MB instead of powers of two.
 *
 * bp_floor.c steps in powers of two, which is enough to show a trend and too coarse to compare
 * two builds: a 4x change in NODE_GROUP_SIZE can read as 2x if the true floor sits just inside a
 * bucket. This bisects on the assumption that the floor is monotone: if a pool of size X loads the
 * table, every larger pool does too.
 */
#include <lbug.h>
#include <stdio.h>
#include <stdlib.h>
#include <string.h>
#include <unistd.h>

static char g_dir[512];
static char g_csv[600];
static uint64_t g_threads = 1;

static void write_csv(int ncols, int nrows) {
    FILE* f = fopen(g_csv, "w");
    fprintf(f, "id");
    for (int i = 1; i <= ncols; i++)
        fprintf(f, ",c%d", i);
    fputc('\n', f);
    for (int r = 0; r < nrows; r++) {
        fprintf(f, "%d", r);
        for (int i = 1; i <= ncols; i++)
            fprintf(f, ",%d", i);
        fputc('\n', f);
    }
    fclose(f);
}

/* 1 = loaded, 0 = failed */
static int attempt(uint64_t bpBytes, int ncols) {
    static int seq = 0;
    char path[600];
    snprintf(path, sizeof path, "%s/db%d", g_dir, seq++);

    lbug_system_config cfg = lbug_default_system_config();
    cfg.buffer_pool_size = bpBytes;
    cfg.max_num_threads = g_threads;

    lbug_database db;
    lbug_connection conn;
    if (lbug_database_init(path, cfg, &db) != LbugSuccess)
        return 0;
    if (lbug_connection_init(&db, &conn) != LbugSuccess) {
        lbug_database_destroy(&db);
        return 0;
    }

    int ok = 1;
    size_t cap = 64 + (size_t)ncols * 24;
    char* q = malloc(cap);
    int n = snprintf(q, cap, "CREATE NODE TABLE t(id INT64");
    for (int i = 1; i <= ncols; i++)
        n += snprintf(q + n, cap - n, ", c%d INT64", i);
    snprintf(q + n, cap - n, ", PRIMARY KEY(id));");
    lbug_query_result r;
    memset(&r, 0, sizeof r);
    if (lbug_connection_query(&conn, q, &r) != LbugSuccess || !lbug_query_result_is_success(&r))
        ok = 0;
    lbug_query_result_destroy(&r);
    free(q);

    if (ok) {
        char cq[800];
        snprintf(cq, sizeof cq, "COPY t FROM '%s' (HEADER=true);", g_csv);
        memset(&r, 0, sizeof r);
        if (lbug_connection_query(&conn, cq, &r) != LbugSuccess ||
            !lbug_query_result_is_success(&r))
            ok = 0;
        lbug_query_result_destroy(&r);
    }
    lbug_connection_destroy(&conn);
    lbug_database_destroy(&db);
    return ok;
}

int main(int argc, char** argv) {
    snprintf(g_dir, sizeof g_dir, "/tmp/bp_bisect_%d", (int)getpid());
    char cmd[700];
    snprintf(cmd, sizeof cmd, "mkdir -p %s", g_dir);
    if (system(cmd) != 0)
        return 1;
    snprintf(g_csv, sizeof g_csv, "%s/rows.csv", g_dir);

    const int ncols = 88; /* 89 columns including id */
    const uint64_t STEP = 8ULL << 20;
    write_csv(ncols, 100);

    uint64_t threads[] = {1, 2, 4, 8, 16, 0};
    printf("| max_num_threads | floor, bisected to 8 MB |\n|---:|---:|\n");
    for (int t = 0; threads[t]; t++) {
        g_threads = threads[t];
        uint64_t lo = STEP, hi = 4096ULL << 20;
        if (!attempt(hi, ncols)) {
            printf("| %llu | more than 4 GB |\n", (unsigned long long)threads[t]);
            continue;
        }
        /* invariant: lo fails (or is untested floor candidate), hi succeeds */
        while (hi - lo > STEP) {
            uint64_t mid = ((lo + hi) / 2 / STEP) * STEP;
            if (mid <= lo)
                break;
            if (attempt(mid, ncols))
                hi = mid;
            else
                lo = mid;
        }
        printf("| %llu | %llu MB |\n", (unsigned long long)threads[t],
            (unsigned long long)(hi >> 20));
        fflush(stdout);
    }

    snprintf(cmd, sizeof cmd, "rm -rf %s", g_dir);
    if (system(cmd) != 0)
        return 1;
    return 0;
}
```

</details>

<details>
<summary>bp_rows.c</summary>

```c
/* bp_rows.c - does the COPY buffer pool floor rise with the number of input rows?
 *
 * If the floor at max_num_threads=16 sits under columns x threads x 1 MiB because a small input
 * engages fewer workers, then a larger input should push the floor up toward that arithmetic.
 * If the floor is flat in the row count, the shortfall is not about how many workers start.
 */
#include <lbug.h>
#include <stdio.h>
#include <stdlib.h>
#include <string.h>
#include <unistd.h>

static char g_dir[512];
static char g_csv[600];
static uint64_t g_threads = 16;

static void write_csv(int ncols, int nrows) {
    FILE* f = fopen(g_csv, "w");
    fprintf(f, "id");
    for (int i = 1; i <= ncols; i++)
        fprintf(f, ",c%d", i);
    fputc('\n', f);
    for (int r = 0; r < nrows; r++) {
        fprintf(f, "%d", r);
        for (int i = 1; i <= ncols; i++)
            fprintf(f, ",%d", i);
        fputc('\n', f);
    }
    fclose(f);
}

static const char* attempt(uint64_t bpBytes, int ncols) {
    static char err[400];
    static int seq = 0;
    char path[600];
    snprintf(path, sizeof path, "%s/db%d", g_dir, seq++);

    lbug_system_config cfg = lbug_default_system_config();
    cfg.buffer_pool_size = bpBytes;
    cfg.max_num_threads = g_threads;

    lbug_database db;
    lbug_connection conn;
    if (lbug_database_init(path, cfg, &db) != LbugSuccess)
        return "database_init failed";
    if (lbug_connection_init(&db, &conn) != LbugSuccess) {
        lbug_database_destroy(&db);
        return "connection_init failed";
    }

    const char* result = NULL;
    size_t cap = 64 + (size_t)ncols * 24;
    char* q = malloc(cap);
    int n = snprintf(q, cap, "CREATE NODE TABLE t(id INT64");
    for (int i = 1; i <= ncols; i++)
        n += snprintf(q + n, cap - n, ", c%d INT64", i);
    snprintf(q + n, cap - n, ", PRIMARY KEY(id));");
    lbug_query_result r;
    memset(&r, 0, sizeof r);
    if (lbug_connection_query(&conn, q, &r) != LbugSuccess || !lbug_query_result_is_success(&r)) {
        snprintf(err, sizeof err, "CREATE failed");
        result = err;
    }
    lbug_query_result_destroy(&r);
    free(q);

    if (!result) {
        char cq[800];
        snprintf(cq, sizeof cq, "COPY t FROM '%s' (HEADER=true);", g_csv);
        memset(&r, 0, sizeof r);
        if (lbug_connection_query(&conn, cq, &r) != LbugSuccess ||
            !lbug_query_result_is_success(&r)) {
            char* m = lbug_query_result_get_error_message(&r);
            snprintf(err, sizeof err, "%s", m ? m : "(no message)");
            if (m)
                free(m);
            result = err;
        }
        lbug_query_result_destroy(&r);
    }
    lbug_connection_destroy(&conn);
    lbug_database_destroy(&db);
    return result;
}

static const char* fmt_mb(uint64_t b) {
    static char s[32];
    if (b >= (1ULL << 30))
        snprintf(s, sizeof s, "%.0f GB", b / 1073741824.0);
    else
        snprintf(s, sizeof s, "%llu MB", (unsigned long long)(b >> 20));
    return s;
}

int main(int argc, char** argv) {
    snprintf(g_dir, sizeof g_dir, "/tmp/bp_rows_%d", (int)getpid());
    char cmd[700];
    snprintf(cmd, sizeof cmd, "mkdir -p %s", g_dir);
    if (system(cmd) != 0)
        return 1;
    snprintf(g_csv, sizeof g_csv, "%s/rows.csv", g_dir);

    const int ncols = 88; /* 89 columns including id */
    if (argc > 1)
        g_threads = (uint64_t)atoi(argv[1]);

    int rows[] = {0, 100, 1000, 10000, 100000, -1};
    uint64_t sizes[] = {64ULL << 20, 128ULL << 20, 256ULL << 20, 512ULL << 20, 1024ULL << 20,
        2048ULL << 20, 4096ULL << 20, 8192ULL << 20, 0};

    printf("89 columns, max_num_threads=%llu. 89 x %llu x 1 MiB would be %.2f GB.\n\n",
        (unsigned long long)g_threads, (unsigned long long)g_threads,
        89.0 * g_threads / 1024.0);
    printf("| rows | smallest buffer pool that loads it |\n|---:|---|\n");
    for (int i = 0; rows[i] >= 0; i++) {
        write_csv(ncols, rows[i]);
        const char* found = NULL;
        for (int j = 0; sizes[j]; j++)
            if (attempt(sizes[j], ncols) == NULL) {
                found = fmt_mb(sizes[j]);
                break;
            }
        printf("| %d | %s |\n", rows[i], found ? found : "more than 8 GB");
        fflush(stdout);
    }

    snprintf(cmd, sizeof cmd, "rm -rf %s", g_dir);
    if (system(cmd) != 0)
        return 1;
    return 0;
}
```

</details>

<details>
<summary>one_copy.c</summary>

```c
/* one_copy.c NCOLS [NROWS] - create one table of NCOLS columns, COPY NROWS rows once. */
#include <lbug.h>
#include <stdio.h>
#include <stdlib.h>
#include <string.h>
#include <unistd.h>
#include <sys/resource.h>
#include <time.h>
static char dir[512], csv[600];
static void run(lbug_connection* c, const char* q) {
    lbug_query_result r; memset(&r, 0, sizeof r);
    if (lbug_connection_query(c, q, &r) != LbugSuccess || !lbug_query_result_is_success(&r)) {
        char* m = lbug_query_result_get_error_message(&r);
        fprintf(stderr, "FAILED: %s\n", m ? m : "?"); exit(1);
    }
    lbug_query_result_destroy(&r);
}
int main(int argc, char** argv) {
    int ncols = (argc > 1 ? atoi(argv[1]) : 89) - 1;
    int nrows = argc > 2 ? atoi(argv[2]) : 0;
    int reps = argc > 3 ? atoi(argv[3]) : 1;
    snprintf(dir, sizeof dir, "/tmp/one_copy_%d", (int)getpid());
    char cmd[700]; snprintf(cmd, sizeof cmd, "mkdir -p %s", dir);
    if (system(cmd)) return 1;
    snprintf(csv, sizeof csv, "%s/r.csv", dir);
    FILE* f = fopen(csv, "w");
    fprintf(f, "id"); for (int i = 1; i <= ncols; i++) fprintf(f, ",c%d", i); fputc('\n', f);
    for (int r = 0; r < nrows; r++) { fprintf(f, "%d", r);
        for (int i = 1; i <= ncols; i++) fprintf(f, ",%d", i); fputc('\n', f); }
    fclose(f);
    char path[600]; snprintf(path, sizeof path, "%s/db", dir);
    lbug_database db; lbug_connection conn;
    lbug_system_config cfg = lbug_default_system_config();
    if (getenv("LBUG_THREADS")) cfg.max_num_threads = atoi(getenv("LBUG_THREADS"));
    lbug_database_init(path, cfg, &db); lbug_connection_init(&db, &conn);
    size_t cap = 64 + (size_t)ncols * 24; char* q = malloc(cap);
    int n = snprintf(q, cap, "CREATE NODE TABLE t(id INT64");
    for (int i = 1; i <= ncols; i++) n += snprintf(q + n, cap - n, ", c%d INT64", i);
    snprintf(q + n, cap - n, ", PRIMARY KEY(id));");
    run(&conn, q); free(q);
    char cq[800]; snprintf(cq, sizeof cq, "COPY t FROM '%s' (HEADER=true);", csv);
    struct rusage r0, r1; struct timespec t0, t1;
    getrusage(RUSAGE_SELF, &r0); clock_gettime(CLOCK_MONOTONIC, &t0);
    for (int i = 0; i < reps; i++) run(&conn, cq);
    clock_gettime(CLOCK_MONOTONIC, &t1); getrusage(RUSAGE_SELF, &r1);
    double ms = (t1.tv_sec - t0.tv_sec) * 1e3 + (t1.tv_nsec - t0.tv_nsec) / 1e6;
    double cpu = ((r1.ru_utime.tv_sec - r0.ru_utime.tv_sec) * 1e3
                + (r1.ru_utime.tv_usec - r0.ru_utime.tv_usec) / 1e3)
               + ((r1.ru_stime.tv_sec - r0.ru_stime.tv_sec) * 1e3
                + (r1.ru_stime.tv_usec - r0.ru_stime.tv_usec) / 1e3);
    double usr = (r1.ru_utime.tv_sec - r0.ru_utime.tv_sec) * 1e3
               + (r1.ru_utime.tv_usec - r0.ru_utime.tv_usec) / 1e3;
    double sys = (r1.ru_stime.tv_sec - r0.ru_stime.tv_sec) * 1e3
               + (r1.ru_stime.tv_usec - r0.ru_stime.tv_usec) / 1e3;
    printf("%4d cols x%-3d  wall=%7.1f  cpu=%7.1f (usr %6.1f sys %6.1f)  minflt=%8ld  per-COPY wall=%6.2f cpu=%6.2f\n",
        ncols + 1, reps, ms, cpu, usr, sys, r1.ru_minflt - r0.ru_minflt, ms / reps, cpu / reps);
    (void)cpu;
    lbug_connection_destroy(&conn); lbug_database_destroy(&db);
    snprintf(cmd, sizeof cmd, "rm -rf %s", dir); if (system(cmd)) return 1;
    return 0;
}
```

</details>
