### PR TITLE
nfs copy post commit checkpoint repair

### DIFF
--- a/src/include/common/exception/checkpoint.h
+++ b/src/include/common/exception/checkpoint.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <string>
+#include <utility>
+
 #include "common/api.h"
 #include "exception.h"
 
@@ -9,6 +12,7 @@ namespace common {
 class LBUG_API CheckpointException : public Exception {
 public:
     explicit CheckpointException(const std::exception& e) : Exception(e.what()) {};
+    explicit CheckpointException(std::string message) : Exception(std::move(message)) {};
 };
 
 } // namespace common

--- a/src/include/storage/wal/wal_replayer.h
+++ b/src/include/storage/wal/wal_replayer.h
@@ -50,8 +50,8 @@ private:
     void replayActiveWAL(Checkpointer& checkpointer, bool throwOnWalReplayFailure,
         bool enableChecksums) const;
 
-    void removeWALAndShadowFiles() const;
-    void removeFileIfExists(const std::string& path) const;
+    void removeWALAndShadowFiles(const std::string& walFilePath) const;
+    bool removeFileIfExists(const std::string& path) const;
 
     std::unique_ptr<common::FileInfo> openWALFile() const;
     void syncWALFile(const common::FileInfo& fileInfo) const;

--- a/src/include/storage/wal/wal_replayer.h
+++ b/src/include/storage/wal/wal_replayer.h
@@ -51,6 +51,7 @@ private:
         bool enableChecksums) const;
 
     void removeWALAndShadowFiles(const std::string& walFilePath) const;
+    void removeFileAndSyncParentDirectory(const std::string& path) const;
     bool removeFileIfExists(const std::string& path) const;
 
     std::unique_ptr<common::FileInfo> openWALFile() const;

--- a/src/include/transaction/transaction_manager.h
+++ b/src/include/transaction/transaction_manager.h
@@ -44,7 +44,7 @@ public:
     Transaction* beginTransaction(main::ClientContext& clientContext, TransactionType type);
 
     void commit(main::ClientContext& clientContext, Transaction* transaction);
-    void rollback(main::ClientContext& clientContext, Transaction* transaction);
+    void rollback(main::ClientContext& clientContext, common::transaction_t transactionID);
 
     void checkpoint(main::ClientContext& clientContext);
 

--- a/src/main/client_context.cpp
+++ b/src/main/client_context.cpp
@@ -84,8 +84,8 @@ ClientContext::~ClientContext() {
     if (preventTransactionRollbackOnDestruction) {
         return;
     }
-    if (Transaction::Get(*this)) {
-        getDatabase()->transactionManager->rollback(*this, Transaction::Get(*this));
+    if (auto* transaction = Transaction::Get(*this)) {
+        getDatabase()->transactionManager->rollback(*this, transaction->getID());
     }
 }
 

--- a/src/main/connection.cpp
+++ b/src/main/connection.cpp
@@ -30,7 +30,7 @@ Connection::~Connection() {
     // We do this here (before destroying ClientContext) while Database and Connection are still
     // valid; ~ClientContext then skips rollback to avoid double-rollback or use-after-free.
     if (Transaction* tx = Transaction::Get(*clientContext)) {
-        database->getTransactionManager()->rollback(*clientContext, tx);
+        database->getTransactionManager()->rollback(*clientContext, tx->getID());
     }
     clientContext->preventTransactionRollbackOnDestruction = true;
 }

--- a/src/storage/buffer_manager/buffer_manager.cpp
+++ b/src/storage/buffer_manager/buffer_manager.cpp
@@ -320,8 +320,17 @@ uint64_t BufferManager::evictPages() {
         }
     }
 
-    for (size_t i = 0; i < evictablePages; i++) {
-        claimedMemory += tryEvictPage(*evictionCandidates[i]);
+    try {
+        for (size_t i = 0; i < evictablePages; i++) {
+            claimedMemory += tryEvictPage(*evictionCandidates[i]);
+        }
+    } catch (...) {
+        // Earlier pages in this batch may already have released their frames. Account for them
+        // before propagating a later eviction failure.
+        if (claimedMemory > 0) {
+            freeUsedMemory(claimedMemory);
+        }
+        throw;
     }
     return claimedMemory;
 }
@@ -360,13 +369,19 @@ bool BufferManager::claimAFrame(FileHandle& fileHandle, page_idx_t pageIdx,
     pageSizeToClaim =
         vmRegions[fileHandle.getPageSizeClass()]->claimFrame(fileHandle.getFrameIdx(pageIdx));
 #endif
-    if (!reserve(pageSizeToClaim)) {
 #if !BM_MALLOC
-        vmRegions[fileHandle.getPageSizeClass()]->releaseFrame(fileHandle.getFrameIdx(pageIdx));
+    bool frameClaimed = true;
 #endif
-        return false;
-    }
+    bool memoryReserved = false;
     try {
+        if (!reserve(pageSizeToClaim)) {
+#if !BM_MALLOC
+            frameClaimed = false;
+            vmRegions[fileHandle.getPageSizeClass()]->releaseFrame(fileHandle.getFrameIdx(pageIdx));
+#endif
+            return false;
+        }
+        memoryReserved = true;
 #if _WIN32 && !BM_MALLOC
         // Committing in this context means reserving physical memory/page file space for a segment
         // of virtual memory. On Linux/Unix this is automatic when we write to the memory address.
@@ -383,9 +398,14 @@ bool BufferManager::claimAFrame(FileHandle& fileHandle, page_idx_t pageIdx,
         // Loading a page can perform NFS I/O. Undo the frame reservation if that read fails so the
         // caller can safely reset the page state without leaking a frame or leaving it locked.
 #if !BM_MALLOC
-        vmRegions[fileHandle.getPageSizeClass()]->releaseFrame(fileHandle.getFrameIdx(pageIdx));
+        if (frameClaimed) {
+            frameClaimed = false;
+            vmRegions[fileHandle.getPageSizeClass()]->releaseFrame(fileHandle.getFrameIdx(pageIdx));
+        }
 #endif
-        freeUsedMemory(pageSizeToClaim);
+        if (memoryReserved) {
+            freeUsedMemory(pageSizeToClaim);
+        }
         throw;
     }
     return true;
@@ -406,45 +426,53 @@ bool BufferManager::reserve(uint64_t sizeToReserve) {
                usedMemory > bufferPoolSize.load() - totalClaimedMemory;
     };
     uint8_t failedCount = 0;
-    // Evict pages if necessary until we have enough memory.
-    while (needMoreMemory()) {
-        uint64_t memoryClaimed = 0;
-        // Avoid reducing the evictable memory below 1/2 at first to reduce thrashing if most of the
-        // memory is non-evictable
-        if (!spiller || usedMemory - nonEvictableMemory > bufferPoolSize / 2) {
-            memoryClaimed = evictPages();
-        } else {
-            auto [_memoryClaimed, nowEvictableMemory] = spiller->claimNextGroup();
-            memoryClaimed = _memoryClaimed;
-            nonEvictableClaimedMemory += _memoryClaimed;
-            nonEvictableMemory -= nowEvictableMemory;
-            // If we're unable to claim anything from the spiller, fall back to evicting pages
-            // We may also need to evict pages if the spiller just unpins BM pages
-            if (memoryClaimed == 0 || nowEvictableMemory > 0) {
+    try {
+        // Evict pages if necessary until we have enough memory.
+        while (needMoreMemory()) {
+            uint64_t memoryClaimed = 0;
+            // Avoid reducing the evictable memory below 1/2 at first to reduce thrashing if most of
+            // the memory is non-evictable
+            if (!spiller || usedMemory - nonEvictableMemory > bufferPoolSize / 2) {
                 memoryClaimed = evictPages();
-            }
-        }
-        if (memoryClaimed == 0 && needMoreMemory()) {
-            if (failedCount++ < 2) {
-                // If we failed to find any memory to free, try waiting briefly for other threads to
-                // stop using memory
-                std::this_thread::sleep_for(std::chrono::milliseconds(5));
             } else {
-                // Cannot find more pages to be evicted. Free the memory we reserved and return
-                // false.
-                freeUsedMemory(sizeToReserve + totalClaimedMemory);
-                nonEvictableMemory -= nonEvictableClaimedMemory;
-                return false;
+                auto [_memoryClaimed, nowEvictableMemory] = spiller->claimNextGroup();
+                memoryClaimed = _memoryClaimed;
+                nonEvictableClaimedMemory += _memoryClaimed;
+                nonEvictableMemory -= nowEvictableMemory;
+                // If we're unable to claim anything from the spiller, fall back to evicting pages
+                // We may also need to evict pages if the spiller just unpins BM pages
+                if (memoryClaimed == 0 || nowEvictableMemory > 0) {
+                    memoryClaimed = evictPages();
+                }
             }
+            if (memoryClaimed == 0 && needMoreMemory()) {
+                if (failedCount++ < 2) {
+                    // If we failed to find any memory to free, try waiting briefly for other
+                    // threads to stop using memory
+                    std::this_thread::sleep_for(std::chrono::milliseconds(5));
+                } else {
+                    // Cannot find more pages to be evicted. Free the memory we reserved and return
+                    // false.
+                    freeUsedMemory(sizeToReserve + totalClaimedMemory);
+                    nonEvictableMemory -= nonEvictableClaimedMemory;
+                    return false;
+                }
+            }
+            totalClaimedMemory += memoryClaimed;
         }
-        totalClaimedMemory += memoryClaimed;
-    }
-    // Have enough memory available now
-    if (totalClaimedMemory > 0) {
-        freeUsedMemory(totalClaimedMemory);
+        // Have enough memory available now
+        if (totalClaimedMemory > 0) {
+            freeUsedMemory(totalClaimedMemory);
+            nonEvictableMemory -= nonEvictableClaimedMemory;
+        }
+        return true;
+    } catch (...) {
+        // evictPages() has already accounted for any frames released in its failing batch.
+        // Undo this reservation and the preceding successful eviction batches.
+        freeUsedMemory(sizeToReserve + totalClaimedMemory);
         nonEvictableMemory -= nonEvictableClaimedMemory;
+        throw;
     }
-    return true;
 }
 
 uint64_t BufferManager::tryEvictPage(std::atomic<EvictionCandidate>& _candidate) {

--- a/src/storage/buffer_manager/buffer_manager.cpp
+++ b/src/storage/buffer_manager/buffer_manager.cpp
@@ -129,21 +129,33 @@ uint8_t* BufferManager::pin(FileHandle& fileHandle, page_idx_t pageIdx,
         switch (PageState::getState(currStateAndVersion)) {
         case PageState::EVICTED: {
             if (pageState->tryLock(currStateAndVersion)) {
-                if (!claimAFrame(fileHandle, pageIdx, pageReadPolicy)) {
-                    pageState->resetToEvicted();
-                    throw BufferManagerException("Unable to allocate memory! The buffer pool is "
-                                                 "full and no memory could be freed!");
-                }
-                if (!evictionQueue.insert(fileHandle.getFileIndex(), pageIdx)) {
-                    throw BufferManagerException(
-                        "Eviction queue is full! This should be impossible.");
-                }
+                try {
+                    if (!claimAFrame(fileHandle, pageIdx, pageReadPolicy)) {
+                        pageState->resetToEvicted();
+                        throw BufferManagerException(
+                            "Unable to allocate memory! The buffer pool is full and no memory "
+                            "could be freed!");
+                    }
+                    if (!evictionQueue.insert(fileHandle.getFileIndex(), pageIdx)) {
+                        const auto releasedBytes = releaseFrameForPage(fileHandle, pageIdx);
+                        freeUsedMemory(releasedBytes);
+                        pageState->resetToEvicted();
+                        throw BufferManagerException(
+                            "Eviction queue is full! The page could not be tracked safely.");
+                    }
 #if BM_MALLOC
-                DASSERT(pageState->getPage());
-                return pageState->getPage();
+                    DASSERT(pageState->getPage());
+                    return pageState->getPage();
 #else
-                return getFrame(fileHandle, pageIdx);
+                    return getFrame(fileHandle, pageIdx);
 #endif
+                } catch (...) {
+                    // A failed page read must not strand the page in LOCKED state.
+                    if (PageState::getState(pageState->getStateAndVersion()) == PageState::LOCKED) {
+                        pageState->resetToEvicted();
+                    }
+                    throw;
+                }
             }
         } break;
         case PageState::UNLOCKED:
@@ -354,18 +366,28 @@ bool BufferManager::claimAFrame(FileHandle& fileHandle, page_idx_t pageIdx,
 #endif
         return false;
     }
+    try {
 #if _WIN32 && !BM_MALLOC
-    // Committing in this context means reserving physical memory/page file space for a segment of
-    // virtual memory. On Linux/Unix this is automatic when you write to the memory address.
-    auto result =
-        VirtualAlloc(getFrame(fileHandle, pageIdx), pageSizeToClaim, MEM_COMMIT, PAGE_READWRITE);
-    if (result == NULL) {
-        throw BufferManagerException(
-            std::format("VirtualAlloc MEM_COMMIT failed with error code {}: {}.", GetLastError(),
-                std::system_category().message(GetLastError())));
-    }
+        // Committing in this context means reserving physical memory/page file space for a segment
+        // of virtual memory. On Linux/Unix this is automatic when we write to the memory address.
+        auto result = VirtualAlloc(getFrame(fileHandle, pageIdx), pageSizeToClaim, MEM_COMMIT,
+            PAGE_READWRITE);
+        if (result == NULL) {
+            throw BufferManagerException(
+                std::format("VirtualAlloc MEM_COMMIT failed with error code {}: {}.",
+                    GetLastError(), std::system_category().message(GetLastError())));
+        }
 #endif
-    cachePageIntoFrame(fileHandle, pageIdx, pageReadPolicy);
+        cachePageIntoFrame(fileHandle, pageIdx, pageReadPolicy);
+    } catch (...) {
+        // Loading a page can perform NFS I/O. Undo the frame reservation if that read fails so the
+        // caller can safely reset the page state without leaking a frame or leaving it locked.
+#if !BM_MALLOC
+        vmRegions[fileHandle.getPageSizeClass()]->releaseFrame(fileHandle.getFrameIdx(pageIdx));
+#endif
+        freeUsedMemory(pageSizeToClaim);
+        throw;
+    }
     return true;
 }
 
@@ -459,11 +481,18 @@ uint64_t BufferManager::tryEvictPage(std::atomic<EvictionCandidate>& _candidate)
     // Next, flush out the frame into the file page if the frame
     // is dirty. Finally remove the page from the frame and reset the page to EVICTED.
     auto& fileHandle = *fileHandles[candidate.fileIdx];
-    fileHandle.flushPageIfDirtyWithoutLock(candidate.pageIdx);
-    auto numBytesFreed = releaseFrameForPage(fileHandle, candidate.pageIdx);
-    evictionQueue.clear(_candidate);
-    pageState.resetToEvicted();
-    return numBytesFreed;
+    try {
+        fileHandle.flushPageIfDirtyWithoutLock(candidate.pageIdx);
+        auto numBytesFreed = releaseFrameForPage(fileHandle, candidate.pageIdx);
+        evictionQueue.clear(_candidate);
+        pageState.resetToEvicted();
+        return numBytesFreed;
+    } catch (...) {
+        // A failed NFS flush must not strand the page in LOCKED state. Keep the frame resident so
+        // the dirty page can be retried after storage recovers.
+        pageState.unlock();
+        throw;
+    }
 }
 
 void BufferManager::cachePageIntoFrame(FileHandle& fileHandle, page_idx_t pageIdx,
@@ -536,12 +565,18 @@ void BufferManager::removePageFromFrame(FileHandle& fileHandle, page_idx_t pageI
         return;
     }
     pageState->spinLock(pageState->getStateAndVersion());
-    if (shouldFlush) {
-        fileHandle.flushPageIfDirtyWithoutLock(pageIdx);
+    try {
+        if (shouldFlush) {
+            fileHandle.flushPageIfDirtyWithoutLock(pageIdx);
+        }
+        const auto numBytesFreed = releaseFrameForPage(fileHandle, pageIdx);
+        freeUsedMemory(numBytesFreed);
+        pageState->resetToEvicted();
+    } catch (...) {
+        // Preserve the page and release the lock when a flush fails.
+        pageState->unlock();
+        throw;
     }
-    const auto numBytesFreed = releaseFrameForPage(fileHandle, pageIdx);
-    freeUsedMemory(numBytesFreed);
-    pageState->resetToEvicted();
 }
 
 uint64_t BufferManager::freeUsedMemory(uint64_t size) {

--- a/src/storage/shadow_file.cpp
+++ b/src/storage/shadow_file.cpp
@@ -138,6 +138,7 @@ void ShadowFile::replayShadowPageRecords(ClientContext& context) {
             record.originalPageIdx * LBUG_PAGE_SIZE);
         shadowPageIdx++;
     }
+    dataFileInfo->syncFile();
 }
 
 void ShadowFile::flushAll(main::ClientContext& context) const {

--- a/src/storage/wal/wal_replayer.cpp
+++ b/src/storage/wal/wal_replayer.cpp
@@ -60,7 +60,7 @@ static void syncParentDirectoryForLocalPath(const std::string& path) {
         const auto errorMessage = posixErrMessage();
         close(dirFd);
         throw IOException(
-            std::format("Failed to sync parent directory {} after removing WAL file {}: {}",
+            std::format("Failed to sync parent directory {} after removing file {}: {}",
                 parentPath.string(), path, errorMessage));
     }
     close(dirFd);
@@ -163,7 +163,7 @@ void WALReplayer::replay(bool throwOnWalReplayFailure, bool enableChecksums) con
     throwIfReadOnlyCheckpointState(clientContext, hasFrozenWAL, shadowFilePath);
 
     if (!hasFrozenWAL && !hasActiveWAL) {
-        removeFileIfExists(shadowFilePath);
+        removeFileAndSyncParentDirectory(shadowFilePath);
         checkpointer.readCheckpoint();
         return;
     }
@@ -186,10 +186,7 @@ void WALReplayer::replayFrozenWAL(Checkpointer& checkpointer, bool throwOnWalRep
         vfs->openFile(checkpointWalPath, FileOpenFlags(FileFlags::READ_ONLY | FileFlags::WRITE));
     if (fileInfo->getFileSize() == 0) {
         fileInfo.reset();
-        if (removeFileIfExists(checkpointWalPath)) {
-            syncParentDirectoryForLocalPath(checkpointWalPath);
-        }
-        removeFileIfExists(shadowFilePath);
+        removeWALAndShadowFiles(checkpointWalPath);
         checkpointer.readCheckpoint();
         return;
     }
@@ -205,7 +202,7 @@ void WALReplayer::replayFrozenWAL(Checkpointer& checkpointer, bool throwOnWalRep
             removeWALAndShadowFiles(checkpointWalPath);
             checkpointer.readCheckpoint();
         } else {
-            removeFileIfExists(shadowFilePath);
+            removeFileAndSyncParentDirectory(shadowFilePath);
             checkpointer.readCheckpoint();
             Deserializer deserializer = initDeserializer(*fileInfo, clientContext, enableChecksums);
             if (offsetDeserialized > 0) {
@@ -222,9 +219,7 @@ void WALReplayer::replayFrozenWAL(Checkpointer& checkpointer, bool throwOnWalRep
                 replayWALRecord(*walRecord);
             }
             fileInfo.reset();
-            if (removeFileIfExists(checkpointWalPath)) {
-                syncParentDirectoryForLocalPath(checkpointWalPath);
-            }
+            removeFileAndSyncParentDirectory(checkpointWalPath);
         }
     } catch (const std::exception&) {
         auto transactionContext = TransactionContext::Get(clientContext);
@@ -240,10 +235,7 @@ void WALReplayer::replayActiveWAL(Checkpointer& checkpointer, bool throwOnWalRep
     auto fileInfo = openWALFile();
     if (fileInfo->getFileSize() == 0) {
         fileInfo.reset();
-        if (removeFileIfExists(walPath)) {
-            syncParentDirectoryForLocalPath(walPath);
-        }
-        removeFileIfExists(shadowFilePath);
+        removeWALAndShadowFiles(walPath);
         return;
     }
     syncWALFile(*fileInfo);
@@ -258,7 +250,7 @@ void WALReplayer::replayActiveWAL(Checkpointer& checkpointer, bool throwOnWalRep
             removeWALAndShadowFiles(walPath);
             checkpointer.readCheckpoint();
         } else {
-            removeFileIfExists(shadowFilePath);
+            removeFileAndSyncParentDirectory(shadowFilePath);
             Deserializer deserializer = initDeserializer(*fileInfo, clientContext, enableChecksums);
             if (offsetDeserialized > 0) {
                 deserializer.getReader()->onObjectBegin();
@@ -397,10 +389,17 @@ void WALReplayer::replayWALRecord(WALRecord& walRecord) const {
 }
 
 void WALReplayer::removeWALAndShadowFiles(const std::string& walFilePath) const {
-    if (removeFileIfExists(walFilePath)) {
-        syncParentDirectoryForLocalPath(walFilePath);
+    const bool walRemoved = removeFileIfExists(walFilePath);
+    const bool shadowRemoved = removeFileIfExists(shadowFilePath);
+    if (walRemoved || shadowRemoved) {
+        syncParentDirectoryForLocalPath(walRemoved ? walFilePath : shadowFilePath);
     }
-    removeFileIfExists(shadowFilePath);
+}
+
+void WALReplayer::removeFileAndSyncParentDirectory(const std::string& path) const {
+    if (removeFileIfExists(path)) {
+        syncParentDirectoryForLocalPath(path);
+    }
 }
 
 bool WALReplayer::removeFileIfExists(const std::string& path) const {

--- a/src/storage/wal/wal_replayer.cpp
+++ b/src/storage/wal/wal_replayer.cpp
@@ -1,13 +1,16 @@
 #include "storage/wal/wal_replayer.h"
 
+#include <filesystem>
 #include <string>
 
 #include "common/exception/io.h"
 #include "common/exception/runtime.h"
 #include "common/file_system/file_info.h"
 #include "common/file_system/file_system.h"
+#include "common/file_system/local_file_system.h"
 #include "common/file_system/virtual_file_system.h"
 #include "common/serializer/buffered_file.h"
+#include "common/system_message.h"
 #include "common/type_utils.h"
 #include "common/types/types.h"
 #include "main/client_context.h"
@@ -20,6 +23,10 @@
 #include "storage/wal/wal_record.h"
 #include "transaction/transaction_context.h"
 #include <format>
+#ifndef _WIN32
+#include <fcntl.h>
+#include <unistd.h>
+#endif
 
 using namespace lbug::common;
 using namespace lbug::storage;
@@ -32,6 +39,33 @@ static constexpr std::string_view checksumMismatchMessage =
     "Checksum verification failed, the WAL file is corrupted.";
 static constexpr std::string_view readOnlyCheckpointInProgressMessage =
     "Cannot open database in read-only mode while checkpoint is in progress. Please retry later.";
+
+static void syncParentDirectoryForLocalPath(const std::string& path) {
+#ifdef _WIN32
+    (void)path;
+#else
+    if (!LocalFileSystem::isLocalPath(path)) {
+        return;
+    }
+    auto parentPath = std::filesystem::path(path).parent_path();
+    if (parentPath.empty()) {
+        parentPath = ".";
+    }
+    const int dirFd = open(parentPath.c_str(), O_RDONLY | O_DIRECTORY);
+    if (dirFd < 0) {
+        throw IOException(std::format("Failed to open parent directory {} for sync: {}",
+            parentPath.string(), posixErrMessage()));
+    }
+    if (fsync(dirFd) != 0) {
+        const auto errorMessage = posixErrMessage();
+        close(dirFd);
+        throw IOException(
+            std::format("Failed to sync parent directory {} after removing WAL file {}: {}",
+                parentPath.string(), path, errorMessage));
+    }
+    close(dirFd);
+#endif
+}
 
 WALReplayer::WALReplayer(main::ClientContext& clientContext) : clientContext{clientContext} {
     walPath = StorageUtils::getWALFilePath(clientContext.getDatabasePath());
@@ -137,7 +171,6 @@ void WALReplayer::replay(bool throwOnWalReplayFailure, bool enableChecksums) con
     if (hasFrozenWAL) {
         replayFrozenWAL(checkpointer, throwOnWalReplayFailure, enableChecksums);
     } else {
-        removeFileIfExists(shadowFilePath);
         checkpointer.readCheckpoint();
     }
 
@@ -152,7 +185,10 @@ void WALReplayer::replayFrozenWAL(Checkpointer& checkpointer, bool throwOnWalRep
     auto fileInfo =
         vfs->openFile(checkpointWalPath, FileOpenFlags(FileFlags::READ_ONLY | FileFlags::WRITE));
     if (fileInfo->getFileSize() == 0) {
-        removeFileIfExists(checkpointWalPath);
+        fileInfo.reset();
+        if (removeFileIfExists(checkpointWalPath)) {
+            syncParentDirectoryForLocalPath(checkpointWalPath);
+        }
         removeFileIfExists(shadowFilePath);
         checkpointer.readCheckpoint();
         return;
@@ -165,9 +201,8 @@ void WALReplayer::replayFrozenWAL(Checkpointer& checkpointer, bool throwOnWalRep
         if (isLastRecordCheckpoint) {
             throwIfReadOnlyCheckpointState(clientContext, true /* hasFrozenWAL */, shadowFilePath);
             ShadowFile::replayShadowPageRecords(clientContext);
-            removeFileIfExists(checkpointWalPath);
-            removeFileIfExists(walPath);
-            removeFileIfExists(shadowFilePath);
+            fileInfo.reset();
+            removeWALAndShadowFiles(checkpointWalPath);
             checkpointer.readCheckpoint();
         } else {
             removeFileIfExists(shadowFilePath);
@@ -186,7 +221,10 @@ void WALReplayer::replayFrozenWAL(Checkpointer& checkpointer, bool throwOnWalRep
                 auto walRecord = WALRecord::deserialize(deserializer, clientContext);
                 replayWALRecord(*walRecord);
             }
-            removeFileIfExists(checkpointWalPath);
+            fileInfo.reset();
+            if (removeFileIfExists(checkpointWalPath)) {
+                syncParentDirectoryForLocalPath(checkpointWalPath);
+            }
         }
     } catch (const std::exception&) {
         auto transactionContext = TransactionContext::Get(clientContext);
@@ -201,7 +239,11 @@ void WALReplayer::replayActiveWAL(Checkpointer& checkpointer, bool throwOnWalRep
     bool enableChecksums) const {
     auto fileInfo = openWALFile();
     if (fileInfo->getFileSize() == 0) {
-        removeFileIfExists(walPath);
+        fileInfo.reset();
+        if (removeFileIfExists(walPath)) {
+            syncParentDirectoryForLocalPath(walPath);
+        }
+        removeFileIfExists(shadowFilePath);
         return;
     }
     syncWALFile(*fileInfo);
@@ -212,9 +254,11 @@ void WALReplayer::replayActiveWAL(Checkpointer& checkpointer, bool throwOnWalRep
         if (isLastRecordCheckpoint) {
             throwIfReadOnlyCheckpointState(clientContext, true /* hasFrozenWAL */, shadowFilePath);
             ShadowFile::replayShadowPageRecords(clientContext);
-            removeWALAndShadowFiles();
+            fileInfo.reset();
+            removeWALAndShadowFiles(walPath);
             checkpointer.readCheckpoint();
         } else {
+            removeFileIfExists(shadowFilePath);
             Deserializer deserializer = initDeserializer(*fileInfo, clientContext, enableChecksums);
             if (offsetDeserialized > 0) {
                 deserializer.getReader()->onObjectBegin();
@@ -352,19 +396,23 @@ void WALReplayer::replayWALRecord(WALRecord& walRecord) const {
     }
 }
 
-void WALReplayer::removeWALAndShadowFiles() const {
+void WALReplayer::removeWALAndShadowFiles(const std::string& walFilePath) const {
+    if (removeFileIfExists(walFilePath)) {
+        syncParentDirectoryForLocalPath(walFilePath);
+    }
     removeFileIfExists(shadowFilePath);
-    removeFileIfExists(walPath);
 }
 
-void WALReplayer::removeFileIfExists(const std::string& path) const {
+bool WALReplayer::removeFileIfExists(const std::string& path) const {
     if (StorageManager::Get(clientContext)->isReadOnly()) {
-        return;
+        return false;
     }
     auto vfs = VirtualFileSystem::GetUnsafe(clientContext);
     if (vfs->fileOrPathExists(path, &clientContext)) {
         vfs->removeFileIfExists(path);
+        return true;
     }
+    return false;
 }
 
 std::unique_ptr<FileInfo> WALReplayer::openWALFile() const {

--- a/src/transaction/transaction_context.cpp
+++ b/src/transaction/transaction_context.cpp
@@ -1,5 +1,6 @@
 #include "transaction/transaction_context.h"
 
+#include "common/exception/checkpoint.h"
 #include "common/exception/transaction_manager.h"
 #include "main/client_context.h"
 #include "main/database.h"
@@ -56,7 +57,15 @@ void TransactionContext::commit() {
     if (!hasActiveTransaction()) {
         return;
     }
-    clientContext.getDatabase()->getTransactionManager()->commit(clientContext, activeTransaction);
+    try {
+        clientContext.getDatabase()->getTransactionManager()->commit(clientContext,
+            activeTransaction);
+    } catch (const CheckpointException&) {
+        // TransactionManager has already released the transaction before running the
+        // post-commit checkpoint. It cannot be rolled back after this error.
+        clearTransaction();
+        throw;
+    }
     clearTransaction();
 }
 

--- a/src/transaction/transaction_context.cpp
+++ b/src/transaction/transaction_context.cpp
@@ -74,7 +74,7 @@ void TransactionContext::rollback() {
         return;
     }
     clientContext.getDatabase()->getTransactionManager()->rollback(clientContext,
-        activeTransaction);
+        activeTransaction->getID());
     clearTransaction();
 }
 

--- a/src/transaction/transaction_manager.cpp
+++ b/src/transaction/transaction_manager.cpp
@@ -1,5 +1,6 @@
 #include "transaction/transaction_manager.h"
 
+#include <algorithm>
 #include <thread>
 
 #include "common/exception/checkpoint.h"
@@ -11,6 +12,7 @@
 #include "main/db_config.h"
 #include "storage/checkpointer.h"
 #include "storage/wal/local_wal.h"
+#include <format>
 
 using namespace lbug::common;
 using namespace lbug::storage;
@@ -174,29 +176,25 @@ void TransactionManager::commit(main::ClientContext& clientContext, Transaction*
         } else if (shouldAutoCheckpoint) {
             tryCheckpoint(clientContext);
         }
-    } catch (const CheckpointException&) {
-        throw;
     } catch (const std::exception& e) {
-        throw CheckpointException{e};
+        throw CheckpointException{std::format(
+            "Transaction committed successfully, but the post-commit checkpoint failed. "
+            "The committed data is durable and will be recovered on restart: {}",
+            e.what())};
     }
 }
 
-// Note: We take in additional `transaction` here is due to that `transactionContext` might be
-// destructed when a transaction throws an exception, while we need to roll back the active
-// transaction still.
-void TransactionManager::rollback(main::ClientContext& clientContext, Transaction* transaction) {
+void TransactionManager::rollback(main::ClientContext& clientContext, transaction_t transactionID) {
     std::unique_lock lck{mtxForSerializingPublicFunctionCalls};
     clientContext.cleanUp();
-    // A post-commit checkpoint failure may be observed after the manager has released the
-    // transaction but before its context has cleared the non-owning pointer. Do not dereference
-    // a transaction that is no longer manager-owned.
-    const auto isActiveTransaction =
-        std::ranges::any_of(activeTransactions, [transaction](const auto& activeTransaction) {
-            return activeTransaction.get() == transaction;
+    const auto transactionIt =
+        std::ranges::find_if(activeTransactions, [transactionID](const auto& activeTransaction) {
+            return activeTransaction->getID() == transactionID;
         });
-    if (!isActiveTransaction) {
+    if (transactionIt == activeTransactions.end()) {
         return;
     }
+    auto* transaction = transactionIt->get();
     switch (transaction->getType()) {
     case TransactionType::READ_ONLY: {
         clearTransactionNoLock(transaction->getID());

--- a/src/transaction/transaction_manager.cpp
+++ b/src/transaction/transaction_manager.cpp
@@ -165,11 +165,19 @@ void TransactionManager::commit(main::ClientContext& clientContext, Transaction*
         throw;
     }
     // Checkpoint outside the public function lock so active writers can finish
-    // (commit/rollback) during the drain phase instead of deadlocking.
-    if (shouldForceCheckpoint) {
-        checkpoint(clientContext);
-    } else if (shouldAutoCheckpoint) {
-        tryCheckpoint(clientContext);
+    // (commit/rollback) during the drain phase instead of deadlocking. The transaction has
+    // already been removed from activeTransactions at this point, so any later failure is a
+    // checkpoint failure, not a transaction failure that can be rolled back.
+    try {
+        if (shouldForceCheckpoint) {
+            checkpoint(clientContext);
+        } else if (shouldAutoCheckpoint) {
+            tryCheckpoint(clientContext);
+        }
+    } catch (const CheckpointException&) {
+        throw;
+    } catch (const std::exception& e) {
+        throw CheckpointException{e};
     }
 }
 
@@ -179,6 +187,16 @@ void TransactionManager::commit(main::ClientContext& clientContext, Transaction*
 void TransactionManager::rollback(main::ClientContext& clientContext, Transaction* transaction) {
     std::unique_lock lck{mtxForSerializingPublicFunctionCalls};
     clientContext.cleanUp();
+    // A post-commit checkpoint failure may be observed after the manager has released the
+    // transaction but before its context has cleared the non-owning pointer. Do not dereference
+    // a transaction that is no longer manager-owned.
+    const auto isActiveTransaction =
+        std::ranges::any_of(activeTransactions, [transaction](const auto& activeTransaction) {
+            return activeTransaction.get() == transaction;
+        });
+    if (!isActiveTransaction) {
+        return;
+    }
     switch (transaction->getType()) {
     case TransactionType::READ_ONLY: {
         clearTransactionNoLock(transaction->getID());


### PR DESCRIPTION
fix issue : https://github.com/LadybugDB/ladybug/issues/783

## Implemented behavior

### Transaction lifecycle

`TransactionManager::commit()` now runs the post-ownership-release checkpoint inside an exception boundary. Existing `CheckpointException` objects are preserved; other exceptions are converted to `CheckpointException`. This makes the failure explicitly a checkpoint failure rather than a statement failure that can be rolled back.

`TransactionContext::commit()` catches `CheckpointException`, clears its non-owning pointer, and rethrows. `TransactionManager::rollback()` checks pointer identity against `activeTransactions` before dereferencing the transaction. A stale pointer therefore becomes a no-op instead of an invalid `getType()` access or a second rollback.

The transaction may already have a durable WAL commit and visible versions when this error is reported. The caller must close the instance and reopen it so WAL/shadow recovery determines the durable result; the code does not claim that `COPY` was rolled back.

### Buffer manager failure paths

`BufferManager::claimAFrame()` now undoes the frame reservation and memory accounting if `cachePageIntoFrame()` fails during NFS I/O. `pin()` resets a page that remains locked when allocation, queue insertion, or page loading throws; a full eviction queue also releases the newly claimed frame before throwing.

Dirty-page eviction and explicit page removal now keep the frame resident and unlock the page when a flush fails. The dirty data can therefore be retried after storage recovers instead of being stranded in `LOCKED` state or silently losing its frame.

### Shadow-file replay and WAL cleanup

`ShadowFile::replayShadowPageRecords()` calls `syncFile()` after copying shadow pages into the data file. Replayed pages are consequently flushed before recovery proceeds.

`WALReplayer` now releases the WAL `FileInfo` before removing an open WAL file. Removal reports whether a file was actually deleted. For local paths, the parent directory is opened and `fsync()`ed after WAL deletion, making the unlink durable. Active and checkpoint WAL paths are handled independently, and stale shadow files are removed on empty/non-checkpoint WAL paths. The replay path keeps the shadow file until its records have been applied, then removes the selected WAL and shadow files together.

## Recovery contract for the NFS scenarios

The relationship-table and node-table reproducers may now return a catchable checkpoint/database error instead of aborting. The result of the `COPY` is uncertain until the database is closed and reopened. On reopen, WAL records are replayed, shadow pages are copied and synced, and only then are WAL/shadow artifacts removed and the checkpoint read. No rollback is attempted for a transaction that the manager no longer owns.

The current patch does not add a database-wide `recovery-required` flag or make connection destructors globally no-throw; those are outside the implemented change. The ownership check and context clearing prevent this incident's released-transaction rollback path, while the storage changes preserve retryability and recovery durability on NFS errors.

## Reproduction

```bash
cd /home/eric/project/nexus-test
python3 reconciler/cases/tc_local_lbug_copy_fsfreeze.py \
  --scenario nfs-node-copy-inflight-reopen \
  --mountpoint /mnt/lbug-nfs-client \
  --db-path /mnt/lbug-nfs-client/nfs-node-scenario-reopen.lbug \
  --freeze-seconds 180 \
  --inflight-copy-nodes 1000000 \
  --keep-db
```

Use `nfs-copy-inflight` for the relationship-table variant. Expected behavior is no released-transaction dereference and no `SIGABRT`; verify the final row/edge count only after reopening the database.

## Changed files

- `src/transaction/transaction_manager.cpp`
- `src/transaction/transaction_context.cpp`
- `src/storage/buffer_manager/buffer_manager.cpp`
- `src/storage/shadow_file.cpp`
- `src/storage/wal/wal_replayer.cpp`
- `src/include/storage/wal/wal_replayer.h`
