### PR TITLE
ci: nightly sanitizer workflow (ASan+UBSan blocking, TSan signal-gathering)

### DIFF
--- a/.github/workflows/nightly-sanitizers.yml
+++ b/.github/workflows/nightly-sanitizers.yml
@@ -1,0 +1,47 @@
+name: Nightly Sanitizers
+
+on:
+  schedule:
+    - cron: '0 6 * * *'
+  workflow_dispatch:
+
+env:
+  PIP_BREAK_SYSTEM_PACKAGES: 1
+  RUNTIME_CHECKS: 1
+
+jobs:
+  asan-ubsan:
+    name: ASan + UBSan (linux, runtime checks on)
+    runs-on: ubuntu-24.04
+    timeout-minutes: 300
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y cmake ninja-build python3 python3-pip git ccache curl
+      - name: Build (RelWithDebInfo, ASan+UBSan)
+        run: ASAN=1 UBSAN=1 make relwithdebinfo NUM_THREADS=$(nproc)
+      - name: Test
+        run: ASAN=1 UBSAN=1 make test NUM_THREADS=$(nproc)
+        env:
+          ASAN_OPTIONS: detect_leaks=0:abort_on_error=1
+          UBSAN_OPTIONS: print_stacktrace=1:halt_on_error=1
+
+  tsan:
+    name: TSan (linux, signal-gathering, non-blocking)
+    runs-on: ubuntu-24.04
+    timeout-minutes: 300
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y cmake ninja-build python3 python3-pip git ccache curl
+      - name: Build (RelWithDebInfo, TSan)
+        run: TSAN=1 make relwithdebinfo NUM_THREADS=$(nproc)
+      - name: Test
+        run: TSAN=1 make test NUM_THREADS=$(nproc)
+        env:
+          TSAN_OPTIONS: halt_on_error=0


### PR DESCRIPTION
The build system already plumbs `ASAN`/`TSAN`/`UBSAN` and `ENABLE_RUNTIME_CHECKS`
through CMake and the Makefile, but no workflow exercises them. This adds a
nightly (cron 06:00 UTC, off the 03:00 CI slot) with two linux legs:

- **asan-ubsan**: blocking. `RUNTIME_CHECKS=1 ASAN=1 UBSAN=1`, so the 1500+
  `DASSERT` invariants run under sanitizers nightly. Leak detection is off for
  the first landing to keep the signal actionable; it can be enabled once the
  baseline is clean.
- **tsan**: `continue-on-error`, pure signal-gathering. The engine is
  morsel-parallel and has never run under TSan in CI; this leg accumulates a
  baseline without blocking anyone.

Motivation from the consumer side: we ship lbug embedded (skybox) and
root-caused a silent wrong-results bug (#692) whose entire class fails
silently in release builds because `DASSERT` compiles out. A nightly with
runtime checks plus sanitizers is the cheapest structural counter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
