### PR TITLE
ci: relocate pg_client libpq dependency on macOS before packaging

### DIFF
--- a/.github/workflows/build-extensions.yml
+++ b/.github/workflows/build-extensions.yml
@@ -173,6 +173,21 @@ jobs:
           MACOSX_DEPLOYMENT_TARGET: 13.3
           CMAKE_OSX_ARCHITECTURES: ${{ matrix.cmake_osx_architectures }}
 
+      - name: Relocate libpq dependency for distribution (macOS)
+        if: runner.os == 'macOS'
+        # pg_client links against the keg-only standalone `libpq` Homebrew
+        # formula at /opt/homebrew/opt/libpq/lib/libpq.5.dylib, which is not
+        # present on machines that install libpq via `postgresql@18` instead.
+        # Relocate the dependency to @rpath with the common Homebrew locations
+        # as fallbacks so the released binary loads in either layout, and
+        # verify the result. See LadybugDB/extensions#48.
+        run: |
+          set -euo pipefail
+          while IFS= read -r -d '' ext; do
+            extension/scripts/relocate-macos-libpq.sh "$ext"
+            extension/scripts/verify-macos-libpq-rpaths.sh "$ext"
+          done < <(find extension/pg_client/build -maxdepth 1 -name '*.lbug_extension' -print0)
+
       - name: Enable long paths (Windows)
         if: runner.os == 'Windows'
         run: |


### PR DESCRIPTION
Wiring for [LadybugDB/extensions#48](https://github.com/LadybugDB/extensions/issues/48) (macOS arm64 `pg_client` 0.19.0 fails to load on machines with only `postgresql@18` installed).

## Changes

After the macOS extension build, relocate and verify the built pg_client extension before `collect-extensions.py` packages the artifacts:

```yaml
extension/scripts/relocate-macos-libpq.sh 
extension/scripts/verify-macos-libpq-rpaths.sh 
```

The new macOS step rewrites the libpq install name recorded by the keg-only standalone `libpq` formula (`/opt/homebrew/opt/libpq/lib/libpq.5.dylib`) to `@rpath/libpq.5.dylib` with the common Homebrew locations (standalone `libpq` + bundled `postgresql@18`, `/opt/homebrew` and `/usr/local`) as `LC_RPATH` fallbacks, so the released binary loads in either layout.

Also bumps the `extension` submodule from `4bd1dc1` to `5ffb349`, which pulls in the two relocation scripts from [LadybugDB/extensions#49](https://github.com/LadybugDB/extensions/pull/49) (plus the 5 extensions commits on main since the previous pin).

## Notes

- This is a two-repo change: LadybugDB/extensions#49 adds the scripts; this PR wires them into the build. The submodule pin points at the extensions PR branch commit `5ffb349`, which stays valid regardless of merge order; once that PR merges, the pin can be advanced to the new extensions main SHA.
- The relocation is macOS-only (`if: runner.os == 'macOS'`), matching where the standalone-libpq link path is recorded.
- Scripts were validated locally: dylib linked against standalone libpq → repositioned to `@rpath` + 6 rpaths, verify passes, idempotent, and a simulated postgresql@18-only machine loads the patched binary.