### PR TITLE
fix(attach): support relationship patterns over attached databases

### DIFF
--- a/src/binder/bind/bind_graph_pattern.cpp
+++ b/src/binder/bind/bind_graph_pattern.cpp
@@ -194,7 +194,32 @@ std::shared_ptr<RelExpression> Binder::bindQueryRel(const RelPattern& relPattern
         throw BinderException("Bind relationship " + parsedName +
                               " to relationship with same name is not supported.");
     }
-    auto entries = bindRelGroupEntries(relPattern.getTableNames());
+    // Infer the catalog context from the endpoint nodes: if every endpoint table belongs
+    // to the same single attached database, unqualified rel labels (and anonymous rel
+    // patterns) resolve in that database's catalog. Mixed or main-only endpoints yield no
+    // context, so rel labels fall back to the default catalog (main unless USE db/GRAPH).
+    std::string contextDbName;
+    bool sawAttached = false;
+    bool sawMain = false;
+    for (auto* node : {leftNode.get(), rightNode.get()}) {
+        for (auto* entry : node->getEntries()) {
+            auto dbName = node->getDbName(entry);
+            if (dbName.empty()) {
+                sawMain = true;
+            } else {
+                sawAttached = true;
+                if (contextDbName.empty()) {
+                    contextDbName = dbName;
+                } else if (contextDbName != dbName) {
+                    contextDbName.clear();
+                }
+            }
+        }
+    }
+    if (sawMain || !sawAttached || contextDbName.empty()) {
+        contextDbName.clear();
+    }
+    auto [entries, dbNames] = bindRelGroupEntries(relPattern.getTableNames(), contextDbName);
     // bind src & dst node
     RelDirectionType directionType = RelDirectionType::UNKNOWN;
     std::shared_ptr<NodeExpression> srcNode;
@@ -223,7 +248,8 @@ std::shared_ptr<RelExpression> Binder::bindQueryRel(const RelPattern& relPattern
     // bind variable length
     std::shared_ptr<RelExpression> queryRel;
     if (QueryRelTypeUtils::isRecursive(relPattern.getRelType())) {
-        queryRel = createRecursiveQueryRel(relPattern, entries, srcNode, dstNode, directionType);
+        queryRel =
+            createRecursiveQueryRel(relPattern, entries, dbNames, srcNode, dstNode, directionType);
     } else {
         queryRel = createNonRecursiveQueryRel(relPattern.getVariableName(), entries, srcNode,
             dstNode, directionType, relPattern.getTableNames());
@@ -238,6 +264,11 @@ std::shared_ptr<RelExpression> Binder::bindQueryRel(const RelPattern& relPattern
     queryRel->setLeftNode(leftNode);
     queryRel->setRightNode(rightNode);
     queryRel->setAlias(parsedName);
+    // Carry the database context for each rel entry so planning/physical routing
+    // (cardinality estimation, extend scan) can resolve the right storage manager.
+    for (auto& [entry, dbName] : dbNames) {
+        queryRel->setDbName(entry, dbName);
+    }
     if (!parsedName.empty()) {
         addToScope(parsedName, queryRel);
     }
@@ -388,18 +419,36 @@ static void checkWeightedShortestPathSupportedType(const LogicalType& type) {
 }
 
 std::shared_ptr<RelExpression> Binder::createRecursiveQueryRel(const parser::RelPattern& relPattern,
-    const std::vector<TableCatalogEntry*>& entries, std::shared_ptr<NodeExpression> srcNode,
-    std::shared_ptr<NodeExpression> dstNode, RelDirectionType directionType) {
-    auto catalog = Catalog::Get(*clientContext);
+    const std::vector<TableCatalogEntry*>& entries,
+    const std::unordered_map<TableCatalogEntry*, std::string>& dbNames,
+    std::shared_ptr<NodeExpression> srcNode, std::shared_ptr<NodeExpression> dstNode,
+    RelDirectionType directionType) {
     auto transaction = transaction::Transaction::Get(*clientContext);
     table_catalog_entry_set_t nodeEntrySet;
+    std::unordered_map<TableCatalogEntry*, std::string> nodeDbNames;
     for (auto entry : entries) {
         auto& relGroupEntry = entry->constCast<RelGroupCatalogEntry>();
+        // Resolve the catalog that owns this rel entry so its endpoint node tables are
+        // looked up in the right database (IDs are 0-based per database).
+        auto dbNameIt = dbNames.find(entry);
+        auto dbName = dbNameIt != dbNames.end() ? dbNameIt->second : "";
+        auto catalog = dbName.empty() ? Catalog::Get(*clientContext) :
+                                        main::DatabaseManager::Get(*clientContext)
+                                            ->getAttachedDatabase(dbName)
+                                            ->getCatalog();
         for (auto id : relGroupEntry.getSrcNodeTableIDSet()) {
-            nodeEntrySet.insert(catalog->getTableCatalogEntry(transaction, id));
+            auto nodeEntry = catalog->getTableCatalogEntry(transaction, id);
+            nodeEntrySet.insert(nodeEntry);
+            if (!dbName.empty()) {
+                nodeDbNames[nodeEntry] = dbName;
+            }
         }
         for (auto id : relGroupEntry.getDstNodeTableIDSet()) {
-            nodeEntrySet.insert(catalog->getTableCatalogEntry(transaction, id));
+            auto nodeEntry = catalog->getTableCatalogEntry(transaction, id);
+            nodeEntrySet.insert(nodeEntry);
+            if (!dbName.empty()) {
+                nodeDbNames[nodeEntry] = dbName;
+            }
         }
     }
     auto nodeEntries = std::vector<TableCatalogEntry*>{nodeEntrySet.begin(), nodeEntrySet.end()};
@@ -407,13 +456,13 @@ std::shared_ptr<RelExpression> Binder::createRecursiveQueryRel(const parser::Rel
     auto prevScope = saveScope();
     scope.clear();
     // Bind intermediate node.
-    auto node = createQueryNode(recursivePatternInfo->nodeName, nodeEntries, {}, {});
+    auto node = createQueryNode(recursivePatternInfo->nodeName, nodeEntries, nodeDbNames, {});
     addToScope(node->toString(), node);
     auto nodeFields = getBaseNodeStructFields();
     auto nodeProjectionList = bindRecursivePatternNodeProjectionList(*recursivePatternInfo, *node);
     bindProjectionListAsStructField(nodeProjectionList, nodeFields);
     node->setDataType(LogicalType::NODE(std::move(nodeFields)));
-    auto nodeCopy = createQueryNode(recursivePatternInfo->nodeName, nodeEntries, {}, {});
+    auto nodeCopy = createQueryNode(recursivePatternInfo->nodeName, nodeEntries, nodeDbNames, {});
     // Bind intermediate rel
     auto rel = createNonRecursiveQueryRel(recursivePatternInfo->relName, entries,
         nullptr /* srcNode */, nullptr /* dstNode */, directionType, {});
@@ -721,15 +770,30 @@ static std::vector<TableCatalogEntry*> sortEntries(const table_catalog_entry_set
 std::pair<std::vector<TableCatalogEntry*>, std::unordered_map<TableCatalogEntry*, std::string>>
 Binder::bindNodeTableEntries(const std::vector<std::string>& tableNames) const {
     auto transaction = transaction::Transaction::Get(*clientContext);
-    auto catalog = Catalog::Get(*clientContext);
     auto useInternal = clientContext->useInternalCatalogEntry();
+    // Select the base catalog for unqualified/anonymous patterns: active graph, then
+    // default database (USE db), then main.
+    auto dbManager = main::DatabaseManager::Get(*clientContext);
+    catalog::Catalog* catalog = nullptr;
+    std::string activeDbName;
+    if (auto defaultGraphCatalog = dbManager->getDefaultGraphCatalog();
+        defaultGraphCatalog != nullptr) {
+        catalog = defaultGraphCatalog;
+    } else if (dbManager->hasDefaultDatabase()) {
+        activeDbName = dbManager->getDefaultDatabase();
+        catalog = dbManager->getAttachedDatabase(activeDbName)->getCatalog();
+    } else {
+        catalog = Catalog::Get(*clientContext);
+    }
     table_catalog_entry_set_t entrySet;
     std::unordered_map<TableCatalogEntry*, std::string> dbNames;
-    if (tableNames.empty()) { // Rewrite as all node tables in database.
+    if (tableNames.empty()) { // Rewrite as all node tables in the active catalog.
         for (auto entry : catalog->getNodeTableEntries(transaction, useInternal)) {
             entrySet.insert(entry);
+            if (!activeDbName.empty()) {
+                dbNames[entry] = activeDbName;
+            }
         }
-        auto dbManager = main::DatabaseManager::Get(*clientContext);
         for (auto attachedDB : dbManager->getAttachedDatabases()) {
             auto attachedCatalog = attachedDB->getCatalog();
             for (auto entry : attachedCatalog->getTableEntries(transaction, useInternal)) {
@@ -782,20 +846,25 @@ std::pair<TableCatalogEntry*, std::string> Binder::bindNodeTableEntry(
         }
         return {attachedCatalog->getTableCatalogEntry(transaction, tableName, useInternal), dbName};
     } else {
-        // Check if there's a default graph set and use its catalog
+        // Check if there's a default graph set and use its catalog; otherwise fall
+        // back to the default database (USE db), then main.
         auto dbManager = main::DatabaseManager::Get(*clientContext);
         catalog::Catalog* catalog = nullptr;
-        auto defaultGraphCatalog = dbManager->getDefaultGraphCatalog();
-        if (defaultGraphCatalog != nullptr) {
+        std::string resolvedDbName;
+        if (auto defaultGraphCatalog = dbManager->getDefaultGraphCatalog();
+            defaultGraphCatalog != nullptr) {
             catalog = defaultGraphCatalog;
+        } else if (dbManager->hasDefaultDatabase()) {
+            resolvedDbName = dbManager->getDefaultDatabase();
+            catalog = dbManager->getAttachedDatabase(resolvedDbName)->getCatalog();
         } else {
             catalog = Catalog::Get(*clientContext);
         }
-        // Unqualified name: only search main catalog
+        // Unqualified name: only search the active catalog
         // Foreign tables require qualified names (db.table) to avoid ambiguity
         bool hasTable = catalog->containsTable(transaction, name, useInternal);
         if (hasTable) {
-            return {catalog->getTableCatalogEntry(transaction, name, useInternal), ""};
+            return {catalog->getTableCatalogEntry(transaction, name, useInternal), resolvedDbName};
         }
         // Check if this is an ANY graph (has _nodes table)
         // In ANY graphs, labels are stored dynamically in the _nodes table
@@ -807,57 +876,87 @@ std::pair<TableCatalogEntry*, std::string> Binder::bindNodeTableEntry(
     }
 }
 
-std::vector<TableCatalogEntry*> Binder::bindRelGroupEntries(
-    const std::vector<std::string>& tableNames) const {
+std::pair<std::vector<TableCatalogEntry*>, std::unordered_map<TableCatalogEntry*, std::string>>
+Binder::bindRelGroupEntries(const std::vector<std::string>& tableNames,
+    const std::string& contextDbName) const {
     auto transaction = transaction::Transaction::Get(*clientContext);
     auto useInternal = clientContext->useInternalCatalogEntry();
 
-    // Check if there's a default graph set and use its catalog
+    // Resolve the catalog for unqualified names / the anonymous case. An explicit
+    // context (all endpoint nodes from the same attached database) wins; otherwise
+    // fall back to the active graph, then the default database (USE db), then main.
     auto dbManager = main::DatabaseManager::Get(*clientContext);
     catalog::Catalog* catalog = nullptr;
-    auto defaultGraphCatalog = dbManager->getDefaultGraphCatalog();
-    if (defaultGraphCatalog != nullptr) {
+    std::string activeDbName;
+    if (!contextDbName.empty()) {
+        activeDbName = contextDbName;
+    } else if (auto defaultGraphCatalog = dbManager->getDefaultGraphCatalog();
+               defaultGraphCatalog != nullptr) {
         catalog = defaultGraphCatalog;
+    } else if (dbManager->hasDefaultDatabase()) {
+        activeDbName = dbManager->getDefaultDatabase();
     } else {
         catalog = Catalog::Get(*clientContext);
     }
+    if (!activeDbName.empty()) {
+        catalog = dbManager->getAttachedDatabase(activeDbName)->getCatalog();
+    }
 
     table_catalog_entry_set_t entrySet;
-    if (tableNames.empty()) { // Rewrite as all rel groups in database.
+    std::unordered_map<TableCatalogEntry*, std::string> dbNames;
+    if (tableNames.empty()) { // Rewrite as all rel groups in the active catalog.
         for (auto entry : catalog->getRelGroupEntries(transaction, useInternal)) {
             entrySet.insert(entry);
+            if (!activeDbName.empty()) {
+                dbNames[entry] = activeDbName;
+            }
         }
-        // Stop-gap: skip attached rel groups; physical routing for rel patterns
-        // over attached databases is not yet implemented. Unlabeled ()-[r]->()
-        // would otherwise crash or silently read the wrong table on ID overlap.
-        // TODO: implement full dbName plumbing for rel patterns (BUG 6).
     } else {
         for (auto& name : tableNames) {
-            // Check for qualified rel name (db.table) — not yet supported.
-            if (name.find('.') != std::string::npos) {
-                throw BinderException(
-                    "Qualified relationship patterns (e.g. -[r:db.rel]->) are not supported yet.");
+            std::string dbName;
+            std::string tableName = name;
+            auto dotPos = name.find('.');
+            if (dotPos != std::string::npos) {
+                dbName = name.substr(0, dotPos);
+                tableName = name.substr(dotPos + 1);
             }
-            if (catalog->containsTable(transaction, name)) {
-                auto entry = catalog->getTableCatalogEntry(transaction, name, useInternal);
+            // Qualified name (db.rel) resolves in that attached database's catalog;
+            // unqualified names resolve in the active catalog selected above.
+            catalog::Catalog* targetCatalog = catalog;
+            std::string resolvedDbName = activeDbName;
+            if (!dbName.empty()) {
+                auto* attachedDB = dbManager->getAttachedDatabase(dbName);
+                targetCatalog = attachedDB->getCatalog();
+                resolvedDbName = dbName;
+            }
+            if (targetCatalog->containsTable(transaction, tableName, useInternal)) {
+                auto entry =
+                    targetCatalog->getTableCatalogEntry(transaction, tableName, useInternal);
                 if (entry->getType() != CatalogEntryType::REL_GROUP_ENTRY) {
                     throw BinderException(std::format(
                         "Cannot bind {} as a relationship pattern label.", entry->getName()));
                 }
                 entrySet.insert(entry);
+                if (!resolvedDbName.empty()) {
+                    dbNames[entry] = resolvedDbName;
+                }
             } else {
                 // Check if this is an ANY graph (has _edges table)
                 // In ANY graphs, labels are stored dynamically in the _edges table
-                if (catalog->containsTable(transaction, "_edges", useInternal)) {
-                    auto entry = catalog->getTableCatalogEntry(transaction, "_edges", useInternal);
+                if (targetCatalog->containsTable(transaction, "_edges", useInternal)) {
+                    auto entry =
+                        targetCatalog->getTableCatalogEntry(transaction, "_edges", useInternal);
                     entrySet.insert(entry);
+                    if (!resolvedDbName.empty()) {
+                        dbNames[entry] = resolvedDbName;
+                    }
                 } else {
                     throw BinderException(std::format("Table {} does not exist.", name));
                 }
             }
         }
     }
-    return sortEntries(entrySet);
+    return {sortEntries(entrySet), std::move(dbNames)};
 }
 
 } // namespace binder

--- a/src/binder/bind/bind_graph_pattern.cpp
+++ b/src/binder/bind/bind_graph_pattern.cpp
@@ -6,6 +6,7 @@
 #include "catalog/catalog.h"
 #include "catalog/catalog_entry/node_table_catalog_entry.h"
 #include "catalog/catalog_entry/rel_group_catalog_entry.h"
+#include "common/constants.h"
 #include "common/enums/rel_direction.h"
 #include "common/exception/binder.h"
 #include "common/types/types.h"
@@ -25,6 +26,14 @@ using namespace lbug::catalog;
 
 namespace lbug {
 namespace binder {
+
+// Returns true only for attached native LBUG databases. Foreign attached databases
+// (sqlite/duckdb/postgres/...) must not participate in default-database or rel-context
+// resolution: rel tables referencing foreign node tables live in the main catalog and
+// unqualified names must keep resolving there.
+static bool isLbugDatabase(main::DatabaseManager* dbManager, const std::string& dbName) {
+    return dbManager->getAttachedDatabase(dbName)->getDBType() == ATTACHED_LBUG_DB_TYPE;
+}
 
 // A graph pattern contains node/rel and a set of key-value pairs associated with the variable. We
 // bind node/rel as query graph and key-value pairs as a separate collection. This collection is
@@ -195,28 +204,27 @@ std::shared_ptr<RelExpression> Binder::bindQueryRel(const RelPattern& relPattern
                               " to relationship with same name is not supported.");
     }
     // Infer the catalog context from the endpoint nodes: if every endpoint table belongs
-    // to the same single attached database, unqualified rel labels (and anonymous rel
-    // patterns) resolve in that database's catalog. Mixed or main-only endpoints yield no
-    // context, so rel labels fall back to the default catalog (main unless USE db/GRAPH).
+    // to the same single attached LBUG database, unqualified rel labels (and anonymous rel
+    // patterns) resolve in that database's catalog. Main and foreign endpoint tables
+    // (sqlite/duckdb/postgres) invalidate the context: rel tables referencing foreign node
+    // tables (e.g. a main-catalog rel table over attached foreign nodes) must still resolve
+    // in the default catalog.
+    auto dbManager = main::DatabaseManager::Get(*clientContext);
     std::string contextDbName;
-    bool sawAttached = false;
-    bool sawMain = false;
+    bool invalidContext = false;
     for (auto* node : {leftNode.get(), rightNode.get()}) {
         for (auto* entry : node->getEntries()) {
             auto dbName = node->getDbName(entry);
-            if (dbName.empty()) {
-                sawMain = true;
-            } else {
-                sawAttached = true;
-                if (contextDbName.empty()) {
-                    contextDbName = dbName;
-                } else if (contextDbName != dbName) {
-                    contextDbName.clear();
-                }
+            if (dbName.empty() || !isLbugDatabase(dbManager, dbName)) {
+                invalidContext = true;
+            } else if (contextDbName.empty()) {
+                contextDbName = dbName;
+            } else if (contextDbName != dbName) {
+                invalidContext = true;
             }
         }
     }
-    if (sawMain || !sawAttached || contextDbName.empty()) {
+    if (invalidContext || contextDbName.empty()) {
         contextDbName.clear();
     }
     auto [entries, dbNames] = bindRelGroupEntries(relPattern.getTableNames(), contextDbName);
@@ -779,7 +787,8 @@ Binder::bindNodeTableEntries(const std::vector<std::string>& tableNames) const {
     if (auto defaultGraphCatalog = dbManager->getDefaultGraphCatalog();
         defaultGraphCatalog != nullptr) {
         catalog = defaultGraphCatalog;
-    } else if (dbManager->hasDefaultDatabase()) {
+    } else if (dbManager->hasDefaultDatabase() &&
+               isLbugDatabase(dbManager, dbManager->getDefaultDatabase())) {
         activeDbName = dbManager->getDefaultDatabase();
         catalog = dbManager->getAttachedDatabase(activeDbName)->getCatalog();
     } else {
@@ -854,7 +863,8 @@ std::pair<TableCatalogEntry*, std::string> Binder::bindNodeTableEntry(
         if (auto defaultGraphCatalog = dbManager->getDefaultGraphCatalog();
             defaultGraphCatalog != nullptr) {
             catalog = defaultGraphCatalog;
-        } else if (dbManager->hasDefaultDatabase()) {
+        } else if (dbManager->hasDefaultDatabase() &&
+                   isLbugDatabase(dbManager, dbManager->getDefaultDatabase())) {
             resolvedDbName = dbManager->getDefaultDatabase();
             catalog = dbManager->getAttachedDatabase(resolvedDbName)->getCatalog();
         } else {
@@ -893,7 +903,8 @@ Binder::bindRelGroupEntries(const std::vector<std::string>& tableNames,
     } else if (auto defaultGraphCatalog = dbManager->getDefaultGraphCatalog();
                defaultGraphCatalog != nullptr) {
         catalog = defaultGraphCatalog;
-    } else if (dbManager->hasDefaultDatabase()) {
+    } else if (dbManager->hasDefaultDatabase() &&
+               isLbugDatabase(dbManager, dbManager->getDefaultDatabase())) {
         activeDbName = dbManager->getDefaultDatabase();
     } else {
         catalog = Catalog::Get(*clientContext);

--- a/src/binder/query/query_graph_label_analyzer.cpp
+++ b/src/binder/query/query_graph_label_analyzer.cpp
@@ -3,6 +3,7 @@
 #include "catalog/catalog.h"
 #include "catalog/catalog_entry/rel_group_catalog_entry.h"
 #include "common/exception/binder.h"
+#include "main/database_manager.h"
 #include "transaction/transaction.h"
 #include <format>
 
@@ -74,7 +75,7 @@ struct Candidates {
 };
 
 void QueryGraphLabelAnalyzer::pruneNode(const QueryGraph& graph, NodeExpression& node) const {
-    auto catalog = Catalog::Get(clientContext);
+    auto tx = transaction::Transaction::Get(clientContext);
     for (auto i = 0u; i < graph.getNumQueryRels(); ++i) {
         auto queryRel = graph.getQueryRel(i);
         if (queryRel->isRecursive()) {
@@ -83,11 +84,23 @@ void QueryGraphLabelAnalyzer::pruneNode(const QueryGraph& graph, NodeExpression&
         Candidates candidates;
         auto isSrcConnect = *queryRel->getSrcNode() == node;
         auto isDstConnect = *queryRel->getDstNode() == node;
-        auto tx = transaction::Transaction::Get(clientContext);
+        // Rel endpoint tables may live in an attached database; resolve the catalog
+        // that owns the rel entry so ID lookups hit the right catalog (IDs are
+        // 0-based per database and overlap across databases).
+        auto resolveCatalog = [&](catalog::TableCatalogEntry* relEntry) -> Catalog* {
+            auto dbName = queryRel->getDbName(relEntry);
+            if (dbName.empty()) {
+                return Catalog::Get(clientContext);
+            }
+            return main::DatabaseManager::Get(clientContext)
+                ->getAttachedDatabase(dbName)
+                ->getCatalog();
+        };
         if (queryRel->getDirectionType() == RelDirectionType::BOTH) {
             if (isSrcConnect || isDstConnect) {
                 for (auto entry : queryRel->getEntries()) {
                     auto& relEntry = entry->constCast<RelGroupCatalogEntry>();
+                    auto catalog = resolveCatalog(entry);
                     candidates.insert(relEntry.getSrcNodeTableIDSet(), catalog, tx);
                     candidates.insert(relEntry.getDstNodeTableIDSet(), catalog, tx);
                 }
@@ -96,11 +109,13 @@ void QueryGraphLabelAnalyzer::pruneNode(const QueryGraph& graph, NodeExpression&
             if (isSrcConnect) {
                 for (auto entry : queryRel->getEntries()) {
                     auto& relEntry = entry->constCast<RelGroupCatalogEntry>();
+                    auto catalog = resolveCatalog(entry);
                     candidates.insert(relEntry.getSrcNodeTableIDSet(), catalog, tx);
                 }
             } else if (isDstConnect) {
                 for (auto entry : queryRel->getEntries()) {
                     auto& relEntry = entry->constCast<RelGroupCatalogEntry>();
+                    auto catalog = resolveCatalog(entry);
                     candidates.insert(relEntry.getDstNodeTableIDSet(), catalog, tx);
                 }
             }

--- a/src/include/binder/binder.h
+++ b/src/include/binder/binder.h
@@ -282,6 +282,7 @@ public:
         RelDirectionType directionType, const std::vector<std::string>& originalLabels);
     std::shared_ptr<RelExpression> createRecursiveQueryRel(const parser::RelPattern& relPattern,
         const std::vector<catalog::TableCatalogEntry*>& entries,
+        const std::unordered_map<catalog::TableCatalogEntry*, std::string>& dbNames,
         std::shared_ptr<NodeExpression> srcNode, std::shared_ptr<NodeExpression> dstNode,
         RelDirectionType directionType);
     expression_vector bindRecursivePatternNodeProjectionList(
@@ -302,8 +303,10 @@ public:
     std::pair<std::vector<catalog::TableCatalogEntry*>,
         std::unordered_map<catalog::TableCatalogEntry*, std::string>>
     bindNodeTableEntries(const std::vector<std::string>& tableNames) const;
-    std::vector<catalog::TableCatalogEntry*> bindRelGroupEntries(
-        const std::vector<std::string>& tableNames) const;
+    std::pair<std::vector<catalog::TableCatalogEntry*>,
+        std::unordered_map<catalog::TableCatalogEntry*, std::string>>
+    bindRelGroupEntries(const std::vector<std::string>& tableNames,
+        const std::string& contextDbName = "") const;
     std::pair<catalog::TableCatalogEntry*, std::string> bindNodeTableEntry(
         const std::string& name) const;
     std::vector<PropertyDefinition> bindRelPropertyDefinitions(const parser::CreateTableInfo& info);

--- a/src/include/planner/operator/scan/logical_count_rel_table.h
+++ b/src/include/planner/operator/scan/logical_count_rel_table.h
@@ -41,10 +41,10 @@ public:
         std::vector<common::table_id_t> relTableIDs,
         std::vector<common::table_id_t> boundNodeTableIDs,
         std::shared_ptr<binder::NodeExpression> boundNode, common::ExtendDirection direction,
-        std::shared_ptr<binder::Expression> countExpr)
+        std::shared_ptr<binder::Expression> countExpr, std::string dbName = {})
         : LogicalOperator{type_}, relGroupEntry{relGroupEntry}, relTableIDs{std::move(relTableIDs)},
           boundNodeTableIDs{std::move(boundNodeTableIDs)}, boundNode{std::move(boundNode)},
-          direction{direction}, countExpr{std::move(countExpr)} {
+          direction{direction}, countExpr{std::move(countExpr)}, dbName{std::move(dbName)} {
         cardinality = 1; // Always returns exactly one row
     }
 
@@ -61,6 +61,7 @@ public:
     std::shared_ptr<binder::NodeExpression> getBoundNode() const { return boundNode; }
     common::ExtendDirection getDirection() const { return direction; }
     std::shared_ptr<binder::Expression> getCountExpr() const { return countExpr; }
+    const std::string& getDbName() const { return dbName; }
 
     std::unique_ptr<OPPrintInfo> getPrintInfo() const override {
         return std::make_unique<LogicalCountRelTablePrintInfo>(relGroupEntry->getName(), countExpr);
@@ -68,7 +69,7 @@ public:
 
     std::unique_ptr<LogicalOperator> copy() override {
         return std::make_unique<LogicalCountRelTable>(relGroupEntry, relTableIDs, boundNodeTableIDs,
-            boundNode, direction, countExpr);
+            boundNode, direction, countExpr, dbName);
     }
 
 private:
@@ -78,6 +79,7 @@ private:
     std::shared_ptr<binder::NodeExpression> boundNode;
     common::ExtendDirection direction;
     std::shared_ptr<binder::Expression> countExpr;
+    std::string dbName;
 };
 
 } // namespace planner

--- a/src/optimizer/count_rel_table_optimizer.cpp
+++ b/src/optimizer/count_rel_table_optimizer.cpp
@@ -327,9 +327,9 @@ std::shared_ptr<LogicalOperator> CountRelTableOptimizer::visitAggregateReplace(
         boundNodeTableIDs.end());
 
     // Create the new COUNT_REL_TABLE operator with all necessary information for scanning
-    auto countRelTable =
-        std::make_shared<LogicalCountRelTable>(relGroupEntry, std::move(relTableIDs),
-            std::move(boundNodeTableIDsVec), boundNode, extend.getDirection(), countExpr);
+    auto countRelTable = std::make_shared<LogicalCountRelTable>(relGroupEntry,
+        std::move(relTableIDs), std::move(boundNodeTableIDsVec), boundNode, extend.getDirection(),
+        countExpr, rel->getDbName(relGroupEntry));
     countRelTable->computeFlatSchema();
 
     return countRelTable;

--- a/src/processor/map/map_count_rel_table.cpp
+++ b/src/processor/map/map_count_rel_table.cpp
@@ -1,3 +1,4 @@
+#include "common/constants.h"
 #include "main/attached_database.h"
 #include "main/database_manager.h"
 #include "planner/operator/scan/logical_count_rel_table.h"
@@ -18,13 +19,18 @@ std::unique_ptr<PhysicalOperator> PlanMapper::mapCountRelTable(
     auto outSchema = logicalCountRelTable.getSchema();
 
     // Resolve the storage manager that owns the rel tables: main by default, or the
-    // attached database recorded on the count operator for attached rels.
+    // attached LBUG database recorded on the count operator for attached rels. Foreign
+    // attached databases (sqlite/duckdb/postgres) are never routed here: the binder
+    // resolves their rel names in the main catalog, so dbName stays empty for them.
     auto dbName = logicalCountRelTable.getDbName();
-    auto storageManager = dbName.empty() ? StorageManager::Get(*clientContext) : [&]() {
+    auto storageManager = StorageManager::Get(*clientContext);
+    if (!dbName.empty()) {
         auto* attachedDB = main::DatabaseManager::Get(*clientContext)->getAttachedDatabase(dbName);
-        auto* attachedLbug = static_cast<main::AttachedLbugDatabase*>(attachedDB);
-        return attachedLbug->getStorageManager();
-    }();
+        if (attachedDB->getDBType() == common::ATTACHED_LBUG_DB_TYPE) {
+            auto* attachedLbug = static_cast<main::AttachedLbugDatabase*>(attachedDB);
+            storageManager = attachedLbug->getStorageManager();
+        }
+    }
 
     // Get the node tables for scanning bound nodes
     std::vector<NodeTable*> nodeTables;

--- a/src/processor/map/map_count_rel_table.cpp
+++ b/src/processor/map/map_count_rel_table.cpp
@@ -1,3 +1,5 @@
+#include "main/attached_database.h"
+#include "main/database_manager.h"
 #include "planner/operator/scan/logical_count_rel_table.h"
 #include "processor/operator/scan/count_rel_table.h"
 #include "processor/plan_mapper.h"
@@ -15,7 +17,14 @@ std::unique_ptr<PhysicalOperator> PlanMapper::mapCountRelTable(
     auto& logicalCountRelTable = logicalOperator->constCast<LogicalCountRelTable>();
     auto outSchema = logicalCountRelTable.getSchema();
 
-    auto storageManager = StorageManager::Get(*clientContext);
+    // Resolve the storage manager that owns the rel tables: main by default, or the
+    // attached database recorded on the count operator for attached rels.
+    auto dbName = logicalCountRelTable.getDbName();
+    auto storageManager = dbName.empty() ? StorageManager::Get(*clientContext) : [&]() {
+        auto* attachedDB = main::DatabaseManager::Get(*clientContext)->getAttachedDatabase(dbName);
+        auto* attachedLbug = static_cast<main::AttachedLbugDatabase*>(attachedDB);
+        return attachedLbug->getStorageManager();
+    }();
 
     // Get the node tables for scanning bound nodes
     std::vector<NodeTable*> nodeTables;

--- a/src/processor/map/map_extend.cpp
+++ b/src/processor/map/map_extend.cpp
@@ -237,11 +237,28 @@ std::unique_ptr<PhysicalOperator> PlanMapper::mapExtend(const LogicalOperator* l
                 for (auto tableID : scanNode->getTableIDs()) {
                     if (tableID == expectedBoundTableID) {
                         // Route each source node table to its owning storage manager/catalog
-                        // (main or the attached database recorded on the scan).
+                        // (main or the attached database recorded on the scan). Only native
+                        // LBUG attached databases participate in this routing; foreign node
+                        // tables (sqlite/duckdb/postgres) are registered in the main storage
+                        // manager/catalog and keep the pre-attach path.
                         auto dbName =
                             nodeDBMap.contains(tableID) ? nodeDBMap.at(tableID) : std::string{};
-                        auto [cat, sm] = main::DatabaseManager::resolveTableStorage(*clientContext,
-                            tableID, dbName);
+                        catalog::Catalog* cat = nullptr;
+                        storage::StorageManager* sm = nullptr;
+                        if (!dbName.empty()) {
+                            auto* attachedDB = main::DatabaseManager::Get(*clientContext)
+                                                   ->getAttachedDatabase(dbName);
+                            if (attachedDB->getDBType() == common::ATTACHED_LBUG_DB_TYPE) {
+                                auto [cat2, sm2] = main::DatabaseManager::resolveTableStorage(
+                                    *clientContext, tableID, dbName);
+                                cat = cat2;
+                                sm = sm2;
+                            }
+                        }
+                        if (cat == nullptr) {
+                            cat = catalog::Catalog::Get(*clientContext);
+                            sm = storage::StorageManager::Get(*clientContext);
+                        }
                         auto table = sm->getTable(tableID)->ptrCast<NodeTable>();
                         sourceNodeTables.push_back(table);
                         auto tableEntry = cat->getTableCatalogEntry(transaction, tableID);

--- a/src/processor/map/map_extend.cpp
+++ b/src/processor/map/map_extend.cpp
@@ -2,8 +2,11 @@
 #include "binder/expression/property_expression.h"
 #include "binder/expression_binder.h"
 #include "catalog/catalog.h"
+#include "common/constants.h"
 #include "common/enums/extend_direction_util.h"
+#include "main/attached_database.h"
 #include "main/client_context.h"
+#include "main/database_manager.h"
 #include "planner/operator/extend/logical_extend.h"
 #include "planner/operator/scan/logical_scan_node_table.h"
 #include "processor/operator/scan/scan_multi_rel_tables.h"
@@ -21,6 +24,24 @@ using namespace lbug::catalog;
 
 namespace lbug {
 namespace processor {
+
+// Resolve the storage manager that owns a rel table belonging to dbName. Empty dbName
+// means the main database; otherwise look up the attached lbug database's storage
+// manager. Extension-backed attached databases cannot be scanned through a local
+// StorageManager, so those raise a clear error.
+static storage::StorageManager* getRelStorageManager(main::ClientContext* clientContext,
+    const std::string& dbName) {
+    if (dbName.empty()) {
+        return storage::StorageManager::Get(*clientContext);
+    }
+    auto* attachedDB = main::DatabaseManager::Get(*clientContext)->getAttachedDatabase(dbName);
+    if (attachedDB->getDBType() != common::ATTACHED_LBUG_DB_TYPE) {
+        throw common::RuntimeException(std::format(
+            "Relationship pattern over attached database {} is not supported.", dbName));
+    }
+    auto* attachedLbug = static_cast<main::AttachedLbugDatabase*>(attachedDB);
+    return attachedLbug->getStorageManager();
+}
 
 static ScanRelTableInfo getRelTableScanInfo(const TableCatalogEntry& tableEntry,
     RelDataDirection direction, RelTable* relTable, bool shouldScanNbrID,
@@ -81,9 +102,10 @@ static bool isRelTableQualifies(ExtendDirection direction, table_id_t srcTableID
 static std::vector<ScanRelTableInfo> populateRelTableCollectionScanner(table_id_t boundNodeTableID,
     const table_id_set_t& nbrTableISet, const RelGroupCatalogEntry& entry,
     ExtendDirection extendDirection, bool shouldScanNbrID, const expression_vector& properties,
-    const std::vector<ColumnPredicateSet>& columnPredicates, main::ClientContext* clientContext) {
+    const std::vector<ColumnPredicateSet>& columnPredicates, const std::string& dbName,
+    main::ClientContext* clientContext) {
     std::vector<ScanRelTableInfo> scanInfos;
-    const auto storageManager = StorageManager::Get(*clientContext);
+    const auto storageManager = getRelStorageManager(clientContext, dbName);
     for (auto& info : entry.getRelEntryInfos()) {
         auto srcTableID = info.nodePair.srcTableID;
         auto dstTableID = info.nodePair.dstTableID;
@@ -183,7 +205,6 @@ std::unique_ptr<PhysicalOperator> PlanMapper::mapExtend(const LogicalOperator* l
     }
     auto scanInfo = ScanOpInfo(inNodeIDPos, outVectorsPos);
     std::vector<std::string> tableNames;
-    auto storageManager = StorageManager::Get(*clientContext);
     for (auto entry : rel->getEntries()) {
         tableNames.push_back(entry->getName());
     }
@@ -194,7 +215,10 @@ std::unique_ptr<PhysicalOperator> PlanMapper::mapExtend(const LogicalOperator* l
         auto entry = rel->getEntry(0)->ptrCast<RelGroupCatalogEntry>();
         auto relDataDirection = ExtendDirectionUtil::getRelDataDirection(extendDirection);
         auto entryInfo = entry->getSingleRelEntryInfo();
-        auto relTable = storageManager->getTable(entryInfo.oid)->ptrCast<RelTable>();
+        // Resolve the storage manager that owns this rel table: main by default, or
+        // the attached database recorded on the rel entry for attached rels.
+        auto relStorageManager = getRelStorageManager(clientContext, rel->getDbName(entry));
+        auto relTable = relStorageManager->getTable(entryInfo.oid)->ptrCast<RelTable>();
         auto scanRelInfo =
             getRelTableScanInfo(*entry, relDataDirection, relTable, extend->shouldScanNbrID(),
                 extend->getProperties(), extend->getPropertyPredicates(), clientContext);
@@ -208,13 +232,19 @@ std::unique_ptr<PhysicalOperator> PlanMapper::mapExtend(const LogicalOperator* l
                 auto expectedBoundTableID = relDataDirection == RelDataDirection::FWD ?
                                                 relTable->getFromNodeTableID() :
                                                 relTable->getToNodeTableID();
-                auto catalog = catalog::Catalog::Get(*clientContext);
                 auto transaction = transaction::Transaction::Get(*clientContext);
+                auto& nodeDBMap = scanNode->getTableDBMap();
                 for (auto tableID : scanNode->getTableIDs()) {
                     if (tableID == expectedBoundTableID) {
-                        auto table = storageManager->getTable(tableID)->ptrCast<NodeTable>();
+                        // Route each source node table to its owning storage manager/catalog
+                        // (main or the attached database recorded on the scan).
+                        auto dbName =
+                            nodeDBMap.contains(tableID) ? nodeDBMap.at(tableID) : std::string{};
+                        auto [cat, sm] = main::DatabaseManager::resolveTableStorage(*clientContext,
+                            tableID, dbName);
+                        auto table = sm->getTable(tableID)->ptrCast<NodeTable>();
                         sourceNodeTables.push_back(table);
-                        auto tableEntry = catalog->getTableCatalogEntry(transaction, tableID);
+                        auto tableEntry = cat->getTableCatalogEntry(transaction, tableID);
                         sourceNodeTableInfos.push_back(
                             getNodeTableScanInfo(*scanNode, table, tableEntry, clientContext));
                         auto semiMask =
@@ -266,10 +296,10 @@ std::unique_ptr<PhysicalOperator> PlanMapper::mapExtend(const LogicalOperator* l
     for (auto boundNodeTableID : boundNode->getTableIDs()) {
         for (auto entry : rel->getEntries()) {
             auto& relGroupEntry = entry->constCast<RelGroupCatalogEntry>();
-            auto scanInfos =
-                populateRelTableCollectionScanner(boundNodeTableID, nbrNode->getTableIDsSet(),
-                    relGroupEntry, extendDirection, extend->shouldScanNbrID(),
-                    extend->getProperties(), extend->getPropertyPredicates(), clientContext);
+            auto scanInfos = populateRelTableCollectionScanner(boundNodeTableID,
+                nbrNode->getTableIDsSet(), relGroupEntry, extendDirection,
+                extend->shouldScanNbrID(), extend->getProperties(), extend->getPropertyPredicates(),
+                rel->getDbName(entry), clientContext);
             if (scanInfos.empty()) {
                 continue;
             }

--- a/test/include/test_runner/test_group.h
+++ b/test/include/test_runner/test_group.h
@@ -101,6 +101,10 @@ struct TestStatement {
 struct TestGroup {
     std::string group;
     std::string dataset;
+    // Optional dataset to build an on-disk `.lbdb` file that test cases can ATTACH.
+    // Built at setup time from `dataset/<attachDataset>/schema.cypher` + `copy.cypher`
+    // and placed under `${DATABASE_PATH}/attach_target.lbdb` (the test temp dir).
+    std::string attachDataset;
     std::unordered_map<std::string, std::vector<TestStatement>> testCases;
     std::unordered_map<std::string, std::vector<TestStatement>> testCasesStatementBlocks;
     std::optional<uint64_t> bufferPoolSize;
@@ -124,6 +128,7 @@ struct TestGroup {
 
     bool isValid() const { return !group.empty() && !dataset.empty(); }
     bool hasStatements() const { return !testCases.empty(); }
+    bool hasAttachDataset() const { return !attachDataset.empty(); }
 };
 
 } // namespace testing

--- a/test/include/test_runner/test_parser.h
+++ b/test/include/test_runner/test_parser.h
@@ -13,6 +13,7 @@ namespace testing {
 enum class TokenType {
     // header only
     DATASET,
+    ATTACH_DATASET,
     BUFFER_POOL_SIZE,
 
     // Skip or enable tests
@@ -72,7 +73,8 @@ enum class TokenType {
 };
 
 const std::unordered_map<std::string, TokenType> TOKEN_MAP = {{"-DATASET", TokenType::DATASET},
-    {"-CASE", TokenType::CASE}, {"-CHECK_ORDER", TokenType::CHECK_ORDER}, {"-LOG", TokenType::LOG},
+    {"-ATTACH_DATASET", TokenType::ATTACH_DATASET}, {"-CASE", TokenType::CASE},
+    {"-CHECK_ORDER", TokenType::CHECK_ORDER}, {"-LOG", TokenType::LOG},
     {"-DEFINE_STATEMENT_BLOCK", TokenType::DEFINE_STATEMENT_BLOCK}, {"-SKIP", TokenType::SKIP},
     {"-SKIP_MUSL", TokenType::SKIP_MUSL}, {"-SKIP_LINE", TokenType::SET},
     {"-SKIP_WASM", TokenType::SKIP_WASM},

--- a/test/runner/e2e_test.cpp
+++ b/test/runner/e2e_test.cpp
@@ -20,10 +20,11 @@ public:
     explicit EndToEndTest(TestGroup::DatasetType datasetType, std::string dataset,
         std::optional<uint64_t> bufferPoolSize, uint64_t checkpointWaitTimeout,
         const std::set<std::string>& connNames, std::vector<TestStatement> testStatements,
-        std::string testPath)
+        std::string testPath, std::string attachDataset)
         : datasetType{datasetType}, dataset{std::move(dataset)}, bufferPoolSize{bufferPoolSize},
           checkpointWaitTimeout{checkpointWaitTimeout}, testStatements{std::move(testStatements)},
-          connNames{connNames}, testPath{std::move(testPath)} {}
+          connNames{connNames}, testPath{std::move(testPath)},
+          attachDataset{std::move(attachDataset)} {}
 
     void SetUp() override {
         setUpDataset();
@@ -53,6 +54,40 @@ public:
             initGraph(TestHelper::appendLbugRootPath(
                 TestHelper::E2E_OVERRIDE_IMPORT_DIR + "/demo-db/parquet/"));
         }
+        if (!attachDataset.empty()) {
+            buildAttachDatabase();
+        }
+    }
+
+    // Build an on-disk `.lbdb` file from `dataset/<attachDataset>/schema.cypher` +
+    // `copy.cypher` and place it at `${DATABASE_PATH}/attach_target.lbdb` so that test
+    // statements can ATTACH it without relying on a pre-existing binary file.
+    void buildAttachDatabase() {
+        const auto attachDatasetPath = TestHelper::appendLbugRootPath("dataset/" + attachDataset);
+        const auto schemaPath = attachDatasetPath + "/" + TestHelper::SCHEMA_FILE_NAME;
+        const auto copyPath = attachDatasetPath + "/" + TestHelper::COPY_FILE_NAME;
+        if (!std::filesystem::exists(schemaPath)) {
+            throw TestException("ATTACH_DATASET schema not found: " + schemaPath);
+        }
+        // Build into a sub-directory of the test temp dir so TearDown's
+        // removeParentDirectoryOfDBPath() cleans everything up.
+        const auto buildDir =
+            TestHelper::getTempDir("attach_target_build_" + getTestGroupAndName());
+        const auto buildDbPath = buildDir + "/" + TESTING_DB_FILE_NAME;
+        {
+            auto buildDb = std::make_unique<lbug::main::Database>(buildDbPath, *systemConfig);
+            auto buildConn = std::make_unique<lbug::main::Connection>(buildDb.get());
+            TestHelper::executeScript(schemaPath, *buildConn);
+            if (std::filesystem::exists(copyPath)) {
+                TestHelper::executeScript(copyPath, *buildConn);
+            }
+            auto ckptResult = buildConn->query("CHECKPOINT;");
+            ASSERT_TRUE(ckptResult->isSuccess()) << ckptResult->toString();
+        }
+        const auto attachDbPath =
+            std::filesystem::path(databasePath).parent_path().string() + "/attach_target.lbdb";
+        std::filesystem::copy(buildDbPath, attachDbPath,
+            std::filesystem::copy_options::overwrite_existing);
     }
 
     void setUpDataset() {
@@ -107,6 +142,7 @@ private:
     std::vector<TestStatement> testStatements;
     std::set<std::string> connNames;
     std::string testPath;
+    std::string attachDataset;
 
     std::string generateTempDatasetPath() const {
         std::string datasetName = dataset;
@@ -318,6 +354,7 @@ void parseAndRegisterTestGroup(const std::string& path, bool generateTestList = 
         auto testCases = std::move(testGroup->testCases);
         auto bufferPoolSize = testGroup->bufferPoolSize;
         auto checkpointWaitTimeout = testGroup->checkpointWaitTimeout;
+        auto attachDataset = testGroup->attachDataset;
         for (auto& [testCaseName, testStatements] : testCases) {
             // Check for invalid characters in the case name (see ISSUE 4510)
             if (testCaseName.find('-') != std::string::npos) {
@@ -334,14 +371,16 @@ void parseAndRegisterTestGroup(const std::string& path, bool generateTestList = 
             testing::RegisterTest(testGroup->group.c_str(), testCaseName.c_str(), nullptr, nullptr,
                 __FILE__, __LINE__,
                 [path, datasetType, dataset, bufferPoolSize, checkpointWaitTimeout, connNames,
-                    testStatements = std::move(testStatements), testCaseName]() mutable -> DBTest* {
+                    testStatements = std::move(testStatements), testCaseName,
+                    attachDataset]() mutable -> DBTest* {
                     std::vector<TestStatement> testStatementsCopy;
                     for (const auto& testStatement : testStatements) {
                         testStatementsCopy.emplace_back(TestStatement(testStatement));
                         testStatementsCopy.back().testCaseName = testCaseName;
                     }
                     return new EndToEndTest(datasetType, dataset, bufferPoolSize,
-                        checkpointWaitTimeout, connNames, std::move(testStatementsCopy), path);
+                        checkpointWaitTimeout, connNames, std::move(testStatementsCopy), path,
+                        attachDataset);
                 });
         }
     } else {

--- a/test/test_files/graph/attach_use.test
+++ b/test/test_files/graph/attach_use.test
@@ -1,0 +1,64 @@
+-DATASET CSV empty
+-ATTACH_DATASET attach_db
+--
+
+# Tests for ATTACH + USE over attached lbug databases.
+# Regression coverage for PR #802 / issue #801: relationship patterns and
+# `USE <alias>` over attached lbug databases.
+#
+# Setup: the -ATTACH_DATASET directive tells the test runner to build a fresh
+# on-disk `.lbdb` file at `${DATABASE_PATH}/attach_target.lbdb` from
+# `dataset/attach_db/` (Person(a,b,c) + Knows(a->b, b->c)). Each -CASE below
+# ATTACHes that file as `db1` and runs the queries from the PR summary table.
+
+-CASE QualifiedNodeLabelCount
+-SKIP_FSM_LEAK_CHECK
+-STATEMENT ATTACH '${DATABASE_PATH}/attach_target.lbdb' AS db1 (DBTYPE lbug);
+---- ok
+-STATEMENT MATCH (p:db1.Person) RETURN count(p);
+---- 1
+3
+
+-CASE QualifiedRelLabelCount
+-SKIP_FSM_LEAK_CHECK
+-STATEMENT ATTACH '${DATABASE_PATH}/attach_target.lbdb' AS db1 (DBTYPE lbug);
+---- ok
+-STATEMENT MATCH (a:db1.Person)-[e:db1.Knows]->(b:db1.Person) RETURN count(e);
+---- 1
+2
+
+-CASE QualifiedNodesUnqualifiedRel
+-SKIP_FSM_LEAK_CHECK
+-STATEMENT ATTACH '${DATABASE_PATH}/attach_target.lbdb' AS db1 (DBTYPE lbug);
+---- ok
+-STATEMENT MATCH (a:db1.Person)-[e:Knows]->(b:db1.Person) RETURN count(e);
+---- 1
+2
+
+-CASE QualifiedNodesAnonymousRel
+-SKIP_FSM_LEAK_CHECK
+-STATEMENT ATTACH '${DATABASE_PATH}/attach_target.lbdb' AS db1 (DBTYPE lbug);
+---- ok
+-STATEMENT MATCH (a:db1.Person)-[e]->(b:db1.Person) RETURN count(e);
+---- 1
+2
+
+-CASE UseSwitchesCatalogUnqualifiedNode
+-SKIP_FSM_LEAK_CHECK
+-STATEMENT ATTACH '${DATABASE_PATH}/attach_target.lbdb' AS db1 (DBTYPE lbug);
+---- ok
+-STATEMENT USE db1
+---- ok
+-STATEMENT MATCH (p:Person) RETURN count(p);
+---- 1
+3
+
+-CASE UseSwitchesCatalogUnqualifiedRel
+-SKIP_FSM_LEAK_CHECK
+-STATEMENT ATTACH '${DATABASE_PATH}/attach_target.lbdb' AS db1 (DBTYPE lbug);
+---- ok
+-STATEMENT USE db1
+---- ok
+-STATEMENT MATCH (a:Person)-[e:Knows]->(b:Person) RETURN count(e);
+---- 1
+2

--- a/test/test_runner/test_parser.cpp
+++ b/test/test_runner/test_parser.cpp
@@ -177,6 +177,12 @@ void TestParser::parseHeader() {
             checkMinimumParams(2);
             extractDataset();
         } break;
+        case TokenType::ATTACH_DATASET: {
+            // -ATTACH_DATASET <name>: build an on-disk `.lbdb` file at
+            // `${DATABASE_PATH}/attach_target.lbdb` from `dataset/<name>/`.
+            checkMinimumParams(1);
+            testGroup->attachDataset = currentToken.params[1];
+        } break;
         case TokenType::BUFFER_POOL_SIZE: {
             checkMinimumParams(1);
             testGroup->bufferPoolSize = stoll(currentToken.params[1]);


### PR DESCRIPTION
## Summary

Implements full `dbName` plumbing for relationship patterns over attached Lbug databases, replacing the previous **BUG 6** stop-gap (which either threw "Qualified relationship patterns are not supported yet" or silently skipped attached rel groups).

Fixes: #801 

All cases from the ATTACH repro now work in the shell:

| Query | Result |
|---|---|
| `MATCH (p:db1.Person) RETURN count(p)` | 3 |
| `MATCH (a:db1.Person)-[e:db1.Knows]->(b:db1.Person) RETURN count(e)` | 2 |
| `MATCH (a:db1.Person)-[e:Knows]->(b:db1.Person) RETURN count(e)` | 2 |
| `MATCH (a:db1.Person)-[e]->(b:db1.Person) RETURN count(e)` | 2 |
| `USE db1; MATCH (p:Person) RETURN count(p)` | 3 |
| `USE db1; MATCH (a:Person)-[e:Knows]->(b:Person) RETURN count(e)` | 2 |

## Changes

**Binder**
- `bindRelGroupEntries` resolves qualified rel names (`db.rel`) and unqualified/anonymous rel labels relative to the active catalog (endpoint context, `USE db`, active graph, or main), returning per-entry `dbNames`.
- `bindQueryRel` computes the endpoint catalog context (all nodes from the same attached db) and threads `dbNames` onto the `RelExpression`.
- `bindNodeTableEntries` / `bindNodeTableEntry` honor `USE db` for unqualified node names.
- `QueryGraphLabelAnalyzer::pruneNode` resolves rel endpoint table IDs in the catalog that owns each rel entry (IDs are 0-based per database and overlap).
- `createRecursiveQueryRel` resolves endpoint/intermediate nodes in the owning catalog.

**Physical**
- `mapExtend` routes rel tables and source node tables to the correct storage manager/catalog per entry.
- `LogicalCountRelTable` / `mapCountRelTable` carry and use the rel dbName so the COUNT optimization works over attached rels.

## Notes
- Recursive multi-hop patterns over *attached* databases still require rerouting the GDS graph-materialization layer (`OnDiskGraph`); out of scope here. Main-database recursive patterns are unaffected.
- `USE main` to return to the main catalog is not supported (pre-existing).