### PR TITLE
symmetrize: add rel-table CSR sorted-by-dest fast path

### DIFF
--- a/src/binder/bind/bind_ddl.cpp
+++ b/src/binder/bind/bind_ddl.cpp
@@ -749,12 +749,38 @@ std::unique_ptr<BoundStatement> Binder::bindSetSortedBy(const Statement& stateme
     auto catalog = Catalog::Get(*clientContext);
     auto transaction = transaction::Transaction::Get(*clientContext);
     auto tableEntry = catalog->getTableCatalogEntry(transaction, tableName);
-    validateNodeTableType(tableEntry);
     std::vector<BoundSortedByProperty> properties;
     properties.reserve(extraInfo->properties.size());
-    for (auto& property : extraInfo->properties) {
-        validateColumnExistence(tableEntry, property.propertyName);
-        properties.push_back(BoundSortedByProperty{property.propertyName, property.ascending});
+    if (tableEntry->getTableType() == common::TableType::REL) {
+        // Rel-table sorted-by is structural: the CSR adjacency lists must be
+        // sorted by (FROM ASC, TO ASC), where FROM and TO are the source and
+        // destination endpoints of the relation. They are reserved structural
+        // names — they are NOT rel properties, so they bypass
+        // validateColumnExistence. Only the CSR form is meaningful for rel
+        // tables (the non-CSR sorted-by is a node-table feature).
+        if (!extraInfo->csr) {
+            throw BinderException(
+                std::format("SORTED BY on rel table {} requires the CSR clause.", tableName));
+        }
+        if (extraInfo->properties.size() != 2 ||
+            !common::StringUtils::caseInsensitiveEquals(extraInfo->properties[0].propertyName,
+                "FROM") ||
+            !extraInfo->properties[0].ascending ||
+            !common::StringUtils::caseInsensitiveEquals(extraInfo->properties[1].propertyName,
+                "TO") ||
+            !extraInfo->properties[1].ascending) {
+            throw BinderException(std::format(
+                "CSR on rel table {} requires SORTED BY (FROM ASC, TO ASC).", tableName));
+        }
+        for (auto& property : extraInfo->properties) {
+            properties.push_back(BoundSortedByProperty{property.propertyName, property.ascending});
+        }
+    } else {
+        validateNodeTableType(tableEntry);
+        for (auto& property : extraInfo->properties) {
+            validateColumnExistence(tableEntry, property.propertyName);
+            properties.push_back(BoundSortedByProperty{property.propertyName, property.ascending});
+        }
     }
     auto boundExtraInfo =
         std::make_unique<BoundExtraSetSortedByInfo>(std::move(properties), extraInfo->csr);

--- a/src/catalog/catalog_entry/rel_group_catalog_entry.cpp
+++ b/src/catalog/catalog_entry/rel_group_catalog_entry.cpp
@@ -132,6 +132,10 @@ void RelGroupCatalogEntry::serialize(Serializer& serializer) const {
     serializer.serializeVector(relTableInfos);
     serializer.writeDebuggingInfo("storageFormat");
     serializer.serializeValue(storageFormat);
+    serializer.writeDebuggingInfo("csrSortedByDest");
+    serializer.serializeValue(csrSortedByDest);
+    serializer.writeDebuggingInfo("csrChangeEpoch");
+    serializer.serializeValue(csrChangeEpoch);
 }
 
 std::unique_ptr<RelGroupCatalogEntry> RelGroupCatalogEntry::deserialize(
@@ -174,6 +178,15 @@ std::unique_ptr<RelGroupCatalogEntry> RelGroupCatalogEntry::deserialize(
     } else {
         upgradeLegacyStorageFormat(storage, storageFormat);
     }
+    bool csrSortedByDest = false;
+    uint64_t csrChangeEpoch = 0;
+    if (deserializer.getStorageVersion() >=
+        ::lbug::storage::StorageVersionInfo::STORAGE_VERSION_45) {
+        deserializer.validateDebuggingInfo(debuggingInfo, "csrSortedByDest");
+        deserializer.deserializeValue(csrSortedByDest);
+        deserializer.validateDebuggingInfo(debuggingInfo, "csrChangeEpoch");
+        deserializer.deserializeValue(csrChangeEpoch);
+    }
     auto relGroupEntry = std::make_unique<RelGroupCatalogEntry>();
     relGroupEntry->srcMultiplicity = srcMultiplicity;
     relGroupEntry->dstMultiplicity = dstMultiplicity;
@@ -182,6 +195,8 @@ std::unique_ptr<RelGroupCatalogEntry> RelGroupCatalogEntry::deserialize(
     relGroupEntry->storageFormat = storageFormat;
     relGroupEntry->scanFunction = scanFunction;
     relGroupEntry->relTableInfos = relTableInfos;
+    relGroupEntry->csrSortedByDest = csrSortedByDest;
+    relGroupEntry->csrChangeEpoch = csrChangeEpoch;
     return relGroupEntry;
 }
 
@@ -264,6 +279,8 @@ std::unique_ptr<TableCatalogEntry> RelGroupCatalogEntry::copy() const {
     other->scanBindData = std::nullopt; // TODO: implement copy for bindData if needed
     other->foreignDatabaseName = foreignDatabaseName;
     other->relTableInfos = relTableInfos;
+    other->csrSortedByDest = csrSortedByDest;
+    other->csrChangeEpoch = csrChangeEpoch;
     other->copyFrom(*this);
     return other;
 }

--- a/src/catalog/catalog_entry/table_catalog_entry.cpp
+++ b/src/catalog/catalog_entry/table_catalog_entry.cpp
@@ -39,14 +39,23 @@ std::unique_ptr<TableCatalogEntry> TableCatalogEntry::alter(transaction_t timest
     } break;
     case AlterType::SET_SORTED_BY: {
         auto& sortedByInfo = *alterInfo.extraInfo->constPtrCast<BoundExtraSetSortedByInfo>();
-        std::vector<SortedByProperty> properties;
-        properties.reserve(sortedByInfo.properties.size());
-        for (auto& property : sortedByInfo.properties) {
-            properties.push_back(SortedByProperty{property.propertyName, property.ascending});
+        if (newEntry->getTableType() == common::TableType::NODE) {
+            std::vector<SortedByProperty> properties;
+            properties.reserve(sortedByInfo.properties.size());
+            for (auto& property : sortedByInfo.properties) {
+                properties.push_back(SortedByProperty{property.propertyName, property.ascending});
+            }
+            newEntry->ptrCast<NodeTableCatalogEntry>()->setSortedByProperties(
+                std::move(properties));
+            newEntry->ptrCast<NodeTableCatalogEntry>()->setCsr(sortedByInfo.csr,
+                sortedByInfo.csrChangeEpoch);
+        } else if (newEntry->getTableType() == common::TableType::REL) {
+            // For rel tables the sorted-by clause is structural (FROM ASC,
+            // TO ASC) — there are no per-property sorted-by columns to
+            // store, only the CSR-sorted-by-dest flag + changeEpoch watermark.
+            newEntry->ptrCast<RelGroupCatalogEntry>()->setCsrSortedByDest(sortedByInfo.csr,
+                sortedByInfo.csrChangeEpoch);
         }
-        newEntry->ptrCast<NodeTableCatalogEntry>()->setSortedByProperties(std::move(properties));
-        newEntry->ptrCast<NodeTableCatalogEntry>()->setCsr(sortedByInfo.csr,
-            sortedByInfo.csrChangeEpoch);
     } break;
     case AlterType::ADD_FROM_TO_CONNECTION: {
         auto& connectionInfo =

--- a/src/include/catalog/catalog_entry/rel_group_catalog_entry.h
+++ b/src/include/catalog/catalog_entry/rel_group_catalog_entry.h
@@ -86,6 +86,26 @@ public:
     common::ExtendDirection getStorageDirection() const { return storageDirection; }
     const std::string& getStorage() const { return storage; }
     common::StorageFormat getStorageFormat() const { return storageFormat; }
+
+    // CSR sorted-by-dest is an explicit user declaration that the rel
+    // table's CSR adjacency lists are physically stored with neighbors
+    // (dest node row IDs) in non-decreasing order within each bound
+    // (source) row. This lets ArrowQueryResult::CSRArrowArrays::symmetrize()
+    // skip the O(m log max-degree) per-row sort and run a two-pointer
+    // merge directly against the raw indices. It is a user assertion: the
+    // storage engine does not (yet) establish the invariant during
+    // checkpoint, so it is the caller's responsibility to only declare it
+    // on data that is actually sorted (e.g. loaded from a pre-sorted
+    // source). The csrChangeEpoch watermark records the rel table's
+    // changeEpoch at declaration time; symmetrize() disregards the flag
+    // when the table has been mutated since declaration, falling back to
+    // the safe per-row sort path.
+    bool isCsrSortedByDest() const { return csrSortedByDest; }
+    uint64_t getCsrChangeEpoch() const { return csrChangeEpoch; }
+    void setCsrSortedByDest(bool enable, uint64_t changeEpoch) {
+        csrSortedByDest = enable;
+        csrChangeEpoch = enable ? changeEpoch : 0;
+    }
     std::optional<function::TableFunction> getScanFunction() const override { return scanFunction; }
     const std::optional<std::shared_ptr<function::TableFuncBindData>>& getScanBindData() const {
         return scanBindData;
@@ -140,6 +160,8 @@ private:
     std::optional<function::TableFunction> scanFunction;
     std::optional<std::shared_ptr<function::TableFuncBindData>> scanBindData;
     std::string foreignDatabaseName; // Database name for foreign-backed rel tables
+    bool csrSortedByDest = false;
+    uint64_t csrChangeEpoch = 0;
 };
 
 } // namespace catalog

--- a/src/include/main/query_result/arrow_query_result.h
+++ b/src/include/main/query_result/arrow_query_result.h
@@ -34,6 +34,12 @@ public:
         std::vector<int64_t> srcRows;
         std::vector<int64_t> counts;
         bool hasEdgeIDs = false;
+        // True when the rel table was declared CSR-sorted-by-dest at
+        // plan-mapping time and the table's changeEpoch still matches the
+        // declaration watermark. Propagated from CSRTrackingInfo by the
+        // collector; consumed by CSRArrowArrays::symmetrize() to skip the
+        // per-row sort. False by default → safe per-row sort path.
+        bool sortedByDest = false;
         // Total number of source (node) rows in the table. Used to pad
         // trailing empty rows in indptr; set at plan-mapping time from the
         // node table cardinality.
@@ -77,6 +83,27 @@ public:
         CSRArrowArray indptr;
         CSRArrowArray indices;
         std::optional<CSRArrowArray> edgeIDs;
+        // Mirrors CSRMetadata::sortedByDest — true when the underlying rel
+        // table was declared CSR-sorted-by-dest and not mutated since. Set
+        // by getCSRArrowArrays(); consumed by symmetrize() to skip the
+        // per-row sort.
+        bool sortedByDest = false;
+
+        // Compute A + A.T, the symmetric (undirected) view of the directed
+        // CSR: nonzero at (u, v) iff (u, v) ∈ A or (v, u) ∈ A. Reciprocal
+        // pairs coalesce into a single structural entry (sparse addition
+        // semantics — same as scipy sparse matrices). The returned arrays
+        // do NOT carry edgeIDs: symmetry makes the edge identity ambiguous
+        // when both (u, v) and (v, u) existed, and per-edge values are
+        // dropped by A + A.T in scipy too. Chains on top of
+        // getCSRArrowArrays(): `result.getCSRArrowArrays().symmetrize()`.
+        //
+        // Fast path: when sortedByDest is set (the rel table was declared
+        // ALTER TABLE ... SET SORTED BY (FROM ASC, TO ASC) CSR and
+        // not mutated since), A's neighbors are already non-decreasing
+        // within each row, so the O(m log max-degree) per-row sort is
+        // skipped and the merge runs directly against the raw indices.
+        CSRArrowArrays symmetrize() const;
     };
 
     // View of the merged Arrow arrays as a chunked sequence, similar to

--- a/src/include/processor/operator/arrow_result_collector.h
+++ b/src/include/processor/operator/arrow_result_collector.h
@@ -71,6 +71,14 @@ struct CSRTrackingInfo {
     // per-chunk CSR indptr so that indptr always has numSourceRows + 1
     // entries (one per node row plus trailing sentinel).
     int64_t numSourceRows = 0;
+    // True when the scanned rel table has been declared CSR-sorted-by-dest
+    // (ALTER TABLE ... SET SORTED BY (FROM ASC, TO ASC) CSR) AND the
+    // table has not been mutated since that declaration (csrChangeEpoch
+    // matches the storage table's current changeEpoch). Set at plan-mapping
+    // time; propagated into CSRMetadata so symmetrize() can take the fast
+    // (no per-row sort) path. False on any mismatch — the safe per-row sort
+    // path is always the default.
+    bool sortedByDest = false;
 
     bool enabled() const {
         return srcRowIDColIdx != common::INVALID_IDX && dstRowIDColIdx != common::INVALID_IDX;

--- a/src/include/storage/storage_version_info.h
+++ b/src/include/storage/storage_version_info.h
@@ -24,6 +24,9 @@ struct StorageVersionInfo {
     // Storage version 44 adds the optional CSR (csr_index) flag and its changeEpoch watermark to
     // node-table sorted-by catalog metadata.
     static constexpr storage_version_t STORAGE_VERSION_44 = 44;
+    // Storage version 45 adds the optional CSR sorted-by-dest flag and its changeEpoch watermark
+    // to rel-table (rel group) catalog metadata.
+    static constexpr storage_version_t STORAGE_VERSION_45 = 45;
 
     static std::unordered_map<std::string, storage_version_t> getStorageVersionInfo() {
         return {{"0.12.0", STORAGE_VERSION_40}, {"0.12.2", STORAGE_VERSION_40},
@@ -35,14 +38,14 @@ struct StorageVersionInfo {
             {"0.16.1", STORAGE_VERSION_40}, {"0.17.0", STORAGE_VERSION_41},
             {"0.17.1", STORAGE_VERSION_41}, {"0.18.0", STORAGE_VERSION_42},
             {"0.18.1", STORAGE_VERSION_42}, {"0.19.0", STORAGE_VERSION_43},
-            {"0.19.1", STORAGE_VERSION_43}, {"0.20.0", STORAGE_VERSION_44}};
+            {"0.19.1", STORAGE_VERSION_43}, {"0.20.0", STORAGE_VERSION_45}};
     }
 
     static LBUG_API storage_version_t getStorageVersion();
     static bool canReadStorageVersion(storage_version_t storageVersion) {
         return storageVersion == STORAGE_VERSION_40 || storageVersion == STORAGE_VERSION_41 ||
                storageVersion == STORAGE_VERSION_42 || storageVersion == STORAGE_VERSION_43 ||
-               storageVersion == getStorageVersion();
+               storageVersion == STORAGE_VERSION_44 || storageVersion == getStorageVersion();
     }
 
     static constexpr const char* MAGIC_BYTES = "LBUG";

--- a/src/main/query_result/arrow_query_result.cpp
+++ b/src/main/query_result/arrow_query_result.cpp
@@ -1,5 +1,6 @@
 #include "main/query_result/arrow_query_result.h"
 
+#include <algorithm>
 #include <array>
 #include <queue>
 
@@ -130,6 +131,9 @@ static ArrowQueryResult::CSRMetadata kwayMergeCSRChunks(
     }
     const auto& first = chunks.front();
     const auto hasEdgeIDs = first.hasEdgeIDs;
+    // All chunks come from the same rel scan, so they share sortedByDest.
+    // Propagate it through the merge so symmetrize() can take the fast path.
+    const auto sortedByDest = first.sortedByDest;
 
     int64_t numSourceRows = 0;
     size_t totalIndices = 0;
@@ -165,6 +169,7 @@ static ArrowQueryResult::CSRMetadata kwayMergeCSRChunks(
     ArrowQueryResult::CSRMetadata merged;
     merged.hasEdgeIDs = hasEdgeIDs;
     merged.numSourceRows = numSourceRows;
+    merged.sortedByDest = sortedByDest;
 
     if (chunks.size() == 1) {
         auto& c = chunks[0];
@@ -351,6 +356,7 @@ ArrowQueryResult::CSRArrowArrays ArrowQueryResult::getCSRArrowArrays() const {
         result.edgeIDs = makeCSRArrowArray(
             std::shared_ptr<const std::vector<int64_t>>(combinedCSR, &merged.edgeIDs));
     }
+    result.sortedByDest = merged.sortedByDest;
     return result;
 }
 
@@ -366,6 +372,122 @@ const ArrowQueryResult::CSRMetadata& ArrowQueryResult::combineCSRChunks() const 
     // is left empty; hasCSRMetadata() stays true via combinedCSR.
     combinedCSR = std::make_shared<const CSRMetadata>(kwayMergeCSRChunks(std::move(csrChunks)));
     return *combinedCSR;
+}
+
+ArrowQueryResult::CSRArrowArrays ArrowQueryResult::CSRArrowArrays::symmetrize() const {
+    const auto n = static_cast<int64_t>(indptr.array.length - 1);
+    const auto m = static_cast<int64_t>(indices.array.length);
+    const auto* indptrData = static_cast<const int64_t*>(indptr.array.buffers[1]);
+    const auto* indicesData = static_cast<const int64_t*>(indices.array.buffers[1]);
+
+    // Step 1: build Aᵀ (CSR) in O(n + m) via counting + scatter. For
+    // each (i, j) ∈ A, increment atIndptr[j + 1] (in-degree of j),
+    // prefix-sum into atIndptr, then scatter i into Aᵀ's row j at the
+    // cursor. Because the scatter iterates source rows i in increasing
+    // order, Aᵀ's neighbors for each row end up sorted in increasing
+    // source-row order, which is what lets the per-row merge below be
+    // a two-pointer walk instead of a per-row sort.
+    std::vector<int64_t> atIndptr(static_cast<size_t>(n) + 1);
+    for (int64_t k = 0; k < m; ++k) {
+        ++atIndptr[indicesData[k] + 1];
+    }
+    for (int64_t j = 1; j <= n; ++j) {
+        atIndptr[j] += atIndptr[j - 1];
+    }
+    std::vector<int64_t> cursor = atIndptr;
+    std::vector<int64_t> atTIndices(static_cast<size_t>(m));
+    for (int64_t i = 0; i < n; ++i) {
+        const auto begin = indptrData[i];
+        const auto end = indptrData[i + 1];
+        for (auto k = begin; k < end; ++k) {
+            atTIndices[cursor[indicesData[k]]++] = i;
+        }
+    }
+
+    // Step 2: provide a sorted view of A's neighbors per row for the
+    // two-pointer merge. When sortedByDest is set (the rel table was
+    // declared ALTER TABLE ... SET SORTED BY (FROM ASC, TO ASC) CSR and
+    // not mutated since), A's neighbors are already
+    // non-decreasing within each row, so we read the raw indices
+    // directly — no copy, no per-row sort, O(m) total. Otherwise the
+    // CSR metadata's neighbors are populated in rel-scan order (see
+    // updateDirectCSRMetadata / updateCSRMetadata), not necessarily
+    // non-decreasing within a row, so we copy into a writable buffer
+    // and sort each row in place. Total work for the slow path is
+    // Σ dᵢ log dᵢ ≤ m log max(dᵢ).
+    std::vector<int64_t> aIndicesStorage;
+    const int64_t* aIndices = nullptr;
+    if (sortedByDest) {
+        // Fast path: read directly from the backing buffer. Safe because
+        // symmetrize() never mutates A's indices — the two-pointer merge
+        // only advances read cursors.
+        aIndices = indicesData;
+    } else {
+        aIndicesStorage.resize(static_cast<size_t>(m));
+        for (int64_t i = 0; i < n; ++i) {
+            const auto begin = indptrData[i];
+            const auto end = indptrData[i + 1];
+            std::copy(indicesData + begin, indicesData + end, aIndicesStorage.begin() + begin);
+            std::sort(aIndicesStorage.begin() + begin, aIndicesStorage.begin() + end);
+        }
+        aIndices = aIndicesStorage.data();
+    }
+
+    // Step 3: per-row two-pointer merge of A's neighbors (sorted) and
+    // Aᵀ's neighbors (sorted by construction). Equal heads collapse
+    // reciprocal pairs (u, v)/(v, u) and self-loops emitted twice into
+    // a single entry, mirroring scipy's sparse-addition coalescing.
+    // Output stays sorted within each row, so the result is itself a
+    // canonical CSR.
+    std::vector<int64_t> outIndptr(static_cast<size_t>(n) + 1);
+    std::vector<int64_t> outIndices;
+    // Upper bound 2m: each input edge contributes at most one (u, v)
+    // and one (v, u) pair; coalesced to one when both existed. The
+    // actual final size is at most 2m (and typically ≪ m for sparse
+    // graphs), so reserve the upper bound and resize down at the end.
+    outIndices.reserve(static_cast<size_t>(2 * m));
+    outIndptr[0] = 0;
+    for (int64_t i = 0; i < n; ++i) {
+        auto aIt = aIndices + indptrData[i];
+        const auto aEnd = aIndices + indptrData[i + 1];
+        auto tIt = atTIndices.begin() + atIndptr[i];
+        const auto tEnd = atTIndices.begin() + atIndptr[i + 1];
+        int64_t last = -1;
+        int64_t count = 0;
+        while (aIt != aEnd || tIt != tEnd) {
+            int64_t v;
+            if (aIt == aEnd) {
+                v = *tIt++;
+            } else if (tIt == tEnd) {
+                v = *aIt++;
+            } else if (*aIt < *tIt) {
+                v = *aIt++;
+            } else if (*tIt < *aIt) {
+                v = *tIt++;
+            } else {
+                // Equal heads: coalesce reciprocal pair or self-loop.
+                v = *aIt++;
+                ++tIt;
+            }
+            if (v != last) {
+                outIndices.push_back(v);
+                last = v;
+                ++count;
+            }
+        }
+        outIndptr[static_cast<size_t>(i) + 1] = outIndptr[i] + count;
+    }
+    outIndices.resize(outIndptr[n]);
+
+    CSRArrowArrays result;
+    result.indptr =
+        makeCSRArrowArray(std::make_shared<const std::vector<int64_t>>(std::move(outIndptr)));
+    result.indices =
+        makeCSRArrowArray(std::make_shared<const std::vector<int64_t>>(std::move(outIndices)));
+    // edgeIDs intentionally left unset: A + Aᵀ drops per-edge values in
+    // scipy's sparse-addition semantics, and a reciprocal pair makes
+    // edge identity ambiguous anyway.
+    return result;
 }
 
 } // namespace main

--- a/src/processor/map/create_arrow_result_collector.cpp
+++ b/src/processor/map/create_arrow_result_collector.cpp
@@ -1,5 +1,7 @@
 #include "binder/expression/property_expression.h"
 #include "binder/expression/scalar_function_expression.h"
+#include "catalog/catalog.h"
+#include "catalog/catalog_entry/rel_group_catalog_entry.h"
 #include "function/schema/vector_node_rel_functions.h"
 #include "processor/operator/arrow_result_collector.h"
 #include "processor/physical_plan_util.h"
@@ -49,6 +51,46 @@ static CSRTrackingInfo getCSRTrackingInfo(const binder::expression_vector& expre
     return info;
 }
 
+// Extract the table ID underlying a projected offset(_id) expression.
+static common::table_id_t getRowIDExprTableID(const binder::Expression& expr) {
+    const auto& scalarFunc = expr.constCast<binder::ScalarFunctionExpression>();
+    const auto& propExpr = scalarFunc.getChild(0)->constCast<binder::PropertyExpression>();
+    return propExpr.getSingleTableID();
+}
+
+// Resolve the rel group catalog entry being scanned, so we can check its
+// CSR-sorted-by-dest declaration. When the rel rowID is projected (the
+// 3-expression shape), the rel variable's table ID directly identifies the
+// rel group. Otherwise (2-expression shape, no rel rowID) we fall back to
+// scanning all rel groups for one whose FROM/TO pair matches the bound (src)
+// and nbr (dst) node tables — this is ambiguous if multiple rel groups share
+// the same endpoint pair, in which case the first match wins (the sorted-by
+// declaration is a user assertion, so ambiguity only risks missing the fast
+// path, never correctness — symmetrize() falls back to the safe per-row sort).
+static const catalog::RelGroupCatalogEntry* getScannedRelGroupEntry(const CSRTrackingInfo& info,
+    const binder::expression_vector& expressions, const transaction::Transaction* trx,
+    main::ClientContext* clientContext) {
+    auto catalog = catalog::Catalog::Get(*clientContext);
+    if (info.hasRelRowID()) {
+        const auto relGroupID = getRowIDExprTableID(*expressions[info.relRowIDColIdx]);
+        return catalog->getTableCatalogEntry(trx, relGroupID)
+            ->ptrCast<catalog::RelGroupCatalogEntry>();
+    }
+    const auto srcTableID = getRowIDExprTableID(*expressions[info.srcRowIDColIdx]);
+    const auto dstTableID = getRowIDExprTableID(*expressions[info.dstRowIDColIdx]);
+    for (auto* relGroup : catalog->getRelGroupEntries(trx)) {
+        for (const auto& relInfo : relGroup->getRelEntryInfos()) {
+            if ((relInfo.nodePair.srcTableID == srcTableID &&
+                    relInfo.nodePair.dstTableID == dstTableID) ||
+                (relInfo.nodePair.srcTableID == dstTableID &&
+                    relInfo.nodePair.dstTableID == srcTableID)) {
+                return relGroup;
+            }
+        }
+    }
+    return nullptr;
+}
+
 std::unique_ptr<PhysicalOperator> PlanMapper::createArrowResultCollector(
     ArrowResultConfig arrowConfig, const binder::expression_vector& expressions,
     planner::Schema* schema, std::unique_ptr<PhysicalOperator> prevOperator,
@@ -67,14 +109,30 @@ std::unique_ptr<PhysicalOperator> PlanMapper::createArrowResultCollector(
         // Look up the source node table's total row count so we can pad
         // trailing empty rows in the CSR indptr (nodes with zero outgoing
         // edges must still have an indptr slot).
-        const auto& srcExpr = *expressions[csrTrackingInfo.srcRowIDColIdx];
-        const auto& scalarFunc = srcExpr.constCast<binder::ScalarFunctionExpression>();
-        const auto& propExpr = scalarFunc.getChild(0)->constCast<binder::PropertyExpression>();
-        auto tableID = propExpr.getSingleTableID();
+        const auto tableID = getRowIDExprTableID(*expressions[csrTrackingInfo.srcRowIDColIdx]);
         auto trx = transaction::Transaction::Get(*clientContext);
         auto table = storage::StorageManager::Get(*clientContext)->getTable(tableID);
         auto nodeTable = table->ptrCast<storage::NodeTable>();
         csrTrackingInfo.numSourceRows = static_cast<int64_t>(nodeTable->getNumTotalRows(trx));
+        // Check whether the scanned rel table has been declared CSR-sorted-
+        // by-dest (ALTER TABLE ... SET SORTED BY (FROM ASC, TO ASC) CSR) and
+        // not mutated since. The declaration is a user assertion;
+        // the changeEpoch watermark is the extra safety net that invalidates
+        // the fast path on post-declaration mutations. We check the first
+        // underlying rel table's storage epoch (matching what alter.cpp
+        // captures) — correct for single-rel-table groups (the common case);
+        // best-effort for multi-table groups.
+        const auto* relGroupEntry =
+            getScannedRelGroupEntry(csrTrackingInfo, expressions, trx, clientContext);
+        if (relGroupEntry != nullptr && relGroupEntry->isCsrSortedByDest() &&
+            !relGroupEntry->getRelEntryInfos().empty()) {
+            const auto relOid = relGroupEntry->getRelEntryInfos()[0].oid;
+            auto* relTable = storage::StorageManager::Get(*clientContext)->getTable(relOid);
+            if (relTable != nullptr &&
+                relGroupEntry->getCsrChangeEpoch() == relTable->getChangeEpoch()) {
+                csrTrackingInfo.sortedByDest = true;
+            }
+        }
     }
     auto opInfo = ArrowResultCollectorInfo(arrowConfig.chunkSize, columnDataPos,
         std::move(columnTypes), csrTrackingInfo, orderPreservation);

--- a/src/processor/operator/arrow_result_collector.cpp
+++ b/src/processor/operator/arrow_result_collector.cpp
@@ -25,6 +25,7 @@ static void updateDirectCSRMetadata(const CSRTrackingInfo& info, const std::vect
         main::ArrowQueryResult::CSRMetadata metadata;
         metadata.hasEdgeIDs = info.hasRelRowID();
         metadata.numSourceRows = info.numSourceRows;
+        metadata.sortedByDest = info.sortedByDest;
         localState.csrMetadata = std::move(metadata);
     }
     auto& metadata = *localState.csrMetadata;
@@ -159,6 +160,7 @@ static void updateCSRMetadata(const CSRTrackingInfo& info, FlatTuple& tuple,
         main::ArrowQueryResult::CSRMetadata metadata;
         metadata.hasEdgeIDs = info.hasRelRowID();
         metadata.numSourceRows = info.numSourceRows;
+        metadata.sortedByDest = info.sortedByDest;
         localState.csrMetadata = std::move(metadata);
     }
     auto& metadata = *localState.csrMetadata;

--- a/src/processor/operator/ddl/alter.cpp
+++ b/src/processor/operator/ddl/alter.cpp
@@ -161,13 +161,19 @@ static bool checkRenameTableConflicts(const BoundAlterInfo& info, main::ClientCo
 
 static bool checkSetSortedByConflicts(const TableCatalogEntry& tableEntry,
     const BoundAlterInfo& info) {
-    if (tableEntry.getTableType() != TableType::NODE) {
-        throw BinderException(std::format("Cannot set sorted-by metadata on non-node table {}.",
-            tableEntry.getName()));
-    }
     auto& extraInfo = info.extraInfo->constCast<BoundExtraSetSortedByInfo>();
     if (extraInfo.properties.empty()) {
         throw BinderException("SORTED BY requires at least one property.");
+    }
+    if (tableEntry.getTableType() == TableType::REL) {
+        // Rel-table CSR sorted-by is validated structurally in the binder
+        // (FROM ASC, TO ASC). Nothing further to check here; the
+        // non-node path does not have per-property columns to validate.
+        return false;
+    }
+    if (tableEntry.getTableType() != TableType::NODE) {
+        throw BinderException(
+            std::format("Cannot set sorted-by metadata on table {}.", tableEntry.getName()));
     }
     for (auto& property : extraInfo.properties) {
         validatePropertyExist(ConflictAction::ON_CONFLICT_THROW, tableEntry, property.propertyName);
@@ -322,12 +328,23 @@ void Alter::alterTable(main::ClientContext* clientContext, const TableCatalogEnt
     case AlterType::SET_SORTED_BY: {
         checkSetSortedByConflicts(entry, info);
         auto& extraInfo = info.extraInfo->cast<BoundExtraSetSortedByInfo>();
-        // Record the node table's changeEpoch at declaration time so the optimizer can
-        // disregard the CSR invariant once the table is mutated.
+        // Record the table's changeEpoch at declaration time so the optimizer
+        // / symmetrize() can disregard the sorted-by invariant once the table
+        // is mutated. For rel tables, every underlying rel table in the group
+        // shares the same changeEpoch watermark; we capture from the first.
         if (extraInfo.csr) {
-            auto* table =
-                storage::StorageManager::Get(*clientContext)->getTable(entry.getTableID());
-            extraInfo.csrChangeEpoch = table ? table->getChangeEpoch() : 0;
+            if (entry.getTableType() == TableType::REL) {
+                auto& relGroupEntry = entry.constCast<RelGroupCatalogEntry>();
+                if (!relGroupEntry.getRelEntryInfos().empty()) {
+                    const auto relOid = relGroupEntry.getRelEntryInfos()[0].oid;
+                    auto* table = storage::StorageManager::Get(*clientContext)->getTable(relOid);
+                    extraInfo.csrChangeEpoch = table ? table->getChangeEpoch() : 0;
+                }
+            } else {
+                auto* table =
+                    storage::StorageManager::Get(*clientContext)->getTable(entry.getTableID());
+                extraInfo.csrChangeEpoch = table ? table->getChangeEpoch() : 0;
+            }
         }
         appendMessage(std::format("Table {} sorted-by metadata updated with {} column(s).",
                           tableName, extraInfo.properties.size()),

--- a/test/api/arrow_test.cpp
+++ b/test/api/arrow_test.cpp
@@ -103,6 +103,59 @@ TEST(ArrowQueryResultTest, exportsCSRMetadataAsZeroCopyArrowArrays) {
         (std::vector<int64_t>{10, 11, 12}));
 }
 
+// Builds an ArrowQueryResult from a raw CSR (indptr, indices) and returns its
+// symmetrized CSRArrowArrays, with sortedByDest controlling the fast/slow path.
+static ArrowQueryResult::CSRArrowArrays symmetrizeCSR(std::vector<int64_t> indptr,
+    std::vector<int64_t> indices, bool sortedByDest) {
+    ArrowQueryResult::CSRMetadata metadata;
+    metadata.indptr = std::move(indptr);
+    metadata.indices = std::move(indices);
+    metadata.sortedByDest = sortedByDest;
+    std::vector<ArrowQueryResult::CSRMetadata> csrChunks;
+    csrChunks.push_back(std::move(metadata));
+    ArrowQueryResult result{{}, 8, std::move(csrChunks)};
+    auto csrArrays = result.getCSRArrowArrays();
+    EXPECT_EQ(csrArrays.sortedByDest, sortedByDest);
+    return csrArrays.symmetrize();
+}
+
+static std::vector<int64_t> csrArrowValues(const ArrowQueryResult::CSRArrowArray& arr) {
+    const auto* data = static_cast<const int64_t*>(arr.array.buffers[1]);
+    return {data, data + arr.array.length};
+}
+
+// A = {(0,1),(0,2),(1,0)} over 3 nodes. Symmetrized (A + Aᵀ, reciprocal
+// pairs coalesced):
+//   row 0: A={1,2} Aᵀ={1}  -> {1,2}
+//   row 1: A={0}   Aᵀ={0}  -> {0}      (reciprocal pair (0,1)/(1,0) coalesces)
+//   row 2: A={}    Aᵀ={0}  -> {0}
+TEST(ArrowQueryResultTest, symmetrizeCoalescesReciprocalPairsSlowPath) {
+    auto out = symmetrizeCSR({0, 2, 3, 3}, {2, 1, 0}, false /*sortedByDest*/);
+    // Row 0's neighbors {2,1} are NOT sorted in A, so the slow path must sort
+    // them before the two-pointer merge — verifying the sort is exercised.
+    EXPECT_EQ(csrArrowValues(out.indptr), (std::vector<int64_t>{0, 2, 3, 4}));
+    EXPECT_EQ(csrArrowValues(out.indices), (std::vector<int64_t>{1, 2, 0, 0}));
+    // Symmetrize drops edgeIDs (sparse-addition semantics).
+    EXPECT_FALSE(out.edgeIDs.has_value());
+}
+
+// Same graph but with A's neighbors already sorted within each row, and the
+// sortedByDest flag set — exercises the fast path (no per-row sort).
+TEST(ArrowQueryResultTest, symmetrizeFastPathMatchesSlowPath) {
+    const auto slow = symmetrizeCSR({0, 2, 3, 3}, {2, 1, 0}, false);
+    const auto fast = symmetrizeCSR({0, 2, 3, 3}, {1, 2, 0}, true /*sortedByDest*/);
+    EXPECT_EQ(csrArrowValues(fast.indptr), csrArrowValues(slow.indptr));
+    EXPECT_EQ(csrArrowValues(fast.indices), csrArrowValues(slow.indices));
+}
+
+// Self-loop (0,0): appears once in A and once in Aᵀ (same edge), so the
+// merge coalesces the two equal heads into a single entry.
+TEST(ArrowQueryResultTest, symmetrizeCoalescesSelfLoop) {
+    auto out = symmetrizeCSR({0, 1, 1}, {0}, true /*sortedByDest*/);
+    EXPECT_EQ(csrArrowValues(out.indptr), (std::vector<int64_t>{0, 1, 1}));
+    EXPECT_EQ(csrArrowValues(out.indices), (std::vector<int64_t>{0}));
+}
+
 TEST(ArrowConverterTest, bindsIntegerBackedSnowflakeDecimalMetadataAsDecimal) {
     ArrowSchema schema{};
     createSchema<int64_t>(&schema, "amount");

--- a/test/test_files/ddl/alter_csr.test
+++ b/test/test_files/ddl/alter_csr.test
@@ -28,7 +28,16 @@ Binder exception: CSR requires exactly one SORTED BY property in ascending order
 Binder exception: CSR requires the SORTED BY property to be the primary key.
 -STATEMENT ALTER TABLE csr_knows SET SORTED BY (id ASC) CSR;
 ---- error
-Binder exception: csr_knows is not of type NODE.
+Binder exception: CSR on rel table csr_knows requires SORTED BY (FROM ASC, TO ASC).
+-STATEMENT ALTER TABLE csr_knows SET SORTED BY (FROM ASC, TO ASC);
+---- error
+Binder exception: SORTED BY on rel table csr_knows requires the CSR clause.
+-STATEMENT ALTER TABLE csr_knows SET SORTED BY (FROM ASC, TO DESC) CSR;
+---- error
+Binder exception: CSR on rel table csr_knows requires SORTED BY (FROM ASC, TO ASC).
+-STATEMENT ALTER TABLE csr_knows SET SORTED BY (FROM ASC, TO ASC) CSR;
+---- 1
+Table csr_knows sorted-by metadata updated with 2 column(s).
 -STATEMENT CREATE (:csr_person {id: 0, name: 'Alice'});
 ---- ok
 -STATEMENT CREATE (:csr_person {id: 1, name: 'Bob'});

--- a/test/test_files/storage_version.test
+++ b/test/test_files/storage_version.test
@@ -5,8 +5,8 @@
 -CASE StorageVersionFunctionAndUpgrade
 -STATEMENT CALL storage_version() RETURN *;
 ---- 1
-44
--CHECK_STORAGE_VERSION 44
+45
+-CHECK_STORAGE_VERSION 45
 -SET_STORAGE_VERSION 40
 -STATEMENT CALL storage_version() RETURN *;
 ---- 1
@@ -17,11 +17,11 @@
 ---- ok
 -STATEMENT CHECKPOINT;
 ---- ok
--CHECK_STORAGE_VERSION 44
+-CHECK_STORAGE_VERSION 45
 -RELOADDB
 -STATEMENT CALL storage_version() RETURN *;
 ---- 1
-44
+45
 -STATEMENT MATCH (u:users) RETURN u.id, u.name;
 ---- 1
 1|Alice


### PR DESCRIPTION
Rename CSRArrowArrays::transpose() to symmetrize() and add a fast path that skips the O(m log max-degree) per-row sort when the rel table has been declared CSR-sorted-by-dest.

Add the DDL: ALTER TABLE <rel> SET SORTED BY (FROM ASC, TO ASC) CSR. This is a user assertion that the CSR adjacency lists are physically stored with neighbors in non-decreasing order within each FROM row; storage does not yet establish the invariant during checkpoint, so it is the caller's responsibility to only declare it on sorted data. The csrChangeEpoch watermark invalidates the fast path when the table is mutated after declaration (falling back to the safe per-row sort).

FROM and TO are the user-facing names for the relation's source and destination endpoints; "bound" and "neighbor" remain internal concepts.

Wire the flag end-to-end:
  - storage version 45 (0.20.0 -> 45); canRead still accepts 44
  - RelGroupCatalogEntry: csrSortedByDest + csrChangeEpoch fields, serialize/deserialize/copy/alter
  - binder: structural validation of (FROM ASC, TO ASC) for rel tables; node-table path unchanged
  - processor alter: capture the rel group's changeEpoch at declaration
  - CSRTrackingInfo/CSRMetadata: sortedByDest bit, propagated by the collector and kwayMergeCSRChunks into CSRArrowArrays
  - plan mapper: resolve the scanned rel group, check its declaration
    + changeEpoch, set csrTrackingInfo.sortedByDest
  - symmetrize(): when sortedByDest, read the raw indices directly for the two-pointer merge (no copy, no per-row sort)

Update alter_csr.test for the new rel-table behavior and add symmetrize() unit tests (slow path, fast/slow equivalence, self-loop coalescing).