### PR TITLE
c_api: exception floor (guard macro with catch-all) and first conversions

### DIFF
--- a/src/c_api/helpers.cpp
+++ b/src/c_api/helpers.cpp
@@ -71,6 +71,9 @@ char* takeLastCAPIErrorMessage() {
 char* convertToOwnedCString(const std::string& str) {
     size_t src_len = str.size();
     auto* c_str = (char*)malloc(sizeof(char) * (src_len + 1));
+    if (c_str == nullptr) {
+        return nullptr;
+    }
     memcpy(c_str, str.c_str(), src_len);
     c_str[src_len] = '\0';
     return c_str;

--- a/src/c_api/query_summary.cpp
+++ b/src/c_api/query_summary.cpp
@@ -2,6 +2,7 @@
 
 #include <cstdlib>
 
+#include "c_api/helpers.h"
 #include "c_api/lbug.h"
 
 using namespace lbug::main;
@@ -15,9 +16,19 @@ void lbug_query_summary_destroy(lbug_query_summary* query_summary) {
 }
 
 double lbug_query_summary_get_compiling_time(lbug_query_summary* query_summary) {
+    if (query_summary == nullptr || query_summary->_query_summary == nullptr) {
+        return 0.0;
+    }
+    LBUG_C_API_GUARD_BEGIN
     return static_cast<QuerySummary*>(query_summary->_query_summary)->getCompilingTime();
+    LBUG_C_API_GUARD_END(0.0)
 }
 
 double lbug_query_summary_get_execution_time(lbug_query_summary* query_summary) {
+    if (query_summary == nullptr || query_summary->_query_summary == nullptr) {
+        return 0.0;
+    }
+    LBUG_C_API_GUARD_BEGIN
     return static_cast<QuerySummary*>(query_summary->_query_summary)->getExecutionTime();
+    LBUG_C_API_GUARD_END(0.0)
 }

--- a/src/c_api/version.cpp
+++ b/src/c_api/version.cpp
@@ -4,13 +4,17 @@
 #include "c_api/lbug.h"
 
 char* lbug_get_version() {
+    LBUG_C_API_GUARD_BEGIN
     auto version = lbug::main::Version::getVersion();
     if (version == nullptr || version[0] == '\0') {
         version = "0.19.1";
     }
     return convertToOwnedCString(version);
+    LBUG_C_API_GUARD_END(nullptr)
 }
 
 uint64_t lbug_get_storage_version() {
+    LBUG_C_API_GUARD_BEGIN
     return lbug::main::Version::getStorageVersion();
+    LBUG_C_API_GUARD_END(0)
 }

--- a/src/include/c_api/helpers.h
+++ b/src/include/c_api/helpers.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstdint>
+#include <exception>
 #include <string>
 #ifdef _WIN32
 #include <time.h>
@@ -19,3 +20,22 @@ void clearLastCAPIErrorMessage();
 char* takeLastCAPIErrorMessage();
 
 char* convertToOwnedCString(const std::string& str);
+
+// Exception floor for C API entry points. No C++ exception may cross the C
+// boundary: an escaping exception in an extern "C" function reaches
+// std::terminate in the caller's process (observed from embedding runtimes).
+// Wrap the throwing region of an entry point:
+//   LBUG_C_API_GUARD_BEGIN
+//   ... body ...
+//   LBUG_C_API_GUARD_END(<value to return on error>)
+#define LBUG_C_API_GUARD_BEGIN try {
+#define LBUG_C_API_GUARD_END(err_ret)                                                              \
+    }                                                                                              \
+    catch (const std::exception& e) {                                                              \
+        setLastCAPIErrorMessage(e.what());                                                         \
+        return err_ret;                                                                            \
+    }                                                                                              \
+    catch (...) {                                                                                  \
+        setLastCAPIErrorMessage("unknown C++ exception in lbug C API");                            \
+        return err_ret;                                                                            \
+    }


### PR DESCRIPTION
No function in `src/c_api/` currently has a `catch (...)`, and several files
have no exception handling at all, so `std::bad_alloc`, `std::system_error`,
or any exception from bundled third-party code escapes the C boundary and
terminates the embedding process. We embed lbug (skybox) and have field
evidence of aborts crossing this boundary.

This PR:
- adds `LBUG_C_API_GUARD_BEGIN` / `LBUG_C_API_GUARD_END(err_ret)` to
  `c_api/helpers.h`: `catch (const std::exception&)` (covers
  `lbug::common::Exception`, which derives from it) plus `catch (...)`,
  both routing through `setLastCAPIErrorMessage`;
- converts the fully-unguarded small files `query_summary.cpp` and
  `version.cpp`, adding null-argument checks where absent;
- null-checks the `malloc` in `convertToOwnedCString`.

Follow-ups (happy to do them as separate PRs to keep review small): apply the
macro across `value.cpp`, `query_result.cpp`, `prepared_statement.cpp`, and
extend the existing `catch (Exception&)` sites with the catch-all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
