### PR TITLE
Add SIMD filter comparison kernels

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -159,6 +159,7 @@ option(ENABLE_UBSAN "Enable undefined behavior sanitizer." FALSE)
 option(ENABLE_RUNTIME_CHECKS "Enable runtime coherency checks (e.g. asserts)" FALSE)
 option(ENABLE_LTO "Enable Link-Time Optimization" FALSE)
 option(ENABLE_MALLOC_BUFFER_MANAGER "Enable Buffer manager using malloc. Default option for webassembly" OFF)
+option(LBUG_ENABLE_SIMD "Enable runtime-dispatched query-processor SIMD kernels." ON)
 
 option(LBUG_DEFAULT_REL_STORAGE_DIRECTION "Only store fwd direction in rel tables by default." BOTH)
 if(NOT LBUG_DEFAULT_REL_STORAGE_DIRECTION)

--- a/scripts/headers.txt
+++ b/scripts/headers.txt
@@ -47,6 +47,8 @@ src/include/common/vector/auxiliary_buffer.h
 src/include/common/vector/value_vector.h
 src/include/function/binary_function_executor.h
 src/include/function/cast/cast_function_bind_data.h
+src/include/function/comparison/comparison_operation.h
+src/include/function/comparison/simd_filter.h
 src/include/function/const_function_executor.h
 src/include/function/function.h
 src/include/function/pointer_function_executor.h

--- a/src/function/CMakeLists.txt
+++ b/src/function/CMakeLists.txt
@@ -19,6 +19,43 @@ add_subdirectory(export)
 add_subdirectory(internal_id)
 add_subdirectory(timestamp)
 
+set(LBUG_FUNCTION_SIMD_SOURCES simd_filter.cpp)
+set(LBUG_BUILD_FILTER_AVX2 FALSE)
+set(LBUG_BUILD_FILTER_NEON FALSE)
+if(LBUG_ENABLE_SIMD AND NOT BUILD_WASM)
+    if(OS_ARCH STREQUAL "amd64")
+        if(MSVC)
+            set(LBUG_BUILD_FILTER_AVX2 TRUE)
+            set_source_files_properties(simd_filter_avx2.cpp PROPERTIES COMPILE_OPTIONS "/arch:AVX2")
+        elseif(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+            include(CheckCXXCompilerFlag)
+            check_cxx_compiler_flag("-mavx2" LBUG_COMPILER_SUPPORTS_MAVX2)
+            if(LBUG_COMPILER_SUPPORTS_MAVX2)
+                set(LBUG_BUILD_FILTER_AVX2 TRUE)
+                set_source_files_properties(simd_filter_avx2.cpp PROPERTIES COMPILE_OPTIONS "-mavx2")
+            endif()
+        endif()
+    elseif(OS_ARCH STREQUAL "arm64")
+        if(MSVC OR CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+            set(LBUG_BUILD_FILTER_NEON TRUE)
+        endif()
+    endif()
+endif()
+
+if(LBUG_BUILD_FILTER_AVX2)
+    list(APPEND LBUG_FUNCTION_SIMD_SOURCES simd_filter_avx2.cpp)
+    set_source_files_properties(simd_filter.cpp
+        PROPERTIES COMPILE_DEFINITIONS LBUG_SIMD_COMPILED_AVX2)
+    message(STATUS "Query processor SIMD: AVX2 filter kernels enabled")
+elseif(LBUG_BUILD_FILTER_NEON)
+    list(APPEND LBUG_FUNCTION_SIMD_SOURCES simd_filter_neon.cpp)
+    set_source_files_properties(simd_filter.cpp
+        PROPERTIES COMPILE_DEFINITIONS LBUG_SIMD_COMPILED_NEON)
+    message(STATUS "Query processor SIMD: NEON filter kernels enabled")
+else()
+    message(STATUS "Query processor SIMD: scalar filter path only")
+endif()
+
 add_library(lbug_function
         OBJECT
         aggregate_function.cpp
@@ -41,7 +78,8 @@ add_library(lbug_function
         vector_string_functions.cpp
         vector_timestamp_functions.cpp
         vector_blob_functions.cpp
-        vector_uuid_functions.cpp)
+        vector_uuid_functions.cpp
+        ${LBUG_FUNCTION_SIMD_SOURCES})
 
 set(ALL_OBJECT_FILES
         ${ALL_OBJECT_FILES} $<TARGET_OBJECTS:lbug_function>

--- a/src/function/simd_filter.cpp
+++ b/src/function/simd_filter.cpp
@@ -1,0 +1,409 @@
+#include "function/comparison/simd_filter.h"
+
+#include <cstdlib>
+#include <string_view>
+
+#include "common/data_chunk/data_chunk_state.h"
+#include "common/data_chunk/sel_vector.h"
+#include "common/exception/runtime.h"
+#include "common/null_mask.h"
+#include "common/vector/value_vector.h"
+
+#if defined(_MSC_VER) && defined(LBUG_SIMD_COMPILED_AVX2)
+#include <intrin.h>
+#endif
+
+namespace lbug {
+namespace function {
+namespace simd {
+
+#if defined(LBUG_SIMD_COMPILED_AVX2)
+common::sel_t selectConstantAVX2(const void* data, common::sel_t count, const void* constant,
+    const uint64_t* nullMask, common::sel_t* output, common::PhysicalTypeID type,
+    ComparisonOperation operation);
+common::sel_t selectVectorAVX2(const void* left, const void* right, common::sel_t count,
+    const uint64_t* leftNullMask, const uint64_t* rightNullMask, common::sel_t* output,
+    common::PhysicalTypeID type, ComparisonOperation operation);
+#endif
+#if defined(LBUG_SIMD_COMPILED_NEON)
+common::sel_t selectConstantNEON(const void* data, common::sel_t count, const void* constant,
+    const uint64_t* nullMask, common::sel_t* output, common::PhysicalTypeID type,
+    ComparisonOperation operation);
+common::sel_t selectVectorNEON(const void* left, const void* right, common::sel_t count,
+    const uint64_t* leftNullMask, const uint64_t* rightNullMask, common::sel_t* output,
+    common::PhysicalTypeID type, ComparisonOperation operation);
+#endif
+
+namespace {
+
+#if defined(LBUG_SIMD_COMPILED_AVX2) || defined(LBUG_SIMD_COMPILED_NEON)
+constexpr common::sel_t MIN_SIMD_FILTER_SIZE = 64;
+#endif
+
+template<typename T, ComparisonOperation OPERATION>
+bool compare(const T& left, const T& right) {
+    if constexpr (OPERATION == ComparisonOperation::EQUAL) {
+        return left == right;
+    } else if constexpr (OPERATION == ComparisonOperation::NOT_EQUAL) {
+        return !(left == right);
+    } else if constexpr (OPERATION == ComparisonOperation::GREATER_THAN) {
+        return left > right;
+    } else if constexpr (OPERATION == ComparisonOperation::GREATER_THAN_EQUAL) {
+        return left > right || left == right;
+    } else if constexpr (OPERATION == ComparisonOperation::LESS_THAN) {
+        // Match LessThan::operation exactly, including its unordered floating-point behavior.
+        return !(left > right || left == right);
+    } else {
+        // Match LessThanEquals::operation exactly, including NaN behavior.
+        return !(left > right);
+    }
+}
+
+template<typename T, ComparisonOperation OPERATION>
+common::sel_t selectConstantScalarTyped(const void* dataPtr, common::sel_t count,
+    const void* constantPtr, const uint64_t* nullMask, common::sel_t* output) {
+    const auto data = static_cast<const T*>(dataPtr);
+    const auto constant = *static_cast<const T*>(constantPtr);
+    common::sel_t selected = 0;
+    for (common::sel_t i = 0; i < count; ++i) {
+        if (nullMask && common::NullMask::isNull(nullMask, i)) {
+            continue;
+        }
+        if (compare<T, OPERATION>(data[i], constant)) {
+            output[selected++] = i;
+        }
+    }
+    return selected;
+}
+
+template<typename T>
+common::sel_t selectConstantScalarTyped(const void* data, common::sel_t count, const void* constant,
+    const uint64_t* nullMask, common::sel_t* output, ComparisonOperation operation) {
+    switch (operation) {
+    case ComparisonOperation::EQUAL:
+        return selectConstantScalarTyped<T, ComparisonOperation::EQUAL>(data, count, constant,
+            nullMask, output);
+    case ComparisonOperation::NOT_EQUAL:
+        return selectConstantScalarTyped<T, ComparisonOperation::NOT_EQUAL>(data, count, constant,
+            nullMask, output);
+    case ComparisonOperation::GREATER_THAN:
+        return selectConstantScalarTyped<T, ComparisonOperation::GREATER_THAN>(data, count,
+            constant, nullMask, output);
+    case ComparisonOperation::GREATER_THAN_EQUAL:
+        return selectConstantScalarTyped<T, ComparisonOperation::GREATER_THAN_EQUAL>(data, count,
+            constant, nullMask, output);
+    case ComparisonOperation::LESS_THAN:
+        return selectConstantScalarTyped<T, ComparisonOperation::LESS_THAN>(data, count, constant,
+            nullMask, output);
+    case ComparisonOperation::LESS_THAN_EQUAL:
+        return selectConstantScalarTyped<T, ComparisonOperation::LESS_THAN_EQUAL>(data, count,
+            constant, nullMask, output);
+    }
+    return 0;
+}
+
+template<typename T, ComparisonOperation OPERATION>
+common::sel_t selectVectorScalarTyped(const void* leftPtr, const void* rightPtr,
+    common::sel_t count, const uint64_t* leftNullMask, const uint64_t* rightNullMask,
+    common::sel_t* output) {
+    const auto left = static_cast<const T*>(leftPtr);
+    const auto right = static_cast<const T*>(rightPtr);
+    common::sel_t selected = 0;
+    for (common::sel_t i = 0; i < count; ++i) {
+        if ((leftNullMask && common::NullMask::isNull(leftNullMask, i)) ||
+            (rightNullMask && common::NullMask::isNull(rightNullMask, i))) {
+            continue;
+        }
+        if (compare<T, OPERATION>(left[i], right[i])) {
+            output[selected++] = i;
+        }
+    }
+    return selected;
+}
+
+template<typename T>
+common::sel_t selectVectorScalarTyped(const void* left, const void* right, common::sel_t count,
+    const uint64_t* leftNullMask, const uint64_t* rightNullMask, common::sel_t* output,
+    ComparisonOperation operation) {
+    switch (operation) {
+    case ComparisonOperation::EQUAL:
+        return selectVectorScalarTyped<T, ComparisonOperation::EQUAL>(left, right, count,
+            leftNullMask, rightNullMask, output);
+    case ComparisonOperation::NOT_EQUAL:
+        return selectVectorScalarTyped<T, ComparisonOperation::NOT_EQUAL>(left, right, count,
+            leftNullMask, rightNullMask, output);
+    case ComparisonOperation::GREATER_THAN:
+        return selectVectorScalarTyped<T, ComparisonOperation::GREATER_THAN>(left, right, count,
+            leftNullMask, rightNullMask, output);
+    case ComparisonOperation::GREATER_THAN_EQUAL:
+        return selectVectorScalarTyped<T, ComparisonOperation::GREATER_THAN_EQUAL>(left, right,
+            count, leftNullMask, rightNullMask, output);
+    case ComparisonOperation::LESS_THAN:
+        return selectVectorScalarTyped<T, ComparisonOperation::LESS_THAN>(left, right, count,
+            leftNullMask, rightNullMask, output);
+    case ComparisonOperation::LESS_THAN_EQUAL:
+        return selectVectorScalarTyped<T, ComparisonOperation::LESS_THAN_EQUAL>(left, right, count,
+            leftNullMask, rightNullMask, output);
+    }
+    return 0;
+}
+
+#if defined(LBUG_SIMD_COMPILED_AVX2) || defined(LBUG_SIMD_COMPILED_NEON)
+bool isSupportedType(common::PhysicalTypeID type) {
+    switch (type) {
+    case common::PhysicalTypeID::INT8:
+    case common::PhysicalTypeID::INT16:
+    case common::PhysicalTypeID::INT32:
+    case common::PhysicalTypeID::INT64:
+    case common::PhysicalTypeID::UINT8:
+    case common::PhysicalTypeID::UINT16:
+    case common::PhysicalTypeID::UINT32:
+    case common::PhysicalTypeID::UINT64:
+    case common::PhysicalTypeID::FLOAT:
+    case common::PhysicalTypeID::DOUBLE:
+        return true;
+    default:
+        return false;
+    }
+}
+
+#endif
+
+#if defined(LBUG_SIMD_COMPILED_AVX2)
+bool cpuSupportsAVX2() {
+#if defined(_MSC_VER)
+    int registers[4] = {};
+    __cpuid(registers, 0);
+    if (registers[0] < 7) {
+        return false;
+    }
+    __cpuidex(registers, 1, 0);
+    constexpr int OSXSAVE = 1 << 27;
+    constexpr int AVX = 1 << 28;
+    if ((registers[2] & (OSXSAVE | AVX)) != (OSXSAVE | AVX) || (_xgetbv(0) & 0x6) != 0x6) {
+        return false;
+    }
+    __cpuidex(registers, 7, 0);
+    constexpr int AVX2 = 1 << 5;
+    return (registers[1] & AVX2) != 0;
+#elif defined(__GNUC__) || defined(__clang__)
+    __builtin_cpu_init();
+    return __builtin_cpu_supports("avx2");
+#else
+    return false;
+#endif
+}
+
+bool useAVX2() {
+    const auto requestedValue = std::getenv("LBUG_SIMD");
+    const auto requested = requestedValue ? std::string_view{requestedValue} : "auto";
+    if (requested == "scalar" || requested == "0") {
+        return false;
+    }
+    if (requested != "auto" && requested != "avx2" && requested != "1") {
+        throw common::RuntimeException("LBUG_SIMD must be one of auto, scalar, avx2, 0, or 1.");
+    }
+    if (cpuSupportsAVX2()) {
+        return true;
+    }
+    if (requested == "avx2" || requested == "1") {
+        throw common::RuntimeException(
+            "LBUG_SIMD requested AVX2, but the running CPU or OS does not support it.");
+    }
+    return false;
+}
+
+#endif
+
+#if defined(LBUG_SIMD_COMPILED_NEON)
+bool useNEON() {
+    const auto requestedValue = std::getenv("LBUG_SIMD");
+    const auto requested = requestedValue ? std::string_view{requestedValue} : "auto";
+    if (requested == "scalar" || requested == "0") {
+        return false;
+    }
+    if (requested == "auto" || requested == "neon" || requested == "1") {
+        return true;
+    }
+    throw common::RuntimeException("LBUG_SIMD must be one of auto, scalar, neon, 0, or 1.");
+}
+#endif
+
+} // namespace
+
+common::sel_t selectConstantScalar(const void* data, common::sel_t count, const void* constant,
+    const uint64_t* nullMask, common::sel_t* output, common::PhysicalTypeID type,
+    ComparisonOperation operation) {
+    switch (type) {
+    case common::PhysicalTypeID::INT8:
+        return selectConstantScalarTyped<int8_t>(data, count, constant, nullMask, output,
+            operation);
+    case common::PhysicalTypeID::INT16:
+        return selectConstantScalarTyped<int16_t>(data, count, constant, nullMask, output,
+            operation);
+    case common::PhysicalTypeID::INT32:
+        return selectConstantScalarTyped<int32_t>(data, count, constant, nullMask, output,
+            operation);
+    case common::PhysicalTypeID::INT64:
+        return selectConstantScalarTyped<int64_t>(data, count, constant, nullMask, output,
+            operation);
+    case common::PhysicalTypeID::UINT8:
+        return selectConstantScalarTyped<uint8_t>(data, count, constant, nullMask, output,
+            operation);
+    case common::PhysicalTypeID::UINT16:
+        return selectConstantScalarTyped<uint16_t>(data, count, constant, nullMask, output,
+            operation);
+    case common::PhysicalTypeID::UINT32:
+        return selectConstantScalarTyped<uint32_t>(data, count, constant, nullMask, output,
+            operation);
+    case common::PhysicalTypeID::UINT64:
+        return selectConstantScalarTyped<uint64_t>(data, count, constant, nullMask, output,
+            operation);
+    case common::PhysicalTypeID::FLOAT:
+        return selectConstantScalarTyped<float>(data, count, constant, nullMask, output, operation);
+    case common::PhysicalTypeID::DOUBLE:
+        return selectConstantScalarTyped<double>(data, count, constant, nullMask, output,
+            operation);
+    default:
+        return 0;
+    }
+}
+
+common::sel_t selectConstant(const void* data, common::sel_t count, const void* constant,
+    const uint64_t* nullMask, common::sel_t* output, common::PhysicalTypeID type,
+    ComparisonOperation operation) {
+#if defined(LBUG_SIMD_COMPILED_AVX2)
+    static const SelectConstantKernel kernel =
+        useAVX2() ? selectConstantAVX2 : selectConstantScalar;
+    return kernel(data, count, constant, nullMask, output, type, operation);
+#elif defined(LBUG_SIMD_COMPILED_NEON)
+    static const SelectConstantKernel kernel =
+        useNEON() ? selectConstantNEON : selectConstantScalar;
+    return kernel(data, count, constant, nullMask, output, type, operation);
+#else
+    return selectConstantScalar(data, count, constant, nullMask, output, type, operation);
+#endif
+}
+
+common::sel_t selectVectorScalar(const void* left, const void* right, common::sel_t count,
+    const uint64_t* leftNullMask, const uint64_t* rightNullMask, common::sel_t* output,
+    common::PhysicalTypeID type, ComparisonOperation operation) {
+    switch (type) {
+    case common::PhysicalTypeID::INT8:
+        return selectVectorScalarTyped<int8_t>(left, right, count, leftNullMask, rightNullMask,
+            output, operation);
+    case common::PhysicalTypeID::INT16:
+        return selectVectorScalarTyped<int16_t>(left, right, count, leftNullMask, rightNullMask,
+            output, operation);
+    case common::PhysicalTypeID::INT32:
+        return selectVectorScalarTyped<int32_t>(left, right, count, leftNullMask, rightNullMask,
+            output, operation);
+    case common::PhysicalTypeID::INT64:
+        return selectVectorScalarTyped<int64_t>(left, right, count, leftNullMask, rightNullMask,
+            output, operation);
+    case common::PhysicalTypeID::UINT8:
+        return selectVectorScalarTyped<uint8_t>(left, right, count, leftNullMask, rightNullMask,
+            output, operation);
+    case common::PhysicalTypeID::UINT16:
+        return selectVectorScalarTyped<uint16_t>(left, right, count, leftNullMask, rightNullMask,
+            output, operation);
+    case common::PhysicalTypeID::UINT32:
+        return selectVectorScalarTyped<uint32_t>(left, right, count, leftNullMask, rightNullMask,
+            output, operation);
+    case common::PhysicalTypeID::UINT64:
+        return selectVectorScalarTyped<uint64_t>(left, right, count, leftNullMask, rightNullMask,
+            output, operation);
+    case common::PhysicalTypeID::FLOAT:
+        return selectVectorScalarTyped<float>(left, right, count, leftNullMask, rightNullMask,
+            output, operation);
+    case common::PhysicalTypeID::DOUBLE:
+        return selectVectorScalarTyped<double>(left, right, count, leftNullMask, rightNullMask,
+            output, operation);
+    default:
+        return 0;
+    }
+}
+
+common::sel_t selectVector(const void* left, const void* right, common::sel_t count,
+    const uint64_t* leftNullMask, const uint64_t* rightNullMask, common::sel_t* output,
+    common::PhysicalTypeID type, ComparisonOperation operation) {
+#if defined(LBUG_SIMD_COMPILED_AVX2)
+    static const SelectVectorKernel kernel = useAVX2() ? selectVectorAVX2 : selectVectorScalar;
+    return kernel(left, right, count, leftNullMask, rightNullMask, output, type, operation);
+#elif defined(LBUG_SIMD_COMPILED_NEON)
+    static const SelectVectorKernel kernel = useNEON() ? selectVectorNEON : selectVectorScalar;
+    return kernel(left, right, count, leftNullMask, rightNullMask, output, type, operation);
+#else
+    return selectVectorScalar(left, right, count, leftNullMask, rightNullMask, output, type,
+        operation);
+#endif
+}
+
+bool trySelectConstant(common::ValueVector& data, common::ValueVector& constant,
+    ComparisonOperation operation, common::SelectionVector& output) {
+#if !defined(LBUG_SIMD_COMPILED_AVX2) && !defined(LBUG_SIMD_COMPILED_NEON)
+    (void)data;
+    (void)constant;
+    (void)operation;
+    (void)output;
+    return false;
+#else
+    if (!data.state || !constant.state || data.state->isFlat() || !constant.state->isFlat()) {
+        return false;
+    }
+    const auto count = data.state->getSelSize();
+    if (count < MIN_SIMD_FILTER_SIZE || !data.state->getSelVector().isUnfiltered()) {
+        return false;
+    }
+    const auto type = data.dataType.getPhysicalType();
+    if (type != constant.dataType.getPhysicalType() || !isSupportedType(type)) {
+        return false;
+    }
+    const auto constantPosition = constant.state->getSelVector()[0];
+    if (constant.isNull(constantPosition)) {
+        return false;
+    }
+    const auto nullMask = data.hasNoNullsGuarantee() ? nullptr : data.getNullMask().getData();
+    const auto selected = selectConstant(data.getData(), count,
+        constant.getData() + constantPosition * constant.getNumBytesPerValue(), nullMask,
+        output.getMutableBuffer().data(), type, operation);
+    // Match BinaryFunctionExecutor's existing contract: fill the mutable buffer and update its
+    // size. ExpressionEvaluator::select activates filtered mode after selectInternal returns.
+    output.setSelSize(selected);
+    return true;
+#endif
+}
+
+bool trySelectVector(common::ValueVector& left, common::ValueVector& right,
+    ComparisonOperation operation, common::SelectionVector& output) {
+#if !defined(LBUG_SIMD_COMPILED_AVX2) && !defined(LBUG_SIMD_COMPILED_NEON)
+    (void)left;
+    (void)right;
+    (void)operation;
+    (void)output;
+    return false;
+#else
+    if (!left.state || left.state != right.state || left.state->isFlat()) {
+        return false;
+    }
+    const auto count = left.state->getSelSize();
+    if (count < MIN_SIMD_FILTER_SIZE || !left.state->getSelVector().isUnfiltered()) {
+        return false;
+    }
+    const auto type = left.dataType.getPhysicalType();
+    if (type != right.dataType.getPhysicalType() || !isSupportedType(type)) {
+        return false;
+    }
+    const auto leftNullMask = left.hasNoNullsGuarantee() ? nullptr : left.getNullMask().getData();
+    const auto rightNullMask =
+        right.hasNoNullsGuarantee() ? nullptr : right.getNullMask().getData();
+    const auto selected = selectVector(left.getData(), right.getData(), count, leftNullMask,
+        rightNullMask, output.getMutableBuffer().data(), type, operation);
+    output.setSelSize(selected);
+    return true;
+#endif
+}
+
+} // namespace simd
+} // namespace function
+} // namespace lbug

--- a/src/function/simd_filter.cpp
+++ b/src/function/simd_filter.cpp
@@ -110,13 +110,11 @@ common::sel_t selectVectorScalarTyped(const void* leftPtr, const void* rightPtr,
     const auto right = static_cast<const T*>(rightPtr);
     common::sel_t selected = 0;
     for (common::sel_t i = 0; i < count; ++i) {
-        if ((leftNullMask && common::NullMask::isNull(leftNullMask, i)) ||
-            (rightNullMask && common::NullMask::isNull(rightNullMask, i))) {
-            continue;
-        }
-        if (compare<T, OPERATION>(left[i], right[i])) {
-            output[selected++] = i;
-        }
+        const auto isValid = (!leftNullMask || !common::NullMask::isNull(leftNullMask, i)) &&
+                             (!rightNullMask || !common::NullMask::isNull(rightNullMask, i));
+        const auto matches = isValid && compare<T, OPERATION>(left[i], right[i]);
+        output[selected] = i;
+        selected += matches;
     }
     return selected;
 }

--- a/src/function/simd_filter_avx2.cpp
+++ b/src/function/simd_filter_avx2.cpp
@@ -1,0 +1,447 @@
+#include <cstdint>
+#include <limits>
+#include <type_traits>
+
+#include "common/null_mask.h"
+#include "function/comparison/simd_filter.h"
+#include <bit>
+#include <immintrin.h>
+
+#if !defined(__AVX2__) && !defined(_MSC_VER)
+#error "simd_filter_avx2.cpp must be compiled with AVX2 enabled"
+#endif
+
+namespace lbug {
+namespace function {
+namespace simd {
+
+namespace {
+
+template<typename T>
+__m256i broadcastIntegral(T value) {
+    using SignedT = std::make_signed_t<T>;
+    const auto bits = std::bit_cast<SignedT>(value);
+    if constexpr (sizeof(T) == 1) {
+        return _mm256_set1_epi8(bits);
+    } else if constexpr (sizeof(T) == 2) {
+        return _mm256_set1_epi16(bits);
+    } else if constexpr (sizeof(T) == 4) {
+        return _mm256_set1_epi32(bits);
+    } else {
+        return _mm256_set1_epi64x(bits);
+    }
+}
+
+template<typename T>
+__m256i equalIntegral(__m256i left, __m256i right) {
+    if constexpr (sizeof(T) == 1) {
+        return _mm256_cmpeq_epi8(left, right);
+    } else if constexpr (sizeof(T) == 2) {
+        return _mm256_cmpeq_epi16(left, right);
+    } else if constexpr (sizeof(T) == 4) {
+        return _mm256_cmpeq_epi32(left, right);
+    } else {
+        return _mm256_cmpeq_epi64(left, right);
+    }
+}
+
+template<typename T>
+__m256i greaterIntegral(__m256i left, __m256i right) {
+    if constexpr (std::is_unsigned_v<T>) {
+        using SignedT = std::make_signed_t<T>;
+        const auto signBit = broadcastIntegral(std::numeric_limits<SignedT>::min());
+        left = _mm256_xor_si256(left, signBit);
+        right = _mm256_xor_si256(right, signBit);
+    }
+    if constexpr (sizeof(T) == 1) {
+        return _mm256_cmpgt_epi8(left, right);
+    } else if constexpr (sizeof(T) == 2) {
+        return _mm256_cmpgt_epi16(left, right);
+    } else if constexpr (sizeof(T) == 4) {
+        return _mm256_cmpgt_epi32(left, right);
+    } else {
+        return _mm256_cmpgt_epi64(left, right);
+    }
+}
+
+template<typename T, ComparisonOperation OPERATION>
+__m256i compareIntegral(__m256i left, __m256i right) {
+    const auto equal = equalIntegral<T>(left, right);
+    if constexpr (OPERATION == ComparisonOperation::EQUAL) {
+        return equal;
+    } else if constexpr (OPERATION == ComparisonOperation::NOT_EQUAL) {
+        return _mm256_xor_si256(equal, _mm256_set1_epi32(-1));
+    } else {
+        const auto greater = greaterIntegral<T>(left, right);
+        if constexpr (OPERATION == ComparisonOperation::GREATER_THAN) {
+            return greater;
+        } else if constexpr (OPERATION == ComparisonOperation::GREATER_THAN_EQUAL) {
+            return _mm256_or_si256(greater, equal);
+        } else if constexpr (OPERATION == ComparisonOperation::LESS_THAN) {
+            const auto greaterOrEqual = _mm256_or_si256(greater, equal);
+            return _mm256_xor_si256(greaterOrEqual, _mm256_set1_epi32(-1));
+        } else {
+            return _mm256_xor_si256(greater, _mm256_set1_epi32(-1));
+        }
+    }
+}
+
+template<typename T, ComparisonOperation OPERATION>
+bool compareScalar(const T& left, const T& right) {
+    if constexpr (OPERATION == ComparisonOperation::EQUAL) {
+        return left == right;
+    } else if constexpr (OPERATION == ComparisonOperation::NOT_EQUAL) {
+        return !(left == right);
+    } else if constexpr (OPERATION == ComparisonOperation::GREATER_THAN) {
+        return left > right;
+    } else if constexpr (OPERATION == ComparisonOperation::GREATER_THAN_EQUAL) {
+        return left > right || left == right;
+    } else if constexpr (OPERATION == ComparisonOperation::LESS_THAN) {
+        return !(left > right || left == right);
+    } else {
+        return !(left > right);
+    }
+}
+
+template<common::sel_t LANE_COUNT>
+uint32_t applyNullMask(uint32_t laneMask, const uint64_t* nullMask, common::sel_t base) {
+    if (!nullMask) {
+        return laneMask;
+    }
+    // Every supported AVX2 lane count divides 64 and base starts at zero, so an AVX2 block never
+    // crosses a NullMask word boundary.
+    const auto nullLanes = nullMask[base >> common::NullMask::NUM_BITS_PER_NULL_ENTRY_LOG2] >>
+                           (base & (common::NullMask::NUM_BITS_PER_NULL_ENTRY - 1));
+    return laneMask & ~static_cast<uint32_t>(nullLanes);
+}
+
+common::sel_t compactLaneMask(uint32_t laneMask, common::sel_t base, common::sel_t* output,
+    common::sel_t selected) {
+    while (laneMask) {
+        const auto lane = static_cast<common::sel_t>(std::countr_zero(laneMask));
+        output[selected++] = base + lane;
+        laneMask &= laneMask - 1;
+    }
+    return selected;
+}
+
+template<typename T, ComparisonOperation OPERATION>
+common::sel_t selectConstantIntegral(const void* dataPtr, common::sel_t count,
+    const void* constantPtr, const uint64_t* nullMask, common::sel_t* output) {
+    constexpr common::sel_t LANE_COUNT = 32 / sizeof(T);
+    const auto data = static_cast<const T*>(dataPtr);
+    const auto constant = *static_cast<const T*>(constantPtr);
+    const auto constantVector = broadcastIntegral(constant);
+    common::sel_t selected = 0;
+    common::sel_t base = 0;
+    for (; base + LANE_COUNT <= count; base += LANE_COUNT) {
+        const auto values = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(data + base));
+        const auto compared = compareIntegral<T, OPERATION>(values, constantVector);
+        const auto byteMask = static_cast<uint32_t>(_mm256_movemask_epi8(compared));
+        uint32_t laneMask = 0;
+        for (common::sel_t lane = 0; lane < LANE_COUNT; ++lane) {
+            laneMask |= ((byteMask >> (lane * sizeof(T))) & 1u) << lane;
+        }
+        laneMask = applyNullMask<LANE_COUNT>(laneMask, nullMask, base);
+        selected = compactLaneMask(laneMask, base, output, selected);
+    }
+    for (; base < count; ++base) {
+        if ((!nullMask || !common::NullMask::isNull(nullMask, base)) &&
+            compareScalar<T, OPERATION>(data[base], constant)) {
+            output[selected++] = base;
+        }
+    }
+    return selected;
+}
+
+template<typename T, ComparisonOperation OPERATION>
+common::sel_t selectVectorIntegral(const void* leftPtr, const void* rightPtr, common::sel_t count,
+    const uint64_t* leftNullMask, const uint64_t* rightNullMask, common::sel_t* output) {
+    constexpr common::sel_t LANE_COUNT = 32 / sizeof(T);
+    const auto left = static_cast<const T*>(leftPtr);
+    const auto right = static_cast<const T*>(rightPtr);
+    common::sel_t selected = 0;
+    common::sel_t base = 0;
+    for (; base + LANE_COUNT <= count; base += LANE_COUNT) {
+        const auto leftValues = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(left + base));
+        const auto rightValues = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(right + base));
+        const auto compared = compareIntegral<T, OPERATION>(leftValues, rightValues);
+        const auto byteMask = static_cast<uint32_t>(_mm256_movemask_epi8(compared));
+        uint32_t laneMask = 0;
+        for (common::sel_t lane = 0; lane < LANE_COUNT; ++lane) {
+            laneMask |= ((byteMask >> (lane * sizeof(T))) & 1u) << lane;
+        }
+        laneMask = applyNullMask<LANE_COUNT>(laneMask, leftNullMask, base);
+        laneMask = applyNullMask<LANE_COUNT>(laneMask, rightNullMask, base);
+        selected = compactLaneMask(laneMask, base, output, selected);
+    }
+    for (; base < count; ++base) {
+        if ((!leftNullMask || !common::NullMask::isNull(leftNullMask, base)) &&
+            (!rightNullMask || !common::NullMask::isNull(rightNullMask, base)) &&
+            compareScalar<T, OPERATION>(left[base], right[base])) {
+            output[selected++] = base;
+        }
+    }
+    return selected;
+}
+
+template<typename T, ComparisonOperation OPERATION>
+common::sel_t selectConstantFloating(const void* dataPtr, common::sel_t count,
+    const void* constantPtr, const uint64_t* nullMask, common::sel_t* output) {
+    constexpr common::sel_t LANE_COUNT = 32 / sizeof(T);
+    const auto data = static_cast<const T*>(dataPtr);
+    const auto constant = *static_cast<const T*>(constantPtr);
+    common::sel_t selected = 0;
+    common::sel_t base = 0;
+    for (; base + LANE_COUNT <= count; base += LANE_COUNT) {
+        uint32_t laneMask;
+        if constexpr (std::is_same_v<T, float>) {
+            const auto values = _mm256_loadu_ps(data + base);
+            const auto constantVector = _mm256_set1_ps(constant);
+            if constexpr (OPERATION == ComparisonOperation::EQUAL) {
+                laneMask = _mm256_movemask_ps(_mm256_cmp_ps(values, constantVector, _CMP_EQ_OQ));
+            } else if constexpr (OPERATION == ComparisonOperation::NOT_EQUAL) {
+                laneMask = _mm256_movemask_ps(_mm256_cmp_ps(values, constantVector, _CMP_NEQ_UQ));
+            } else if constexpr (OPERATION == ComparisonOperation::GREATER_THAN) {
+                laneMask = _mm256_movemask_ps(_mm256_cmp_ps(values, constantVector, _CMP_GT_OQ));
+            } else if constexpr (OPERATION == ComparisonOperation::GREATER_THAN_EQUAL) {
+                laneMask = _mm256_movemask_ps(_mm256_cmp_ps(values, constantVector, _CMP_GE_OQ));
+            } else if constexpr (OPERATION == ComparisonOperation::LESS_THAN) {
+                laneMask = _mm256_movemask_ps(_mm256_cmp_ps(values, constantVector, _CMP_NGE_UQ));
+            } else {
+                laneMask = _mm256_movemask_ps(_mm256_cmp_ps(values, constantVector, _CMP_NGT_UQ));
+            }
+        } else {
+            const auto values = _mm256_loadu_pd(data + base);
+            const auto constantVector = _mm256_set1_pd(constant);
+            if constexpr (OPERATION == ComparisonOperation::EQUAL) {
+                laneMask = _mm256_movemask_pd(_mm256_cmp_pd(values, constantVector, _CMP_EQ_OQ));
+            } else if constexpr (OPERATION == ComparisonOperation::NOT_EQUAL) {
+                laneMask = _mm256_movemask_pd(_mm256_cmp_pd(values, constantVector, _CMP_NEQ_UQ));
+            } else if constexpr (OPERATION == ComparisonOperation::GREATER_THAN) {
+                laneMask = _mm256_movemask_pd(_mm256_cmp_pd(values, constantVector, _CMP_GT_OQ));
+            } else if constexpr (OPERATION == ComparisonOperation::GREATER_THAN_EQUAL) {
+                laneMask = _mm256_movemask_pd(_mm256_cmp_pd(values, constantVector, _CMP_GE_OQ));
+            } else if constexpr (OPERATION == ComparisonOperation::LESS_THAN) {
+                laneMask = _mm256_movemask_pd(_mm256_cmp_pd(values, constantVector, _CMP_NGE_UQ));
+            } else {
+                laneMask = _mm256_movemask_pd(_mm256_cmp_pd(values, constantVector, _CMP_NGT_UQ));
+            }
+        }
+        laneMask = applyNullMask<LANE_COUNT>(laneMask, nullMask, base);
+        selected = compactLaneMask(laneMask, base, output, selected);
+    }
+    for (; base < count; ++base) {
+        if ((!nullMask || !common::NullMask::isNull(nullMask, base)) &&
+            compareScalar<T, OPERATION>(data[base], constant)) {
+            output[selected++] = base;
+        }
+    }
+    return selected;
+}
+
+template<typename T, ComparisonOperation OPERATION>
+common::sel_t selectVectorFloating(const void* leftPtr, const void* rightPtr, common::sel_t count,
+    const uint64_t* leftNullMask, const uint64_t* rightNullMask, common::sel_t* output) {
+    constexpr common::sel_t LANE_COUNT = 32 / sizeof(T);
+    const auto left = static_cast<const T*>(leftPtr);
+    const auto right = static_cast<const T*>(rightPtr);
+    common::sel_t selected = 0;
+    common::sel_t base = 0;
+    for (; base + LANE_COUNT <= count; base += LANE_COUNT) {
+        uint32_t laneMask;
+        if constexpr (std::is_same_v<T, float>) {
+            const auto leftValues = _mm256_loadu_ps(left + base);
+            const auto rightValues = _mm256_loadu_ps(right + base);
+            if constexpr (OPERATION == ComparisonOperation::EQUAL) {
+                laneMask = _mm256_movemask_ps(_mm256_cmp_ps(leftValues, rightValues, _CMP_EQ_OQ));
+            } else if constexpr (OPERATION == ComparisonOperation::NOT_EQUAL) {
+                laneMask = _mm256_movemask_ps(_mm256_cmp_ps(leftValues, rightValues, _CMP_NEQ_UQ));
+            } else if constexpr (OPERATION == ComparisonOperation::GREATER_THAN) {
+                laneMask = _mm256_movemask_ps(_mm256_cmp_ps(leftValues, rightValues, _CMP_GT_OQ));
+            } else if constexpr (OPERATION == ComparisonOperation::GREATER_THAN_EQUAL) {
+                laneMask = _mm256_movemask_ps(_mm256_cmp_ps(leftValues, rightValues, _CMP_GE_OQ));
+            } else if constexpr (OPERATION == ComparisonOperation::LESS_THAN) {
+                laneMask = _mm256_movemask_ps(_mm256_cmp_ps(leftValues, rightValues, _CMP_NGE_UQ));
+            } else {
+                laneMask = _mm256_movemask_ps(_mm256_cmp_ps(leftValues, rightValues, _CMP_NGT_UQ));
+            }
+        } else {
+            const auto leftValues = _mm256_loadu_pd(left + base);
+            const auto rightValues = _mm256_loadu_pd(right + base);
+            if constexpr (OPERATION == ComparisonOperation::EQUAL) {
+                laneMask = _mm256_movemask_pd(_mm256_cmp_pd(leftValues, rightValues, _CMP_EQ_OQ));
+            } else if constexpr (OPERATION == ComparisonOperation::NOT_EQUAL) {
+                laneMask = _mm256_movemask_pd(_mm256_cmp_pd(leftValues, rightValues, _CMP_NEQ_UQ));
+            } else if constexpr (OPERATION == ComparisonOperation::GREATER_THAN) {
+                laneMask = _mm256_movemask_pd(_mm256_cmp_pd(leftValues, rightValues, _CMP_GT_OQ));
+            } else if constexpr (OPERATION == ComparisonOperation::GREATER_THAN_EQUAL) {
+                laneMask = _mm256_movemask_pd(_mm256_cmp_pd(leftValues, rightValues, _CMP_GE_OQ));
+            } else if constexpr (OPERATION == ComparisonOperation::LESS_THAN) {
+                laneMask = _mm256_movemask_pd(_mm256_cmp_pd(leftValues, rightValues, _CMP_NGE_UQ));
+            } else {
+                laneMask = _mm256_movemask_pd(_mm256_cmp_pd(leftValues, rightValues, _CMP_NGT_UQ));
+            }
+        }
+        laneMask = applyNullMask<LANE_COUNT>(laneMask, leftNullMask, base);
+        laneMask = applyNullMask<LANE_COUNT>(laneMask, rightNullMask, base);
+        selected = compactLaneMask(laneMask, base, output, selected);
+    }
+    for (; base < count; ++base) {
+        if ((!leftNullMask || !common::NullMask::isNull(leftNullMask, base)) &&
+            (!rightNullMask || !common::NullMask::isNull(rightNullMask, base)) &&
+            compareScalar<T, OPERATION>(left[base], right[base])) {
+            output[selected++] = base;
+        }
+    }
+    return selected;
+}
+
+template<typename T, ComparisonOperation OPERATION>
+common::sel_t selectConstantTyped(const void* data, common::sel_t count, const void* constant,
+    const uint64_t* nullMask, common::sel_t* output) {
+    if constexpr (std::is_integral_v<T>) {
+        return selectConstantIntegral<T, OPERATION>(data, count, constant, nullMask, output);
+    } else {
+        return selectConstantFloating<T, OPERATION>(data, count, constant, nullMask, output);
+    }
+}
+
+template<typename T>
+common::sel_t selectConstantTyped(const void* data, common::sel_t count, const void* constant,
+    const uint64_t* nullMask, common::sel_t* output, ComparisonOperation operation) {
+    switch (operation) {
+    case ComparisonOperation::EQUAL:
+        return selectConstantTyped<T, ComparisonOperation::EQUAL>(data, count, constant, nullMask,
+            output);
+    case ComparisonOperation::NOT_EQUAL:
+        return selectConstantTyped<T, ComparisonOperation::NOT_EQUAL>(data, count, constant,
+            nullMask, output);
+    case ComparisonOperation::GREATER_THAN:
+        return selectConstantTyped<T, ComparisonOperation::GREATER_THAN>(data, count, constant,
+            nullMask, output);
+    case ComparisonOperation::GREATER_THAN_EQUAL:
+        return selectConstantTyped<T, ComparisonOperation::GREATER_THAN_EQUAL>(data, count,
+            constant, nullMask, output);
+    case ComparisonOperation::LESS_THAN:
+        return selectConstantTyped<T, ComparisonOperation::LESS_THAN>(data, count, constant,
+            nullMask, output);
+    case ComparisonOperation::LESS_THAN_EQUAL:
+        return selectConstantTyped<T, ComparisonOperation::LESS_THAN_EQUAL>(data, count, constant,
+            nullMask, output);
+    }
+    return 0;
+}
+
+template<typename T, ComparisonOperation OPERATION>
+common::sel_t selectVectorTyped(const void* left, const void* right, common::sel_t count,
+    const uint64_t* leftNullMask, const uint64_t* rightNullMask, common::sel_t* output) {
+    if constexpr (std::is_integral_v<T>) {
+        return selectVectorIntegral<T, OPERATION>(left, right, count, leftNullMask, rightNullMask,
+            output);
+    } else {
+        return selectVectorFloating<T, OPERATION>(left, right, count, leftNullMask, rightNullMask,
+            output);
+    }
+}
+
+template<typename T>
+common::sel_t selectVectorTyped(const void* left, const void* right, common::sel_t count,
+    const uint64_t* leftNullMask, const uint64_t* rightNullMask, common::sel_t* output,
+    ComparisonOperation operation) {
+    switch (operation) {
+    case ComparisonOperation::EQUAL:
+        return selectVectorTyped<T, ComparisonOperation::EQUAL>(left, right, count, leftNullMask,
+            rightNullMask, output);
+    case ComparisonOperation::NOT_EQUAL:
+        return selectVectorTyped<T, ComparisonOperation::NOT_EQUAL>(left, right, count,
+            leftNullMask, rightNullMask, output);
+    case ComparisonOperation::GREATER_THAN:
+        return selectVectorTyped<T, ComparisonOperation::GREATER_THAN>(left, right, count,
+            leftNullMask, rightNullMask, output);
+    case ComparisonOperation::GREATER_THAN_EQUAL:
+        return selectVectorTyped<T, ComparisonOperation::GREATER_THAN_EQUAL>(left, right, count,
+            leftNullMask, rightNullMask, output);
+    case ComparisonOperation::LESS_THAN:
+        return selectVectorTyped<T, ComparisonOperation::LESS_THAN>(left, right, count,
+            leftNullMask, rightNullMask, output);
+    case ComparisonOperation::LESS_THAN_EQUAL:
+        return selectVectorTyped<T, ComparisonOperation::LESS_THAN_EQUAL>(left, right, count,
+            leftNullMask, rightNullMask, output);
+    }
+    return 0;
+}
+
+} // namespace
+
+common::sel_t selectConstantAVX2(const void* data, common::sel_t count, const void* constant,
+    const uint64_t* nullMask, common::sel_t* output, common::PhysicalTypeID type,
+    ComparisonOperation operation) {
+    switch (type) {
+    case common::PhysicalTypeID::INT8:
+        return selectConstantTyped<int8_t>(data, count, constant, nullMask, output, operation);
+    case common::PhysicalTypeID::INT16:
+        return selectConstantTyped<int16_t>(data, count, constant, nullMask, output, operation);
+    case common::PhysicalTypeID::INT32:
+        return selectConstantTyped<int32_t>(data, count, constant, nullMask, output, operation);
+    case common::PhysicalTypeID::INT64:
+        return selectConstantTyped<int64_t>(data, count, constant, nullMask, output, operation);
+    case common::PhysicalTypeID::UINT8:
+        return selectConstantTyped<uint8_t>(data, count, constant, nullMask, output, operation);
+    case common::PhysicalTypeID::UINT16:
+        return selectConstantTyped<uint16_t>(data, count, constant, nullMask, output, operation);
+    case common::PhysicalTypeID::UINT32:
+        return selectConstantTyped<uint32_t>(data, count, constant, nullMask, output, operation);
+    case common::PhysicalTypeID::UINT64:
+        return selectConstantTyped<uint64_t>(data, count, constant, nullMask, output, operation);
+    case common::PhysicalTypeID::FLOAT:
+        return selectConstantTyped<float>(data, count, constant, nullMask, output, operation);
+    case common::PhysicalTypeID::DOUBLE:
+        return selectConstantTyped<double>(data, count, constant, nullMask, output, operation);
+    default:
+        return 0;
+    }
+}
+
+common::sel_t selectVectorAVX2(const void* left, const void* right, common::sel_t count,
+    const uint64_t* leftNullMask, const uint64_t* rightNullMask, common::sel_t* output,
+    common::PhysicalTypeID type, ComparisonOperation operation) {
+    switch (type) {
+    case common::PhysicalTypeID::INT8:
+        return selectVectorTyped<int8_t>(left, right, count, leftNullMask, rightNullMask, output,
+            operation);
+    case common::PhysicalTypeID::INT16:
+        return selectVectorTyped<int16_t>(left, right, count, leftNullMask, rightNullMask, output,
+            operation);
+    case common::PhysicalTypeID::INT32:
+        return selectVectorTyped<int32_t>(left, right, count, leftNullMask, rightNullMask, output,
+            operation);
+    case common::PhysicalTypeID::INT64:
+        return selectVectorTyped<int64_t>(left, right, count, leftNullMask, rightNullMask, output,
+            operation);
+    case common::PhysicalTypeID::UINT8:
+        return selectVectorTyped<uint8_t>(left, right, count, leftNullMask, rightNullMask, output,
+            operation);
+    case common::PhysicalTypeID::UINT16:
+        return selectVectorTyped<uint16_t>(left, right, count, leftNullMask, rightNullMask, output,
+            operation);
+    case common::PhysicalTypeID::UINT32:
+        return selectVectorTyped<uint32_t>(left, right, count, leftNullMask, rightNullMask, output,
+            operation);
+    case common::PhysicalTypeID::UINT64:
+        return selectVectorTyped<uint64_t>(left, right, count, leftNullMask, rightNullMask, output,
+            operation);
+    case common::PhysicalTypeID::FLOAT:
+        return selectVectorTyped<float>(left, right, count, leftNullMask, rightNullMask, output,
+            operation);
+    case common::PhysicalTypeID::DOUBLE:
+        return selectVectorTyped<double>(left, right, count, leftNullMask, rightNullMask, output,
+            operation);
+    default:
+        return 0;
+    }
+}
+
+} // namespace simd
+} // namespace function
+} // namespace lbug

--- a/src/function/simd_filter_neon.cpp
+++ b/src/function/simd_filter_neon.cpp
@@ -1,4 +1,3 @@
-#include <array>
 #include <cstdint>
 #include <type_traits>
 
@@ -22,11 +21,6 @@ namespace function {
 namespace simd {
 
 namespace {
-
-template<typename T>
-using MaskLane = std::conditional_t<sizeof(T) == 1, uint8_t,
-    std::conditional_t<sizeof(T) == 2, uint16_t,
-        std::conditional_t<sizeof(T) == 4, uint32_t, uint64_t>>>;
 
 template<typename T>
 auto loadVector(const T* data) {
@@ -154,19 +148,6 @@ auto notMask(MASK mask) {
     }
 }
 
-template<typename T, typename MASK>
-void storeMask(MaskLane<T>* data, MASK mask) {
-    if constexpr (sizeof(T) == 1) {
-        vst1q_u8(data, mask);
-    } else if constexpr (sizeof(T) == 2) {
-        vst1q_u16(data, mask);
-    } else if constexpr (sizeof(T) == 4) {
-        vst1q_u32(data, mask);
-    } else {
-        vst1q_u64(data, mask);
-    }
-}
-
 template<typename T, ComparisonOperation OPERATION, typename VECTOR>
 auto compareVector(VECTOR left, VECTOR right) {
     const auto equal = equalVector<T>(left, right);
@@ -215,8 +196,21 @@ uint32_t applyNullMask(uint32_t laneMask, const uint64_t* nullMask, common::sel_
     return laneMask & ~static_cast<uint32_t>(nullLanes);
 }
 
+template<common::sel_t LANE_COUNT>
 common::sel_t compactLaneMask(uint32_t laneMask, common::sel_t base, common::sel_t* output,
     common::sel_t selected) {
+    constexpr auto FULL_MASK = UINT32_MAX >> (32 - LANE_COUNT);
+    if (laneMask == 0) {
+        return selected;
+    }
+    if (laneMask == FULL_MASK) {
+        auto positions = vaddq_u64(vdupq_n_u64(base), vsetq_lane_u64(1, vdupq_n_u64(0), 1));
+        for (common::sel_t lane = 0; lane < LANE_COUNT; lane += 2) {
+            vst1q_u64(output + selected + lane, positions);
+            positions = vaddq_u64(positions, vdupq_n_u64(2));
+        }
+        return selected + LANE_COUNT;
+    }
     while (laneMask) {
         const auto lane = static_cast<common::sel_t>(std::countr_zero(laneMask));
         output[selected++] = base + lane;
@@ -227,30 +221,51 @@ common::sel_t compactLaneMask(uint32_t laneMask, common::sel_t base, common::sel
 
 template<typename T, typename MASK>
 uint32_t toLaneMask(MASK mask) {
-    constexpr common::sel_t LANE_COUNT = 16 / sizeof(T);
-    alignas(16) std::array<MaskLane<T>, LANE_COUNT> lanes;
-    storeMask<T>(lanes.data(), mask);
-    uint32_t laneMask = 0;
-    for (common::sel_t lane = 0; lane < LANE_COUNT; ++lane) {
-        laneMask |= static_cast<uint32_t>(lanes[lane] != 0) << lane;
+    if constexpr (sizeof(T) == 1) {
+        const auto bits = vshrq_n_u8(mask, 7);
+        const uint8x8_t weights = {1, 2, 4, 8, 16, 32, 64, 128};
+        const auto low = vaddv_u8(vmul_u8(vget_low_u8(bits), weights));
+        const auto high = vaddv_u8(vmul_u8(vget_high_u8(bits), weights));
+        return static_cast<uint32_t>(low) | (static_cast<uint32_t>(high) << 8);
+    } else if constexpr (sizeof(T) == 2) {
+        const uint16x8_t weights = {1, 2, 4, 8, 16, 32, 64, 128};
+        return vaddvq_u16(vmulq_u16(vshrq_n_u16(mask, 15), weights));
+    } else if constexpr (sizeof(T) == 4) {
+        const uint32x4_t weights = {1, 2, 4, 8};
+        return vaddvq_u32(vmulq_u32(vshrq_n_u32(mask, 31), weights));
+    } else {
+        const auto bits = vshrq_n_u64(mask, 63);
+        return static_cast<uint32_t>(vgetq_lane_u64(bits, 0) | (vgetq_lane_u64(bits, 1) << 1));
     }
-    return laneMask;
 }
 
 template<typename T, ComparisonOperation OPERATION>
 common::sel_t selectConstantTyped(const void* dataPtr, common::sel_t count, const void* constantPtr,
     const uint64_t* nullMask, common::sel_t* output) {
     constexpr common::sel_t LANE_COUNT = 16 / sizeof(T);
+    constexpr common::sel_t GROUP_LANE_COUNT = 32;
+    constexpr common::sel_t VECTORS_PER_GROUP = GROUP_LANE_COUNT / LANE_COUNT;
     const auto data = static_cast<const T*>(dataPtr);
     const auto constant = *static_cast<const T*>(constantPtr);
     const auto constantVector = broadcastVector(constant);
     common::sel_t selected = 0;
     common::sel_t base = 0;
+    for (; base + GROUP_LANE_COUNT <= count; base += GROUP_LANE_COUNT) {
+        uint32_t groupMask = 0;
+        for (common::sel_t vector = 0; vector < VECTORS_PER_GROUP; ++vector) {
+            const auto vectorBase = base + vector * LANE_COUNT;
+            auto laneMask = toLaneMask<T>(
+                compareVector<T, OPERATION>(loadVector(data + vectorBase), constantVector));
+            laneMask = applyNullMask<LANE_COUNT>(laneMask, nullMask, vectorBase);
+            groupMask |= laneMask << (vector * LANE_COUNT);
+        }
+        selected = compactLaneMask<GROUP_LANE_COUNT>(groupMask, base, output, selected);
+    }
     for (; base + LANE_COUNT <= count; base += LANE_COUNT) {
         auto laneMask =
             toLaneMask<T>(compareVector<T, OPERATION>(loadVector(data + base), constantVector));
         laneMask = applyNullMask<LANE_COUNT>(laneMask, nullMask, base);
-        selected = compactLaneMask(laneMask, base, output, selected);
+        selected = compactLaneMask<LANE_COUNT>(laneMask, base, output, selected);
     }
     for (; base < count; ++base) {
         if ((!nullMask || !common::NullMask::isNull(nullMask, base)) &&
@@ -291,16 +306,30 @@ template<typename T, ComparisonOperation OPERATION>
 common::sel_t selectVectorTyped(const void* leftPtr, const void* rightPtr, common::sel_t count,
     const uint64_t* leftNullMask, const uint64_t* rightNullMask, common::sel_t* output) {
     constexpr common::sel_t LANE_COUNT = 16 / sizeof(T);
+    constexpr common::sel_t GROUP_LANE_COUNT = 32;
+    constexpr common::sel_t VECTORS_PER_GROUP = GROUP_LANE_COUNT / LANE_COUNT;
     const auto left = static_cast<const T*>(leftPtr);
     const auto right = static_cast<const T*>(rightPtr);
     common::sel_t selected = 0;
     common::sel_t base = 0;
+    for (; base + GROUP_LANE_COUNT <= count; base += GROUP_LANE_COUNT) {
+        uint32_t groupMask = 0;
+        for (common::sel_t vector = 0; vector < VECTORS_PER_GROUP; ++vector) {
+            const auto vectorBase = base + vector * LANE_COUNT;
+            auto laneMask = toLaneMask<T>(compareVector<T, OPERATION>(loadVector(left + vectorBase),
+                loadVector(right + vectorBase)));
+            laneMask = applyNullMask<LANE_COUNT>(laneMask, leftNullMask, vectorBase);
+            laneMask = applyNullMask<LANE_COUNT>(laneMask, rightNullMask, vectorBase);
+            groupMask |= laneMask << (vector * LANE_COUNT);
+        }
+        selected = compactLaneMask<GROUP_LANE_COUNT>(groupMask, base, output, selected);
+    }
     for (; base + LANE_COUNT <= count; base += LANE_COUNT) {
         auto laneMask = toLaneMask<T>(
             compareVector<T, OPERATION>(loadVector(left + base), loadVector(right + base)));
         laneMask = applyNullMask<LANE_COUNT>(laneMask, leftNullMask, base);
         laneMask = applyNullMask<LANE_COUNT>(laneMask, rightNullMask, base);
-        selected = compactLaneMask(laneMask, base, output, selected);
+        selected = compactLaneMask<LANE_COUNT>(laneMask, base, output, selected);
     }
     for (; base < count; ++base) {
         if ((!leftNullMask || !common::NullMask::isNull(leftNullMask, base)) &&
@@ -384,7 +413,7 @@ common::sel_t selectVectorNEON(const void* left, const void* right, common::sel_
         return selectVectorTyped<int32_t>(left, right, count, leftNullMask, rightNullMask, output,
             operation);
     case common::PhysicalTypeID::INT64:
-        return selectVectorTyped<int64_t>(left, right, count, leftNullMask, rightNullMask, output,
+        return selectVectorScalar(left, right, count, leftNullMask, rightNullMask, output, type,
             operation);
     case common::PhysicalTypeID::UINT8:
         return selectVectorTyped<uint8_t>(left, right, count, leftNullMask, rightNullMask, output,
@@ -396,13 +425,13 @@ common::sel_t selectVectorNEON(const void* left, const void* right, common::sel_
         return selectVectorTyped<uint32_t>(left, right, count, leftNullMask, rightNullMask, output,
             operation);
     case common::PhysicalTypeID::UINT64:
-        return selectVectorTyped<uint64_t>(left, right, count, leftNullMask, rightNullMask, output,
+        return selectVectorScalar(left, right, count, leftNullMask, rightNullMask, output, type,
             operation);
     case common::PhysicalTypeID::FLOAT:
         return selectVectorTyped<float>(left, right, count, leftNullMask, rightNullMask, output,
             operation);
     case common::PhysicalTypeID::DOUBLE:
-        return selectVectorTyped<double>(left, right, count, leftNullMask, rightNullMask, output,
+        return selectVectorScalar(left, right, count, leftNullMask, rightNullMask, output, type,
             operation);
     default:
         return 0;

--- a/src/function/simd_filter_neon.cpp
+++ b/src/function/simd_filter_neon.cpp
@@ -1,0 +1,414 @@
+#include <array>
+#include <cstdint>
+#include <type_traits>
+
+#include <bit>
+
+#if defined(_MSC_VER)
+#include <arm64_neon.h>
+#else
+#include <arm_neon.h>
+#endif
+
+#include "common/null_mask.h"
+#include "function/comparison/simd_filter.h"
+
+#if !defined(__aarch64__) && !defined(_M_ARM64)
+#error "simd_filter_neon.cpp requires ARM64 NEON"
+#endif
+
+namespace lbug {
+namespace function {
+namespace simd {
+
+namespace {
+
+template<typename T>
+using MaskLane = std::conditional_t<sizeof(T) == 1, uint8_t,
+    std::conditional_t<sizeof(T) == 2, uint16_t,
+        std::conditional_t<sizeof(T) == 4, uint32_t, uint64_t>>>;
+
+template<typename T>
+auto loadVector(const T* data) {
+    if constexpr (std::is_same_v<T, int8_t>) {
+        return vld1q_s8(data);
+    } else if constexpr (std::is_same_v<T, int16_t>) {
+        return vld1q_s16(data);
+    } else if constexpr (std::is_same_v<T, int32_t>) {
+        return vld1q_s32(data);
+    } else if constexpr (std::is_same_v<T, int64_t>) {
+        return vld1q_s64(data);
+    } else if constexpr (std::is_same_v<T, uint8_t>) {
+        return vld1q_u8(data);
+    } else if constexpr (std::is_same_v<T, uint16_t>) {
+        return vld1q_u16(data);
+    } else if constexpr (std::is_same_v<T, uint32_t>) {
+        return vld1q_u32(data);
+    } else if constexpr (std::is_same_v<T, uint64_t>) {
+        return vld1q_u64(data);
+    } else if constexpr (std::is_same_v<T, float>) {
+        return vld1q_f32(data);
+    } else {
+        return vld1q_f64(data);
+    }
+}
+
+template<typename T>
+auto broadcastVector(T value) {
+    if constexpr (std::is_same_v<T, int8_t>) {
+        return vdupq_n_s8(value);
+    } else if constexpr (std::is_same_v<T, int16_t>) {
+        return vdupq_n_s16(value);
+    } else if constexpr (std::is_same_v<T, int32_t>) {
+        return vdupq_n_s32(value);
+    } else if constexpr (std::is_same_v<T, int64_t>) {
+        return vdupq_n_s64(value);
+    } else if constexpr (std::is_same_v<T, uint8_t>) {
+        return vdupq_n_u8(value);
+    } else if constexpr (std::is_same_v<T, uint16_t>) {
+        return vdupq_n_u16(value);
+    } else if constexpr (std::is_same_v<T, uint32_t>) {
+        return vdupq_n_u32(value);
+    } else if constexpr (std::is_same_v<T, uint64_t>) {
+        return vdupq_n_u64(value);
+    } else if constexpr (std::is_same_v<T, float>) {
+        return vdupq_n_f32(value);
+    } else {
+        return vdupq_n_f64(value);
+    }
+}
+
+template<typename T, typename VECTOR>
+auto equalVector(VECTOR left, VECTOR right) {
+    if constexpr (std::is_same_v<T, int8_t>) {
+        return vceqq_s8(left, right);
+    } else if constexpr (std::is_same_v<T, int16_t>) {
+        return vceqq_s16(left, right);
+    } else if constexpr (std::is_same_v<T, int32_t>) {
+        return vceqq_s32(left, right);
+    } else if constexpr (std::is_same_v<T, int64_t>) {
+        return vceqq_s64(left, right);
+    } else if constexpr (std::is_same_v<T, uint8_t>) {
+        return vceqq_u8(left, right);
+    } else if constexpr (std::is_same_v<T, uint16_t>) {
+        return vceqq_u16(left, right);
+    } else if constexpr (std::is_same_v<T, uint32_t>) {
+        return vceqq_u32(left, right);
+    } else if constexpr (std::is_same_v<T, uint64_t>) {
+        return vceqq_u64(left, right);
+    } else if constexpr (std::is_same_v<T, float>) {
+        return vceqq_f32(left, right);
+    } else {
+        return vceqq_f64(left, right);
+    }
+}
+
+template<typename T, typename VECTOR>
+auto greaterVector(VECTOR left, VECTOR right) {
+    if constexpr (std::is_same_v<T, int8_t>) {
+        return vcgtq_s8(left, right);
+    } else if constexpr (std::is_same_v<T, int16_t>) {
+        return vcgtq_s16(left, right);
+    } else if constexpr (std::is_same_v<T, int32_t>) {
+        return vcgtq_s32(left, right);
+    } else if constexpr (std::is_same_v<T, int64_t>) {
+        return vcgtq_s64(left, right);
+    } else if constexpr (std::is_same_v<T, uint8_t>) {
+        return vcgtq_u8(left, right);
+    } else if constexpr (std::is_same_v<T, uint16_t>) {
+        return vcgtq_u16(left, right);
+    } else if constexpr (std::is_same_v<T, uint32_t>) {
+        return vcgtq_u32(left, right);
+    } else if constexpr (std::is_same_v<T, uint64_t>) {
+        return vcgtq_u64(left, right);
+    } else if constexpr (std::is_same_v<T, float>) {
+        return vcgtq_f32(left, right);
+    } else {
+        return vcgtq_f64(left, right);
+    }
+}
+
+template<typename T, typename MASK>
+auto orMask(MASK left, MASK right) {
+    if constexpr (sizeof(T) == 1) {
+        return vorrq_u8(left, right);
+    } else if constexpr (sizeof(T) == 2) {
+        return vorrq_u16(left, right);
+    } else if constexpr (sizeof(T) == 4) {
+        return vorrq_u32(left, right);
+    } else {
+        return vorrq_u64(left, right);
+    }
+}
+
+template<typename T, typename MASK>
+auto notMask(MASK mask) {
+    if constexpr (sizeof(T) == 1) {
+        return veorq_u8(mask, vdupq_n_u8(UINT8_MAX));
+    } else if constexpr (sizeof(T) == 2) {
+        return veorq_u16(mask, vdupq_n_u16(UINT16_MAX));
+    } else if constexpr (sizeof(T) == 4) {
+        return veorq_u32(mask, vdupq_n_u32(UINT32_MAX));
+    } else {
+        return veorq_u64(mask, vdupq_n_u64(UINT64_MAX));
+    }
+}
+
+template<typename T, typename MASK>
+void storeMask(MaskLane<T>* data, MASK mask) {
+    if constexpr (sizeof(T) == 1) {
+        vst1q_u8(data, mask);
+    } else if constexpr (sizeof(T) == 2) {
+        vst1q_u16(data, mask);
+    } else if constexpr (sizeof(T) == 4) {
+        vst1q_u32(data, mask);
+    } else {
+        vst1q_u64(data, mask);
+    }
+}
+
+template<typename T, ComparisonOperation OPERATION, typename VECTOR>
+auto compareVector(VECTOR left, VECTOR right) {
+    const auto equal = equalVector<T>(left, right);
+    if constexpr (OPERATION == ComparisonOperation::EQUAL) {
+        return equal;
+    } else if constexpr (OPERATION == ComparisonOperation::NOT_EQUAL) {
+        return notMask<T>(equal);
+    } else {
+        const auto greater = greaterVector<T>(left, right);
+        if constexpr (OPERATION == ComparisonOperation::GREATER_THAN) {
+            return greater;
+        } else if constexpr (OPERATION == ComparisonOperation::GREATER_THAN_EQUAL) {
+            return orMask<T>(greater, equal);
+        } else if constexpr (OPERATION == ComparisonOperation::LESS_THAN) {
+            return notMask<T>(orMask<T>(greater, equal));
+        } else {
+            return notMask<T>(greater);
+        }
+    }
+}
+
+template<typename T, ComparisonOperation OPERATION>
+bool compareScalar(const T& left, const T& right) {
+    if constexpr (OPERATION == ComparisonOperation::EQUAL) {
+        return left == right;
+    } else if constexpr (OPERATION == ComparisonOperation::NOT_EQUAL) {
+        return !(left == right);
+    } else if constexpr (OPERATION == ComparisonOperation::GREATER_THAN) {
+        return left > right;
+    } else if constexpr (OPERATION == ComparisonOperation::GREATER_THAN_EQUAL) {
+        return left > right || left == right;
+    } else if constexpr (OPERATION == ComparisonOperation::LESS_THAN) {
+        return !(left > right || left == right);
+    } else {
+        return !(left > right);
+    }
+}
+
+template<common::sel_t LANE_COUNT>
+uint32_t applyNullMask(uint32_t laneMask, const uint64_t* nullMask, common::sel_t base) {
+    if (!nullMask) {
+        return laneMask;
+    }
+    const auto nullLanes = nullMask[base >> common::NullMask::NUM_BITS_PER_NULL_ENTRY_LOG2] >>
+                           (base & (common::NullMask::NUM_BITS_PER_NULL_ENTRY - 1));
+    return laneMask & ~static_cast<uint32_t>(nullLanes);
+}
+
+common::sel_t compactLaneMask(uint32_t laneMask, common::sel_t base, common::sel_t* output,
+    common::sel_t selected) {
+    while (laneMask) {
+        const auto lane = static_cast<common::sel_t>(std::countr_zero(laneMask));
+        output[selected++] = base + lane;
+        laneMask &= laneMask - 1;
+    }
+    return selected;
+}
+
+template<typename T, typename MASK>
+uint32_t toLaneMask(MASK mask) {
+    constexpr common::sel_t LANE_COUNT = 16 / sizeof(T);
+    alignas(16) std::array<MaskLane<T>, LANE_COUNT> lanes;
+    storeMask<T>(lanes.data(), mask);
+    uint32_t laneMask = 0;
+    for (common::sel_t lane = 0; lane < LANE_COUNT; ++lane) {
+        laneMask |= static_cast<uint32_t>(lanes[lane] != 0) << lane;
+    }
+    return laneMask;
+}
+
+template<typename T, ComparisonOperation OPERATION>
+common::sel_t selectConstantTyped(const void* dataPtr, common::sel_t count, const void* constantPtr,
+    const uint64_t* nullMask, common::sel_t* output) {
+    constexpr common::sel_t LANE_COUNT = 16 / sizeof(T);
+    const auto data = static_cast<const T*>(dataPtr);
+    const auto constant = *static_cast<const T*>(constantPtr);
+    const auto constantVector = broadcastVector(constant);
+    common::sel_t selected = 0;
+    common::sel_t base = 0;
+    for (; base + LANE_COUNT <= count; base += LANE_COUNT) {
+        auto laneMask =
+            toLaneMask<T>(compareVector<T, OPERATION>(loadVector(data + base), constantVector));
+        laneMask = applyNullMask<LANE_COUNT>(laneMask, nullMask, base);
+        selected = compactLaneMask(laneMask, base, output, selected);
+    }
+    for (; base < count; ++base) {
+        if ((!nullMask || !common::NullMask::isNull(nullMask, base)) &&
+            compareScalar<T, OPERATION>(data[base], constant)) {
+            output[selected++] = base;
+        }
+    }
+    return selected;
+}
+
+template<typename T>
+common::sel_t selectConstantTyped(const void* data, common::sel_t count, const void* constant,
+    const uint64_t* nullMask, common::sel_t* output, ComparisonOperation operation) {
+    switch (operation) {
+    case ComparisonOperation::EQUAL:
+        return selectConstantTyped<T, ComparisonOperation::EQUAL>(data, count, constant, nullMask,
+            output);
+    case ComparisonOperation::NOT_EQUAL:
+        return selectConstantTyped<T, ComparisonOperation::NOT_EQUAL>(data, count, constant,
+            nullMask, output);
+    case ComparisonOperation::GREATER_THAN:
+        return selectConstantTyped<T, ComparisonOperation::GREATER_THAN>(data, count, constant,
+            nullMask, output);
+    case ComparisonOperation::GREATER_THAN_EQUAL:
+        return selectConstantTyped<T, ComparisonOperation::GREATER_THAN_EQUAL>(data, count,
+            constant, nullMask, output);
+    case ComparisonOperation::LESS_THAN:
+        return selectConstantTyped<T, ComparisonOperation::LESS_THAN>(data, count, constant,
+            nullMask, output);
+    case ComparisonOperation::LESS_THAN_EQUAL:
+        return selectConstantTyped<T, ComparisonOperation::LESS_THAN_EQUAL>(data, count, constant,
+            nullMask, output);
+    }
+    return 0;
+}
+
+template<typename T, ComparisonOperation OPERATION>
+common::sel_t selectVectorTyped(const void* leftPtr, const void* rightPtr, common::sel_t count,
+    const uint64_t* leftNullMask, const uint64_t* rightNullMask, common::sel_t* output) {
+    constexpr common::sel_t LANE_COUNT = 16 / sizeof(T);
+    const auto left = static_cast<const T*>(leftPtr);
+    const auto right = static_cast<const T*>(rightPtr);
+    common::sel_t selected = 0;
+    common::sel_t base = 0;
+    for (; base + LANE_COUNT <= count; base += LANE_COUNT) {
+        auto laneMask = toLaneMask<T>(
+            compareVector<T, OPERATION>(loadVector(left + base), loadVector(right + base)));
+        laneMask = applyNullMask<LANE_COUNT>(laneMask, leftNullMask, base);
+        laneMask = applyNullMask<LANE_COUNT>(laneMask, rightNullMask, base);
+        selected = compactLaneMask(laneMask, base, output, selected);
+    }
+    for (; base < count; ++base) {
+        if ((!leftNullMask || !common::NullMask::isNull(leftNullMask, base)) &&
+            (!rightNullMask || !common::NullMask::isNull(rightNullMask, base)) &&
+            compareScalar<T, OPERATION>(left[base], right[base])) {
+            output[selected++] = base;
+        }
+    }
+    return selected;
+}
+
+template<typename T>
+common::sel_t selectVectorTyped(const void* left, const void* right, common::sel_t count,
+    const uint64_t* leftNullMask, const uint64_t* rightNullMask, common::sel_t* output,
+    ComparisonOperation operation) {
+    switch (operation) {
+    case ComparisonOperation::EQUAL:
+        return selectVectorTyped<T, ComparisonOperation::EQUAL>(left, right, count, leftNullMask,
+            rightNullMask, output);
+    case ComparisonOperation::NOT_EQUAL:
+        return selectVectorTyped<T, ComparisonOperation::NOT_EQUAL>(left, right, count,
+            leftNullMask, rightNullMask, output);
+    case ComparisonOperation::GREATER_THAN:
+        return selectVectorTyped<T, ComparisonOperation::GREATER_THAN>(left, right, count,
+            leftNullMask, rightNullMask, output);
+    case ComparisonOperation::GREATER_THAN_EQUAL:
+        return selectVectorTyped<T, ComparisonOperation::GREATER_THAN_EQUAL>(left, right, count,
+            leftNullMask, rightNullMask, output);
+    case ComparisonOperation::LESS_THAN:
+        return selectVectorTyped<T, ComparisonOperation::LESS_THAN>(left, right, count,
+            leftNullMask, rightNullMask, output);
+    case ComparisonOperation::LESS_THAN_EQUAL:
+        return selectVectorTyped<T, ComparisonOperation::LESS_THAN_EQUAL>(left, right, count,
+            leftNullMask, rightNullMask, output);
+    }
+    return 0;
+}
+
+} // namespace
+
+common::sel_t selectConstantNEON(const void* data, common::sel_t count, const void* constant,
+    const uint64_t* nullMask, common::sel_t* output, common::PhysicalTypeID type,
+    ComparisonOperation operation) {
+    switch (type) {
+    case common::PhysicalTypeID::INT8:
+        return selectConstantTyped<int8_t>(data, count, constant, nullMask, output, operation);
+    case common::PhysicalTypeID::INT16:
+        return selectConstantTyped<int16_t>(data, count, constant, nullMask, output, operation);
+    case common::PhysicalTypeID::INT32:
+        return selectConstantTyped<int32_t>(data, count, constant, nullMask, output, operation);
+    case common::PhysicalTypeID::INT64:
+        return selectConstantTyped<int64_t>(data, count, constant, nullMask, output, operation);
+    case common::PhysicalTypeID::UINT8:
+        return selectConstantTyped<uint8_t>(data, count, constant, nullMask, output, operation);
+    case common::PhysicalTypeID::UINT16:
+        return selectConstantTyped<uint16_t>(data, count, constant, nullMask, output, operation);
+    case common::PhysicalTypeID::UINT32:
+        return selectConstantTyped<uint32_t>(data, count, constant, nullMask, output, operation);
+    case common::PhysicalTypeID::UINT64:
+        return selectConstantTyped<uint64_t>(data, count, constant, nullMask, output, operation);
+    case common::PhysicalTypeID::FLOAT:
+        return selectConstantTyped<float>(data, count, constant, nullMask, output, operation);
+    case common::PhysicalTypeID::DOUBLE:
+        return selectConstantTyped<double>(data, count, constant, nullMask, output, operation);
+    default:
+        return 0;
+    }
+}
+
+common::sel_t selectVectorNEON(const void* left, const void* right, common::sel_t count,
+    const uint64_t* leftNullMask, const uint64_t* rightNullMask, common::sel_t* output,
+    common::PhysicalTypeID type, ComparisonOperation operation) {
+    switch (type) {
+    case common::PhysicalTypeID::INT8:
+        return selectVectorTyped<int8_t>(left, right, count, leftNullMask, rightNullMask, output,
+            operation);
+    case common::PhysicalTypeID::INT16:
+        return selectVectorTyped<int16_t>(left, right, count, leftNullMask, rightNullMask, output,
+            operation);
+    case common::PhysicalTypeID::INT32:
+        return selectVectorTyped<int32_t>(left, right, count, leftNullMask, rightNullMask, output,
+            operation);
+    case common::PhysicalTypeID::INT64:
+        return selectVectorTyped<int64_t>(left, right, count, leftNullMask, rightNullMask, output,
+            operation);
+    case common::PhysicalTypeID::UINT8:
+        return selectVectorTyped<uint8_t>(left, right, count, leftNullMask, rightNullMask, output,
+            operation);
+    case common::PhysicalTypeID::UINT16:
+        return selectVectorTyped<uint16_t>(left, right, count, leftNullMask, rightNullMask, output,
+            operation);
+    case common::PhysicalTypeID::UINT32:
+        return selectVectorTyped<uint32_t>(left, right, count, leftNullMask, rightNullMask, output,
+            operation);
+    case common::PhysicalTypeID::UINT64:
+        return selectVectorTyped<uint64_t>(left, right, count, leftNullMask, rightNullMask, output,
+            operation);
+    case common::PhysicalTypeID::FLOAT:
+        return selectVectorTyped<float>(left, right, count, leftNullMask, rightNullMask, output,
+            operation);
+    case common::PhysicalTypeID::DOUBLE:
+        return selectVectorTyped<double>(left, right, count, leftNullMask, rightNullMask, output,
+            operation);
+    default:
+        return 0;
+    }
+}
+
+} // namespace simd
+} // namespace function
+} // namespace lbug

--- a/src/include/function/binary_function_executor.h
+++ b/src/include/function/binary_function_executor.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "common/vector/value_vector.h"
+#include "function/comparison/simd_filter.h"
 
 namespace lbug {
 namespace function {
@@ -313,15 +314,43 @@ struct BinaryFunctionExecutor {
             return selectBothFlat<LEFT_TYPE, RIGHT_TYPE, FUNC, BinaryComparisonSelectWrapper>(left,
                 right, dataPtr);
         } else if (left.state->isFlat() && !right.state->isFlat()) {
+            if (simd::trySelectConstant(right, left,
+                    reverseComparisonOperation(FUNC::comparisonOperation), selVector)) {
+                return selVector.getSelSize() > 0;
+            }
             return selectFlatUnFlat<LEFT_TYPE, RIGHT_TYPE, FUNC, BinaryComparisonSelectWrapper>(
                 left, right, selVector, dataPtr);
         } else if (!left.state->isFlat() && right.state->isFlat()) {
+            if (simd::trySelectConstant(left, right, FUNC::comparisonOperation, selVector)) {
+                return selVector.getSelSize() > 0;
+            }
             return selectUnFlatFlat<LEFT_TYPE, RIGHT_TYPE, FUNC, BinaryComparisonSelectWrapper>(
                 left, right, selVector, dataPtr);
         } else {
+            if (simd::trySelectVector(left, right, FUNC::comparisonOperation, selVector)) {
+                return selVector.getSelSize() > 0;
+            }
             return selectBothUnFlat<LEFT_TYPE, RIGHT_TYPE, FUNC, BinaryComparisonSelectWrapper>(
                 left, right, selVector, dataPtr);
         }
+    }
+
+private:
+    static constexpr ComparisonOperation reverseComparisonOperation(ComparisonOperation operation) {
+        switch (operation) {
+        case ComparisonOperation::LESS_THAN:
+            return ComparisonOperation::GREATER_THAN;
+        case ComparisonOperation::LESS_THAN_EQUAL:
+            return ComparisonOperation::GREATER_THAN_EQUAL;
+        case ComparisonOperation::GREATER_THAN:
+            return ComparisonOperation::LESS_THAN;
+        case ComparisonOperation::GREATER_THAN_EQUAL:
+            return ComparisonOperation::LESS_THAN_EQUAL;
+        case ComparisonOperation::EQUAL:
+        case ComparisonOperation::NOT_EQUAL:
+            return operation;
+        }
+        return operation;
     }
 };
 

--- a/src/include/function/comparison/comparison_functions.h
+++ b/src/include/function/comparison/comparison_functions.h
@@ -1,11 +1,14 @@
 #pragma once
 
 #include "common/vector/value_vector.h"
+#include "function/comparison/comparison_operation.h"
 
 namespace lbug {
 namespace function {
 
 struct Equals {
+    static constexpr auto comparisonOperation = ComparisonOperation::EQUAL;
+
     template<class A, class B>
     static inline void operation(const A& left, const B& right, uint8_t& result,
         common::ValueVector* /*leftVector*/, common::ValueVector* /*rightVector*/) {
@@ -21,6 +24,8 @@ struct Equals {
 };
 
 struct NotEquals {
+    static constexpr auto comparisonOperation = ComparisonOperation::NOT_EQUAL;
+
     template<class A, class B>
     static inline void operation(const A& left, const B& right, uint8_t& result,
         common::ValueVector* leftVector, common::ValueVector* rightVector) {
@@ -37,6 +42,8 @@ struct NotEquals {
 };
 
 struct GreaterThan {
+    static constexpr auto comparisonOperation = ComparisonOperation::GREATER_THAN;
+
     template<class A, class B>
     static inline void operation(const A& left, const B& right, uint8_t& result,
         common::ValueVector* /*leftVector*/, common::ValueVector* /*rightVector*/) {
@@ -52,6 +59,8 @@ struct GreaterThan {
 };
 
 struct GreaterThanEquals {
+    static constexpr auto comparisonOperation = ComparisonOperation::GREATER_THAN_EQUAL;
+
     template<class A, class B>
     static inline void operation(const A& left, const B& right, uint8_t& result,
         common::ValueVector* leftVector, common::ValueVector* rightVector) {
@@ -71,6 +80,8 @@ struct GreaterThanEquals {
 };
 
 struct LessThan {
+    static constexpr auto comparisonOperation = ComparisonOperation::LESS_THAN;
+
     template<class A, class B>
     static inline void operation(const A& left, const B& right, uint8_t& result,
         common::ValueVector* leftVector, common::ValueVector* rightVector) {
@@ -87,6 +98,8 @@ struct LessThan {
 };
 
 struct LessThanEquals {
+    static constexpr auto comparisonOperation = ComparisonOperation::LESS_THAN_EQUAL;
+
     template<class A, class B>
     static inline void operation(const A& left, const B& right, uint8_t& result,
         common::ValueVector* leftVector, common::ValueVector* rightVector) {

--- a/src/include/function/comparison/comparison_operation.h
+++ b/src/include/function/comparison/comparison_operation.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <cstdint>
+
+namespace lbug {
+namespace function {
+
+enum class ComparisonOperation : uint8_t {
+    EQUAL,
+    NOT_EQUAL,
+    GREATER_THAN,
+    GREATER_THAN_EQUAL,
+    LESS_THAN,
+    LESS_THAN_EQUAL,
+};
+
+} // namespace function
+} // namespace lbug

--- a/src/include/function/comparison/simd_filter.h
+++ b/src/include/function/comparison/simd_filter.h
@@ -1,0 +1,54 @@
+#pragma once
+
+#include "common/api.h"
+#include "common/types/types.h"
+#include "function/comparison/comparison_operation.h"
+
+namespace lbug {
+namespace common {
+class SelectionVector;
+class ValueVector;
+} // namespace common
+
+namespace function {
+namespace simd {
+
+using SelectConstantKernel = common::sel_t (*)(const void* data, common::sel_t count,
+    const void* constant, const uint64_t* nullMask, common::sel_t* output,
+    common::PhysicalTypeID type, ComparisonOperation operation);
+using SelectVectorKernel = common::sel_t (*)(const void* left, const void* right,
+    common::sel_t count, const uint64_t* leftNullMask, const uint64_t* rightNullMask,
+    common::sel_t* output, common::PhysicalTypeID type, ComparisonOperation operation);
+
+// Scalar oracle for differential tests and machines without AVX2.
+LBUG_API common::sel_t selectConstantScalar(const void* data, common::sel_t count,
+    const void* constant, const uint64_t* nullMask, common::sel_t* output,
+    common::PhysicalTypeID type, ComparisonOperation operation);
+
+// Invokes the automatically selected kernel. An x86 build containing AVX2 dispatches once to AVX2
+// or scalar; an ARM64 build uses NEON unless scalar execution is explicitly requested.
+LBUG_API common::sel_t selectConstant(const void* data, common::sel_t count, const void* constant,
+    const uint64_t* nullMask, common::sel_t* output, common::PhysicalTypeID type,
+    ComparisonOperation operation);
+
+LBUG_API common::sel_t selectVectorScalar(const void* left, const void* right, common::sel_t count,
+    const uint64_t* leftNullMask, const uint64_t* rightNullMask, common::sel_t* output,
+    common::PhysicalTypeID type, ComparisonOperation operation);
+
+LBUG_API common::sel_t selectVector(const void* left, const void* right, common::sel_t count,
+    const uint64_t* leftNullMask, const uint64_t* rightNullMask, common::sel_t* output,
+    common::PhysicalTypeID type, ComparisonOperation operation);
+
+// Attempts the dense vector-versus-flat filter path. Returns false when the input shape or type is
+// unsupported, so the caller can execute the existing generic loop. When it returns true, output
+// has been updated even when no rows matched.
+LBUG_API bool trySelectConstant(common::ValueVector& data, common::ValueVector& constant,
+    ComparisonOperation operation, common::SelectionVector& output);
+
+// Attempts the dense vector-versus-vector path when both vectors share one unfiltered state.
+LBUG_API bool trySelectVector(common::ValueVector& left, common::ValueVector& right,
+    ComparisonOperation operation, common::SelectionVector& output);
+
+} // namespace simd
+} // namespace function
+} // namespace lbug

--- a/test/common/CMakeLists.txt
+++ b/test/common/CMakeLists.txt
@@ -11,4 +11,5 @@ add_lbug_test(types_test
         timestamp_test.cpp
         vfs_test.cpp
         boolean_filter_test.cpp
+        simd_filter_test.cpp
 )

--- a/test/common/simd_filter_test.cpp
+++ b/test/common/simd_filter_test.cpp
@@ -1,0 +1,279 @@
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <cstdint>
+#include <limits>
+#include <memory>
+#include <type_traits>
+#include <vector>
+
+#include "common/data_chunk/data_chunk_state.h"
+#include "common/data_chunk/sel_vector.h"
+#include "common/null_mask.h"
+#include "common/types/types.h"
+#include "common/vector/value_vector.h"
+#include "function/binary_function_executor.h"
+#include "function/comparison/comparison_functions.h"
+#include "function/comparison/simd_filter.h"
+#include "gtest/gtest.h"
+
+using namespace lbug;
+
+namespace {
+
+template<typename T>
+bool evaluateComparison(T left, T right, function::ComparisonOperation operation) {
+    switch (operation) {
+    case function::ComparisonOperation::EQUAL:
+        return function::Equals::operation(left, right);
+    case function::ComparisonOperation::NOT_EQUAL:
+        return function::NotEquals::operation(left, right);
+    case function::ComparisonOperation::GREATER_THAN:
+        return function::GreaterThan::operation(left, right);
+    case function::ComparisonOperation::GREATER_THAN_EQUAL:
+        return function::GreaterThanEquals::operation(left, right);
+    case function::ComparisonOperation::LESS_THAN:
+        return function::LessThan::operation(left, right);
+    case function::ComparisonOperation::LESS_THAN_EQUAL:
+        return function::LessThanEquals::operation(left, right);
+    }
+    return false;
+}
+
+constexpr std::array COMPARISON_OPERATIONS = {function::ComparisonOperation::EQUAL,
+    function::ComparisonOperation::NOT_EQUAL, function::ComparisonOperation::GREATER_THAN,
+    function::ComparisonOperation::GREATER_THAN_EQUAL, function::ComparisonOperation::LESS_THAN,
+    function::ComparisonOperation::LESS_THAN_EQUAL};
+
+template<typename T>
+void verifyIntegerKernels(common::PhysicalTypeID type) {
+    constexpr common::sel_t COUNT = 257;
+    std::vector<T> data(COUNT);
+    T constant;
+    if constexpr (std::is_unsigned_v<T>) {
+        constant = static_cast<T>(T{1} << (sizeof(T) * 8 - 1));
+        for (common::sel_t i = 0; i < COUNT; ++i) {
+            switch (i % 5) {
+            case 0:
+                data[i] = 0;
+                break;
+            case 1:
+                data[i] = constant - 1;
+                break;
+            case 2:
+                data[i] = constant;
+                break;
+            case 3:
+                data[i] = constant + 1;
+                break;
+            default:
+                data[i] = std::numeric_limits<T>::max();
+            }
+        }
+    } else {
+        constant = static_cast<T>(47);
+        for (common::sel_t i = 0; i < COUNT; ++i) {
+            data[i] = static_cast<T>((i * 37 + 11) % 101);
+        }
+        data[0] = std::numeric_limits<T>::min();
+        data[1] = std::numeric_limits<T>::max();
+    }
+    common::NullMask nullMask{COUNT};
+    for (common::sel_t i = 3; i < COUNT; i += 17) {
+        nullMask.setNull(i, true);
+    }
+    for (const auto i : {63u, 64u, 127u, 128u}) {
+        nullMask.setNull(i, true);
+    }
+
+    std::vector<common::sel_t> scalar(COUNT);
+    std::vector<common::sel_t> dispatched(COUNT);
+    std::vector<common::sel_t> expected;
+    expected.reserve(COUNT);
+    for (const auto operation : COMPARISON_OPERATIONS) {
+        const auto scalarCount = function::simd::selectConstantScalar(data.data(), COUNT, &constant,
+            nullMask.getData(), scalar.data(), type, operation);
+        const auto dispatchedCount = function::simd::selectConstant(data.data(), COUNT, &constant,
+            nullMask.getData(), dispatched.data(), type, operation);
+        expected.clear();
+        for (common::sel_t i = 0; i < COUNT; ++i) {
+            if (!nullMask.isNull(i) && evaluateComparison(data[i], constant, operation)) {
+                expected.push_back(i);
+            }
+        }
+        ASSERT_EQ(scalarCount, expected.size());
+        ASSERT_EQ(dispatchedCount, expected.size());
+        EXPECT_TRUE(std::equal(expected.begin(), expected.end(), scalar.begin()));
+        EXPECT_TRUE(std::equal(expected.begin(), expected.end(), dispatched.begin()));
+    }
+
+    std::vector<T> right(COUNT);
+    for (common::sel_t i = 0; i < COUNT; ++i) {
+        right[i] = data[(i * 13 + 7) % COUNT];
+    }
+    common::NullMask rightNullMask{COUNT};
+    for (const auto i : {5u, 64u, 126u, 127u, 192u}) {
+        rightNullMask.setNull(i, true);
+    }
+    for (const auto operation : COMPARISON_OPERATIONS) {
+        const auto scalarCount = function::simd::selectVectorScalar(data.data(), right.data(),
+            COUNT, nullMask.getData(), rightNullMask.getData(), scalar.data(), type, operation);
+        const auto dispatchedCount = function::simd::selectVector(data.data(), right.data(), COUNT,
+            nullMask.getData(), rightNullMask.getData(), dispatched.data(), type, operation);
+        expected.clear();
+        for (common::sel_t i = 0; i < COUNT; ++i) {
+            if (!nullMask.isNull(i) && !rightNullMask.isNull(i) &&
+                evaluateComparison(data[i], right[i], operation)) {
+                expected.push_back(i);
+            }
+        }
+        ASSERT_EQ(scalarCount, expected.size());
+        ASSERT_EQ(dispatchedCount, expected.size());
+        EXPECT_TRUE(std::equal(expected.begin(), expected.end(), scalar.begin()));
+        EXPECT_TRUE(std::equal(expected.begin(), expected.end(), dispatched.begin()));
+    }
+}
+
+template<typename T>
+void verifyFloatingKernel(common::PhysicalTypeID type) {
+    constexpr common::sel_t COUNT = 257;
+    std::vector<T> data(COUNT);
+    for (common::sel_t i = 0; i < COUNT; ++i) {
+        data[i] = static_cast<T>(static_cast<int64_t>(i % 17) - 8);
+    }
+    data[0] = -std::numeric_limits<T>::infinity();
+    data[1] = -T{0};
+    data[2] = T{0};
+    data[31] = std::numeric_limits<T>::infinity();
+    data[32] = std::numeric_limits<T>::quiet_NaN();
+    data[129] = std::numeric_limits<T>::signaling_NaN();
+    const T constant = T{1};
+    common::NullMask nullMask{COUNT};
+    for (const auto i : {17u, 63u, 64u, 127u, 128u, 255u}) {
+        nullMask.setNull(i, true);
+    }
+
+    std::vector<common::sel_t> scalar(COUNT);
+    std::vector<common::sel_t> dispatched(COUNT);
+    for (const auto operation : COMPARISON_OPERATIONS) {
+        const auto scalarCount = function::simd::selectConstantScalar(data.data(), COUNT, &constant,
+            nullMask.getData(), scalar.data(), type, operation);
+        const auto dispatchedCount = function::simd::selectConstant(data.data(), COUNT, &constant,
+            nullMask.getData(), dispatched.data(), type, operation);
+        std::vector<common::sel_t> expected;
+        for (common::sel_t i = 0; i < COUNT; ++i) {
+            if (!nullMask.isNull(i) && evaluateComparison(data[i], constant, operation)) {
+                expected.push_back(i);
+            }
+        }
+        ASSERT_EQ(scalarCount, expected.size());
+        ASSERT_EQ(dispatchedCount, expected.size());
+        EXPECT_TRUE(std::equal(expected.begin(), expected.end(), scalar.begin()));
+        EXPECT_TRUE(std::equal(expected.begin(), expected.end(), dispatched.begin()));
+    }
+
+    std::vector<T> right(COUNT);
+    for (common::sel_t i = 0; i < COUNT; ++i) {
+        right[i] = data[(i * 19 + 3) % COUNT];
+    }
+    right[65] = std::numeric_limits<T>::quiet_NaN();
+    common::NullMask rightNullMask{COUNT};
+    for (const auto i : {5u, 64u, 126u, 127u, 192u}) {
+        rightNullMask.setNull(i, true);
+    }
+    for (const auto operation : COMPARISON_OPERATIONS) {
+        const auto scalarCount = function::simd::selectVectorScalar(data.data(), right.data(),
+            COUNT, nullMask.getData(), rightNullMask.getData(), scalar.data(), type, operation);
+        const auto dispatchedCount = function::simd::selectVector(data.data(), right.data(), COUNT,
+            nullMask.getData(), rightNullMask.getData(), dispatched.data(), type, operation);
+        std::vector<common::sel_t> expected;
+        for (common::sel_t i = 0; i < COUNT; ++i) {
+            if (!nullMask.isNull(i) && !rightNullMask.isNull(i) &&
+                evaluateComparison(data[i], right[i], operation)) {
+                expected.push_back(i);
+            }
+        }
+        ASSERT_EQ(scalarCount, expected.size());
+        ASSERT_EQ(dispatchedCount, expected.size());
+        EXPECT_TRUE(std::equal(expected.begin(), expected.end(), scalar.begin()));
+        EXPECT_TRUE(std::equal(expected.begin(), expected.end(), dispatched.begin()));
+    }
+}
+
+} // namespace
+
+TEST(SIMDFilterTest, KernelsMatchIntegerComparisons) {
+    verifyIntegerKernels<int8_t>(common::PhysicalTypeID::INT8);
+    verifyIntegerKernels<int16_t>(common::PhysicalTypeID::INT16);
+    verifyIntegerKernels<int32_t>(common::PhysicalTypeID::INT32);
+    verifyIntegerKernels<int64_t>(common::PhysicalTypeID::INT64);
+    verifyIntegerKernels<uint8_t>(common::PhysicalTypeID::UINT8);
+    verifyIntegerKernels<uint16_t>(common::PhysicalTypeID::UINT16);
+    verifyIntegerKernels<uint32_t>(common::PhysicalTypeID::UINT32);
+    verifyIntegerKernels<uint64_t>(common::PhysicalTypeID::UINT64);
+}
+
+TEST(SIMDFilterTest, KernelsPreserveFloatingPointSemantics) {
+    verifyFloatingKernel<float>(common::PhysicalTypeID::FLOAT);
+    verifyFloatingKernel<double>(common::PhysicalTypeID::DOUBLE);
+}
+
+TEST(SIMDFilterTest, BinaryExecutorHandlesBothConstantDirections) {
+    constexpr common::sel_t COUNT = 128;
+    auto dataState = std::make_shared<common::DataChunkState>(COUNT);
+    dataState->setToUnflat();
+    dataState->initOriginalAndSelectedSize(COUNT);
+    common::ValueVector data{common::LogicalType::INT64(), nullptr, dataState};
+    for (common::sel_t i = 0; i < COUNT; ++i) {
+        data.setValue<int64_t>(i, static_cast<int64_t>(i));
+    }
+    data.setNull(73, true);
+
+    auto constantState = common::DataChunkState::getSingleValueDataChunkState();
+    common::ValueVector constant{common::LogicalType::INT64(), nullptr, constantState};
+    constant.setValue<int64_t>(0, 63);
+
+    common::SelectionVector output{COUNT};
+    ASSERT_TRUE((
+        function::BinaryFunctionExecutor::selectComparison<int64_t, int64_t, function::GreaterThan>(
+            data, constant, output, nullptr)));
+    ASSERT_EQ(output.getSelSize(), 63u);
+    output.setToFiltered();
+    EXPECT_EQ(output[0], 64u);
+    EXPECT_EQ(output[62], 127u);
+
+    output.setToUnfiltered(COUNT);
+    ASSERT_TRUE(
+        (function::BinaryFunctionExecutor::selectComparison<int64_t, int64_t, function::LessThan>(
+            constant, data, output, nullptr)));
+    ASSERT_EQ(output.getSelSize(), 63u);
+    output.setToFiltered();
+    EXPECT_EQ(output[0], 64u);
+    EXPECT_EQ(output[62], 127u);
+}
+
+TEST(SIMDFilterTest, BinaryExecutorHandlesSharedDenseVectors) {
+    constexpr common::sel_t COUNT = 128;
+    auto state = std::make_shared<common::DataChunkState>(COUNT);
+    state->setToUnflat();
+    state->initOriginalAndSelectedSize(COUNT);
+    common::ValueVector left{common::LogicalType::INT32(), nullptr, state};
+    common::ValueVector right{common::LogicalType::INT32(), nullptr, state};
+    for (common::sel_t i = 0; i < COUNT; ++i) {
+        left.setValue<int32_t>(i, static_cast<int32_t>(i));
+        right.setValue<int32_t>(i, static_cast<int32_t>(COUNT - 1 - i));
+    }
+    left.setNull(17, true);
+    right.setNull(18, true);
+
+    common::SelectionVector output{COUNT};
+    ASSERT_TRUE(
+        (function::BinaryFunctionExecutor::selectComparison<int32_t, int32_t, function::LessThan>(
+            left, right, output, nullptr)));
+    ASSERT_EQ(output.getSelSize(), 62u);
+    output.setToFiltered();
+    EXPECT_EQ(output[0], 0u);
+    EXPECT_EQ(output[16], 16u);
+    EXPECT_EQ(output[17], 19u);
+    EXPECT_EQ(output[61], 63u);
+}


### PR DESCRIPTION
## Summary

Add specialized filter-selection kernels for fixed-width numeric comparisons.

The implementation accelerates dense, unfiltered filter inputs while preserving the existing generic executor as the fallback for unsupported shapes and types.

## What changed

- Add AVX2 kernels for x86-64.
- Add NEON kernels for ARM64.
- Support MSVC, GCC, and Clang builds.
- Add runtime AVX2 CPU detection on x86-64.
- Add `LBUG_ENABLE_SIMD`, enabled by default.
- Add `LBUG_SIMD` runtime selection:
  - `auto` / `1`: select the platform backend
  - `scalar` / `0`: force the scalar reference kernel
  - `avx2` or `neon`: force the corresponding platform backend
- Add dense fast paths to `BinaryFunctionExecutor` for:
  - vector-to-constant comparisons
  - constant-to-vector comparisons
  - vector-to-vector comparisons
- Support:
  - `INT8`–`INT64`
  - `UINT8`–`UINT64`
  - `FLOAT`
  - `DOUBLE`
  - equality and ordered comparisons
- Apply null masks to generated lane masks.
- Preserve existing floating-point/NaN comparison semantics.
- Fall back to the existing generic executor for filtered selection vectors,
  small inputs, unsupported types, and incompatible vector states.

## ARM64 optimization

The initial NEON implementation regressed at medium and high selectivity because
it stored comparison masks to the stack and compacted every vector separately.

This PR now:

- extracts lane masks directly from NEON registers;
- evaluates and compacts 32 rows at a time;
- special-cases empty and all-selected masks;
- writes contiguous selection positions with vector stores;
- uses branchless dense scalar compaction for 64-bit vector-to-vector comparisons,
  where two-lane NEON was slower.

## Performance

Apple M5 Pro, Release build, one thread, warm 10-million-row dataset.

Each result is the median of 100 interleaved SIMD-on/off executions. Query
compilation and dataset creation are excluded.

| Filter | Matches | SIMD off | Optimized | Improvement |
|---|---:|---:|---:|---:|
| `value < 10` | 1% | 5.851 ms | 4.964 ms | 17.9% |
| `value < 100` | 10% | 5.806 ms | 4.981 ms | 16.6% |
| `value < 500` | 50% | 5.824 ms | 5.089 ms | 14.4% |
| `value < 900` | 90% | 5.782 ms | 5.290 ms | 9.3% |
| `value < other` | ~50% | 7.473 ms | 7.219 ms | 3.5% |

All benchmark result counts matched the expected values.

The final ARM64-enabled benchmark executable is approximately 166 KB larger
than the otherwise-identical SIMD-disabled Release executable.

AVX2 performance has not yet been measured on x86 hardware.

## Testing

Added differential tests covering:

- every supported integer width;
- signed and unsigned comparisons;
- `FLOAT` and `DOUBLE`;
- all six comparison operations;
- null masks and null-word boundaries;
- floating-point infinities, signed zero, and NaNs;
- vector-to-constant comparisons in both operand directions;
- dense vector-to-vector comparisons.

Verified locally:

```text
LBUG_SIMD=neon types_test --gtest_filter='SIMDFilterTest.*'
4 tests passed

LBUG_SIMD=scalar types_test --gtest_filter='SIMDFilterTest.*'
4 tests passed
