### PR TITLE
add time_bucket feature

### DIFF
--- a/src/function/function_collection.cpp
+++ b/src/function/function_collection.cpp
@@ -24,6 +24,7 @@
 #include "function/struct/vector_struct_functions.h"
 #include "function/table/simple_table_function.h"
 #include "function/table/standalone_call_function.h"
+#include "function/timestamp/time_bucket.h"
 #include "function/timestamp/vector_timestamp_functions.h"
 #include "function/union/vector_union_functions.h"
 #include "function/utility/vector_utility_functions.h"
@@ -164,7 +165,7 @@ FunctionCollection* FunctionCollection::getFunctions() {
         // Timestamp functions
         SCALAR_FUNCTION(CenturyFunction), SCALAR_FUNCTION(EpochMsFunction),
         SCALAR_FUNCTION(ToTimestampFunction), SCALAR_FUNCTION(CurrentTimestampFunction),
-        SCALAR_FUNCTION(ToEpochMsFunction),
+        SCALAR_FUNCTION(ToEpochMsFunction), SCALAR_FUNCTION(TimeBucketFunction),
 
         // Interval functions
         SCALAR_FUNCTION(ToYearsFunction), SCALAR_FUNCTION(ToMonthsFunction),

--- a/src/function/timestamp/CMakeLists.txt
+++ b/src/function/timestamp/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_library(lbug_timestamp_function
         OBJECT
+        time_bucket.cpp
         to_epoch_ms.cpp)
 
 set(ALL_OBJECT_FILES

--- a/src/function/timestamp/time_bucket.cpp
+++ b/src/function/timestamp/time_bucket.cpp
@@ -1,0 +1,294 @@
+#include "function/timestamp/time_bucket.h"
+
+#include <limits>
+#include <memory>
+#include <type_traits>
+#include <vector>
+
+#include "binder/expression/literal_expression.h"
+#include "common/exception/binder.h"
+#include "common/exception/overflow.h"
+#include "common/types/date_t.h"
+#include "common/types/interval_t.h"
+#include "common/types/timestamp_t.h"
+
+using namespace lbug::binder;
+using namespace lbug::common;
+
+namespace lbug {
+namespace function {
+
+namespace {
+
+// Ladybug stores DATE and TIMESTAMP values relative to the Unix epoch.
+const int64_t EPOCH_ANCHOR_MICROS = 0;
+
+struct TimeBucketBindData final : FunctionBindData {
+    explicit TimeBucketBindData(std::vector<LogicalType> paramTypes, LogicalType resultType,
+        interval_t interval)
+        : FunctionBindData{std::move(paramTypes), std::move(resultType)}, interval{interval} {}
+
+    std::unique_ptr<FunctionBindData> copy() const override {
+        return std::make_unique<TimeBucketBindData>(LogicalType::copy(paramTypes),
+            resultType.copy(), interval);
+    }
+
+    interval_t interval;
+};
+
+static __int128 floorDiv(__int128 value, __int128 divisor) {
+    auto quotient = value / divisor;
+    if (value % divisor < 0) {
+        --quotient;
+    }
+    return quotient;
+}
+
+static int64_t fixedDurationMicros(const interval_t& interval) {
+    const auto duration = static_cast<__int128>(interval.days) * Interval::MICROS_PER_DAY +
+                          static_cast<__int128>(interval.micros);
+    if (duration <= 0 || duration > std::numeric_limits<int64_t>::max()) {
+        throw BinderException("time_bucket interval must be positive and representable.");
+    }
+    return static_cast<int64_t>(duration);
+}
+
+static interval_t multiplyInterval(const interval_t& interval, int64_t multiplier) {
+    const auto months = static_cast<__int128>(interval.months) * multiplier;
+    const auto days = static_cast<__int128>(interval.days) * multiplier;
+    const auto micros = static_cast<__int128>(interval.micros) * multiplier;
+    if (months < std::numeric_limits<int32_t>::min() ||
+        months > std::numeric_limits<int32_t>::max() ||
+        days < std::numeric_limits<int32_t>::min() || days > std::numeric_limits<int32_t>::max() ||
+        micros < std::numeric_limits<int64_t>::min() ||
+        micros > std::numeric_limits<int64_t>::max()) {
+        throw OverflowException("time_bucket interval multiplier is out of range.");
+    }
+    return interval_t{static_cast<int32_t>(months), static_cast<int32_t>(days),
+        static_cast<int64_t>(micros)};
+}
+
+static timestamp_t calendarBucket(timestamp_t value, const interval_t& interval) {
+    const timestamp_t anchor{EPOCH_ANCHOR_MICROS};
+    auto candidate = [&](int64_t index) { return anchor + multiplyInterval(interval, index); };
+    int64_t low = 0;
+    int64_t high = 0;
+    if (value >= anchor) {
+        high = 1;
+        while (candidate(high) <= value) {
+            low = high;
+            if (high > std::numeric_limits<int32_t>::max() / 2) {
+                throw OverflowException("time_bucket calendar bucket is out of range.");
+            }
+            high *= 2;
+        }
+    } else {
+        low = -1;
+        while (candidate(low) > value) {
+            high = low;
+            if (low < std::numeric_limits<int32_t>::min() / 2) {
+                throw OverflowException("time_bucket calendar bucket is out of range.");
+            }
+            low *= 2;
+        }
+    }
+    while (high - low > 1) {
+        const auto mid = low + (high - low) / 2;
+        if (candidate(mid) <= value) {
+            low = mid;
+        } else {
+            high = mid;
+        }
+    }
+    return candidate(low);
+}
+
+static timestamp_t bucketTimestamp(timestamp_t value, const interval_t& interval) {
+    if (interval.months != 0) {
+        return calendarBucket(value, interval);
+    }
+    const auto width = fixedDurationMicros(interval);
+    const auto result = floorDiv(value.value, width) * width;
+    if (result < std::numeric_limits<int64_t>::min() ||
+        result > std::numeric_limits<int64_t>::max()) {
+        throw OverflowException("time_bucket result is out of TIMESTAMP range.");
+    }
+    return timestamp_t{static_cast<int64_t>(result)};
+}
+
+static date_t bucketDate(date_t value, const interval_t& interval) {
+    if (interval.micros % Interval::MICROS_PER_DAY != 0) {
+        throw BinderException("time_bucket DATE interval must be a whole number of days.");
+    }
+    const auto timestamp = Timestamp::fromDateTime(value, dtime_t{0});
+    return Timestamp::getDate(bucketTimestamp(timestamp, interval));
+}
+
+template<typename T>
+static T bucketTimestampValue(T value, const interval_t& interval) {
+    if (interval.months == 0) {
+        const auto widthMicros = fixedDurationMicros(interval);
+        __int128 bucketValue = 0;
+        if constexpr (std::is_same_v<T, timestamp_sec_t>) {
+            const auto width = widthMicros / Interval::MICROS_PER_SEC;
+            bucketValue = floorDiv(value.value, width) * width;
+        } else if constexpr (std::is_same_v<T, timestamp_ms_t>) {
+            const auto width = widthMicros / Interval::MICROS_PER_MSEC;
+            bucketValue = floorDiv(value.value, width) * width;
+        } else if constexpr (std::is_same_v<T, timestamp_ns_t>) {
+            const auto width = static_cast<__int128>(widthMicros) * Interval::NANOS_PER_MICRO;
+            bucketValue = floorDiv(value.value, width) * width;
+        } else {
+            bucketValue = floorDiv(value.value, widthMicros) * widthMicros;
+        }
+        if (bucketValue < std::numeric_limits<int64_t>::min() ||
+            bucketValue > std::numeric_limits<int64_t>::max()) {
+            throw OverflowException("time_bucket result is out of range.");
+        }
+        return T{static_cast<int64_t>(bucketValue)};
+    }
+
+    timestamp_t timestamp;
+    if constexpr (std::is_same_v<T, timestamp_sec_t>) {
+        timestamp = Timestamp::fromEpochSeconds(value.value);
+    } else if constexpr (std::is_same_v<T, timestamp_ms_t>) {
+        timestamp = Timestamp::fromEpochMilliSeconds(value.value);
+    } else if constexpr (std::is_same_v<T, timestamp_ns_t>) {
+        timestamp =
+            timestamp_t{static_cast<int64_t>(floorDiv(value.value, Interval::NANOS_PER_MICRO))};
+    } else {
+        timestamp = timestamp_t{value.value};
+    }
+    const auto result = bucketTimestamp(timestamp, interval);
+    if constexpr (std::is_same_v<T, timestamp_sec_t>) {
+        return timestamp_sec_t{Timestamp::getEpochSeconds(result)};
+    } else if constexpr (std::is_same_v<T, timestamp_ms_t>) {
+        return timestamp_ms_t{Timestamp::getEpochMilliSeconds(result)};
+    } else if constexpr (std::is_same_v<T, timestamp_ns_t>) {
+        const auto resultNanos = static_cast<__int128>(result.value) * Interval::NANOS_PER_MICRO;
+        if (resultNanos < std::numeric_limits<int64_t>::min() ||
+            resultNanos > std::numeric_limits<int64_t>::max()) {
+            throw OverflowException("time_bucket result is out of TIMESTAMP_NS range.");
+        }
+        return timestamp_ns_t{static_cast<int64_t>(resultNanos)};
+    } else {
+        return T{result.value};
+    }
+}
+
+template<typename T>
+static void executeTimestamp(const ValueVector& input, SelectionVector* inputSel,
+    ValueVector& result, SelectionVector* resultSel, const interval_t& interval) {
+    const auto inputUnfiltered = inputSel->isUnfiltered();
+    const auto resultUnfiltered = resultSel->isUnfiltered();
+    for (auto i = 0u; i < inputSel->getSelSize(); ++i) {
+        const auto inputPos = inputUnfiltered ? i : (*inputSel)[i];
+        const auto resultPos = resultUnfiltered ? i : (*resultSel)[i];
+        result.setNull(resultPos, input.isNull(inputPos));
+        if (!result.isNull(resultPos)) {
+            result.setValue(resultPos, bucketTimestampValue(input.getValue<T>(inputPos), interval));
+        }
+    }
+}
+
+static void executeDate(const ValueVector& input, SelectionVector* inputSel, ValueVector& result,
+    SelectionVector* resultSel, const interval_t& interval) {
+    const auto inputUnfiltered = inputSel->isUnfiltered();
+    const auto resultUnfiltered = resultSel->isUnfiltered();
+    for (auto i = 0u; i < inputSel->getSelSize(); ++i) {
+        const auto inputPos = inputUnfiltered ? i : (*inputSel)[i];
+        const auto resultPos = resultUnfiltered ? i : (*resultSel)[i];
+        result.setNull(resultPos, input.isNull(inputPos));
+        if (!result.isNull(resultPos)) {
+            result.setValue(resultPos, bucketDate(input.getValue<date_t>(inputPos), interval));
+        }
+    }
+}
+
+static void execFunc(const std::vector<std::shared_ptr<ValueVector>>& parameters,
+    const std::vector<SelectionVector*>& parameterSelVectors, ValueVector& result,
+    SelectionVector* resultSelVector, void* dataPtr) {
+    DASSERT(parameters.size() == 2);
+    const auto& bindData = *reinterpret_cast<TimeBucketBindData*>(dataPtr);
+    const auto& input = *parameters[1];
+    switch (input.dataType.getLogicalTypeID()) {
+    case LogicalTypeID::DATE:
+        executeDate(input, parameterSelVectors[1], result, resultSelVector, bindData.interval);
+        return;
+    case LogicalTypeID::TIMESTAMP:
+        executeTimestamp<timestamp_t>(input, parameterSelVectors[1], result, resultSelVector,
+            bindData.interval);
+        return;
+    case LogicalTypeID::TIMESTAMP_TZ:
+        executeTimestamp<timestamp_tz_t>(input, parameterSelVectors[1], result, resultSelVector,
+            bindData.interval);
+        return;
+    case LogicalTypeID::TIMESTAMP_SEC:
+        executeTimestamp<timestamp_sec_t>(input, parameterSelVectors[1], result, resultSelVector,
+            bindData.interval);
+        return;
+    case LogicalTypeID::TIMESTAMP_MS:
+        executeTimestamp<timestamp_ms_t>(input, parameterSelVectors[1], result, resultSelVector,
+            bindData.interval);
+        return;
+    case LogicalTypeID::TIMESTAMP_NS:
+        executeTimestamp<timestamp_ns_t>(input, parameterSelVectors[1], result, resultSelVector,
+            bindData.interval);
+        return;
+    default:
+        throw BinderException("time_bucket requires a Ladybug date/time value.");
+    }
+}
+
+static std::unique_ptr<FunctionBindData> bindFunc(const ScalarBindFuncInput& input) {
+    if (input.arguments.size() != 2 ||
+        input.arguments[0]->expressionType != ExpressionType::LITERAL) {
+        throw BinderException("First parameter of time_bucket must be a constant INTERVAL.");
+    }
+    const auto& intervalValue = input.arguments[0]->constPtrCast<LiteralExpression>()->getValue();
+    if (intervalValue.isNull()) {
+        throw BinderException("First parameter of time_bucket must be a non-null INTERVAL.");
+    }
+    const auto interval = intervalValue.getValue<interval_t>();
+    if (interval.months < 0 || interval.days < 0 || interval.micros < 0 ||
+        (interval.months == 0 && interval.days == 0 && interval.micros == 0)) {
+        throw BinderException("time_bucket interval must be positive.");
+    }
+    if (interval.months == 0) {
+        fixedDurationMicros(interval);
+    }
+    const auto typeID = input.arguments[1]->dataType.getLogicalTypeID();
+    if (typeID == LogicalTypeID::DATE && interval.micros % Interval::MICROS_PER_DAY != 0) {
+        throw BinderException("time_bucket DATE interval must be a whole number of days.");
+    }
+    if (typeID == LogicalTypeID::TIMESTAMP_SEC && interval.micros % Interval::MICROS_PER_SEC != 0) {
+        throw BinderException("time_bucket interval must align with TIMESTAMP_SEC precision.");
+    }
+    if (typeID == LogicalTypeID::TIMESTAMP_MS && interval.micros % Interval::MICROS_PER_MSEC != 0) {
+        throw BinderException("time_bucket interval must align with TIMESTAMP_MS precision.");
+    }
+    std::vector<LogicalType> paramTypes;
+    paramTypes.push_back(input.arguments[0]->dataType.copy());
+    paramTypes.push_back(input.arguments[1]->dataType.copy());
+    return std::make_unique<TimeBucketBindData>(std::move(paramTypes),
+        input.arguments[1]->dataType.copy(), interval);
+}
+
+} // namespace
+
+function_set TimeBucketFunction::getFunctionSet() {
+    function_set result;
+    const std::vector<LogicalTypeID> dateTimeTypes{LogicalTypeID::DATE, LogicalTypeID::TIMESTAMP,
+        LogicalTypeID::TIMESTAMP_SEC, LogicalTypeID::TIMESTAMP_MS, LogicalTypeID::TIMESTAMP_NS,
+        LogicalTypeID::TIMESTAMP_TZ};
+    for (const auto typeID : dateTimeTypes) {
+        auto function = std::make_unique<ScalarFunction>(name,
+            std::vector<LogicalTypeID>{LogicalTypeID::INTERVAL, typeID}, typeID, execFunc);
+        function->bindFunc = bindFunc;
+        result.push_back(std::move(function));
+    }
+    return result;
+}
+
+} // namespace function
+} // namespace lbug

--- a/src/include/function/timestamp/time_bucket.h
+++ b/src/include/function/timestamp/time_bucket.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include "function/scalar_function.h"
+
+namespace lbug {
+namespace function {
+
+struct TimeBucketFunction {
+    static constexpr const char* name = "TIME_BUCKET";
+
+    static function_set getFunctionSet();
+};
+
+} // namespace function
+} // namespace lbug

--- a/test/test_files/function/time_bucket.test
+++ b/test/test_files/function/time_bucket.test
@@ -1,0 +1,74 @@
+-DATASET CSV empty
+
+--
+
+-CASE TimeBucket
+-STATEMENT UNWIND [timestamp('2026-08-01 00:00:00'), timestamp('2026-08-01 10:23:45'),
+                    timestamp('2026-08-01 23:59:59'), timestamp('2026-08-02 00:00:00'), NULL] AS ts
+           RETURN time_bucket(interval('1 day'), ts),
+                  time_bucket(interval('1 day'), ts) + interval('1 day')
+---- 5
+2026-08-01 00:00:00|2026-08-02 00:00:00
+2026-08-01 00:00:00|2026-08-02 00:00:00
+2026-08-01 00:00:00|2026-08-02 00:00:00
+2026-08-02 00:00:00|2026-08-03 00:00:00
+|
+
+-STATEMENT UNWIND [date('2024-02-29'), date('2024-06-30')] AS d
+           RETURN time_bucket(interval('5 months'), d)
+---- 2
+2023-10-01
+2024-03-01
+
+-STATEMENT UNWIND [date('2025-08-20')] AS d
+           RETURN time_bucket(interval('2 years'), d),
+                  time_bucket(interval('3 weeks'), d)
+---- 1
+2024-01-01|2025-08-07
+
+-STATEMENT CREATE NODE TABLE CampusUser(id INT64, PRIMARY KEY(id));
+---- ok
+
+-STATEMENT CREATE NODE TABLE EventNetworkOnline(id INT64, PRIMARY KEY(id));
+---- ok
+
+-STATEMENT CREATE REL TABLE CampusUserHasOnlineSession(
+             FROM CampusUser TO EventNetworkOnline, login_time TIMESTAMP, user_ipv4 STRING);
+---- ok
+
+-STATEMENT CREATE (:CampusUser {id: 1}), (:CampusUser {id: 2}),
+                  (:EventNetworkOnline {id: 101}), (:EventNetworkOnline {id: 102}),
+                  (:EventNetworkOnline {id: 103});
+---- ok
+
+-STATEMENT MATCH (s:CampusUser), (e:EventNetworkOnline) WHERE s.id = 1 AND e.id = 101
+           CREATE (s)-[:CampusUserHasOnlineSession {
+             login_time: timestamp('2026-08-01 10:23:45'), user_ipv4: '10.0.0.1'
+           }]->(e);
+---- ok
+
+-STATEMENT MATCH (s:CampusUser), (e:EventNetworkOnline) WHERE s.id = 1 AND e.id = 102
+           CREATE (s)-[:CampusUserHasOnlineSession {
+             login_time: timestamp('2026-08-02 00:00:00'), user_ipv4: '10.0.0.2'
+           }]->(e);
+---- ok
+
+-STATEMENT MATCH (s:CampusUser), (e:EventNetworkOnline) WHERE s.id = 2 AND e.id = 103
+           CREATE (s)-[:CampusUserHasOnlineSession {user_ipv4: '10.0.0.3'}]->(e);
+---- ok
+
+-STATEMENT MATCH (s:CampusUser)-[r:CampusUserHasOnlineSession]->(e:EventNetworkOnline)
+           WITH s.id AS entity_id, e.id AS event_id,
+                time_bucket(interval('1 day'), r.login_time) AS window_start
+           RETURN entity_id, event_id, window_start,
+                  window_start + interval('1 day') AS window_end
+           ORDER BY entity_id, event_id;
+---- 3
+1|101|2026-08-01 00:00:00|2026-08-02 00:00:00
+1|102|2026-08-02 00:00:00|2026-08-03 00:00:00
+2|103||
+
+-STATEMENT UNWIND [timestamp('2026-08-01')] AS ts
+           RETURN time_bucket(interval('0 seconds'), ts)
+---- error
+Binder exception: time_bucket interval must be positive.


### PR DESCRIPTION
## Required Syntax

```cypher
time_bucket(interval('<period>'), <date/time-expression>)
```

The first argument uses Ladybug's existing `interval('...')` expression and
must describe a non-null positive interval. It must support the units accepted
by Ladybug's current interval parser: years, quarters, months, weeks, days,
hours, minutes, seconds, and smaller units. The function is semantically
similar to DuckDB; it does not need to reproduce DuckDB's literal spelling.

Equivalent bucket-start usage for the existing daily IPv4 feature is:

```cypher
MATCH (s:CampusUser)-[:CampusUserHasOnlineSession]->(e:EventNetworkOnline)
WITH s.id AS entity_id,
     time_bucket(interval('1 day'), e.login_time) AS window_start,
     e.user_ipv4 AS user_ipv4
WITH entity_id, window_start,
     window_start + interval('1 day') AS window_end,
     count(DISTINCT user_ipv4) AS daily_ipv4_count
RETURN entity_id, window_start, window_end, daily_ipv4_count;
```

The first `WITH` is only needed when the caller wants to reuse the bucket
start. `window_end` is not generated by `time_bucket`; callers compute it as
an ordinary expression when required.

Complete example:

```cypher
CREATE NODE TABLE EventNetworkOnline(
  id INT64,
  login_time TIMESTAMP,
  user_ipv4 STRING,
  PRIMARY KEY(id)
);

CREATE
  (:EventNetworkOnline {id: 101, login_time: timestamp('2026-08-01 00:00:00'), user_ipv4: '10.0.0.1'}),
  (:EventNetworkOnline {id: 102, login_time: timestamp('2026-08-01 10:23:45'), user_ipv4: '10.0.0.2'}),
  (:EventNetworkOnline {id: 103, login_time: timestamp('2026-08-01 23:59:59'), user_ipv4: '10.0.0.3'}),
  (:EventNetworkOnline {id: 104, login_time: timestamp('2026-08-02 00:00:00'), user_ipv4: '10.0.0.4'}),
  (:EventNetworkOnline {id: 105, user_ipv4: '10.0.0.5'});

MATCH (e:EventNetworkOnline)
WITH e, time_bucket(interval('1 day'), e.login_time) AS window_start
RETURN e.id, window_start,
       window_start + interval('1 day') AS window_end
ORDER BY e.id;
```

Expected result:

```text
101|2026-08-01 00:00:00|2026-08-02 00:00:00
102|2026-08-01 00:00:00|2026-08-02 00:00:00
103|2026-08-01 00:00:00|2026-08-02 00:00:00
104|2026-08-02 00:00:00|2026-08-03 00:00:00
105||
```

Edge-table / relationship-property example:

```cypher
CREATE NODE TABLE CampusUser(id INT64, PRIMARY KEY(id));
CREATE NODE TABLE EventNetworkOnline(id INT64, PRIMARY KEY(id));
CREATE REL TABLE CampusUserHasOnlineSession(
  FROM CampusUser TO EventNetworkOnline,
  login_time TIMESTAMP,
  user_ipv4 STRING
);

CREATE (:CampusUser {id: 1}), (:CampusUser {id: 2}),
       (:EventNetworkOnline {id: 101}),
       (:EventNetworkOnline {id: 102}),
       (:EventNetworkOnline {id: 103});

MATCH (s:CampusUser), (e:EventNetworkOnline)
WHERE s.id = 1 AND e.id = 101
CREATE (s)-[:CampusUserHasOnlineSession {
  login_time: timestamp('2026-08-01 10:23:45'), user_ipv4: '10.0.0.1'
}]->(e);

MATCH (s:CampusUser), (e:EventNetworkOnline)
WHERE s.id = 1 AND e.id = 102
CREATE (s)-[:CampusUserHasOnlineSession {
  login_time: timestamp('2026-08-02 00:00:00'), user_ipv4: '10.0.0.2'
}]->(e);

MATCH (s:CampusUser), (e:EventNetworkOnline)
WHERE s.id = 2 AND e.id = 103
CREATE (s)-[:CampusUserHasOnlineSession {user_ipv4: '10.0.0.3'}]->(e);

MATCH (s:CampusUser)-[r:CampusUserHasOnlineSession]->(e:EventNetworkOnline)
WITH s.id AS entity_id, e.id AS event_id,
     time_bucket(interval('1 day'), r.login_time) AS window_start
RETURN entity_id, event_id, window_start,
       window_start + interval('1 day') AS window_end
ORDER BY entity_id, event_id;
```

Expected result:

```text
1|101|2026-08-01 00:00:00|2026-08-02 00:00:00
1|102|2026-08-02 00:00:00|2026-08-03 00:00:00
2|103||
```

## Interval Reuse Requirements

`time_bucket` must directly reuse Ladybug's `interval('...')` syntax, existing
interval parser, and its constant-folded result. It must not add a second unit
parser or reparse the input string. An `INTERVAL` is represented by three
independent components, `months`, `days`, and `micros`; the implementation must
preserve all three.

- Supported units follow the current parser, including years, quarters, months,
  weeks, days, hours, minutes, seconds, milliseconds, microseconds, and their
  currently supported aliases.
- When `months == 0`, `days` and `micros` can be treated as a fixed bucket
  width.
- When `months != 0`, bucketing must use calendar year/month arithmetic. It
  must not call a helper that approximates months as 30 days or years as 365
  days.
- `interval('5 months')`, `interval('2 years')`, `interval('3 weeks')`, and
  composite intervals are valid `time_bucket` inputs. The function binder may
  validate constantness, non-nullness, positivity, and representability in the
  output type, but must not narrow Ladybug's supported interval units.

## Required Semantics

- The first argument must be a non-null positive constant `INTERVAL` value
  produced by `interval('...')`. It must not reject a value merely because it
  has a month or year component: `interval('5 months')`,
  `interval('2 years')`, `interval('3 weeks')`, `interval('13 days')`, and
  current parser-supported hour/minute/second units are in scope.
- The second argument must be any current Ladybug date/time logical type:
  `DATE`, `TIMESTAMP`, `TIMESTAMP_SEC`, `TIMESTAMP_MS`, `TIMESTAMP_NS`, or
  `TIMESTAMP_TZ`. The implementation must not arbitrarily omit a type that
  the current type system supports.
- The return type is the same date/time logical type as the second argument.
- Bucket anchors follow Ladybug's own date/time representation: `DATE` counts
  days from `1970-01-01`, and `TIMESTAMP` counts microseconds from
  `1970-01-01 00:00:00`. Fixed widths floor directly from that epoch; calendar
  widths with a month component advance from `1970-01-01` using Ladybug's
  `interval_t` calendar addition. `TIMESTAMP_TZ` uses its represented instant;
  `interval('1 day')` means exactly 24 hours, not a session-local civil day.
- Bucket boundaries are integer multiples of the width from the Ladybug epoch;
  they do not restart for the input year. For example,
  `time_bucket(interval('5 months'), date('2024-02-29'))` returns `2023-10-01`:
  the interval from `2023-10-01` through `2024-03-01` contains that date. This
  matches Ladybug's single calendar addition of `interval_t * n` to a timestamp.
- Each type's precision must be respected: `DATE` requires a whole-day width,
  `TIMESTAMP_SEC` a whole-second width, and `TIMESTAMP_MS` a whole-millisecond
  width. The other current types accept fixed widths representable by their
  storage precision.
- A fixed width without a month component uses `floor(t / width) * width`.
  A width containing a month component uses calendar year/month arithmetic
  from `1970-01-01` and must not turn months or years into a fixed number of
  days or microseconds. Results are bucket starts with half-open membership
  `[start, next_start)`.
- A null date/time input returns null. A null is not filtered and no additional
  columns are produced.
- Pre-epoch arithmetic uses floor division. In particular, a negative
  `TIMESTAMP_NS` value with a sub-microsecond remainder is normalized toward
  negative infinity before bucket arithmetic.
- The result is deterministic for a fixed database snapshot and query.
