### PR TITLE
perf(copy): defer the primary key index buffers to the first insert

### DIFF
--- a/src/include/processor/operator/persistent/index_builder.h
+++ b/src/include/processor/operator/persistent/index_builder.h
@@ -89,7 +89,7 @@ public:
     void insert(std::string key, common::offset_t value, OptionalWarningSourceData&& warningData,
         NodeBatchInsertErrorHandler& errorHandler) {
         auto indexPos = storage::HashIndexUtils::getHashIndexPosition(std::string_view(key));
-        auto& stringBuffer = (*std::get<UniqueBuffers<std::string>>(buffers))[indexPos];
+        auto& stringBuffer = getBuffers<std::string>()[indexPos];
 
         if (stringBuffer.full()) {
             // StaticVector's move constructor leaves the original vector valid and empty
@@ -105,7 +105,7 @@ public:
     void insert(T key, common::offset_t value, OptionalWarningSourceData&& warningData,
         NodeBatchInsertErrorHandler& errorHandler) {
         auto indexPos = storage::HashIndexUtils::getHashIndexPosition(key);
-        auto& buffer = (*std::get<UniqueBuffers<T>>(buffers))[indexPos];
+        auto& buffer = getBuffers<T>()[indexPos];
 
         if (buffer.full()) {
             globalQueues->insert(indexPos, std::move(buffer), errorHandler);
@@ -126,6 +126,20 @@ private:
     using Buffers = std::array<IndexBufferWithWarningData<T>, storage::NUM_HASH_INDEXES>;
     template<typename T>
     using UniqueBuffers = std::unique_ptr<Buffers<T>>;
+
+    // Allocate on the first insert rather than in the constructor, so that a worker which
+    // receives no rows leaves the array unbuilt. Every COPY worker constructs an
+    // IndexBuilder, and one set of buffers is NUM_HASH_INDEXES times INDEX_BUFFER_SIZE
+    // entries, about 4 MiB, zeroed at construction whatever the input holds.
+    template<typename T>
+    Buffers<T>& getBuffers() {
+        auto& owned = std::get<UniqueBuffers<T>>(buffers);
+        if (!owned) {
+            owned = std::make_unique<Buffers<T>>();
+        }
+        return *owned;
+    }
+
     std::variant<UniqueBuffers<std::string>, UniqueBuffers<int64_t>, UniqueBuffers<int32_t>,
         UniqueBuffers<int16_t>, UniqueBuffers<int8_t>, UniqueBuffers<uint64_t>,
         UniqueBuffers<uint32_t>, UniqueBuffers<uint16_t>, UniqueBuffers<uint8_t>,

--- a/src/processor/operator/persistent/index_builder.cpp
+++ b/src/processor/operator/persistent/index_builder.cpp
@@ -104,16 +104,21 @@ void IndexBuilderGlobalQueues::maybeConsumeIndex(size_t index,
 
 IndexBuilderLocalBuffers::IndexBuilderLocalBuffers(IndexBuilderGlobalQueues& globalQueues)
     : globalQueues(&globalQueues) {
+    // Select the buffer type without allocating it: the buffers are built at the first
+    // insert, so a worker which receives no rows leaves them unbuilt.
     TypeUtils::visit(
-        globalQueues.pkTypeID(),
-        [&](string_t) { buffers = std::make_unique<Buffers<std::string>>(); },
-        [&]<HashablePrimitive T>(T) { buffers = std::make_unique<Buffers<T>>(); },
+        globalQueues.pkTypeID(), [&](string_t) { buffers = UniqueBuffers<std::string>{}; },
+        [&]<HashablePrimitive T>(T) { buffers = UniqueBuffers<T>{}; },
         [](auto) { UNREACHABLE_CODE; });
 }
 
 void IndexBuilderLocalBuffers::flush(NodeBatchInsertErrorHandler& errorHandler) {
     std::visit(
         [&](auto&& buffers) {
+            if (!buffers) {
+                // No insert reached this worker, so the queues receive no buffer.
+                return;
+            }
             for (auto i = 0u; i < buffers->size(); i++) {
                 globalQueues->insert(i, std::move((*buffers)[i]), errorHandler);
             }

--- a/test/copy/copy_test.cpp
+++ b/test/copy/copy_test.cpp
@@ -940,5 +940,57 @@ TEST_F(CopyTest, CopySmallInputIntoWideTableUnderSmallBufferPool) {
     ASSERT_TRUE(result->hasNext());
     ASSERT_EQ(result->getNext()->getValue(0)->getValue<int64_t>(), 59);
 }
+
+TEST_F(CopyTest, CopyBuildsPrimaryKeyBuffersOnFirstInsert) {
+    if (inMemMode) {
+        GTEST_SKIP();
+    }
+    // A COPY worker builds its primary-key buffers at its first insert, so a worker that
+    // receives no rows never builds them and its flush has nothing to hand to the global
+    // queues. Those buffers are C++ heap rather than buffer pool, so the saving is not a
+    // floor the way CopySmallInputIntoWideTableUnderSmallBufferPool's is. What has to hold is
+    // that an empty input leaves a usable builder behind, that both arms of the key-type
+    // variant allocate once a row does arrive, and that a duplicate key is still reported.
+    systemConfig->maxNumThreads = 16;
+    createDBAndConn();
+    auto result = conn->query("CREATE NODE TABLE Account(id INT64, PRIMARY KEY(id))");
+    ASSERT_TRUE(result->isSuccess()) << result->getErrorMessage();
+    result = conn->query("CREATE NODE TABLE Person(name STRING, PRIMARY KEY(name))");
+    ASSERT_TRUE(result->isSuccess()) << result->getErrorMessage();
+    result = conn->query("CREATE NODE TABLE Repeat(name STRING, PRIMARY KEY(name))");
+    ASSERT_TRUE(result->isSuccess()) << result->getErrorMessage();
+
+    // No worker inserts anything, on either arm of the variant.
+    const auto emptyIntPath = writeCSV("empty_int.csv", {"id"});
+    result = conn->query(std::format("COPY Account FROM '{}' (HEADER=true)", emptyIntPath));
+    ASSERT_TRUE(result->isSuccess()) << result->getErrorMessage();
+    const auto emptyStringPath = writeCSV("empty_string.csv", {"name"});
+    result = conn->query(std::format("COPY Person FROM '{}' (HEADER=true)", emptyStringPath));
+    ASSERT_TRUE(result->isSuccess()) << result->getErrorMessage();
+
+    // The same tables then take rows, so the buffers are built by a COPY that follows one
+    // which built none, and the index they feed has to be complete.
+    const auto accountPath = writeCSV("accounts.csv", {"1", "2", "3"});
+    result = conn->query(std::format("COPY Account FROM '{}'", accountPath));
+    ASSERT_TRUE(result->isSuccess()) << result->getErrorMessage();
+    const auto personPath = writeCSV("people.csv", {"ann", "bo", "cy"});
+    result = conn->query(std::format("COPY Person FROM '{}'", personPath));
+    ASSERT_TRUE(result->isSuccess()) << result->getErrorMessage();
+
+    result = conn->query("MATCH (a:Account) WHERE a.id = 2 RETURN COUNT(*)");
+    ASSERT_TRUE(result->isSuccess()) << result->getErrorMessage();
+    ASSERT_TRUE(result->hasNext());
+    ASSERT_EQ(result->getNext()->getValue(0)->getValue<int64_t>(), 1);
+    result = conn->query("MATCH (p:Person) WHERE p.name = 'bo' RETURN COUNT(*)");
+    ASSERT_TRUE(result->isSuccess()) << result->getErrorMessage();
+    ASSERT_TRUE(result->hasNext());
+    ASSERT_EQ(result->getNext()->getValue(0)->getValue<int64_t>(), 1);
+
+    // The error path runs through the same lazily built buffers.
+    const auto duplicatePath = writeCSV("duplicate_string.csv", {"dd", "dd"});
+    result = conn->query(std::format("COPY Repeat FROM '{}'", duplicatePath));
+    ASSERT_FALSE(result->isSuccess());
+    ASSERT_NE(result->getErrorMessage().find("duplicated primary key"), std::string::npos);
+}
 } // namespace testing
 } // namespace lbug


### PR DESCRIPTION
_This work was produced with the help of language models._

Follow-up to #781 (1/2 suggested patches). Every `COPY` worker builds ~4 MiB of primary-key buffers before the scan produces a row; this patch builds them at the worker's first insert. 

On a zero-row `COPY` at 16 threads, `perf` attributes 47.6% of the profile to that construction before the patch and 0.6% after, CPU per statement falls from 56.0 ms to 15.1 ms, and minor faults fall from 276 877 to 59 567 over fifty statements. 

Measurements below are against `main` at `213891756`, `relwithdebinfo`, gcc 14.2.0, with both unpatched and patched builds rebuilt in one session on the same host.

## Every worker builds the whole buffer array before the first row

`NodeBatchInsert::initLocalStateInternal` clones the shared `IndexBuilder` for each worker (`src/processor/operator/persistent/node_batch_insert.cpp::NodeBatchInsert::initLocalStateInternal`), and the `IndexBuilder` constructor builds an `IndexBuilderLocalBuffers` (`src/processor/operator/persistent/index_builder.cpp::IndexBuilder::IndexBuilder`). That constructor allocated a `Buffers<T>`, which is `NUM_HASH_INDEXES` arrays of `INDEX_BUFFER_SIZE` key and offset pairs: 256 by 1024 by 16 bytes for an `INT64` key, about 4.2 MiB per worker (`src/include/storage/index/in_mem_hash_index.h::IndexBuffer`, `src/include/common/constants.h::HashIndexConstants`).

The memory is zeroed as well as reserved. `std::make_unique` value-initialises, and `IndexBufferWithWarningData` has no user-provided default constructor, so each of the 256 elements is zero-initialized before its members are constructed, and `StaticVector`'s own constructor then writes only its length. A profile of the unpatched build finds `__memset_avx512_unaligned_erms` holding 40.8% of the samples by self time, and 58.4% including its callers.

## The allocation moves to the first insert

The constructor still selects the arm of the variant that matches the primary key type, so the type dispatch is unchanged. The array behind it is built on demand, by the first insert that needs it:

```diff
 IndexBuilderLocalBuffers::IndexBuilderLocalBuffers(IndexBuilderGlobalQueues& globalQueues)
     : globalQueues(&globalQueues) {
+    // Select the buffer type without allocating it: the buffers are built at the first
+    // insert, so a worker which receives no rows leaves them unbuilt.
     TypeUtils::visit(
-        globalQueues.pkTypeID(),
-        [&](string_t) { buffers = std::make_unique<Buffers<std::string>>(); },
-        [&]<HashablePrimitive T>(T) { buffers = std::make_unique<Buffers<T>>(); },
+        globalQueues.pkTypeID(), [&](string_t) { buffers = UniqueBuffers<std::string>{}; },
+        [&]<HashablePrimitive T>(T) { buffers = UniqueBuffers<T>{}; },
         [](auto) { UNREACHABLE_CODE; });
 }
 
 void IndexBuilderLocalBuffers::flush(NodeBatchInsertErrorHandler& errorHandler) {
     std::visit(
         [&](auto&& buffers) {
+            if (!buffers) {
+                // No insert reached this worker, so the queues receive no buffer.
+                return;
+            }
             for (auto i = 0u; i < buffers->size(); i++) {
                 globalQueues->insert(i, std::move((*buffers)[i]), errorHandler);
             }
         },
         buffers);
 }
```

Both `insert` overloads reach the array through one accessor, which allocates when the pointer is null:

```diff
+    template<typename T>
+    Buffers<T>& getBuffers() {
+        auto& owned = std::get<UniqueBuffers<T>>(buffers);
+        if (!owned) {
+            owned = std::make_unique<Buffers<T>>();
+        }
+        return *owned;
+    }
```

Three sites read the pointer: the two `insert` overloads, which now go through `getBuffers`, and `flush`, which returns early when no insert happened. `flush` runs from `IndexBuilder::finishedProducing` and from `IndexBuilder::finalize`, and a worker that inserted no row reaches both, as does the global builder, which inserts on no path.

## The construction leaves the profile, and CPU per statement falls by two thirds

Allocation counts for one `COPY` into an 89-column table at 16 threads, under gdb, with a conditional breakpoint on `operator new` for requests of 4 MiB or more:

| input    | metric                                   | before | after |
|----------|------------------------------------------|-------:|------:|
| 0 rows   | `IndexBuilderLocalBuffers` constructions |     17 |    17 |
| 0 rows   | `operator new` of 4 MiB or more          |     18 |     1 |
| 100 rows | `operator new` of 4 MiB or more          |     18 |     2 |

Seventeen constructions are the sixteen workers and the global builder. After the patch a zero-row `COPY` allocates none of the arrays, and a 100-row input allocates one, in the single worker the morsel reached.

`perf record -g --call-graph dwarf` over fifty zero-row statements at 16 threads, cumulative share of the profile:

| symbol                                               | before |              after |
|------------------------------------------------------|-------:|-------------------:|
| `TaskScheduler::runWorkerThread`                     |  67.7% |              21.6% |
| `IndexBuilderLocalBuffers::IndexBuilderLocalBuffers` |  47.6% | below the 0.4% cut |
| `NodeBatchInsert::initLocalStateInternal`            |  46.5% |               0.6% |
| `__memset_avx512_unaligned_erms`                     |  58.4% |               8.9% |

The largest self-time symbol in the patched profile is `BufferManager::removeEvictedCandidates` at 44.2%, which is eviction bookkeeping rather than allocation, and which this patch leaves alone.

One zero-row `COPY`, `one_copy.c 89 0 20`, twenty statements divided by twenty, faults for all twenty:

| `max_num_threads` | metric          | before           | after            |
|------------------:|-----------------|------------------|------------------|
|                 1 | wall per `COPY` | 8.1, 7.8, 8.1 ms | 8.5, 7.6, 8.3 ms |
|                16 | wall per `COPY` | 14.6, 15.6 ms    | 9.4, 9.8 ms      |
|                16 | CPU per `COPY`  | 50.8, 59.1 ms    | 15.9, 15.5 ms    |
|                16 | minor faults    | 122k, 145k       | 30k, 31k         |

At one worker the patch removes one allocation, and the three runs of each build overlap.

A populated input, `many_copies.c 89 100 20`, which creates twenty tables up front and times twenty `COPY` statements of 100 rows at 16 threads:

| metric                          | before          | after           |
|---------------------------------|-----------------|-----------------|
| wall per `COPY`                 | 56.3, 56.7 ms   | 53.9, 53.0 ms   |
| CPU per `COPY`                  | 163.7, 159.7 ms | 107.8, 110.3 ms |
| minor faults, twenty statements | 517k, 581k      | 470k, 500k      |

The saving follows the key type, because the array holds one buffer set per key. A `std::string` pair is 40 bytes against 16 for an `INT64` pair, so the array is about 10.5 MiB per worker against 4.2 MiB. Twenty statements into a 9-column table at 16 threads, `many_copies.c`:

| primary key | input    | CPU per `COPY` before | after   | minor faults before | after |
|-------------|----------|----------------------:|--------:|--------------------:|------:|
| `INT64`     | 0 rows   |               52.9 ms | 10.2 ms |              220841 | 12782 |
| `INT64`     | 100 rows |               63.3 ms | 20.4 ms |              261512 | 72307 |
| `STRING`    | 0 rows   |              111.1 ms | 10.8 ms |              521683 | 12903 |
| `STRING`    | 100 rows |              107.5 ms | 21.1 ms |              370777 | 79930 |

Instruction counts carry the same result without depending on how busy the machine is. `perf stat` over twenty zero-row statements at 16 threads: 4.181e9 instructions and 4.524e9 cycles before, 3.507e9 instructions and 1.651e9 cycles after, with task-clock falling from 1108 ms to 418 ms. Instructions fall by 16% and cycles by 64%, which is the signature of removing memory traffic rather than computation.

## The pool ceiling is unchanged, and a partly engaged input now reaches it in every run

These buffers come from the C++ heap rather than from the buffer pool, so the pool floor #781 measured moves for a different reason than allocation volume. On small inputs it is unchanged: 96 MB at one thread and 184 MB at two for the 89-column 100-row case, and the 250 to 300 MB band above four threads that #781 reported.

On a 10000-row input at 16 threads, the patched build asked for a larger pool. Four interleaved samples of the bisected floor:

| sample | before |  after |
|-------:|-------:|-------:|
|      1 | 688 MB | 768 MB |
|      2 | 832 MB | 880 MB |
|      3 | 904 MB | 968 MB |
|      4 | 832 MB | 896 MB |

The cause is scheduling, and an instrumented build measures it. Adding a peak watermark to `BufferManager::reserve` and running the same input nine times per build gives a demand ceiling of 1544.5 MB on both builds, reached by 9 runs of 9 after the patch and by 5 runs of 9 before it, where the other four peaked at 1516.1, 1503.9, 1454.1 and 1363.7 MB. Sixteen workers each holding a full-capacity node group is 1544.5 MB, so the ceiling is the arithmetic. What the patch changes is how often a run reaches that ceiling. A worker that skips 4 MiB of zeroing at startup is readier to take a morsel while its neighbours still hold theirs.

Two consequences, to keep in mind before merging this: 
* A `COPY` sized to engage every worker already paid 1544.5 MB, and at 100000 rows both builds bisect to 1456 MB. 
* A `COPY` that engages some of them now pays the ceiling more often, which is 5 to 10% above what the unpatched build happened to need. 

Sizing the worker pool or the first node group to the input removes the ceiling itself, which is another discussion stemming from #781.

## The lazy path is covered on both arms of the key variant

`CopyBuildsPrimaryKeyBuffersOnFirstInsert` in the existing `test/copy/copy_test.cpp`. The test copies an empty input into an `INT64`-keyed table and into a `STRING`-keyed one at 16 threads, then copies rows into both, then checks a point lookup on each and a duplicate key on a third table. The three readers of the pointer are each reached: the empty input reaches `flush` with no allocation, the populated input reaches both `insert` overloads, and the duplicate reaches the error path through a lazily built buffer.

It is a regression test rather than a negative control, and it passes on the unpatched tree. `CopySmallInputIntoWideTableUnderSmallBufferPool` could fail before #781 because the allocation it targets comes from the buffer pool, which a test can cap. These buffers are heap, so their absence is invisible to a query, and the evidence that the allocation is gone is the breakpoint count above.

`make test NUM_THREADS=14 TEST_JOBS=8` on the patched tree: 2669 passed and 4 failed out of 2673. The four are `dictionary_bug~orb383_relationship_projection_obfuscated.AnonymousParquetDeleteReload`, which needs gitignored Parquet fixtures, and three `extension` tests that download from `extension.ladybugdb.com`. The same four fail on unpatched `main` at `213891756` in the same session.

A thread sanitiser build reports no race in the paths this patch changes. `make test-build TSAN=1 BUILD_PATH=tsan` builds, and the gtest suite cannot run under it on this host: the engine's default 8 TB `max_db_size` reservation fails inside TSan's address space, so every test that opens a database fails with `Buffer manager exception: Mmap for size 8796093022208 failed`. `tsan_probe.c`, attached, drives the same paths from the C API with `max_db_size` set to 1 GB at 16 threads: an empty node `COPY`, a 500-row `COPY` into an `INT64`-keyed table and into a `STRING`-keyed one, a duplicate key, and a 500-edge rel `COPY`. Every statement behaves as expected and ThreadSanitizer reports zero warnings.


## Not measured

Interaction with spill-to-disk. These buffers are heap rather than buffer pool, so spilling does not move them, and a workload that spills was not run.

`NODE_GROUP_SIZE` scales the floor numbers and leaves the mechanism alone: the buffers are sized by `NUM_HASH_INDEXES` times `INDEX_BUFFER_SIZE`, so a build with a different node group size shifts the 1544.5 MB ceiling rather than the allocation this patch removes.

The rel `COPY` path needs no measurement here, and a counter says why. With the breakpoints armed after the setup `COPY` completes, a rel `COPY` of 100 edges constructs zero `IndexBuilderLocalBuffers` and makes zero `operator new` requests of 4 MiB or more, on both builds. The second patch of the pair measures the rel path with its own harness.

## How the numbers were taken

Tree `main` at `213891756`, branch `defer-index-builder-buffers`. Build `make test-build NUM_THREADS=14`, gcc 14.2.0. Timings are `clock_gettime` and `getrusage` around the `COPY` loop; the allocation counts are gdb breakpoint hit counts; the profiles are `perf record -g --call-graph dwarf -F 499` with `perf report --children`; the floors are bisected to 8 MB. `clang-tidy-19` with the repository's own `.clang-tidy` reports no diagnostic for the changed translation unit or its header, on this branch and on `main`. Machine: 16 core (8 physical) AMD Ryzen 7 7840U, 64 GB RAM, Linux 7.1.3, carrying light background load rather than idle: the one-minute load average sat between 1.4 and 1.9 with CPU pressure `some avg10` between 0.00 and 0.14. Every comparison therefore interleaves the two builds run by run, and the tables give each run rather than a mean. The 89-column table in the reproducers is the width of the widest node table in the workload these reports come from.

`bp_bisect_rows.c` is `bp_bisect.c` with the row count on `argv`, and `many_copies.c` times a populated input the way `one_copy.c` times an empty one. Both are attached, with the gdb scripts that produced the counts.

<details>
<summary>bp_bisect_rows.c</summary>

```c
/* bp_bisect_rows.c - bp_bisect.c with the row count and the column count on argv.
 *
 * bp_floor.c steps in powers of two, which is enough to show a trend and too coarse to compare
 * two builds: a 4x change in NODE_GROUP_SIZE can read as 2x if the true floor sits just inside a
 * bucket. This bisects on the assumption that the floor is monotone: if a pool of size X loads the
 * table, every larger pool does too.
 */
#include <lbug.h>
#include <stdio.h>
#include <stdlib.h>
#include <string.h>
#include <unistd.h>

static char g_dir[512];
static char g_csv[600];
static uint64_t g_threads = 1;

static void write_csv(int ncols, int nrows) {
    FILE* f = fopen(g_csv, "w");
    fprintf(f, "id");
    for (int i = 1; i <= ncols; i++)
        fprintf(f, ",c%d", i);
    fputc('\n', f);
    for (int r = 0; r < nrows; r++) {
        fprintf(f, "%d", r);
        for (int i = 1; i <= ncols; i++)
            fprintf(f, ",%d", i);
        fputc('\n', f);
    }
    fclose(f);
}

/* 1 = loaded, 0 = failed */
static int attempt(uint64_t bpBytes, int ncols) {
    static int seq = 0;
    char path[600];
    snprintf(path, sizeof path, "%s/db%d", g_dir, seq++);

    lbug_system_config cfg = lbug_default_system_config();
    cfg.buffer_pool_size = bpBytes;
    cfg.max_num_threads = g_threads;

    lbug_database db;
    lbug_connection conn;
    if (lbug_database_init(path, cfg, &db) != LbugSuccess)
        return 0;
    if (lbug_connection_init(&db, &conn) != LbugSuccess) {
        lbug_database_destroy(&db);
        return 0;
    }

    int ok = 1;
    size_t cap = 64 + (size_t)ncols * 24;
    char* q = malloc(cap);
    int n = snprintf(q, cap, "CREATE NODE TABLE t(id INT64");
    for (int i = 1; i <= ncols; i++)
        n += snprintf(q + n, cap - n, ", c%d INT64", i);
    snprintf(q + n, cap - n, ", PRIMARY KEY(id));");
    lbug_query_result r;
    memset(&r, 0, sizeof r);
    if (lbug_connection_query(&conn, q, &r) != LbugSuccess || !lbug_query_result_is_success(&r))
        ok = 0;
    lbug_query_result_destroy(&r);
    free(q);

    if (ok) {
        char cq[800];
        snprintf(cq, sizeof cq, "COPY t FROM '%s' (HEADER=true);", g_csv);
        memset(&r, 0, sizeof r);
        if (lbug_connection_query(&conn, cq, &r) != LbugSuccess ||
            !lbug_query_result_is_success(&r))
            ok = 0;
        lbug_query_result_destroy(&r);
    }
    lbug_connection_destroy(&conn);
    lbug_database_destroy(&db);
    return ok;
}

int main(int argc, char** argv) {
    snprintf(g_dir, sizeof g_dir, "/tmp/bp_bisect_%d", (int)getpid());
    char cmd[700];
    snprintf(cmd, sizeof cmd, "mkdir -p %s", g_dir);
    if (system(cmd) != 0)
        return 1;
    snprintf(g_csv, sizeof g_csv, "%s/rows.csv", g_dir);

    /* Same sweep as bp_bisect.c, with the input size on argv: the row count is what decides
     * how many workers receive data, and a deferral only changes the floor through that. */
    const int nrows = argc > 1 ? atoi(argv[1]) : 100;
    const int ncols = (argc > 2 ? atoi(argv[2]) : 89) - 1;
    const uint64_t STEP = 8ULL << 20;
    write_csv(ncols, nrows);
    printf("%d columns, %d rows\n\n", ncols + 1, nrows);

    uint64_t threads[] = {1, 2, 4, 8, 16, 0};
    printf("| max_num_threads | floor, bisected to 8 MB |\n|---:|---:|\n");
    for (int t = 0; threads[t]; t++) {
        g_threads = threads[t];
        uint64_t lo = STEP, hi = 4096ULL << 20;
        if (!attempt(hi, ncols)) {
            printf("| %llu | more than 4 GB |\n", (unsigned long long)threads[t]);
            continue;
        }
        /* invariant: lo fails (or is untested floor candidate), hi succeeds */
        while (hi - lo > STEP) {
            uint64_t mid = ((lo + hi) / 2 / STEP) * STEP;
            if (mid <= lo)
                break;
            if (attempt(mid, ncols))
                hi = mid;
            else
                lo = mid;
        }
        printf("| %llu | %llu MB |\n", (unsigned long long)threads[t],
            (unsigned long long)(hi >> 20));
        fflush(stdout);
    }

    snprintf(cmd, sizeof cmd, "rm -rf %s", g_dir);
    if (system(cmd) != 0)
        return 1;
    return 0;
}
```

</details>

<details>
<summary>many_copies.c</summary>

```c
/* many_copies.c - time N COPY statements of the same populated input, in one process.
 *
 * one_copy.c repeats a COPY into one table, which only works for a zero-row input: a second
 * COPY of the same rows violates the primary key. This creates one table per repetition up
 * front, outside the timing window, and then times the COPY statements alone. That gives a
 * populated input the same signal-to-noise a zero-row input already had, and a profile in
 * which the COPY dominates process setup.
 *
 * Build:
 *   cc -O2 -o many_copies many_copies.c -I $LBUG/src/include -I $LBUG/src/include/c_api \
 *      -L $LBUG/build/relwithdebinfo/src -llbug -Wl,-rpath,$LBUG/build/relwithdebinfo/src
 *
 * Usage: LBUG_THREADS=16 many_copies [NCOLS] [NROWS] [REPS]
 */
#include <lbug.h>
#include <stdio.h>
#include <stdlib.h>
#include <string.h>
#include <sys/resource.h>
#include <time.h>
#include <unistd.h>

static char dir[512], csv[600];

static void run(lbug_connection* c, const char* q) {
    lbug_query_result r;
    memset(&r, 0, sizeof r);
    if (lbug_connection_query(c, q, &r) != LbugSuccess || !lbug_query_result_is_success(&r)) {
        printf("FAILED: %s\n", lbug_query_result_get_error_message(&r));
        exit(1);
    }
    lbug_query_result_destroy(&r);
}

int main(int argc, char** argv) {
    const int ncols = (argc > 1 ? atoi(argv[1]) : 89) - 1;
    const int nrows = argc > 2 ? atoi(argv[2]) : 100;
    const int reps = argc > 3 ? atoi(argv[3]) : 20;

    snprintf(dir, sizeof dir, "/tmp/many_copies_%d", (int)getpid());
    char cmd[700];
    snprintf(cmd, sizeof cmd, "mkdir -p %s", dir);
    if (system(cmd) != 0)
        return 1;
    snprintf(csv, sizeof csv, "%s/r.csv", dir);
    FILE* f = fopen(csv, "w");
    fprintf(f, "id");
    for (int i = 1; i <= ncols; i++)
        fprintf(f, ",c%d", i);
    fputc('\n', f);
    for (int r = 0; r < nrows; r++) {
        fprintf(f, "%d", r);
        for (int i = 1; i <= ncols; i++)
            fprintf(f, ",%d", i);
        fputc('\n', f);
    }
    fclose(f);

    char path[600];
    snprintf(path, sizeof path, "%s/db", dir);
    lbug_system_config cfg = lbug_default_system_config();
    if (getenv("LBUG_THREADS"))
        cfg.max_num_threads = atoi(getenv("LBUG_THREADS"));
    lbug_database db;
    lbug_connection conn;
    lbug_database_init(path, cfg, &db);
    lbug_connection_init(&db, &conn);

    const size_t cap = 96 + (size_t)ncols * 24;
    char* q = malloc(cap);
    for (int i = 0; i < reps; i++) {
        int n = snprintf(q, cap, "CREATE NODE TABLE t%d(id INT64", i);
        for (int c = 1; c <= ncols; c++)
            n += snprintf(q + n, cap - n, ", c%d INT64", c);
        snprintf(q + n, cap - n, ", PRIMARY KEY(id));");
        run(&conn, q);
    }
    free(q);

    struct rusage r0, r1;
    struct timespec t0, t1;
    getrusage(RUSAGE_SELF, &r0);
    clock_gettime(CLOCK_MONOTONIC, &t0);
    for (int i = 0; i < reps; i++) {
        char cq[800];
        snprintf(cq, sizeof cq, "COPY t%d FROM '%s' (HEADER=true);", i, csv);
        run(&conn, cq);
    }
    clock_gettime(CLOCK_MONOTONIC, &t1);
    getrusage(RUSAGE_SELF, &r1);

    const double ms = (t1.tv_sec - t0.tv_sec) * 1e3 + (t1.tv_nsec - t0.tv_nsec) / 1e6;
    const double usr = (r1.ru_utime.tv_sec - r0.ru_utime.tv_sec) * 1e3 +
                       (r1.ru_utime.tv_usec - r0.ru_utime.tv_usec) / 1e3;
    const double sys = (r1.ru_stime.tv_sec - r0.ru_stime.tv_sec) * 1e3 +
                       (r1.ru_stime.tv_usec - r0.ru_stime.tv_usec) / 1e3;
    printf("%4d cols %6d rows x%-3d  wall=%8.1f  cpu=%8.1f (usr %7.1f sys %7.1f)  "
           "minflt=%8ld  per-COPY wall=%6.2f cpu=%6.2f\n",
        ncols + 1, nrows, reps, ms, usr + sys, usr, sys, r1.ru_minflt - r0.ru_minflt, ms / reps,
        (usr + sys) / reps);

    lbug_connection_destroy(&conn);
    lbug_database_destroy(&db);
    snprintf(cmd, sizeof cmd, "rm -rf %s", dir);
    if (system(cmd) != 0)
        return 1;
    return 0;
}
```

</details>

<details>
<summary>count_alloc.gdb</summary>

```gdb
set confirm off
set pagination off
set breakpoint pending on
# operator new(size_t) with a request of 4 MiB or more: on x86-64 the size is in rdi.
break _Znwm if $rdi >= 0x400000
ignore 1 1000000
# The per-worker constructor only, not the move constructors the variant generates.
break lbug::processor::IndexBuilderLocalBuffers::IndexBuilderLocalBuffers(lbug::processor::IndexBuilderGlobalQueues&)
ignore 2 1000000
run
info breakpoints
quit
```

</details>

<details>
<summary>tsan_probe.c</summary>

```c
/* tsan_probe.c - drive the COPY paths a deferral touches, under ThreadSanitizer.
 *
 * The gtest suite cannot run under TSan on this host: the engine's default 8 TB max_db_size
 * mmap fails inside TSan's address space ("Buffer manager exception: Mmap for size
 * 8796093022208 failed"), and every test that opens a database fails for that reason alone.
 * This drives the same paths from the C API with max_db_size set to 1 GB, at 16 threads:
 * an empty node COPY, a populated node COPY on both key types, a duplicate key, and a rel
 * COPY. A race in a lazily built per-worker buffer shows up here.
 *
 * Build against a TSan build of the library:
 *   cc -O1 -g -fsanitize=thread -o tsan_probe tsan_probe.c \
 *      -I $LBUG/src/include -I $LBUG/src/include/c_api \
 *      -L $LBUG/build/tsan/src -llbug -Wl,-rpath,$LBUG/build/tsan/src
 */
#include <lbug.h>
#include <stdio.h>
#include <stdlib.h>
#include <string.h>
#include <unistd.h>

static char dir[512];

static int run(lbug_connection* c, const char* q, int expect_ok) {
    lbug_query_result r;
    memset(&r, 0, sizeof r);
    const int ok = lbug_connection_query(c, q, &r) == LbugSuccess && lbug_query_result_is_success(&r);
    if (ok != expect_ok) {
        printf("UNEXPECTED (%s): %s\n", expect_ok ? "wanted success" : "wanted failure",
            ok ? q : lbug_query_result_get_error_message(&r));
        lbug_query_result_destroy(&r);
        return 0;
    }
    lbug_query_result_destroy(&r);
    return 1;
}

static void write_csv(const char* path, int ncols, int nrows, int duplicate) {
    FILE* f = fopen(path, "w");
    fprintf(f, "id");
    for (int i = 1; i <= ncols; i++)
        fprintf(f, ",c%d", i);
    fputc('\n', f);
    for (int r = 0; r < nrows; r++) {
        fprintf(f, "%d", duplicate ? 0 : r);
        for (int i = 1; i <= ncols; i++)
            fprintf(f, ",%d", i);
        fputc('\n', f);
    }
    fclose(f);
}

int main(void) {
    snprintf(dir, sizeof dir, "/tmp/tsan_probe_%d", (int)getpid());
    char cmd[700];
    snprintf(cmd, sizeof cmd, "mkdir -p %s", dir);
    if (system(cmd) != 0)
        return 1;

    char empty[600], rows[600], dup[600], strrows[600], edges[600], ids[600];
    snprintf(empty, sizeof empty, "%s/empty.csv", dir);
    snprintf(rows, sizeof rows, "%s/rows.csv", dir);
    snprintf(dup, sizeof dup, "%s/dup.csv", dir);
    snprintf(strrows, sizeof strrows, "%s/str.csv", dir);
    snprintf(edges, sizeof edges, "%s/edges.csv", dir);
    snprintf(ids, sizeof ids, "%s/ids.csv", dir);
    write_csv(empty, 8, 0, 0);
    write_csv(rows, 8, 500, 0);
    write_csv(dup, 8, 4, 1);
    write_csv(ids, 0, 500, 0);
    FILE* f = fopen(strrows, "w");
    fprintf(f, "name\n");
    for (int i = 0; i < 500; i++)
        fprintf(f, "n%d\n", i);
    fclose(f);
    f = fopen(edges, "w");
    fprintf(f, "from,to,position\n");
    for (int i = 0; i < 500; i++)
        fprintf(f, "%d,%d,%d\n", i % 500, (i + 1) % 500, i);
    fclose(f);

    char path[600];
    snprintf(path, sizeof path, "%s/db", dir);
    lbug_system_config cfg = lbug_default_system_config();
    cfg.max_num_threads = 16;
    cfg.max_db_size = 1ULL << 30; /* TSan cannot back the default 8 TB reservation */
    lbug_database db;
    lbug_connection conn;
    if (lbug_database_init(path, cfg, &db) != LbugSuccess) {
        printf("database init failed\n");
        return 1;
    }
    lbug_connection_init(&db, &conn);

    int ok = 1;
    char q[900];
    ok &= run(&conn, "CREATE NODE TABLE wide(id INT64, c1 INT64, c2 INT64, c3 INT64, c4 INT64,"
                     " c5 INT64, c6 INT64, c7 INT64, c8 INT64, PRIMARY KEY(id));", 1);
    ok &= run(&conn, "CREATE NODE TABLE person(name STRING, PRIMARY KEY(name));", 1);
    ok &= run(&conn, "CREATE NODE TABLE dupt(id INT64, c1 INT64, c2 INT64, c3 INT64, c4 INT64,"
                     " c5 INT64, c6 INT64, c7 INT64, c8 INT64, PRIMARY KEY(id));", 1);
    snprintf(q, sizeof q, "COPY wide FROM '%s' (HEADER=true);", empty);
    ok &= run(&conn, q, 1);
    snprintf(q, sizeof q, "COPY wide FROM '%s' (HEADER=true);", rows);
    ok &= run(&conn, q, 1);
    snprintf(q, sizeof q, "COPY person FROM '%s' (HEADER=true);", strrows);
    ok &= run(&conn, q, 1);
    snprintf(q, sizeof q, "COPY dupt FROM '%s' (HEADER=true);", dup);
    ok &= run(&conn, q, 0);
    ok &= run(&conn, "CREATE REL TABLE knows(FROM person TO person, position INT64);", 1);
    ok &= run(&conn, "CREATE NODE TABLE n(id INT64, PRIMARY KEY(id));", 1);
    snprintf(q, sizeof q, "COPY n FROM '%s' (HEADER=true);", ids);
    ok &= run(&conn, q, 1);
    ok &= run(&conn, "CREATE REL TABLE e(FROM n TO n, position INT64);", 1);
    snprintf(q, sizeof q, "COPY e FROM '%s' (HEADER=true);", edges);
    ok &= run(&conn, q, 1);
    printf("%s\n", ok ? "all statements behaved as expected" : "a statement misbehaved");

    lbug_connection_destroy(&conn);
    lbug_database_destroy(&db);
    snprintf(cmd, sizeof cmd, "rm -rf %s", dir);
    if (system(cmd) != 0)
        return 1;
    return ok ? 0 : 1;
}
```

</details>
