### PR TITLE
c_api: exception floor across all surfaces

### DIFF
--- a/src/c_api/helpers.cpp
+++ b/src/c_api/helpers.cpp
@@ -71,6 +71,9 @@ char* takeLastCAPIErrorMessage() {
 char* convertToOwnedCString(const std::string& str) {
     size_t src_len = str.size();
     auto* c_str = (char*)malloc(sizeof(char) * (src_len + 1));
+    if (c_str == nullptr) {
+        return nullptr;
+    }
     memcpy(c_str, str.c_str(), src_len);
     c_str[src_len] = '\0';
     return c_str;

--- a/src/c_api/prepared_statement.cpp
+++ b/src/c_api/prepared_statement.cpp
@@ -9,13 +9,19 @@ using namespace lbug::main;
 
 void lbug_prepared_statement_bind_cpp_value(lbug_prepared_statement* prepared_statement,
     const char* param_name, std::unique_ptr<Value> value) {
+    if (prepared_statement == nullptr || prepared_statement->_prepared_statement == nullptr) {
+        return;
+    }
+    LBUG_C_API_GUARD_BEGIN
     auto* bound_values = static_cast<std::unordered_map<std::string, std::unique_ptr<Value>>*>(
         prepared_statement->_bound_values);
     bound_values->erase(param_name);
     bound_values->insert({param_name, std::move(value)});
+    LBUG_C_API_GUARD_END_VOID
 }
 
 void lbug_prepared_statement_destroy(lbug_prepared_statement* prepared_statement) {
+    LBUG_C_API_GUARD_BEGIN
     if (prepared_statement == nullptr) {
         return;
     }
@@ -28,27 +34,47 @@ void lbug_prepared_statement_destroy(lbug_prepared_statement* prepared_statement
             prepared_statement->_bound_values);
         prepared_statement->_bound_values = nullptr;
     }
+    LBUG_C_API_GUARD_END_VOID
 }
 
 bool lbug_prepared_statement_is_success(lbug_prepared_statement* prepared_statement) {
+    if (prepared_statement == nullptr || prepared_statement->_prepared_statement == nullptr) {
+        return false;
+    }
+    LBUG_C_API_GUARD_BEGIN
     return static_cast<PreparedStatement*>(prepared_statement->_prepared_statement)->isSuccess();
+    LBUG_C_API_GUARD_END(false)
 }
 
 bool lbug_prepared_statement_is_read_only(lbug_prepared_statement* prepared_statement) {
+    if (prepared_statement == nullptr || prepared_statement->_prepared_statement == nullptr) {
+        return false;
+    }
+    LBUG_C_API_GUARD_BEGIN
     return static_cast<PreparedStatement*>(prepared_statement->_prepared_statement)->isReadOnly();
+    LBUG_C_API_GUARD_END(false)
 }
 
 char* lbug_prepared_statement_get_error_message(lbug_prepared_statement* prepared_statement) {
+    if (prepared_statement == nullptr || prepared_statement->_prepared_statement == nullptr) {
+        return nullptr;
+    }
+    LBUG_C_API_GUARD_BEGIN
     auto error_message =
         static_cast<PreparedStatement*>(prepared_statement->_prepared_statement)->getErrorMessage();
     if (error_message.empty()) {
         return nullptr;
     }
     return convertToOwnedCString(error_message);
+    LBUG_C_API_GUARD_END(nullptr)
 }
 
 lbug_state lbug_prepared_statement_bind_bool(lbug_prepared_statement* prepared_statement,
     const char* param_name, bool value) {
+    if (prepared_statement == nullptr || prepared_statement->_prepared_statement == nullptr) {
+        return LbugError;
+    }
+    LBUG_C_API_GUARD_BEGIN
     try {
         auto value_ptr = std::make_unique<Value>(value);
         lbug_prepared_statement_bind_cpp_value(prepared_statement, param_name,
@@ -57,10 +83,15 @@ lbug_state lbug_prepared_statement_bind_bool(lbug_prepared_statement* prepared_s
     } catch (Exception& e) {
         return LbugError;
     }
+    LBUG_C_API_GUARD_END(LbugError)
 }
 
 lbug_state lbug_prepared_statement_bind_int64(lbug_prepared_statement* prepared_statement,
     const char* param_name, int64_t value) {
+    if (prepared_statement == nullptr || prepared_statement->_prepared_statement == nullptr) {
+        return LbugError;
+    }
+    LBUG_C_API_GUARD_BEGIN
     try {
         auto value_ptr = std::make_unique<Value>(value);
         lbug_prepared_statement_bind_cpp_value(prepared_statement, param_name,
@@ -69,10 +100,15 @@ lbug_state lbug_prepared_statement_bind_int64(lbug_prepared_statement* prepared_
     } catch (Exception& e) {
         return LbugError;
     }
+    LBUG_C_API_GUARD_END(LbugError)
 }
 
 lbug_state lbug_prepared_statement_bind_int32(lbug_prepared_statement* prepared_statement,
     const char* param_name, int32_t value) {
+    if (prepared_statement == nullptr || prepared_statement->_prepared_statement == nullptr) {
+        return LbugError;
+    }
+    LBUG_C_API_GUARD_BEGIN
     try {
         auto value_ptr = std::make_unique<Value>(value);
         lbug_prepared_statement_bind_cpp_value(prepared_statement, param_name,
@@ -81,10 +117,15 @@ lbug_state lbug_prepared_statement_bind_int32(lbug_prepared_statement* prepared_
     } catch (Exception& e) {
         return LbugError;
     }
+    LBUG_C_API_GUARD_END(LbugError)
 }
 
 lbug_state lbug_prepared_statement_bind_int16(lbug_prepared_statement* prepared_statement,
     const char* param_name, int16_t value) {
+    if (prepared_statement == nullptr || prepared_statement->_prepared_statement == nullptr) {
+        return LbugError;
+    }
+    LBUG_C_API_GUARD_BEGIN
     try {
         auto value_ptr = std::make_unique<Value>(value);
         lbug_prepared_statement_bind_cpp_value(prepared_statement, param_name,
@@ -93,10 +134,15 @@ lbug_state lbug_prepared_statement_bind_int16(lbug_prepared_statement* prepared_
     } catch (Exception& e) {
         return LbugError;
     }
+    LBUG_C_API_GUARD_END(LbugError)
 }
 
 lbug_state lbug_prepared_statement_bind_int8(lbug_prepared_statement* prepared_statement,
     const char* param_name, int8_t value) {
+    if (prepared_statement == nullptr || prepared_statement->_prepared_statement == nullptr) {
+        return LbugError;
+    }
+    LBUG_C_API_GUARD_BEGIN
     try {
         auto value_ptr = std::make_unique<Value>(value);
         lbug_prepared_statement_bind_cpp_value(prepared_statement, param_name,
@@ -105,10 +151,15 @@ lbug_state lbug_prepared_statement_bind_int8(lbug_prepared_statement* prepared_s
     } catch (Exception& e) {
         return LbugError;
     }
+    LBUG_C_API_GUARD_END(LbugError)
 }
 
 lbug_state lbug_prepared_statement_bind_uint64(lbug_prepared_statement* prepared_statement,
     const char* param_name, uint64_t value) {
+    if (prepared_statement == nullptr || prepared_statement->_prepared_statement == nullptr) {
+        return LbugError;
+    }
+    LBUG_C_API_GUARD_BEGIN
     try {
         auto value_ptr = std::make_unique<Value>(value);
         lbug_prepared_statement_bind_cpp_value(prepared_statement, param_name,
@@ -117,10 +168,15 @@ lbug_state lbug_prepared_statement_bind_uint64(lbug_prepared_statement* prepared
     } catch (Exception& e) {
         return LbugError;
     }
+    LBUG_C_API_GUARD_END(LbugError)
 }
 
 lbug_state lbug_prepared_statement_bind_uint32(lbug_prepared_statement* prepared_statement,
     const char* param_name, uint32_t value) {
+    if (prepared_statement == nullptr || prepared_statement->_prepared_statement == nullptr) {
+        return LbugError;
+    }
+    LBUG_C_API_GUARD_BEGIN
     try {
         auto value_ptr = std::make_unique<Value>(value);
         lbug_prepared_statement_bind_cpp_value(prepared_statement, param_name,
@@ -129,10 +185,15 @@ lbug_state lbug_prepared_statement_bind_uint32(lbug_prepared_statement* prepared
     } catch (Exception& e) {
         return LbugError;
     }
+    LBUG_C_API_GUARD_END(LbugError)
 }
 
 lbug_state lbug_prepared_statement_bind_uint16(lbug_prepared_statement* prepared_statement,
     const char* param_name, uint16_t value) {
+    if (prepared_statement == nullptr || prepared_statement->_prepared_statement == nullptr) {
+        return LbugError;
+    }
+    LBUG_C_API_GUARD_BEGIN
     try {
         auto value_ptr = std::make_unique<Value>(value);
         lbug_prepared_statement_bind_cpp_value(prepared_statement, param_name,
@@ -141,10 +202,15 @@ lbug_state lbug_prepared_statement_bind_uint16(lbug_prepared_statement* prepared
     } catch (Exception& e) {
         return LbugError;
     }
+    LBUG_C_API_GUARD_END(LbugError)
 }
 
 lbug_state lbug_prepared_statement_bind_uint8(lbug_prepared_statement* prepared_statement,
     const char* param_name, uint8_t value) {
+    if (prepared_statement == nullptr || prepared_statement->_prepared_statement == nullptr) {
+        return LbugError;
+    }
+    LBUG_C_API_GUARD_BEGIN
     try {
         auto value_ptr = std::make_unique<Value>(value);
         lbug_prepared_statement_bind_cpp_value(prepared_statement, param_name,
@@ -153,10 +219,15 @@ lbug_state lbug_prepared_statement_bind_uint8(lbug_prepared_statement* prepared_
     } catch (Exception& e) {
         return LbugError;
     }
+    LBUG_C_API_GUARD_END(LbugError)
 }
 
 lbug_state lbug_prepared_statement_bind_double(lbug_prepared_statement* prepared_statement,
     const char* param_name, double value) {
+    if (prepared_statement == nullptr || prepared_statement->_prepared_statement == nullptr) {
+        return LbugError;
+    }
+    LBUG_C_API_GUARD_BEGIN
     try {
         auto value_ptr = std::make_unique<Value>(value);
         lbug_prepared_statement_bind_cpp_value(prepared_statement, param_name,
@@ -165,10 +236,15 @@ lbug_state lbug_prepared_statement_bind_double(lbug_prepared_statement* prepared
     } catch (Exception& e) {
         return LbugError;
     }
+    LBUG_C_API_GUARD_END(LbugError)
 }
 
 lbug_state lbug_prepared_statement_bind_float(lbug_prepared_statement* prepared_statement,
     const char* param_name, float value) {
+    if (prepared_statement == nullptr || prepared_statement->_prepared_statement == nullptr) {
+        return LbugError;
+    }
+    LBUG_C_API_GUARD_BEGIN
     try {
         auto value_ptr = std::make_unique<Value>(value);
         lbug_prepared_statement_bind_cpp_value(prepared_statement, param_name,
@@ -177,10 +253,15 @@ lbug_state lbug_prepared_statement_bind_float(lbug_prepared_statement* prepared_
     } catch (Exception& e) {
         return LbugError;
     }
+    LBUG_C_API_GUARD_END(LbugError)
 }
 
 lbug_state lbug_prepared_statement_bind_date(lbug_prepared_statement* prepared_statement,
     const char* param_name, lbug_date_t value) {
+    if (prepared_statement == nullptr || prepared_statement->_prepared_statement == nullptr) {
+        return LbugError;
+    }
+    LBUG_C_API_GUARD_BEGIN
     try {
         auto value_ptr = std::make_unique<Value>(date_t(value.days));
         lbug_prepared_statement_bind_cpp_value(prepared_statement, param_name,
@@ -189,10 +270,15 @@ lbug_state lbug_prepared_statement_bind_date(lbug_prepared_statement* prepared_s
     } catch (Exception& e) {
         return LbugError;
     }
+    LBUG_C_API_GUARD_END(LbugError)
 }
 
 lbug_state lbug_prepared_statement_bind_timestamp_ns(lbug_prepared_statement* prepared_statement,
     const char* param_name, lbug_timestamp_ns_t value) {
+    if (prepared_statement == nullptr || prepared_statement->_prepared_statement == nullptr) {
+        return LbugError;
+    }
+    LBUG_C_API_GUARD_BEGIN
     try {
         auto value_ptr = std::make_unique<Value>(timestamp_ns_t(value.value));
         lbug_prepared_statement_bind_cpp_value(prepared_statement, param_name,
@@ -201,10 +287,15 @@ lbug_state lbug_prepared_statement_bind_timestamp_ns(lbug_prepared_statement* pr
     } catch (Exception& e) {
         return LbugError;
     }
+    LBUG_C_API_GUARD_END(LbugError)
 }
 
 lbug_state lbug_prepared_statement_bind_timestamp_ms(lbug_prepared_statement* prepared_statement,
     const char* param_name, lbug_timestamp_ms_t value) {
+    if (prepared_statement == nullptr || prepared_statement->_prepared_statement == nullptr) {
+        return LbugError;
+    }
+    LBUG_C_API_GUARD_BEGIN
     try {
         auto value_ptr = std::make_unique<Value>(timestamp_ms_t(value.value));
         lbug_prepared_statement_bind_cpp_value(prepared_statement, param_name,
@@ -213,10 +304,15 @@ lbug_state lbug_prepared_statement_bind_timestamp_ms(lbug_prepared_statement* pr
     } catch (Exception& e) {
         return LbugError;
     }
+    LBUG_C_API_GUARD_END(LbugError)
 }
 
 lbug_state lbug_prepared_statement_bind_timestamp_sec(lbug_prepared_statement* prepared_statement,
     const char* param_name, lbug_timestamp_sec_t value) {
+    if (prepared_statement == nullptr || prepared_statement->_prepared_statement == nullptr) {
+        return LbugError;
+    }
+    LBUG_C_API_GUARD_BEGIN
     try {
         auto value_ptr = std::make_unique<Value>(timestamp_sec_t(value.value));
         lbug_prepared_statement_bind_cpp_value(prepared_statement, param_name,
@@ -225,10 +321,15 @@ lbug_state lbug_prepared_statement_bind_timestamp_sec(lbug_prepared_statement* p
     } catch (Exception& e) {
         return LbugError;
     }
+    LBUG_C_API_GUARD_END(LbugError)
 }
 
 lbug_state lbug_prepared_statement_bind_timestamp_tz(lbug_prepared_statement* prepared_statement,
     const char* param_name, lbug_timestamp_tz_t value) {
+    if (prepared_statement == nullptr || prepared_statement->_prepared_statement == nullptr) {
+        return LbugError;
+    }
+    LBUG_C_API_GUARD_BEGIN
     try {
         auto value_ptr = std::make_unique<Value>(timestamp_tz_t(value.value));
         lbug_prepared_statement_bind_cpp_value(prepared_statement, param_name,
@@ -237,10 +338,15 @@ lbug_state lbug_prepared_statement_bind_timestamp_tz(lbug_prepared_statement* pr
     } catch (Exception& e) {
         return LbugError;
     }
+    LBUG_C_API_GUARD_END(LbugError)
 }
 
 lbug_state lbug_prepared_statement_bind_timestamp(lbug_prepared_statement* prepared_statement,
     const char* param_name, lbug_timestamp_t value) {
+    if (prepared_statement == nullptr || prepared_statement->_prepared_statement == nullptr) {
+        return LbugError;
+    }
+    LBUG_C_API_GUARD_BEGIN
     try {
         auto value_ptr = std::make_unique<Value>(timestamp_t(value.value));
         lbug_prepared_statement_bind_cpp_value(prepared_statement, param_name,
@@ -249,10 +355,15 @@ lbug_state lbug_prepared_statement_bind_timestamp(lbug_prepared_statement* prepa
     } catch (Exception& e) {
         return LbugError;
     }
+    LBUG_C_API_GUARD_END(LbugError)
 }
 
 lbug_state lbug_prepared_statement_bind_interval(lbug_prepared_statement* prepared_statement,
     const char* param_name, lbug_interval_t value) {
+    if (prepared_statement == nullptr || prepared_statement->_prepared_statement == nullptr) {
+        return LbugError;
+    }
+    LBUG_C_API_GUARD_BEGIN
     try {
         auto value_ptr =
             std::make_unique<Value>(interval_t(value.months, value.days, value.micros));
@@ -262,10 +373,15 @@ lbug_state lbug_prepared_statement_bind_interval(lbug_prepared_statement* prepar
     } catch (Exception& e) {
         return LbugError;
     }
+    LBUG_C_API_GUARD_END(LbugError)
 }
 
 lbug_state lbug_prepared_statement_bind_string(lbug_prepared_statement* prepared_statement,
     const char* param_name, const char* value) {
+    if (prepared_statement == nullptr || prepared_statement->_prepared_statement == nullptr) {
+        return LbugError;
+    }
+    LBUG_C_API_GUARD_BEGIN
     try {
         auto value_ptr = std::make_unique<Value>(std::string(value));
         lbug_prepared_statement_bind_cpp_value(prepared_statement, param_name,
@@ -274,10 +390,15 @@ lbug_state lbug_prepared_statement_bind_string(lbug_prepared_statement* prepared
     } catch (Exception& e) {
         return LbugError;
     }
+    LBUG_C_API_GUARD_END(LbugError)
 }
 
 lbug_state lbug_prepared_statement_bind_value(lbug_prepared_statement* prepared_statement,
     const char* param_name, lbug_value* value) {
+    if (prepared_statement == nullptr || prepared_statement->_prepared_statement == nullptr) {
+        return LbugError;
+    }
+    LBUG_C_API_GUARD_BEGIN
     try {
         auto value_ptr = std::make_unique<Value>(*static_cast<Value*>(value->_value));
         lbug_prepared_statement_bind_cpp_value(prepared_statement, param_name,
@@ -286,4 +407,5 @@ lbug_state lbug_prepared_statement_bind_value(lbug_prepared_statement* prepared_
     } catch (Exception& e) {
         return LbugError;
     }
+    LBUG_C_API_GUARD_END(LbugError)
 }

--- a/src/c_api/query_result.cpp
+++ b/src/c_api/query_result.cpp
@@ -8,6 +8,7 @@ using namespace lbug::common;
 using namespace lbug::processor;
 
 void lbug_query_result_destroy(lbug_query_result* query_result) {
+    LBUG_C_API_GUARD_BEGIN
     if (query_result == nullptr) {
         return;
     }
@@ -17,36 +18,61 @@ void lbug_query_result_destroy(lbug_query_result* query_result) {
         }
         query_result->_query_result = nullptr;
     }
+    LBUG_C_API_GUARD_END_VOID
 }
 
 bool lbug_query_result_is_success(lbug_query_result* query_result) {
+    if (query_result == nullptr || query_result->_query_result == nullptr) {
+        return false;
+    }
+    LBUG_C_API_GUARD_BEGIN
     return static_cast<QueryResult*>(query_result->_query_result)->isSuccess();
+    LBUG_C_API_GUARD_END(false)
 }
 
 char* lbug_query_result_get_error_message(lbug_query_result* query_result) {
+    if (query_result == nullptr || query_result->_query_result == nullptr) {
+        return nullptr;
+    }
+    LBUG_C_API_GUARD_BEGIN
     auto error_message = static_cast<QueryResult*>(query_result->_query_result)->getErrorMessage();
     if (error_message.empty()) {
         return nullptr;
     }
     return convertToOwnedCString(error_message);
+    LBUG_C_API_GUARD_END(nullptr)
 }
 
 uint64_t lbug_query_result_get_num_columns(lbug_query_result* query_result) {
+    if (query_result == nullptr || query_result->_query_result == nullptr) {
+        return 0;
+    }
+    LBUG_C_API_GUARD_BEGIN
     return static_cast<QueryResult*>(query_result->_query_result)->getNumColumns();
+    LBUG_C_API_GUARD_END(0)
 }
 
 lbug_state lbug_query_result_get_column_name(lbug_query_result* query_result, uint64_t index,
     char** out_column_name) {
+    if (query_result == nullptr || query_result->_query_result == nullptr) {
+        return LbugError;
+    }
+    LBUG_C_API_GUARD_BEGIN
     auto column_names = static_cast<QueryResult*>(query_result->_query_result)->getColumnNames();
     if (index >= column_names.size()) {
         return LbugError;
     }
     *out_column_name = convertToOwnedCString(column_names[index]);
     return LbugSuccess;
+    LBUG_C_API_GUARD_END(LbugError)
 }
 
 lbug_state lbug_query_result_get_column_data_type(lbug_query_result* query_result, uint64_t index,
     lbug_logical_type* out_column_data_type) {
+    if (query_result == nullptr || query_result->_query_result == nullptr) {
+        return LbugError;
+    }
+    LBUG_C_API_GUARD_BEGIN
     auto column_data_types =
         static_cast<QueryResult*>(query_result->_query_result)->getColumnDataTypes();
     if (index >= column_data_types.size()) {
@@ -55,32 +81,57 @@ lbug_state lbug_query_result_get_column_data_type(lbug_query_result* query_resul
     const auto& column_data_type = column_data_types[index];
     out_column_data_type->_data_type = new LogicalType(column_data_type.copy());
     return LbugSuccess;
+    LBUG_C_API_GUARD_END(LbugError)
 }
 
 uint64_t lbug_query_result_get_num_tuples(lbug_query_result* query_result) {
+    if (query_result == nullptr || query_result->_query_result == nullptr) {
+        return 0;
+    }
+    LBUG_C_API_GUARD_BEGIN
     return static_cast<QueryResult*>(query_result->_query_result)->getNumTuples();
+    LBUG_C_API_GUARD_END(0)
 }
 
 lbug_state lbug_query_result_get_query_summary(lbug_query_result* query_result,
     lbug_query_summary* out_query_summary) {
+    if (query_result == nullptr || query_result->_query_result == nullptr) {
+        return LbugError;
+    }
+    LBUG_C_API_GUARD_BEGIN
     if (out_query_summary == nullptr) {
         return LbugError;
     }
     auto query_summary = static_cast<QueryResult*>(query_result->_query_result)->getQuerySummary();
     out_query_summary->_query_summary = query_summary;
     return LbugSuccess;
+    LBUG_C_API_GUARD_END(LbugError)
 }
 
 bool lbug_query_result_has_next(lbug_query_result* query_result) {
+    if (query_result == nullptr || query_result->_query_result == nullptr) {
+        return false;
+    }
+    LBUG_C_API_GUARD_BEGIN
     return static_cast<QueryResult*>(query_result->_query_result)->hasNext();
+    LBUG_C_API_GUARD_END(false)
 }
 
 bool lbug_query_result_has_next_query_result(lbug_query_result* query_result) {
+    if (query_result == nullptr || query_result->_query_result == nullptr) {
+        return false;
+    }
+    LBUG_C_API_GUARD_BEGIN
     return static_cast<QueryResult*>(query_result->_query_result)->hasNextQueryResult();
+    LBUG_C_API_GUARD_END(false)
 }
 
 lbug_state lbug_query_result_get_next_query_result(lbug_query_result* query_result,
     lbug_query_result* out_query_result) {
+    if (query_result == nullptr || query_result->_query_result == nullptr) {
+        return LbugError;
+    }
+    LBUG_C_API_GUARD_BEGIN
     if (!lbug_query_result_has_next_query_result(query_result)) {
         return LbugError;
     }
@@ -92,10 +143,15 @@ lbug_state lbug_query_result_get_next_query_result(lbug_query_result* query_resu
     out_query_result->_query_result = next_query_result;
     out_query_result->_is_owned_by_cpp = true;
     return LbugSuccess;
+    LBUG_C_API_GUARD_END(LbugError)
 }
 
 lbug_state lbug_query_result_get_next(lbug_query_result* query_result,
     lbug_flat_tuple* out_flat_tuple) {
+    if (query_result == nullptr || query_result->_query_result == nullptr) {
+        return LbugError;
+    }
+    LBUG_C_API_GUARD_BEGIN
     try {
         clearLastCAPIErrorMessage();
         auto flat_tuple = static_cast<QueryResult*>(query_result->_query_result)->getNext();
@@ -106,29 +162,49 @@ lbug_state lbug_query_result_get_next(lbug_query_result* query_result,
         setLastCAPIErrorMessage(e.what());
         return LbugError;
     }
+    LBUG_C_API_GUARD_END(LbugError)
 }
 
 char* lbug_query_result_to_string(lbug_query_result* query_result) {
+    if (query_result == nullptr || query_result->_query_result == nullptr) {
+        return nullptr;
+    }
+    LBUG_C_API_GUARD_BEGIN
     std::string result_string = static_cast<QueryResult*>(query_result->_query_result)->toString();
     return convertToOwnedCString(result_string);
+    LBUG_C_API_GUARD_END(nullptr)
 }
 
 void lbug_query_result_reset_iterator(lbug_query_result* query_result) {
+    if (query_result == nullptr || query_result->_query_result == nullptr) {
+        return;
+    }
+    LBUG_C_API_GUARD_BEGIN
     static_cast<QueryResult*>(query_result->_query_result)->resetIterator();
+    LBUG_C_API_GUARD_END_VOID
 }
 
 lbug_state lbug_query_result_get_arrow_schema(lbug_query_result* query_result,
     ArrowSchema* out_schema) {
+    if (query_result == nullptr || query_result->_query_result == nullptr) {
+        return LbugError;
+    }
+    LBUG_C_API_GUARD_BEGIN
     try {
         *out_schema = *static_cast<QueryResult*>(query_result->_query_result)->getArrowSchema();
         return LbugSuccess;
     } catch (Exception& e) {
         return LbugError;
     }
+    LBUG_C_API_GUARD_END(LbugError)
 }
 
 lbug_state lbug_query_result_get_next_arrow_chunk(lbug_query_result* query_result,
     int64_t chunk_size, ArrowArray* out_arrow_array) {
+    if (query_result == nullptr || query_result->_query_result == nullptr) {
+        return LbugError;
+    }
+    LBUG_C_API_GUARD_BEGIN
     try {
         *out_arrow_array =
             *static_cast<QueryResult*>(query_result->_query_result)->getNextArrowChunk(chunk_size);
@@ -136,4 +212,5 @@ lbug_state lbug_query_result_get_next_arrow_chunk(lbug_query_result* query_resul
     } catch (Exception& e) {
         return LbugError;
     }
+    LBUG_C_API_GUARD_END(LbugError)
 }

--- a/src/c_api/query_summary.cpp
+++ b/src/c_api/query_summary.cpp
@@ -2,22 +2,35 @@
 
 #include <cstdlib>
 
+#include "c_api/helpers.h"
 #include "c_api/lbug.h"
 
 using namespace lbug::main;
 
 void lbug_query_summary_destroy(lbug_query_summary* query_summary) {
+    LBUG_C_API_GUARD_BEGIN
     if (query_summary == nullptr) {
         return;
     }
     // The query summary is owned by the query result, so it should not be deleted here.
     query_summary->_query_summary = nullptr;
+    LBUG_C_API_GUARD_END_VOID
 }
 
 double lbug_query_summary_get_compiling_time(lbug_query_summary* query_summary) {
+    if (query_summary == nullptr || query_summary->_query_summary == nullptr) {
+        return 0.0;
+    }
+    LBUG_C_API_GUARD_BEGIN
     return static_cast<QuerySummary*>(query_summary->_query_summary)->getCompilingTime();
+    LBUG_C_API_GUARD_END(0.0)
 }
 
 double lbug_query_summary_get_execution_time(lbug_query_summary* query_summary) {
+    if (query_summary == nullptr || query_summary->_query_summary == nullptr) {
+        return 0.0;
+    }
+    LBUG_C_API_GUARD_BEGIN
     return static_cast<QuerySummary*>(query_summary->_query_summary)->getExecutionTime();
+    LBUG_C_API_GUARD_END(0.0)
 }

--- a/src/c_api/value.cpp
+++ b/src/c_api/value.cpp
@@ -125,107 +125,154 @@ static std::unique_ptr<Value> copyValueForNested(const Value& value,
 }
 
 lbug_value* lbug_value_create_null() {
+    LBUG_C_API_GUARD_BEGIN
     auto* c_value = (lbug_value*)calloc(1, sizeof(lbug_value));
     c_value->_value = new Value(Value::createNullValue());
     return c_value;
+    LBUG_C_API_GUARD_END(nullptr)
 }
 
 lbug_value* lbug_value_create_null_with_data_type(lbug_logical_type* data_type) {
+    if (data_type == nullptr || data_type->_data_type == nullptr) {
+        return nullptr;
+    }
+    LBUG_C_API_GUARD_BEGIN
     auto* c_value = (lbug_value*)calloc(1, sizeof(lbug_value));
     c_value->_value =
         new Value(Value::createNullValue(*static_cast<LogicalType*>(data_type->_data_type)));
     return c_value;
+    LBUG_C_API_GUARD_END(nullptr)
 }
 
 bool lbug_value_is_null(lbug_value* value) {
+    if (value == nullptr || value->_value == nullptr) {
+        return false;
+    }
+    LBUG_C_API_GUARD_BEGIN
     return static_cast<Value*>(value->_value)->isNull();
+    LBUG_C_API_GUARD_END(false)
 }
 
 void lbug_value_set_null(lbug_value* value, bool is_null) {
+    if (value == nullptr || value->_value == nullptr) {
+        return;
+    }
+    LBUG_C_API_GUARD_BEGIN
     static_cast<Value*>(value->_value)->setNull(is_null);
+    LBUG_C_API_GUARD_END_VOID
 }
 
 lbug_value* lbug_value_create_default(lbug_logical_type* data_type) {
+    if (data_type == nullptr || data_type->_data_type == nullptr) {
+        return nullptr;
+    }
+    LBUG_C_API_GUARD_BEGIN
     auto* c_value = (lbug_value*)calloc(1, sizeof(lbug_value));
     c_value->_value =
         new Value(Value::createDefaultValue(*static_cast<LogicalType*>(data_type->_data_type)));
     return c_value;
+    LBUG_C_API_GUARD_END(nullptr)
 }
 
 lbug_value* lbug_value_create_bool(bool val_) {
+    LBUG_C_API_GUARD_BEGIN
     auto* c_value = (lbug_value*)calloc(1, sizeof(lbug_value));
     c_value->_value = new Value(val_);
     return c_value;
+    LBUG_C_API_GUARD_END(nullptr)
 }
 
 lbug_value* lbug_value_create_int8(int8_t val_) {
+    LBUG_C_API_GUARD_BEGIN
     auto* c_value = (lbug_value*)calloc(1, sizeof(lbug_value));
     c_value->_value = new Value(val_);
     return c_value;
+    LBUG_C_API_GUARD_END(nullptr)
 }
 
 lbug_value* lbug_value_create_int16(int16_t val_) {
+    LBUG_C_API_GUARD_BEGIN
     auto* c_value = (lbug_value*)calloc(1, sizeof(lbug_value));
     c_value->_value = new Value(val_);
     return c_value;
+    LBUG_C_API_GUARD_END(nullptr)
 }
 
 lbug_value* lbug_value_create_int32(int32_t val_) {
+    LBUG_C_API_GUARD_BEGIN
     auto* c_value = (lbug_value*)calloc(1, sizeof(lbug_value));
     c_value->_value = new Value(val_);
     return c_value;
+    LBUG_C_API_GUARD_END(nullptr)
 }
 
 lbug_value* lbug_value_create_int64(int64_t val_) {
+    LBUG_C_API_GUARD_BEGIN
     auto* c_value = (lbug_value*)calloc(1, sizeof(lbug_value));
     c_value->_value = new Value(val_);
     return c_value;
+    LBUG_C_API_GUARD_END(nullptr)
 }
 
 lbug_value* lbug_value_create_uint8(uint8_t val_) {
+    LBUG_C_API_GUARD_BEGIN
     auto* c_value = (lbug_value*)calloc(1, sizeof(lbug_value));
     c_value->_value = new Value(val_);
     return c_value;
+    LBUG_C_API_GUARD_END(nullptr)
 }
 
 lbug_value* lbug_value_create_uint16(uint16_t val_) {
+    LBUG_C_API_GUARD_BEGIN
     auto* c_value = (lbug_value*)calloc(1, sizeof(lbug_value));
     c_value->_value = new Value(val_);
     return c_value;
+    LBUG_C_API_GUARD_END(nullptr)
 }
 
 lbug_value* lbug_value_create_uint32(uint32_t val_) {
+    LBUG_C_API_GUARD_BEGIN
     auto* c_value = (lbug_value*)calloc(1, sizeof(lbug_value));
     c_value->_value = new Value(val_);
     return c_value;
+    LBUG_C_API_GUARD_END(nullptr)
 }
 
 lbug_value* lbug_value_create_uint64(uint64_t val_) {
+    LBUG_C_API_GUARD_BEGIN
     auto* c_value = (lbug_value*)calloc(1, sizeof(lbug_value));
     c_value->_value = new Value(val_);
     return c_value;
+    LBUG_C_API_GUARD_END(nullptr)
 }
 
 lbug_value* lbug_value_create_int128(lbug_int128_t val_) {
+    LBUG_C_API_GUARD_BEGIN
     auto* c_value = (lbug_value*)calloc(1, sizeof(lbug_value));
     int128_t int128(val_.low, val_.high);
     c_value->_value = new Value(int128);
     return c_value;
+    LBUG_C_API_GUARD_END(nullptr)
 }
 
 lbug_value* lbug_value_create_float(float val_) {
+    LBUG_C_API_GUARD_BEGIN
     auto* c_value = (lbug_value*)calloc(1, sizeof(lbug_value));
     c_value->_value = new Value(val_);
     return c_value;
+    LBUG_C_API_GUARD_END(nullptr)
 }
 
 lbug_value* lbug_value_create_double(double val_) {
+    LBUG_C_API_GUARD_BEGIN
     auto* c_value = (lbug_value*)calloc(1, sizeof(lbug_value));
     c_value->_value = new Value(val_);
     return c_value;
+    LBUG_C_API_GUARD_END(nullptr)
 }
 
 lbug_value* lbug_value_create_decimal(const char* val_, uint32_t precision, uint32_t scale) {
+    LBUG_C_API_GUARD_BEGIN
     auto* c_value = (lbug_value*)calloc(1, sizeof(lbug_value));
     auto decimalType = LogicalType::DECIMAL(precision, scale);
     auto value = Value::createDefaultValue(decimalType);
@@ -248,85 +295,109 @@ lbug_value* lbug_value_create_decimal(const char* val_, uint32_t precision, uint
     }
     c_value->_value = new Value(std::move(value));
     return c_value;
+    LBUG_C_API_GUARD_END(nullptr)
 }
 
 lbug_value* lbug_value_create_internal_id(lbug_internal_id_t val_) {
+    LBUG_C_API_GUARD_BEGIN
     auto* c_value = (lbug_value*)calloc(1, sizeof(lbug_value));
     internalID_t id(val_.offset, val_.table_id);
     c_value->_value = new Value(id);
     return c_value;
+    LBUG_C_API_GUARD_END(nullptr)
 }
 
 lbug_value* lbug_value_create_date(lbug_date_t val_) {
+    LBUG_C_API_GUARD_BEGIN
     auto* c_value = (lbug_value*)calloc(1, sizeof(lbug_value));
     auto date = date_t(val_.days);
     c_value->_value = new Value(date);
     return c_value;
+    LBUG_C_API_GUARD_END(nullptr)
 }
 
 lbug_value* lbug_value_create_timestamp_ns(lbug_timestamp_ns_t val_) {
+    LBUG_C_API_GUARD_BEGIN
     auto* c_value = (lbug_value*)calloc(1, sizeof(lbug_value));
     auto timestamp_ns = timestamp_ns_t(val_.value);
     c_value->_value = new Value(timestamp_ns);
     return c_value;
+    LBUG_C_API_GUARD_END(nullptr)
 }
 
 lbug_value* lbug_value_create_timestamp_ms(lbug_timestamp_ms_t val_) {
+    LBUG_C_API_GUARD_BEGIN
     auto* c_value = (lbug_value*)calloc(1, sizeof(lbug_value));
     auto timestamp_ms = timestamp_ms_t(val_.value);
     c_value->_value = new Value(timestamp_ms);
     return c_value;
+    LBUG_C_API_GUARD_END(nullptr)
 }
 
 lbug_value* lbug_value_create_timestamp_sec(lbug_timestamp_sec_t val_) {
+    LBUG_C_API_GUARD_BEGIN
     auto* c_value = (lbug_value*)calloc(1, sizeof(lbug_value));
     auto timestamp_sec = timestamp_sec_t(val_.value);
     c_value->_value = new Value(timestamp_sec);
     return c_value;
+    LBUG_C_API_GUARD_END(nullptr)
 }
 
 lbug_value* lbug_value_create_timestamp_tz(lbug_timestamp_tz_t val_) {
+    LBUG_C_API_GUARD_BEGIN
     auto* c_value = (lbug_value*)calloc(1, sizeof(lbug_value));
     auto timestamp_tz = timestamp_tz_t(val_.value);
     c_value->_value = new Value(timestamp_tz);
     return c_value;
+    LBUG_C_API_GUARD_END(nullptr)
 }
 
 lbug_value* lbug_value_create_timestamp(lbug_timestamp_t val_) {
+    LBUG_C_API_GUARD_BEGIN
     auto* c_value = (lbug_value*)calloc(1, sizeof(lbug_value));
     auto timestamp = timestamp_t(val_.value);
     c_value->_value = new Value(timestamp);
     return c_value;
+    LBUG_C_API_GUARD_END(nullptr)
 }
 
 lbug_value* lbug_value_create_interval(lbug_interval_t val_) {
+    LBUG_C_API_GUARD_BEGIN
     auto* c_value = (lbug_value*)calloc(1, sizeof(lbug_value));
     auto interval = interval_t(val_.months, val_.days, val_.micros);
     c_value->_value = new Value(interval);
     return c_value;
+    LBUG_C_API_GUARD_END(nullptr)
 }
 
 lbug_value* lbug_value_create_string(const char* val_) {
+    LBUG_C_API_GUARD_BEGIN
     auto* c_value = (lbug_value*)calloc(1, sizeof(lbug_value));
     c_value->_value = new Value(val_);
     return c_value;
+    LBUG_C_API_GUARD_END(nullptr)
 }
 
 lbug_value* lbug_value_create_json(const char* val_) {
+    LBUG_C_API_GUARD_BEGIN
     auto* c_value = (lbug_value*)calloc(1, sizeof(lbug_value));
     c_value->_value = new Value(LogicalType::JSON(), val_);
     return c_value;
+    LBUG_C_API_GUARD_END(nullptr)
 }
 
 lbug_value* lbug_value_create_uuid(const char* val_) {
+    LBUG_C_API_GUARD_BEGIN
     auto* c_value = (lbug_value*)calloc(1, sizeof(lbug_value));
     c_value->_value =
         new Value(lbug::common::uuid{lbug::common::UUID::fromCString(val_, strlen(val_))});
     return c_value;
+    LBUG_C_API_GUARD_END(nullptr)
 }
 
 lbug_state lbug_value_create_list(uint64_t num_elements, lbug_value** elements,
     lbug_value** out_value) {
+    LBUG_C_API_GUARD_BEGIN
     if (out_value == nullptr) {
         return LbugError;
     }
@@ -364,10 +435,12 @@ lbug_state lbug_value_create_list(uint64_t num_elements, lbug_value** elements,
         std::make_unique<Value>(LogicalType::LIST(type.copy()), std::move(children)));
     *out_value = c_value;
     return LbugSuccess;
+    LBUG_C_API_GUARD_END(LbugError)
 }
 
 lbug_state lbug_value_create_struct(uint64_t num_fields, const char** field_names,
     lbug_value** field_values, lbug_value** out_value) {
+    LBUG_C_API_GUARD_BEGIN
     if (out_value == nullptr) {
         return LbugError;
     }
@@ -389,10 +462,12 @@ lbug_state lbug_value_create_struct(uint64_t num_fields, const char** field_name
     c_value->_is_owned_by_cpp = false;
     *out_value = c_value;
     return LbugSuccess;
+    LBUG_C_API_GUARD_END(LbugError)
 }
 
 lbug_state lbug_value_create_map(uint64_t num_fields, lbug_value** keys, lbug_value** values,
     lbug_value** out_value) {
+    LBUG_C_API_GUARD_BEGIN
     if (out_value == nullptr) {
         return LbugError;
     }
@@ -455,19 +530,31 @@ lbug_state lbug_value_create_map(uint64_t num_fields, lbug_value** keys, lbug_va
         LogicalType::MAP(key_type.copy(), value_type.copy()), std::move(children)));
     *out_value = c_value;
     return LbugSuccess;
+    LBUG_C_API_GUARD_END(LbugError)
 }
 
 lbug_value* lbug_value_clone(lbug_value* value) {
+    if (value == nullptr || value->_value == nullptr) {
+        return nullptr;
+    }
+    LBUG_C_API_GUARD_BEGIN
     auto* c_value = (lbug_value*)calloc(1, sizeof(lbug_value));
     c_value->_value = new Value(*static_cast<Value*>(value->_value));
     return c_value;
+    LBUG_C_API_GUARD_END(nullptr)
 }
 
 void lbug_value_copy(lbug_value* value, lbug_value* other) {
+    if (value == nullptr || value->_value == nullptr) {
+        return;
+    }
+    LBUG_C_API_GUARD_BEGIN
     static_cast<Value*>(value->_value)->copyValueFrom(*static_cast<Value*>(other->_value));
+    LBUG_C_API_GUARD_END_VOID
 }
 
 void lbug_value_destroy(lbug_value* value) {
+    LBUG_C_API_GUARD_BEGIN
     if (value == nullptr) {
         return;
     }
@@ -477,18 +564,28 @@ void lbug_value_destroy(lbug_value* value) {
         }
         free(value);
     }
+    LBUG_C_API_GUARD_END_VOID
 }
 
 lbug_state lbug_value_get_list_size(lbug_value* value, uint64_t* out_result) {
+    if (value == nullptr || value->_value == nullptr) {
+        return LbugError;
+    }
+    LBUG_C_API_GUARD_BEGIN
     if (static_cast<Value*>(value->_value)->getDataType().getLogicalTypeID() !=
         LogicalTypeID::LIST) {
         return LbugError;
     }
     *out_result = NestedVal::getChildrenSize(static_cast<Value*>(value->_value));
     return LbugSuccess;
+    LBUG_C_API_GUARD_END(LbugError)
 }
 
 lbug_state lbug_value_get_list_element(lbug_value* value, uint64_t index, lbug_value* out_value) {
+    if (value == nullptr || value->_value == nullptr) {
+        return LbugError;
+    }
+    LBUG_C_API_GUARD_BEGIN
     auto physical_type_id = static_cast<Value*>(value->_value)->getDataType().getPhysicalType();
     if (physical_type_id != PhysicalTypeID::ARRAY && physical_type_id != PhysicalTypeID::STRUCT &&
         physical_type_id != PhysicalTypeID::LIST) {
@@ -506,9 +603,14 @@ lbug_state lbug_value_get_list_element(lbug_value* value, uint64_t index, lbug_v
         return LbugError;
     }
     return LbugSuccess;
+    LBUG_C_API_GUARD_END(LbugError)
 }
 
 lbug_state lbug_value_get_struct_num_fields(lbug_value* value, uint64_t* out_result) {
+    if (value == nullptr || value->_value == nullptr) {
+        return LbugError;
+    }
+    LBUG_C_API_GUARD_BEGIN
     auto physical_type_id = static_cast<Value*>(value->_value)->getDataType().getPhysicalType();
     if (physical_type_id != PhysicalTypeID::STRUCT) {
         return LbugError;
@@ -521,9 +623,14 @@ lbug_state lbug_value_get_struct_num_fields(lbug_value* value, uint64_t* out_res
     } catch (Exception& e) {
         return LbugError;
     }
+    LBUG_C_API_GUARD_END(LbugError)
 }
 
 lbug_state lbug_value_get_struct_field_name(lbug_value* value, uint64_t index, char** out_result) {
+    if (value == nullptr || value->_value == nullptr) {
+        return LbugError;
+    }
+    LBUG_C_API_GUARD_BEGIN
     auto physical_type_id = static_cast<Value*>(value->_value)->getDataType().getPhysicalType();
     if (physical_type_id != PhysicalTypeID::STRUCT) {
         return LbugError;
@@ -539,10 +646,15 @@ lbug_state lbug_value_get_struct_field_name(lbug_value* value, uint64_t index, c
     }
     *out_result = convertToOwnedCString(struct_field_name);
     return LbugSuccess;
+    LBUG_C_API_GUARD_END(LbugError)
 }
 
 lbug_state lbug_value_get_struct_field_index(lbug_value* value, const char* field_name,
     uint64_t* out_result) {
+    if (value == nullptr || value->_value == nullptr) {
+        return LbugError;
+    }
+    LBUG_C_API_GUARD_BEGIN
     auto physical_type_id = static_cast<Value*>(value->_value)->getDataType().getPhysicalType();
     if (physical_type_id != PhysicalTypeID::STRUCT) {
         return LbugError;
@@ -555,14 +667,24 @@ lbug_state lbug_value_get_struct_field_index(lbug_value* value, const char* fiel
     }
     *out_result = index;
     return LbugSuccess;
+    LBUG_C_API_GUARD_END(LbugError)
 }
 
 lbug_state lbug_value_get_struct_field_value(lbug_value* value, uint64_t index,
     lbug_value* out_value) {
+    if (value == nullptr || value->_value == nullptr) {
+        return LbugError;
+    }
+    LBUG_C_API_GUARD_BEGIN
     return lbug_value_get_list_element(value, index, out_value);
+    LBUG_C_API_GUARD_END(LbugError)
 }
 
 lbug_state lbug_value_get_map_size(lbug_value* value, uint64_t* out_result) {
+    if (value == nullptr || value->_value == nullptr) {
+        return LbugError;
+    }
+    LBUG_C_API_GUARD_BEGIN
     auto logical_type_id = static_cast<Value*>(value->_value)->getDataType().getLogicalTypeID();
     if (logical_type_id != LogicalTypeID::MAP) {
         return LbugError;
@@ -570,25 +692,40 @@ lbug_state lbug_value_get_map_size(lbug_value* value, uint64_t* out_result) {
     auto listValue = static_cast<Value*>(value->_value);
     *out_result = NestedVal::getChildrenSize(listValue);
     return LbugSuccess;
+    LBUG_C_API_GUARD_END(LbugError)
 }
 
 lbug_state lbug_value_get_map_key(lbug_value* value, uint64_t index, lbug_value* out_key) {
+    if (value == nullptr || value->_value == nullptr) {
+        return LbugError;
+    }
+    LBUG_C_API_GUARD_BEGIN
     lbug_value map_entry;
     if (lbug_value_get_list_element(value, index, &map_entry) == LbugError) {
         return LbugError;
     }
     return lbug_value_get_struct_field_value(&map_entry, 0, out_key);
+    LBUG_C_API_GUARD_END(LbugError)
 }
 
 lbug_state lbug_value_get_map_value(lbug_value* value, uint64_t index, lbug_value* out_value) {
+    if (value == nullptr || value->_value == nullptr) {
+        return LbugError;
+    }
+    LBUG_C_API_GUARD_BEGIN
     lbug_value map_entry;
     if (lbug_value_get_list_element(value, index, &map_entry) == LbugError) {
         return LbugError;
     }
     return lbug_value_get_struct_field_value(&map_entry, 1, out_value);
+    LBUG_C_API_GUARD_END(LbugError)
 }
 
 lbug_state lbug_value_get_recursive_rel_node_list(lbug_value* value, lbug_value* out_value) {
+    if (value == nullptr || value->_value == nullptr) {
+        return LbugError;
+    }
+    LBUG_C_API_GUARD_BEGIN
     auto logical_type_id = static_cast<Value*>(value->_value)->getDataType().getLogicalTypeID();
     if (logical_type_id != LogicalTypeID::RECURSIVE_REL) {
         return LbugError;
@@ -600,9 +737,14 @@ lbug_state lbug_value_get_recursive_rel_node_list(lbug_value* value, lbug_value*
         return LbugError;
     }
     return LbugSuccess;
+    LBUG_C_API_GUARD_END(LbugError)
 }
 
 lbug_state lbug_value_get_recursive_rel_rel_list(lbug_value* value, lbug_value* out_value) {
+    if (value == nullptr || value->_value == nullptr) {
+        return LbugError;
+    }
+    LBUG_C_API_GUARD_BEGIN
     auto logical_type_id = static_cast<Value*>(value->_value)->getDataType().getLogicalTypeID();
     if (logical_type_id != LogicalTypeID::RECURSIVE_REL) {
         return LbugError;
@@ -614,14 +756,24 @@ lbug_state lbug_value_get_recursive_rel_rel_list(lbug_value* value, lbug_value* 
         return LbugError;
     }
     return LbugSuccess;
+    LBUG_C_API_GUARD_END(LbugError)
 }
 
 void lbug_value_get_data_type(lbug_value* value, lbug_logical_type* out_data_type) {
+    if (value == nullptr || value->_value == nullptr) {
+        return;
+    }
+    LBUG_C_API_GUARD_BEGIN
     out_data_type->_data_type =
         new LogicalType(static_cast<Value*>(value->_value)->getDataType().copy());
+    LBUG_C_API_GUARD_END_VOID
 }
 
 lbug_state lbug_value_get_bool(lbug_value* value, bool* out_result) {
+    if (value == nullptr || value->_value == nullptr) {
+        return LbugError;
+    }
+    LBUG_C_API_GUARD_BEGIN
     auto logical_type_id = static_cast<Value*>(value->_value)->getDataType().getLogicalTypeID();
     if (logical_type_id != LogicalTypeID::BOOL) {
         return LbugError;
@@ -632,9 +784,14 @@ lbug_state lbug_value_get_bool(lbug_value* value, bool* out_result) {
         return LbugError;
     }
     return LbugSuccess;
+    LBUG_C_API_GUARD_END(LbugError)
 }
 
 lbug_state lbug_value_get_int8(lbug_value* value, int8_t* out_result) {
+    if (value == nullptr || value->_value == nullptr) {
+        return LbugError;
+    }
+    LBUG_C_API_GUARD_BEGIN
     auto logical_type_id = static_cast<Value*>(value->_value)->getDataType().getLogicalTypeID();
     if (logical_type_id != LogicalTypeID::INT8) {
         return LbugError;
@@ -645,9 +802,14 @@ lbug_state lbug_value_get_int8(lbug_value* value, int8_t* out_result) {
         return LbugError;
     }
     return LbugSuccess;
+    LBUG_C_API_GUARD_END(LbugError)
 }
 
 lbug_state lbug_value_get_int16(lbug_value* value, int16_t* out_result) {
+    if (value == nullptr || value->_value == nullptr) {
+        return LbugError;
+    }
+    LBUG_C_API_GUARD_BEGIN
     auto logical_type_id = static_cast<Value*>(value->_value)->getDataType().getLogicalTypeID();
     if (logical_type_id != LogicalTypeID::INT16) {
         return LbugError;
@@ -658,9 +820,14 @@ lbug_state lbug_value_get_int16(lbug_value* value, int16_t* out_result) {
         return LbugError;
     }
     return LbugSuccess;
+    LBUG_C_API_GUARD_END(LbugError)
 }
 
 lbug_state lbug_value_get_int32(lbug_value* value, int32_t* out_result) {
+    if (value == nullptr || value->_value == nullptr) {
+        return LbugError;
+    }
+    LBUG_C_API_GUARD_BEGIN
     auto logical_type_id = static_cast<Value*>(value->_value)->getDataType().getLogicalTypeID();
     if (logical_type_id != LogicalTypeID::INT32) {
         return LbugError;
@@ -671,9 +838,14 @@ lbug_state lbug_value_get_int32(lbug_value* value, int32_t* out_result) {
         return LbugError;
     }
     return LbugSuccess;
+    LBUG_C_API_GUARD_END(LbugError)
 }
 
 lbug_state lbug_value_get_int64(lbug_value* value, int64_t* out_result) {
+    if (value == nullptr || value->_value == nullptr) {
+        return LbugError;
+    }
+    LBUG_C_API_GUARD_BEGIN
     auto logical_type_id = static_cast<Value*>(value->_value)->getDataType().getLogicalTypeID();
     if (logical_type_id != LogicalTypeID::INT64) {
         return LbugError;
@@ -684,9 +856,14 @@ lbug_state lbug_value_get_int64(lbug_value* value, int64_t* out_result) {
         return LbugError;
     }
     return LbugSuccess;
+    LBUG_C_API_GUARD_END(LbugError)
 }
 
 lbug_state lbug_value_get_uint8(lbug_value* value, uint8_t* out_result) {
+    if (value == nullptr || value->_value == nullptr) {
+        return LbugError;
+    }
+    LBUG_C_API_GUARD_BEGIN
     auto logical_type_id = static_cast<Value*>(value->_value)->getDataType().getLogicalTypeID();
     if (logical_type_id != LogicalTypeID::UINT8) {
         return LbugError;
@@ -697,9 +874,14 @@ lbug_state lbug_value_get_uint8(lbug_value* value, uint8_t* out_result) {
         return LbugError;
     }
     return LbugSuccess;
+    LBUG_C_API_GUARD_END(LbugError)
 }
 
 lbug_state lbug_value_get_uint16(lbug_value* value, uint16_t* out_result) {
+    if (value == nullptr || value->_value == nullptr) {
+        return LbugError;
+    }
+    LBUG_C_API_GUARD_BEGIN
     auto logical_type_id = static_cast<Value*>(value->_value)->getDataType().getLogicalTypeID();
     if (logical_type_id != LogicalTypeID::UINT16) {
         return LbugError;
@@ -710,9 +892,14 @@ lbug_state lbug_value_get_uint16(lbug_value* value, uint16_t* out_result) {
         return LbugError;
     }
     return LbugSuccess;
+    LBUG_C_API_GUARD_END(LbugError)
 }
 
 lbug_state lbug_value_get_uint32(lbug_value* value, uint32_t* out_result) {
+    if (value == nullptr || value->_value == nullptr) {
+        return LbugError;
+    }
+    LBUG_C_API_GUARD_BEGIN
     auto logical_type_id = static_cast<Value*>(value->_value)->getDataType().getLogicalTypeID();
     if (logical_type_id != LogicalTypeID::UINT32) {
         return LbugError;
@@ -723,9 +910,14 @@ lbug_state lbug_value_get_uint32(lbug_value* value, uint32_t* out_result) {
         return LbugError;
     }
     return LbugSuccess;
+    LBUG_C_API_GUARD_END(LbugError)
 }
 
 lbug_state lbug_value_get_uint64(lbug_value* value, uint64_t* out_result) {
+    if (value == nullptr || value->_value == nullptr) {
+        return LbugError;
+    }
+    LBUG_C_API_GUARD_BEGIN
     auto logical_type_id = static_cast<Value*>(value->_value)->getDataType().getLogicalTypeID();
     if (logical_type_id != LogicalTypeID::UINT64) {
         return LbugError;
@@ -736,9 +928,14 @@ lbug_state lbug_value_get_uint64(lbug_value* value, uint64_t* out_result) {
         return LbugError;
     }
     return LbugSuccess;
+    LBUG_C_API_GUARD_END(LbugError)
 }
 
 lbug_state lbug_value_get_int128(lbug_value* value, lbug_int128_t* out_result) {
+    if (value == nullptr || value->_value == nullptr) {
+        return LbugError;
+    }
+    LBUG_C_API_GUARD_BEGIN
     auto logical_type_id = static_cast<Value*>(value->_value)->getDataType().getLogicalTypeID();
     if (logical_type_id != LogicalTypeID::INT128) {
         return LbugError;
@@ -751,9 +948,11 @@ lbug_state lbug_value_get_int128(lbug_value* value, lbug_int128_t* out_result) {
         return LbugError;
     }
     return LbugSuccess;
+    LBUG_C_API_GUARD_END(LbugError)
 }
 
 lbug_state lbug_int128_t_from_string(const char* str, lbug_int128_t* out_result) {
+    LBUG_C_API_GUARD_BEGIN
     int128_t int128_val = 0;
     try {
         lbug::function::CastString::operation(string_t{str, strlen(str)}, int128_val);
@@ -763,9 +962,11 @@ lbug_state lbug_int128_t_from_string(const char* str, lbug_int128_t* out_result)
         return LbugError;
     }
     return LbugSuccess;
+    LBUG_C_API_GUARD_END(LbugError)
 }
 
 lbug_state lbug_int128_t_to_string(lbug_int128_t int128_val, char** out_result) {
+    LBUG_C_API_GUARD_BEGIN
     int128_t c_int128 = 0;
     c_int128.low = int128_val.low;
     c_int128.high = int128_val.high;
@@ -775,10 +976,15 @@ lbug_state lbug_int128_t_to_string(lbug_int128_t int128_val, char** out_result) 
         return LbugError;
     }
     return LbugSuccess;
+    LBUG_C_API_GUARD_END(LbugError)
 }
 // TODO: bind all int128_t supported functions
 
 lbug_state lbug_value_get_float(lbug_value* value, float* out_result) {
+    if (value == nullptr || value->_value == nullptr) {
+        return LbugError;
+    }
+    LBUG_C_API_GUARD_BEGIN
     auto logical_type_id = static_cast<Value*>(value->_value)->getDataType().getLogicalTypeID();
     if (logical_type_id != LogicalTypeID::FLOAT) {
         return LbugError;
@@ -789,9 +995,14 @@ lbug_state lbug_value_get_float(lbug_value* value, float* out_result) {
         return LbugError;
     }
     return LbugSuccess;
+    LBUG_C_API_GUARD_END(LbugError)
 }
 
 lbug_state lbug_value_get_double(lbug_value* value, double* out_result) {
+    if (value == nullptr || value->_value == nullptr) {
+        return LbugError;
+    }
+    LBUG_C_API_GUARD_BEGIN
     auto logical_type_id = static_cast<Value*>(value->_value)->getDataType().getLogicalTypeID();
     if (logical_type_id != LogicalTypeID::DOUBLE) {
         return LbugError;
@@ -802,9 +1013,14 @@ lbug_state lbug_value_get_double(lbug_value* value, double* out_result) {
         return LbugError;
     }
     return LbugSuccess;
+    LBUG_C_API_GUARD_END(LbugError)
 }
 
 lbug_state lbug_value_get_internal_id(lbug_value* value, lbug_internal_id_t* out_result) {
+    if (value == nullptr || value->_value == nullptr) {
+        return LbugError;
+    }
+    LBUG_C_API_GUARD_BEGIN
     auto logical_type_id = static_cast<Value*>(value->_value)->getDataType().getLogicalTypeID();
     if (logical_type_id != LogicalTypeID::INTERNAL_ID) {
         return LbugError;
@@ -817,9 +1033,14 @@ lbug_state lbug_value_get_internal_id(lbug_value* value, lbug_internal_id_t* out
         return LbugError;
     }
     return LbugSuccess;
+    LBUG_C_API_GUARD_END(LbugError)
 }
 
 lbug_state lbug_value_get_date(lbug_value* value, lbug_date_t* out_result) {
+    if (value == nullptr || value->_value == nullptr) {
+        return LbugError;
+    }
+    LBUG_C_API_GUARD_BEGIN
     auto logical_type_id = static_cast<Value*>(value->_value)->getDataType().getLogicalTypeID();
     if (logical_type_id != LogicalTypeID::DATE) {
         return LbugError;
@@ -831,9 +1052,14 @@ lbug_state lbug_value_get_date(lbug_value* value, lbug_date_t* out_result) {
         return LbugError;
     }
     return LbugSuccess;
+    LBUG_C_API_GUARD_END(LbugError)
 }
 
 lbug_state lbug_value_get_timestamp(lbug_value* value, lbug_timestamp_t* out_result) {
+    if (value == nullptr || value->_value == nullptr) {
+        return LbugError;
+    }
+    LBUG_C_API_GUARD_BEGIN
     auto logical_type_id = static_cast<Value*>(value->_value)->getDataType().getLogicalTypeID();
     if (logical_type_id != LogicalTypeID::TIMESTAMP) {
         return LbugError;
@@ -845,9 +1071,14 @@ lbug_state lbug_value_get_timestamp(lbug_value* value, lbug_timestamp_t* out_res
         return LbugError;
     }
     return LbugSuccess;
+    LBUG_C_API_GUARD_END(LbugError)
 }
 
 lbug_state lbug_value_get_timestamp_ns(lbug_value* value, lbug_timestamp_ns_t* out_result) {
+    if (value == nullptr || value->_value == nullptr) {
+        return LbugError;
+    }
+    LBUG_C_API_GUARD_BEGIN
     auto logical_type_id = static_cast<Value*>(value->_value)->getDataType().getLogicalTypeID();
     if (logical_type_id != LogicalTypeID::TIMESTAMP_NS) {
         return LbugError;
@@ -859,9 +1090,14 @@ lbug_state lbug_value_get_timestamp_ns(lbug_value* value, lbug_timestamp_ns_t* o
         return LbugError;
     }
     return LbugSuccess;
+    LBUG_C_API_GUARD_END(LbugError)
 }
 
 lbug_state lbug_value_get_timestamp_ms(lbug_value* value, lbug_timestamp_ms_t* out_result) {
+    if (value == nullptr || value->_value == nullptr) {
+        return LbugError;
+    }
+    LBUG_C_API_GUARD_BEGIN
     auto logical_type_id = static_cast<Value*>(value->_value)->getDataType().getLogicalTypeID();
     if (logical_type_id != LogicalTypeID::TIMESTAMP_MS) {
         return LbugError;
@@ -873,9 +1109,14 @@ lbug_state lbug_value_get_timestamp_ms(lbug_value* value, lbug_timestamp_ms_t* o
         return LbugError;
     }
     return LbugSuccess;
+    LBUG_C_API_GUARD_END(LbugError)
 }
 
 lbug_state lbug_value_get_timestamp_sec(lbug_value* value, lbug_timestamp_sec_t* out_result) {
+    if (value == nullptr || value->_value == nullptr) {
+        return LbugError;
+    }
+    LBUG_C_API_GUARD_BEGIN
     auto logical_type_id = static_cast<Value*>(value->_value)->getDataType().getLogicalTypeID();
     if (logical_type_id != LogicalTypeID::TIMESTAMP_SEC) {
         return LbugError;
@@ -887,9 +1128,14 @@ lbug_state lbug_value_get_timestamp_sec(lbug_value* value, lbug_timestamp_sec_t*
         return LbugError;
     }
     return LbugSuccess;
+    LBUG_C_API_GUARD_END(LbugError)
 }
 
 lbug_state lbug_value_get_timestamp_tz(lbug_value* value, lbug_timestamp_tz_t* out_result) {
+    if (value == nullptr || value->_value == nullptr) {
+        return LbugError;
+    }
+    LBUG_C_API_GUARD_BEGIN
     auto logical_type_id = static_cast<Value*>(value->_value)->getDataType().getLogicalTypeID();
     if (logical_type_id != LogicalTypeID::TIMESTAMP_TZ) {
         return LbugError;
@@ -901,9 +1147,14 @@ lbug_state lbug_value_get_timestamp_tz(lbug_value* value, lbug_timestamp_tz_t* o
         return LbugError;
     }
     return LbugSuccess;
+    LBUG_C_API_GUARD_END(LbugError)
 }
 
 lbug_state lbug_value_get_decimal_as_string(lbug_value* value, char** out_result) {
+    if (value == nullptr || value->_value == nullptr) {
+        return LbugError;
+    }
+    LBUG_C_API_GUARD_BEGIN
     auto decimal_val = static_cast<Value*>(value->_value);
     auto logical_type_id = decimal_val->getDataType().getLogicalTypeID();
     if (logical_type_id != LogicalTypeID::DECIMAL) {
@@ -912,9 +1163,14 @@ lbug_state lbug_value_get_decimal_as_string(lbug_value* value, char** out_result
 
     *out_result = convertToOwnedCString(decimal_val->toString());
     return LbugSuccess;
+    LBUG_C_API_GUARD_END(LbugError)
 }
 
 lbug_state lbug_value_get_interval(lbug_value* value, lbug_interval_t* out_result) {
+    if (value == nullptr || value->_value == nullptr) {
+        return LbugError;
+    }
+    LBUG_C_API_GUARD_BEGIN
     auto logical_type_id = static_cast<Value*>(value->_value)->getDataType().getLogicalTypeID();
     if (logical_type_id != LogicalTypeID::INTERVAL) {
         return LbugError;
@@ -928,9 +1184,14 @@ lbug_state lbug_value_get_interval(lbug_value* value, lbug_interval_t* out_resul
         return LbugError;
     }
     return LbugSuccess;
+    LBUG_C_API_GUARD_END(LbugError)
 }
 
 lbug_state lbug_value_get_string(lbug_value* value, char** out_result) {
+    if (value == nullptr || value->_value == nullptr) {
+        return LbugError;
+    }
+    LBUG_C_API_GUARD_BEGIN
     auto logical_type_id = static_cast<Value*>(value->_value)->getDataType().getLogicalTypeID();
     if (logical_type_id != LogicalTypeID::STRING) {
         return LbugError;
@@ -942,9 +1203,14 @@ lbug_state lbug_value_get_string(lbug_value* value, char** out_result) {
         return LbugError;
     }
     return LbugSuccess;
+    LBUG_C_API_GUARD_END(LbugError)
 }
 
 lbug_state lbug_value_get_blob(lbug_value* value, uint8_t** out_result, uint64_t* out_length) {
+    if (value == nullptr || value->_value == nullptr) {
+        return LbugError;
+    }
+    LBUG_C_API_GUARD_BEGIN
     auto logical_type_id = static_cast<Value*>(value->_value)->getDataType().getLogicalTypeID();
     if (logical_type_id != LogicalTypeID::BLOB) {
         return LbugError;
@@ -959,9 +1225,14 @@ lbug_state lbug_value_get_blob(lbug_value* value, uint8_t** out_result, uint64_t
         return LbugError;
     }
     return LbugSuccess;
+    LBUG_C_API_GUARD_END(LbugError)
 }
 
 lbug_state lbug_value_get_uuid(lbug_value* value, char** out_result) {
+    if (value == nullptr || value->_value == nullptr) {
+        return LbugError;
+    }
+    LBUG_C_API_GUARD_BEGIN
     auto logical_type_id = static_cast<Value*>(value->_value)->getDataType().getLogicalTypeID();
     if (logical_type_id != LogicalTypeID::UUID) {
         return LbugError;
@@ -972,13 +1243,23 @@ lbug_state lbug_value_get_uuid(lbug_value* value, char** out_result) {
         return LbugError;
     }
     return LbugSuccess;
+    LBUG_C_API_GUARD_END(LbugError)
 }
 
 char* lbug_value_to_string(lbug_value* value) {
+    if (value == nullptr || value->_value == nullptr) {
+        return nullptr;
+    }
+    LBUG_C_API_GUARD_BEGIN
     return convertToOwnedCString(static_cast<Value*>(value->_value)->toString());
+    LBUG_C_API_GUARD_END(nullptr)
 }
 
 lbug_state lbug_node_val_get_id_val(lbug_value* node_val, lbug_value* out_value) {
+    if (node_val == nullptr || node_val->_value == nullptr) {
+        return LbugError;
+    }
+    LBUG_C_API_GUARD_BEGIN
     auto logical_type_id = static_cast<Value*>(node_val->_value)->getDataType().getLogicalTypeID();
     if (logical_type_id != LogicalTypeID::NODE) {
         return LbugError;
@@ -991,9 +1272,14 @@ lbug_state lbug_node_val_get_id_val(lbug_value* node_val, lbug_value* out_value)
         return LbugError;
     }
     return LbugSuccess;
+    LBUG_C_API_GUARD_END(LbugError)
 }
 
 lbug_state lbug_node_val_get_label_val(lbug_value* node_val, lbug_value* out_value) {
+    if (node_val == nullptr || node_val->_value == nullptr) {
+        return LbugError;
+    }
+    LBUG_C_API_GUARD_BEGIN
     auto logical_type_id = static_cast<Value*>(node_val->_value)->getDataType().getLogicalTypeID();
     if (logical_type_id != LogicalTypeID::NODE) {
         return LbugError;
@@ -1006,9 +1292,14 @@ lbug_state lbug_node_val_get_label_val(lbug_value* node_val, lbug_value* out_val
         return LbugError;
     }
     return LbugSuccess;
+    LBUG_C_API_GUARD_END(LbugError)
 }
 
 lbug_state lbug_node_val_get_property_size(lbug_value* node_val, uint64_t* out_result) {
+    if (node_val == nullptr || node_val->_value == nullptr) {
+        return LbugError;
+    }
+    LBUG_C_API_GUARD_BEGIN
     auto logical_type_id = static_cast<Value*>(node_val->_value)->getDataType().getLogicalTypeID();
     if (logical_type_id != LogicalTypeID::NODE) {
         return LbugError;
@@ -1019,10 +1310,15 @@ lbug_state lbug_node_val_get_property_size(lbug_value* node_val, uint64_t* out_r
         return LbugError;
     }
     return LbugSuccess;
+    LBUG_C_API_GUARD_END(LbugError)
 }
 
 lbug_state lbug_node_val_get_property_name_at(lbug_value* node_val, uint64_t index,
     char** out_result) {
+    if (node_val == nullptr || node_val->_value == nullptr) {
+        return LbugError;
+    }
+    LBUG_C_API_GUARD_BEGIN
     auto logical_type_id = static_cast<Value*>(node_val->_value)->getDataType().getLogicalTypeID();
     if (logical_type_id != LogicalTypeID::NODE) {
         return LbugError;
@@ -1038,10 +1334,15 @@ lbug_state lbug_node_val_get_property_name_at(lbug_value* node_val, uint64_t ind
         return LbugError;
     }
     return LbugSuccess;
+    LBUG_C_API_GUARD_END(LbugError)
 }
 
 lbug_state lbug_node_val_get_property_value_at(lbug_value* node_val, uint64_t index,
     lbug_value* out_value) {
+    if (node_val == nullptr || node_val->_value == nullptr) {
+        return LbugError;
+    }
+    LBUG_C_API_GUARD_BEGIN
     auto logical_type_id = static_cast<Value*>(node_val->_value)->getDataType().getLogicalTypeID();
     if (logical_type_id != LogicalTypeID::NODE) {
         return LbugError;
@@ -1054,9 +1355,14 @@ lbug_state lbug_node_val_get_property_value_at(lbug_value* node_val, uint64_t in
         return LbugError;
     }
     return LbugSuccess;
+    LBUG_C_API_GUARD_END(LbugError)
 }
 
 lbug_state lbug_node_val_to_string(lbug_value* node_val, char** out_result) {
+    if (node_val == nullptr || node_val->_value == nullptr) {
+        return LbugError;
+    }
+    LBUG_C_API_GUARD_BEGIN
     auto logical_type_id = static_cast<Value*>(node_val->_value)->getDataType().getLogicalTypeID();
     if (logical_type_id != LogicalTypeID::NODE) {
         return LbugError;
@@ -1068,9 +1374,14 @@ lbug_state lbug_node_val_to_string(lbug_value* node_val, char** out_result) {
         return LbugError;
     }
     return LbugSuccess;
+    LBUG_C_API_GUARD_END(LbugError)
 }
 
 lbug_state lbug_rel_val_get_id_val(lbug_value* rel_val, lbug_value* out_value) {
+    if (rel_val == nullptr || rel_val->_value == nullptr) {
+        return LbugError;
+    }
+    LBUG_C_API_GUARD_BEGIN
     auto logical_type_id = static_cast<Value*>(rel_val->_value)->getDataType().getLogicalTypeID();
     if (logical_type_id != LogicalTypeID::REL) {
         return LbugError;
@@ -1083,9 +1394,14 @@ lbug_state lbug_rel_val_get_id_val(lbug_value* rel_val, lbug_value* out_value) {
         return LbugError;
     }
     return LbugSuccess;
+    LBUG_C_API_GUARD_END(LbugError)
 }
 
 lbug_state lbug_rel_val_get_src_id_val(lbug_value* rel_val, lbug_value* out_value) {
+    if (rel_val == nullptr || rel_val->_value == nullptr) {
+        return LbugError;
+    }
+    LBUG_C_API_GUARD_BEGIN
     auto logical_type_id = static_cast<Value*>(rel_val->_value)->getDataType().getLogicalTypeID();
     if (logical_type_id != LogicalTypeID::REL) {
         return LbugError;
@@ -1098,9 +1414,14 @@ lbug_state lbug_rel_val_get_src_id_val(lbug_value* rel_val, lbug_value* out_valu
         return LbugError;
     }
     return LbugSuccess;
+    LBUG_C_API_GUARD_END(LbugError)
 }
 
 lbug_state lbug_rel_val_get_dst_id_val(lbug_value* rel_val, lbug_value* out_value) {
+    if (rel_val == nullptr || rel_val->_value == nullptr) {
+        return LbugError;
+    }
+    LBUG_C_API_GUARD_BEGIN
     auto logical_type_id = static_cast<Value*>(rel_val->_value)->getDataType().getLogicalTypeID();
     if (logical_type_id != LogicalTypeID::REL) {
         return LbugError;
@@ -1113,9 +1434,14 @@ lbug_state lbug_rel_val_get_dst_id_val(lbug_value* rel_val, lbug_value* out_valu
         return LbugError;
     }
     return LbugSuccess;
+    LBUG_C_API_GUARD_END(LbugError)
 }
 
 lbug_state lbug_rel_val_get_label_val(lbug_value* rel_val, lbug_value* out_value) {
+    if (rel_val == nullptr || rel_val->_value == nullptr) {
+        return LbugError;
+    }
+    LBUG_C_API_GUARD_BEGIN
     auto logical_type_id = static_cast<Value*>(rel_val->_value)->getDataType().getLogicalTypeID();
     if (logical_type_id != LogicalTypeID::REL) {
         return LbugError;
@@ -1128,9 +1454,14 @@ lbug_state lbug_rel_val_get_label_val(lbug_value* rel_val, lbug_value* out_value
         return LbugError;
     }
     return LbugSuccess;
+    LBUG_C_API_GUARD_END(LbugError)
 }
 
 lbug_state lbug_rel_val_get_property_size(lbug_value* rel_val, uint64_t* out_result) {
+    if (rel_val == nullptr || rel_val->_value == nullptr) {
+        return LbugError;
+    }
+    LBUG_C_API_GUARD_BEGIN
     auto logical_type_id = static_cast<Value*>(rel_val->_value)->getDataType().getLogicalTypeID();
     if (logical_type_id != LogicalTypeID::REL) {
         return LbugError;
@@ -1141,9 +1472,14 @@ lbug_state lbug_rel_val_get_property_size(lbug_value* rel_val, uint64_t* out_res
         return LbugError;
     }
     return LbugSuccess;
+    LBUG_C_API_GUARD_END(LbugError)
 }
 lbug_state lbug_rel_val_get_property_name_at(lbug_value* rel_val, uint64_t index,
     char** out_result) {
+    if (rel_val == nullptr || rel_val->_value == nullptr) {
+        return LbugError;
+    }
+    LBUG_C_API_GUARD_BEGIN
     auto logical_type_id = static_cast<Value*>(rel_val->_value)->getDataType().getLogicalTypeID();
     if (logical_type_id != LogicalTypeID::REL) {
         return LbugError;
@@ -1159,10 +1495,15 @@ lbug_state lbug_rel_val_get_property_name_at(lbug_value* rel_val, uint64_t index
         return LbugError;
     }
     return LbugSuccess;
+    LBUG_C_API_GUARD_END(LbugError)
 }
 
 lbug_state lbug_rel_val_get_property_value_at(lbug_value* rel_val, uint64_t index,
     lbug_value* out_value) {
+    if (rel_val == nullptr || rel_val->_value == nullptr) {
+        return LbugError;
+    }
+    LBUG_C_API_GUARD_BEGIN
     auto logical_type_id = static_cast<Value*>(rel_val->_value)->getDataType().getLogicalTypeID();
     if (logical_type_id != LogicalTypeID::REL) {
         return LbugError;
@@ -1175,9 +1516,14 @@ lbug_state lbug_rel_val_get_property_value_at(lbug_value* rel_val, uint64_t inde
         return LbugError;
     }
     return LbugSuccess;
+    LBUG_C_API_GUARD_END(LbugError)
 }
 
 lbug_state lbug_rel_val_to_string(lbug_value* rel_val, char** out_result) {
+    if (rel_val == nullptr || rel_val->_value == nullptr) {
+        return LbugError;
+    }
+    LBUG_C_API_GUARD_BEGIN
     auto logical_type_id = static_cast<Value*>(rel_val->_value)->getDataType().getLogicalTypeID();
     if (logical_type_id != LogicalTypeID::REL) {
         return LbugError;
@@ -1188,17 +1534,23 @@ lbug_state lbug_rel_val_to_string(lbug_value* rel_val, char** out_result) {
         return LbugError;
     }
     return LbugSuccess;
+    LBUG_C_API_GUARD_END(LbugError)
 }
 
 void lbug_destroy_string(char* str) {
+    LBUG_C_API_GUARD_BEGIN
     free(str);
+    LBUG_C_API_GUARD_END_VOID
 }
 
 void lbug_destroy_blob(uint8_t* blob) {
+    LBUG_C_API_GUARD_BEGIN
     free(blob);
+    LBUG_C_API_GUARD_END_VOID
 }
 
 lbug_state lbug_timestamp_ns_to_tm(lbug_timestamp_ns_t timestamp, struct tm* out_result) {
+    LBUG_C_API_GUARD_BEGIN
     time_t time = timestamp.value / 1000000000;
 #ifdef _WIN32
     if (convertTimeToTm(time, out_result) != 0) {
@@ -1210,9 +1562,11 @@ lbug_state lbug_timestamp_ns_to_tm(lbug_timestamp_ns_t timestamp, struct tm* out
     }
 #endif
     return LbugSuccess;
+    LBUG_C_API_GUARD_END(LbugError)
 }
 
 lbug_state lbug_timestamp_ms_to_tm(lbug_timestamp_ms_t timestamp, struct tm* out_result) {
+    LBUG_C_API_GUARD_BEGIN
     time_t time = timestamp.value / 1000;
 #ifdef _WIN32
     if (convertTimeToTm(time, out_result) != 0) {
@@ -1224,9 +1578,11 @@ lbug_state lbug_timestamp_ms_to_tm(lbug_timestamp_ms_t timestamp, struct tm* out
     }
 #endif
     return LbugSuccess;
+    LBUG_C_API_GUARD_END(LbugError)
 }
 
 lbug_state lbug_timestamp_sec_to_tm(lbug_timestamp_sec_t timestamp, struct tm* out_result) {
+    LBUG_C_API_GUARD_BEGIN
     time_t time = timestamp.value;
 #ifdef _WIN32
     if (convertTimeToTm(time, out_result) != 0) {
@@ -1238,9 +1594,11 @@ lbug_state lbug_timestamp_sec_to_tm(lbug_timestamp_sec_t timestamp, struct tm* o
     }
 #endif
     return LbugSuccess;
+    LBUG_C_API_GUARD_END(LbugError)
 }
 
 lbug_state lbug_timestamp_tz_to_tm(lbug_timestamp_tz_t timestamp, struct tm* out_result) {
+    LBUG_C_API_GUARD_BEGIN
     time_t time = timestamp.value / 1000000;
 #ifdef _WIN32
     if (convertTimeToTm(time, out_result) != 0) {
@@ -1252,9 +1610,11 @@ lbug_state lbug_timestamp_tz_to_tm(lbug_timestamp_tz_t timestamp, struct tm* out
     }
 #endif
     return LbugSuccess;
+    LBUG_C_API_GUARD_END(LbugError)
 }
 
 lbug_state lbug_timestamp_to_tm(lbug_timestamp_t timestamp, struct tm* out_result) {
+    LBUG_C_API_GUARD_BEGIN
     time_t time = timestamp.value / 1000000;
 #ifdef _WIN32
     if (convertTimeToTm(time, out_result) != 0) {
@@ -1266,9 +1626,11 @@ lbug_state lbug_timestamp_to_tm(lbug_timestamp_t timestamp, struct tm* out_resul
     }
 #endif
     return LbugSuccess;
+    LBUG_C_API_GUARD_END(LbugError)
 }
 
 lbug_state lbug_timestamp_ns_from_tm(struct tm tm, lbug_timestamp_ns_t* out_result) {
+    LBUG_C_API_GUARD_BEGIN
 #ifdef _WIN32
     int64_t time = convertTmToTime(tm);
 #else
@@ -1279,9 +1641,11 @@ lbug_state lbug_timestamp_ns_from_tm(struct tm tm, lbug_timestamp_ns_t* out_resu
     }
     out_result->value = time * 1000000000;
     return LbugSuccess;
+    LBUG_C_API_GUARD_END(LbugError)
 }
 
 lbug_state lbug_timestamp_ms_from_tm(struct tm tm, lbug_timestamp_ms_t* out_result) {
+    LBUG_C_API_GUARD_BEGIN
 #ifdef _WIN32
     int64_t time = convertTmToTime(tm);
 #else
@@ -1292,9 +1656,11 @@ lbug_state lbug_timestamp_ms_from_tm(struct tm tm, lbug_timestamp_ms_t* out_resu
     }
     out_result->value = time * 1000;
     return LbugSuccess;
+    LBUG_C_API_GUARD_END(LbugError)
 }
 
 lbug_state lbug_timestamp_sec_from_tm(struct tm tm, lbug_timestamp_sec_t* out_result) {
+    LBUG_C_API_GUARD_BEGIN
 #ifdef _WIN32
     int64_t time = convertTmToTime(tm);
 #else
@@ -1305,9 +1671,11 @@ lbug_state lbug_timestamp_sec_from_tm(struct tm tm, lbug_timestamp_sec_t* out_re
     }
     out_result->value = time;
     return LbugSuccess;
+    LBUG_C_API_GUARD_END(LbugError)
 }
 
 lbug_state lbug_timestamp_tz_from_tm(struct tm tm, lbug_timestamp_tz_t* out_result) {
+    LBUG_C_API_GUARD_BEGIN
 #ifdef _WIN32
     int64_t time = convertTmToTime(tm);
 #else
@@ -1318,9 +1686,11 @@ lbug_state lbug_timestamp_tz_from_tm(struct tm tm, lbug_timestamp_tz_t* out_resu
     }
     out_result->value = time * 1000000;
     return LbugSuccess;
+    LBUG_C_API_GUARD_END(LbugError)
 }
 
 lbug_state lbug_timestamp_from_tm(struct tm tm, lbug_timestamp_t* out_result) {
+    LBUG_C_API_GUARD_BEGIN
 #ifdef _WIN32
     int64_t time = convertTmToTime(tm);
 #else
@@ -1331,9 +1701,11 @@ lbug_state lbug_timestamp_from_tm(struct tm tm, lbug_timestamp_t* out_result) {
     }
     out_result->value = time * 1000000;
     return LbugSuccess;
+    LBUG_C_API_GUARD_END(LbugError)
 }
 
 lbug_state lbug_date_to_tm(lbug_date_t date, struct tm* out_result) {
+    LBUG_C_API_GUARD_BEGIN
     time_t time = date.days * 86400;
 #ifdef _WIN32
     if (convertTimeToTm(time, out_result) != 0) {
@@ -1348,9 +1720,11 @@ lbug_state lbug_date_to_tm(lbug_date_t date, struct tm* out_result) {
     out_result->tm_min = 0;
     out_result->tm_sec = 0;
     return LbugSuccess;
+    LBUG_C_API_GUARD_END(LbugError)
 }
 
 lbug_state lbug_date_from_tm(struct tm tm, lbug_date_t* out_result) {
+    LBUG_C_API_GUARD_BEGIN
 #ifdef _WIN32
     int64_t time = convertTmToTime(tm);
 #else
@@ -1361,9 +1735,11 @@ lbug_state lbug_date_from_tm(struct tm tm, lbug_date_t* out_result) {
     }
     out_result->days = time / 86400;
     return LbugSuccess;
+    LBUG_C_API_GUARD_END(LbugError)
 }
 
 lbug_state lbug_date_to_string(lbug_date_t date, char** out_result) {
+    LBUG_C_API_GUARD_BEGIN
     tm tm{};
     if (lbug_date_to_tm(date, &tm) != LbugSuccess) {
         return LbugError;
@@ -1374,9 +1750,11 @@ lbug_state lbug_date_to_string(lbug_date_t date, char** out_result) {
     }
     *out_result = convertToOwnedCString(buffer);
     return LbugSuccess;
+    LBUG_C_API_GUARD_END(LbugError)
 }
 
 lbug_state lbug_date_from_string(const char* str, lbug_date_t* out_result) {
+    LBUG_C_API_GUARD_BEGIN
     try {
         date_t date = Date::fromCString(str, strlen(str));
         out_result->days = date.days;
@@ -1384,20 +1762,25 @@ lbug_state lbug_date_from_string(const char* str, lbug_date_t* out_result) {
         return LbugError;
     }
     return LbugSuccess;
+    LBUG_C_API_GUARD_END(LbugError)
 }
 
 void lbug_interval_to_difftime(lbug_interval_t interval, double* out_result) {
+    LBUG_C_API_GUARD_BEGIN
     auto micros = interval.micros + interval.months * Interval::MICROS_PER_MONTH +
                   interval.days * Interval::MICROS_PER_DAY;
     double seconds = micros / 1000000.0;
     *out_result = seconds;
+    LBUG_C_API_GUARD_END_VOID
 }
 
 void lbug_interval_from_difftime(double difftime, lbug_interval_t* out_result) {
+    LBUG_C_API_GUARD_BEGIN
     int64_t total_micros = static_cast<int64_t>(difftime * 1000000);
     out_result->months = total_micros / Interval::MICROS_PER_MONTH;
     total_micros -= out_result->months * Interval::MICROS_PER_MONTH;
     out_result->days = total_micros / Interval::MICROS_PER_DAY;
     total_micros -= out_result->days * Interval::MICROS_PER_DAY;
     out_result->micros = total_micros;
+    LBUG_C_API_GUARD_END_VOID
 }

--- a/src/c_api/version.cpp
+++ b/src/c_api/version.cpp
@@ -4,13 +4,17 @@
 #include "c_api/lbug.h"
 
 char* lbug_get_version() {
+    LBUG_C_API_GUARD_BEGIN
     auto version = lbug::main::Version::getVersion();
     if (version == nullptr || version[0] == '\0') {
         version = "0.18.1";
     }
     return convertToOwnedCString(version);
+    LBUG_C_API_GUARD_END(nullptr)
 }
 
 uint64_t lbug_get_storage_version() {
+    LBUG_C_API_GUARD_BEGIN
     return lbug::main::Version::getStorageVersion();
+    LBUG_C_API_GUARD_END(0)
 }

--- a/src/include/c_api/helpers.h
+++ b/src/include/c_api/helpers.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstdint>
+#include <exception>
 #include <string>
 #ifdef _WIN32
 #include <time.h>
@@ -19,3 +20,33 @@ void clearLastCAPIErrorMessage();
 char* takeLastCAPIErrorMessage();
 
 char* convertToOwnedCString(const std::string& str);
+
+// Exception floor for C API entry points. No C++ exception may cross the C
+// boundary: an escaping exception in an extern "C" function reaches
+// std::terminate in the caller's process (observed from embedding runtimes).
+// Wrap the throwing region of an entry point:
+//   LBUG_C_API_GUARD_BEGIN
+//   ... body ...
+//   LBUG_C_API_GUARD_END(<value to return on error>)
+#define LBUG_C_API_GUARD_BEGIN try {
+#define LBUG_C_API_GUARD_END(err_ret)                                                              \
+    }                                                                                              \
+    catch (const std::exception& e) {                                                              \
+        setLastCAPIErrorMessage(e.what());                                                         \
+        return err_ret;                                                                            \
+    }                                                                                              \
+    catch (...) {                                                                                  \
+        setLastCAPIErrorMessage("unknown C++ exception in lbug C API");                            \
+        return err_ret;                                                                            \
+    }
+
+// Void-returning variant of the exception floor: swallows the exception after
+// recording it, since there is no error value to return.
+#define LBUG_C_API_GUARD_END_VOID                                                                  \
+    }                                                                                              \
+    catch (const std::exception& e) {                                                              \
+        setLastCAPIErrorMessage(e.what());                                                         \
+    }                                                                                              \
+    catch (...) {                                                                                  \
+        setLastCAPIErrorMessage("unknown C++ exception in lbug C API");                            \
+    }

--- a/test/c_api/value_test.cpp
+++ b/test/c_api/value_test.cpp
@@ -2354,3 +2354,15 @@ TEST_F(CApiValueTest, GetIntervalFromDifftime) {
     ASSERT_EQ(interval.days, 13);
     ASSERT_EQ(interval.micros, 34960479000);
 }
+
+TEST(CApiValueTestEmptyDB, NullHandleReturnsErrorNotCrash) {
+    // The C API exception floor: null or empty handles come back as errors, never as
+    // dereferences of nullptr crossing the C boundary.
+    int64_t int_out = 42;
+    ASSERT_EQ(lbug_value_get_int64(nullptr, &int_out), LbugError);
+    uint64_t size_out = 42;
+    ASSERT_EQ(lbug_value_get_list_size(nullptr, &size_out), LbugError);
+    ASSERT_EQ(lbug_value_clone(nullptr), nullptr);
+    ASSERT_EQ(lbug_value_to_string(nullptr), nullptr);
+    ASSERT_EQ(lbug_value_create_null_with_data_type(nullptr), nullptr);
+}


### PR DESCRIPTION
[source](https://github.com/skylence-be/ladybug/pull/16)

No C++ exception may cross the C ABI: an escaping exception in an extern "C" function reaches std::terminate in the embedder's process. Introduces LBUG_C_API_GUARD_BEGIN/END(err)/END_VOID macros (c_api/helpers.h) and wraps every entry point in value.cpp (106), query_result.cpp (16), prepared_statement.cpp (25), query_summary.cpp (3), and version.cpp (2) — 152 total. A null or empty first handle returns the function's error value (LbugError / nullptr / false / 0) instead of dereferencing nullptr; destroy functions keep their own null handling and are guard-only. Also null-checks convertToOwnedCString's malloc. Regression test:
CApiValueTestEmptyDB.NullHandleReturnsErrorNotCrash.

The conversion was mechanical (scripted guard/null-check insertion, then clang-format), so the diff is large but strictly additive: no existing statement was modified.
