### PR TITLE
perf(copy): build the rel COPY worker's local state at its first partition

### DIFF
--- a/src/include/processor/operator/persistent/rel_batch_insert.h
+++ b/src/include/processor/operator/persistent/rel_batch_insert.h
@@ -148,6 +148,10 @@ public:
     }
 
 private:
+    // The chunked CSR group, its header and the all-null gap-filling chunk, built at the
+    // worker's first partition rather than in initLocalStateInternal.
+    void initLocalStateForFirstPartition(ExecutionContext* context);
+
     void appendNodeGroup(const catalog::RelGroupCatalogEntry& relGroupEntry,
         storage::MemoryManager& mm, transaction::Transaction* transaction,
         storage::CSRNodeGroup& nodeGroup, const RelBatchInsertInfo& relInfo,

--- a/src/processor/operator/persistent/rel_batch_insert.cpp
+++ b/src/processor/operator/persistent/rel_batch_insert.cpp
@@ -30,8 +30,14 @@ std::string RelBatchInsertPrintInfo::toString() const {
     return result;
 }
 
-void RelBatchInsert::initLocalStateInternal(ResultSet*, ExecutionContext* context) {
+void RelBatchInsert::initLocalStateInternal(ResultSet*, ExecutionContext*) {
+    // Everything a worker needs to write a partition is built at its first partition instead,
+    // in initLocalStateForFirstPartition. A rel COPY starts a worker per thread and hands out
+    // partitions to whichever ones ask, so on a small input most workers build none of it.
     localState = std::make_unique<RelBatchInsertLocalState>();
+}
+
+void RelBatchInsert::initLocalStateForFirstPartition(ExecutionContext* context) {
     const auto relInfo = info->ptrCast<RelBatchInsertInfo>();
     localState->chunkedGroup =
         std::make_unique<InMemChunkedCSRNodeGroup>(*MemoryManager::Get(*context->clientContext),
@@ -108,6 +114,9 @@ void RelBatchInsert::executeInternal(ExecutionContext* context) {
         if (relLocalState->nodeGroupIdx == INVALID_PARTITION_IDX) {
             // No more partitions left in the partitioning buffer.
             break;
+        }
+        if (!localState->chunkedGroup) {
+            initLocalStateForFirstPartition(context);
         }
         ++progressSharedState->partitionsDone;
         // TODO(Guodong): We need to handle the concurrency between COPY and other insertions

--- a/test/copy/copy_test.cpp
+++ b/test/copy/copy_test.cpp
@@ -992,5 +992,51 @@ TEST_F(CopyTest, CopyBuildsPrimaryKeyBuffersOnFirstInsert) {
     ASSERT_FALSE(result->isSuccess());
     ASSERT_NE(result->getErrorMessage().find("duplicated primary key"), std::string::npos);
 }
+
+TEST_F(CopyTest, RelCopyBuildsWorkerStateOnFirstPartition) {
+    if (inMemMode) {
+        GTEST_SKIP();
+    }
+    // A rel COPY worker builds its chunked CSR group, whose header is sized NODE_GROUP_SIZE,
+    // at its first partition. An input with no edges hands out no partitions at all, so no
+    // worker builds one and nothing downstream may assume the group exists.
+    systemConfig->maxNumThreads = 16;
+    createDBAndConn();
+    auto result = conn->query("CREATE NODE TABLE Account(id INT64, PRIMARY KEY(id))");
+    ASSERT_TRUE(result->isSuccess()) << result->getErrorMessage();
+    result = conn->query("CREATE REL TABLE Knows(FROM Account TO Account, since INT64)");
+    ASSERT_TRUE(result->isSuccess()) << result->getErrorMessage();
+    result = conn->query("CREATE REL TABLE Follows(FROM Account TO Account, since INT64)");
+    ASSERT_TRUE(result->isSuccess()) << result->getErrorMessage();
+
+    const auto accountPath = writeCSV("rel_accounts.csv", {"1", "2", "3"});
+    result = conn->query(std::format("COPY Account FROM '{}'", accountPath));
+    ASSERT_TRUE(result->isSuccess()) << result->getErrorMessage();
+
+    // No partition reaches any of the sixteen workers.
+    const auto emptyEdgePath = writeCSV("rel_empty.csv", {"from,to,since"});
+    result = conn->query(std::format("COPY Knows FROM '{}' (HEADER=true)", emptyEdgePath));
+    ASSERT_TRUE(result->isSuccess()) << result->getErrorMessage();
+    result = conn->query("MATCH (:Account)-[k:Knows]->(:Account) RETURN COUNT(k)");
+    ASSERT_TRUE(result->isSuccess()) << result->getErrorMessage();
+    ASSERT_TRUE(result->hasNext());
+    ASSERT_EQ(result->getNext()->getValue(0)->getValue<int64_t>(), 0);
+
+    // One partition reaches one worker, in each direction, and the other fifteen build nothing.
+    const auto edgePath = writeCSV("rel_edges.csv", {"from,to,since", "1,2,2020", "2,3,2021"});
+    result = conn->query(std::format("COPY Follows FROM '{}' (HEADER=true)", edgePath));
+    ASSERT_TRUE(result->isSuccess()) << result->getErrorMessage();
+    result = conn->query("MATCH (:Account)-[f:Follows]->(:Account) RETURN COUNT(f)");
+    ASSERT_TRUE(result->isSuccess()) << result->getErrorMessage();
+    ASSERT_TRUE(result->hasNext());
+    ASSERT_EQ(result->getNext()->getValue(0)->getValue<int64_t>(), 2);
+    result = conn->query("MATCH (a:Account)-[f:Follows]->(b:Account) WHERE a.id = 1 RETURN "
+                         "b.id, f.since");
+    ASSERT_TRUE(result->isSuccess()) << result->getErrorMessage();
+    ASSERT_TRUE(result->hasNext());
+    auto tuple = result->getNext();
+    ASSERT_EQ(tuple->getValue(0)->getValue<int64_t>(), 2);
+    ASSERT_EQ(tuple->getValue(1)->getValue<int64_t>(), 2020);
+}
 } // namespace testing
 } // namespace lbug


### PR DESCRIPTION
_This work was produced with the help of language models._

Follow-up to #781 (2/2 patches), the rel path's instance of the same pattern. `RelBatchInsert::initLocalStateInternal` gives every worker a chunked CSR group before the worker knows whether it would receive a partition.  The group's header has  `NODE_GROUP_SIZE` irrespective of input. At 16 threads a 100-edge `COPY` constructs 36 capacity-sized CSR headers; with this PR it would construct 6.  **CPU per statement falls from about 51 ms to about 21 ms, and it stops growing with the thread count.** The load's buffer pool floor drops from 24 to 32 MB back to the 16 MB pool minimum. Measurements are for `main` at `213891756`, `relwithdebinfo`, gcc 14.2.0, with both unpatched + patched builds rebuilt in one session on the same host.

The patch applies alone, on top of `main`, and it is disjoint from the first patch, which touches the node path's index buffers. Fold the two if you prefer one review; I kept them apart thinking of bisect convenience.

## Every worker builds a full-capacity CSR header before its first partition

`RelBatchInsert::initLocalStateInternal` built an `InMemChunkedCSRNodeGroup` for each worker (`src/processor/operator/persistent/rel_batch_insert.cpp::RelBatchInsert::initLocalStateInternal`). Its data chunks hold capacity 0 and cost little, and its member `csrHeader` is constructed with `StorageConfig::NODE_GROUP_SIZE` (`src/include/storage/table/csr_chunked_node_group.h::InMemChunkedCSRNodeGroup`), which is an offset chunk and a length chunk of 131072 entries, about 1.5 MiB of buffer pool per worker. The same function built an all-null `DataChunk` for gap filling and registered an optimistic page allocator.

Partitions are handed out inside `executeInternal`, one at a time, to whichever worker asks (`src/processor/operator/persistent/rel_batch_insert.cpp::RelBatchInsert::executeInternal`). On an input with one partition per direction, two workers do the work and the rest hold their state unused for the length of the statement.

The workload these reports come from meets that case on every load. One document is written as one `COPY` per non-empty node table and one per non-empty `(from, to)` edge pair. A census of fifteen documents, spanning 22 to 21935 nodes, gives 366 statements carrying 145593 rows, with a median statement of 30 rows, and 68% of the statements carry under 100 rows.

## The construction moves to the first partition

`initLocalStateInternal` allocates the local state object, and the state a partition needs is built by the first partition that arrives:

```diff
-void RelBatchInsert::initLocalStateInternal(ResultSet*, ExecutionContext* context) {
+void RelBatchInsert::initLocalStateInternal(ResultSet*, ExecutionContext*) {
+    // Everything a worker needs to write a partition is built at its first partition instead,
+    // in initLocalStateForFirstPartition. A rel COPY starts a worker per thread and hands out
+    // partitions to whichever ones ask, so on a small input most workers build none of it.
     localState = std::make_unique<RelBatchInsertLocalState>();
+}
+
+void RelBatchInsert::initLocalStateForFirstPartition(ExecutionContext* context) {
     const auto relInfo = info->ptrCast<RelBatchInsertInfo>();
```

```diff
         if (relLocalState->nodeGroupIdx == INVALID_PARTITION_IDX) {
             // No more partitions left in the partitioning buffer.
             break;
         }
+        if (!localState->chunkedGroup) {
+            initLocalStateForFirstPartition(context);
+        }
         ++progressSharedState->partitionsDone;
```

The body of the old initialiser is unchanged, including the hard-coded nbr and rel column IDs and their `TODO`. `localState->chunkedGroup` is the flag, and every reader of the local state sits below `appendNodeGroup`, which runs for a partition only. `addOptimisticAllocator` takes the local storage mutex (`src/storage/local_storage/local_storage.cpp::LocalStorage::addOptimisticAllocator`), so moving it into execution is safe under concurrent workers.

## Header constructions fall from 36 to 6, and CPU stops tracking the thread count

Header constructions for one `COPY` of 100 edges at 16 threads, under gdb, breaking on the capacity-taking `InMemChunkedCSRHeader` constructor:

| metric                                       | before | after |
|----------------------------------------------|-------:|------:|
| `InMemChunkedCSRHeader(mm, …)` constructions    |     36 |     6 |
| `initLocalStateForFirstPartition` calls         |    n/a |     2 |
|                                              |        |       |

Thirty-two of the thirty-six were the eager ones, sixteen threads by two directions. Two remain, in the workers that received a partition, and four come from paths this patch leaves alone.

`perf record -g --call-graph dwarf` over fifteen rel `COPY` processes at 16 threads, cumulative share of the profile:

| symbol                                                | before |              after |
|-------------------------------------------------------|-------:|-------------------:|
| `InMemChunkedCSRHeader::InMemChunkedCSRHeader(mm, …)` |  7.65% |              0.65% |
| `RelBatchInsert::initLocalStateInternal`              |  7.13% | below the 0.4% cut |
| `RelBatchInsert::initLocalStateForFirstPartition`     |    n/a |              0.07% |
| `TaskScheduler::runWorkerThread`                      | 25.40% |             22.58% |
| `__memset_avx512_unaligned_erms`                      | 23.31% |             21.05% |

One rel `COPY` of 100 edges into a table of 100 nodes, `rel_once.c`, which times the rel `COPY` alone:

| `max_num_threads` | CPU before | CPU after | minor faults before | minor faults after |
|------------------:|-----------:|----------:|--------------------:|-------------------:|
|                 1 |    18.9 ms |   19.5 ms |                1478 |               1478 |
|                 2 |    20.8 ms |   17.2 ms |                2012 |               1505 |
|                 4 |    22.2 ms |   20.2 ms |                2621 |               1904 |
|                 8 |    27.9 ms |   20.8 ms |                4321 |               1974 |
|                16 |    48.6 ms |   21.2 ms |                7470 |               2164 |

Three interleaved runs at 16 threads give 49.7, 51.8 and 53.1 ms of CPU before, against 22.2, 20.8 and 19.1 ms after, and 7.6k faults against 2.1k. Wall time is 18 to 21 ms throughout on both builds, because a 100-edge load is short enough that the workers' own cost sits beside the critical path rather than on it.

The subquery source behaves the same way, and it is the one a caller with UUID keys has to use, because the endpoints must be resolved against the node tables. `rel_subquery.c`, attached, stages the edge list as a node table and runs `COPY e FROM (MATCH (s:stg), (a:n), (b:n) WHERE a.id = s.f AND b.id = s.t RETURN a.id, b.id, s.pos)`. Six interleaved pairs at 16 threads, 100 nodes and 100 edges, with a settle before the timing window:

| metric        | before                                | after                                 |
|---------------|---------------------------------------|---------------------------------------|
| CPU           | 64.0, 70.6, 75.6, 78.1, 80.4, 86.6 ms | 31.9, 34.0, 34.7, 36.5, 37.6, 41.1 ms |
| wall          | 30.6 to 42.9 ms                       | 28.0 to 33.6 ms                       |
| minor faults  | 6175 to 8373                          | 2588 to 3246                          |

Both harnesses sleep before the timing window when `LBUG_SETTLE_MS` is set, because `getrusage` counts every thread in the process, so the tail of a setup `COPY`'s teardown otherwise lands inside the measurement.

## The rel load's floor returns to the pool minimum

Buffer pool floor of the whole load, bisected to 8 MB, 2000 nodes and 10000 edges, three samples each:

| `max_num_threads` | before        | after         |
|------------------:|---------------|---------------|
|            1 to 8 | 16 MB         | 16 MB         |
|                16 | 24, 32, 24 MB | 16, 16, 16 MB |
|                32 | 24, 24, 24 MB | 16, 16, 16 MB |

16 MB is the smallest pool this database starts with at all, so below 16 threads the floor belongs to the database rather than to the rel path. Above it, the eager headers are what push the load off that minimum, and with the patch the load stays on it. A 100-edge input gives the same pattern.

## The empty input is the case that would fault, and the test covers it

`RelCopyBuildsWorkerStateOnFirstPartition` in `test/copy/copy_test.cpp`. At 16 threads the test copies an edge input with no rows, where no partition is handed out and no worker builds a group. It then copies two edges into a second table and reads one back with its property. The first case is the one that would fault if a reader of the local state ran outside a partition.

Like the first patch's test, it passes on the unpatched tree, because the allocation it targets is invisible to a query. The floor table above is the evidence that the memory is gone, and the breakpoint counts are the evidence that the constructions are.

The rest of `copy_tests` passes, including the two that inject buffer manager failures into a rel `COPY` and check the recovery, `RelCopyBMExceptionRecoverySameConnection` and `RelCopyCheckpointBMExceptionRecovery`. Those two are the ones this patch could plausibly break, because they fail an allocation in the middle of a statement, and the local state is now built inside one.

`make test NUM_THREADS=14 TEST_JOBS=8` on the patched tree: 2669 passed and 4 failed out of 2673. The four are `dictionary_bug~orb383_relationship_projection_obfuscated.AnonymousParquetDeleteReload`, which needs gitignored Parquet fixtures, and three `extension` tests that download from `extension.ladybugdb.com`. The same four fail on unpatched `main` at `213891756` in the same session.

A thread sanitiser build reports no race in this path either. The gtest suite cannot run under TSan on this host, because the engine's default 8 TB `max_db_size` reservation fails inside TSan's address space. `tsan_probe.c`, attached to the first patch of the pair, drives the node and rel `COPY` paths from the C API with `max_db_size` set to 1 GB at 16 threads, including a 500-edge rel `COPY`, and ThreadSanitizer reports zero warnings on this branch. That check matters more here than in the first patch, because this one moves `addOptimisticAllocator` from local-state initialisation into execution.


## Not measured

The `PROJECT_GRAPH` arrow CSR materialisation added in `ce4d3bbff` runs beside this path rather than through it: `InMemChunkedCSRNodeGroup` has two users in the tree, `rel_batch_insert.cpp` and `CSRNodeGroup::appendChunkedCSRGroup`, which the rel batch insert calls. The five `ProjectGraphCsrTest` cases pass on this branch as part of the suite above, and no profile of that path was taken.

## How the numbers were taken

Tree `main` at `213891756`, branch `defer-rel-local-state`. Build `make test-build NUM_THREADS=14`, gcc 14.2.0. Timings are `clock_gettime` and `getrusage` around the rel `COPY` alone; the counts are gdb breakpoint hit counts; the profiles are `perf record -g --call-graph dwarf -F 499` with `perf report --children`; the floors are bisected to 8 MB. `clang-tidy-19` with the repository's own `.clang-tidy` reports no diagnostic for the changed translation unit or its header, on this branch and on `main`. Machine: 16 core (8 physical) AMD Ryzen 7 7840U, 64 GB RAM, Linux 7.1.3, carrying light background load rather than idle: the one-minute load average ran between 1.4 and 7.2 across the sessions, so every comparison interleaves the two builds run by run, and the tables give each run rather than a mean.

`rel_floor.c`, `rel_once.c` and `rel_subquery.c` are attached below with the gdb script. The first two are the rel analogues of the `bp_bisect.c` and `one_copy.c` used on #760 and #781; the third runs the same load from a subquery.

<details>
<summary>rel_subquery.c</summary>

```c
/* rel_subquery.c - the same rel COPY, sourced from a subquery instead of a CSV file.
 *
 * rel_once.c loads edges from a file. A caller that keys its nodes by UUID cannot, because
 * the endpoints have to be resolved against the node tables, so it stages the edge list as a
 * node table and joins:
 *
 *   COPY e FROM (MATCH (s:stg), (a:n), (b:n) WHERE a.id = s.f AND b.id = s.t
 *                RETURN a.id, b.id, s.pos);
 *
 * That is the shape this reproducer times, with the staging table loaded from CSV rather than
 * from an Arrow batch, since the write path below the scan is the same either way.
 *
 * LBUG_SETTLE_MS sleeps before the timing window, so that the setup COPY statements' teardown
 * stays out of the measurement: getrusage counts every thread in the process.
 *
 * Build:
 *   cc -O2 -o rel_subquery rel_subquery.c -I $LBUG/src/include -I $LBUG/src/include/c_api \
 *      -L $LBUG/build/relwithdebinfo/src -llbug -Wl,-rpath,$LBUG/build/relwithdebinfo/src
 *
 * Usage: LBUG_THREADS=16 LBUG_SETTLE_MS=500 rel_subquery [NNODES] [NEDGES]
 */
#include <lbug.h>
#include <stdio.h>
#include <stdlib.h>
#include <string.h>
#include <sys/resource.h>
#include <time.h>
#include <unistd.h>

static char dir[512], nodes_csv[600], edges_csv[600];

static void run(lbug_connection* c, const char* q) {
    lbug_query_result r;
    memset(&r, 0, sizeof r);
    if (lbug_connection_query(c, q, &r) != LbugSuccess || !lbug_query_result_is_success(&r)) {
        printf("FAILED: %s\n", lbug_query_result_get_error_message(&r));
        exit(1);
    }
    lbug_query_result_destroy(&r);
}

int main(int argc, char** argv) {
    const int nnodes = argc > 1 ? atoi(argv[1]) : 100;
    const int nedges = argc > 2 ? atoi(argv[2]) : 100;

    snprintf(dir, sizeof dir, "/tmp/rel_subquery_%d", (int)getpid());
    char cmd[700];
    snprintf(cmd, sizeof cmd, "mkdir -p %s", dir);
    if (system(cmd) != 0)
        return 1;
    snprintf(nodes_csv, sizeof nodes_csv, "%s/nodes.csv", dir);
    snprintf(edges_csv, sizeof edges_csv, "%s/edges.csv", dir);

    FILE* f = fopen(nodes_csv, "w");
    fprintf(f, "id\n");
    for (int i = 0; i < nnodes; i++)
        fprintf(f, "%d\n", i);
    fclose(f);
    f = fopen(edges_csv, "w");
    fprintf(f, "rid,f,t,pos\n");
    for (int i = 0; i < nedges; i++)
        fprintf(f, "%d,%d,%d,%d\n", i, (i % 3 == 0) ? 0 : (i % nnodes), (i + 1) % nnodes, i);
    fclose(f);

    char path[600];
    snprintf(path, sizeof path, "%s/db", dir);
    lbug_system_config cfg = lbug_default_system_config();
    if (getenv("LBUG_THREADS"))
        cfg.max_num_threads = atoi(getenv("LBUG_THREADS"));
    lbug_database db;
    lbug_connection conn;
    lbug_database_init(path, cfg, &db);
    lbug_connection_init(&db, &conn);

    char q[900];
    run(&conn, "CREATE NODE TABLE n(id INT64, PRIMARY KEY(id));");
    snprintf(q, sizeof q, "COPY n FROM '%s' (HEADER=true);", nodes_csv);
    run(&conn, q);
    run(&conn, "CREATE NODE TABLE stg(rid INT64, f INT64, t INT64, pos INT64, PRIMARY KEY(rid));");
    snprintf(q, sizeof q, "COPY stg FROM '%s' (HEADER=true);", edges_csv);
    run(&conn, q);
    run(&conn, "CREATE REL TABLE e(FROM n TO n, position INT64);");

    if (getenv("LBUG_SETTLE_MS"))
        usleep(1000 * (useconds_t)atoi(getenv("LBUG_SETTLE_MS")));

    struct rusage r0, r1;
    struct timespec t0, t1;
    getrusage(RUSAGE_SELF, &r0);
    clock_gettime(CLOCK_MONOTONIC, &t0);
    run(&conn, "COPY e FROM (MATCH (s:stg), (a:n), (b:n) WHERE a.id = s.f AND b.id = s.t "
               "RETURN a.id, b.id, s.pos);");
    clock_gettime(CLOCK_MONOTONIC, &t1);
    getrusage(RUSAGE_SELF, &r1);

    const double ms = (t1.tv_sec - t0.tv_sec) * 1e3 + (t1.tv_nsec - t0.tv_nsec) / 1e6;
    const double usr = (r1.ru_utime.tv_sec - r0.ru_utime.tv_sec) * 1e3 +
                       (r1.ru_utime.tv_usec - r0.ru_utime.tv_usec) / 1e3;
    const double sys = (r1.ru_stime.tv_sec - r0.ru_stime.tv_sec) * 1e3 +
                       (r1.ru_stime.tv_usec - r0.ru_stime.tv_usec) / 1e3;
    printf("%6d nodes %6d edges via subquery  wall=%7.2f  cpu=%7.2f (usr %6.2f sys %6.2f)  "
           "minflt=%8ld\n",
        nnodes, nedges, ms, usr + sys, usr, sys, r1.ru_minflt - r0.ru_minflt);

    lbug_connection_destroy(&conn);
    lbug_database_destroy(&db);
    snprintf(cmd, sizeof cmd, "rm -rf %s", dir);
    if (system(cmd) != 0)
        return 1;
    return 0;
}
```

</details>

<details>
<summary>rel_floor.c</summary>

```c
/* rel_floor.c - the buffer pool floor of a rel COPY, bisected to 8 MB.
 *
 * bp_bisect.c does this for a node COPY, where the floor is set by the per-worker column
 * chunks. The rel path allocates something else per worker: an InMemChunkedCSRNodeGroup whose
 * data chunks hold capacity 0 but whose CSR header is sized NODE_GROUP_SIZE, about 1.5 MiB of
 * buffer pool, before the worker knows whether it will receive a partition.
 *
 * The node table here is deliberately narrow, two columns, so the node side of the load
 * contributes a small floor that does not move with the thread count, and what does move is
 * the rel side. A rel COPY runs one RelBatchInsert per direction, so the eager allocation is
 * paid twice per thread.
 *
 * Build:
 *   cc -O2 -o rel_floor rel_floor.c -I $LBUG/src/include -I $LBUG/src/include/c_api \
 *      -L $LBUG/build/relwithdebinfo/src -llbug -Wl,-rpath,$LBUG/build/relwithdebinfo/src
 *
 * Usage: rel_floor [NNODES] [NEDGES]   (defaults: 100 nodes, 100 edges)
 */
#include <lbug.h>
#include <stdio.h>
#include <stdlib.h>
#include <string.h>
#include <unistd.h>

static char g_dir[512];
static char g_nodes_csv[600];
static char g_edges_csv[600];
static uint64_t g_threads = 1;

static void write_csvs(int nnodes, int nedges) {
    FILE* f = fopen(g_nodes_csv, "w");
    fprintf(f, "id,label\n");
    for (int i = 0; i < nnodes; i++)
        fprintf(f, "%d,n%d\n", i, i);
    fclose(f);

    /* A chain plus a fan out of the first node, so the CSR is neither one row per node nor
     * one node with everything. */
    f = fopen(g_edges_csv, "w");
    fprintf(f, "from,to,position\n");
    for (int i = 0; i < nedges; i++) {
        int from = (i % 3 == 0) ? 0 : (i % nnodes);
        int to = (i + 1) % nnodes;
        fprintf(f, "%d,%d,%d\n", from, to, i);
    }
    fclose(f);
}

/* 1 = loaded, 0 = failed */
static int attempt(uint64_t bpBytes) {
    static int seq = 0;
    char path[600];
    snprintf(path, sizeof path, "%s/db%d", g_dir, seq++);

    lbug_system_config cfg = lbug_default_system_config();
    cfg.buffer_pool_size = bpBytes;
    cfg.max_num_threads = g_threads;

    lbug_database db;
    lbug_connection conn;
    if (lbug_database_init(path, cfg, &db) != LbugSuccess)
        return 0;
    if (lbug_connection_init(&db, &conn) != LbugSuccess) {
        lbug_database_destroy(&db);
        return 0;
    }

    const char* ddl[2] = {"CREATE NODE TABLE n(id INT64, label STRING, PRIMARY KEY(id));",
        "CREATE REL TABLE e(FROM n TO n, position INT64);"};
    char copies[2][800];
    snprintf(copies[0], sizeof copies[0], "COPY n FROM '%s' (HEADER=true);", g_nodes_csv);
    snprintf(copies[1], sizeof copies[1], "COPY e FROM '%s' (HEADER=true);", g_edges_csv);

    int ok = 1;
    for (int i = 0; i < 2 && ok; i++) {
        lbug_query_result r;
        memset(&r, 0, sizeof r);
        if (lbug_connection_query(&conn, ddl[i], &r) != LbugSuccess ||
            !lbug_query_result_is_success(&r))
            ok = 0;
        lbug_query_result_destroy(&r);
        if (!ok)
            break;
        memset(&r, 0, sizeof r);
        if (lbug_connection_query(&conn, copies[i], &r) != LbugSuccess ||
            !lbug_query_result_is_success(&r))
            ok = 0;
        lbug_query_result_destroy(&r);
    }

    lbug_connection_destroy(&conn);
    lbug_database_destroy(&db);
    return ok;
}

int main(int argc, char** argv) {
    const int nnodes = argc > 1 ? atoi(argv[1]) : 100;
    const int nedges = argc > 2 ? atoi(argv[2]) : 100;
    /* max_num_threads is not capped at the core count, and the eager allocation is per
     * worker, so sweeping past it is how the per-worker cost shows above the pool minimum. */
    const uint64_t maxthreads = argc > 3 ? (uint64_t)atoi(argv[3]) : 16;

    snprintf(g_dir, sizeof g_dir, "/tmp/rel_floor_%d", (int)getpid());
    char cmd[700];
    snprintf(cmd, sizeof cmd, "mkdir -p %s", g_dir);
    if (system(cmd) != 0)
        return 1;
    snprintf(g_nodes_csv, sizeof g_nodes_csv, "%s/nodes.csv", g_dir);
    snprintf(g_edges_csv, sizeof g_edges_csv, "%s/edges.csv", g_dir);
    write_csvs(nnodes, nedges);

    const uint64_t STEP = 8ULL << 20;
    uint64_t threads[] = {1, 2, 4, 8, 16, 32, 64, 128, 0};
    printf("%d nodes, %d edges\n\n", nnodes, nedges);
    printf("| max_num_threads | floor, bisected to 8 MB |\n|---:|---:|\n");
    for (int t = 0; threads[t] && threads[t] <= maxthreads; t++) {
        g_threads = threads[t];
        uint64_t lo = STEP, hi = 4096ULL << 20;
        if (!attempt(hi)) {
            printf("| %llu | more than 4 GB |\n", (unsigned long long)threads[t]);
            continue;
        }
        /* invariant: hi loads the data, lo is the largest size known not to */
        while (hi - lo > STEP) {
            uint64_t mid = ((lo + hi) / 2 / STEP) * STEP;
            if (mid <= lo)
                break;
            if (attempt(mid))
                hi = mid;
            else
                lo = mid;
        }
        printf("| %llu | %llu MB |\n", (unsigned long long)threads[t],
            (unsigned long long)(hi >> 20));
        fflush(stdout);
    }

    snprintf(cmd, sizeof cmd, "rm -rf %s", g_dir);
    if (system(cmd) != 0)
        return 1;
    return 0;
}
```

</details>

<details>
<summary>rel_once.c</summary>

```c
/* rel_once.c - time one rel COPY, the way one_copy.c times one node COPY.
 *
 * The node table and its COPY are setup: only the rel COPY is inside the timing window, so
 * what the numbers carry is the rel path's own fixed cost. One statement per process, because
 * a second COPY into the same rel table would measure a different thing.
 *
 * Build:
 *   cc -O2 -o rel_once rel_once.c -I $LBUG/src/include -I $LBUG/src/include/c_api \
 *      -L $LBUG/build/relwithdebinfo/src -llbug -Wl,-rpath,$LBUG/build/relwithdebinfo/src
 *
 * Usage: LBUG_THREADS=16 rel_once [NNODES] [NEDGES]
 */
#include <lbug.h>
#include <stdio.h>
#include <stdlib.h>
#include <string.h>
#include <sys/resource.h>
#include <time.h>
#include <unistd.h>

static char dir[512], nodes_csv[600], edges_csv[600];

static void run(lbug_connection* c, const char* q) {
    lbug_query_result r;
    memset(&r, 0, sizeof r);
    if (lbug_connection_query(c, q, &r) != LbugSuccess || !lbug_query_result_is_success(&r)) {
        printf("FAILED: %s\n", lbug_query_result_get_error_message(&r));
        exit(1);
    }
    lbug_query_result_destroy(&r);
}

int main(int argc, char** argv) {
    const int nnodes = argc > 1 ? atoi(argv[1]) : 100;
    const int nedges = argc > 2 ? atoi(argv[2]) : 100;

    snprintf(dir, sizeof dir, "/tmp/rel_once_%d", (int)getpid());
    char cmd[700];
    snprintf(cmd, sizeof cmd, "mkdir -p %s", dir);
    if (system(cmd) != 0)
        return 1;
    snprintf(nodes_csv, sizeof nodes_csv, "%s/nodes.csv", dir);
    snprintf(edges_csv, sizeof edges_csv, "%s/edges.csv", dir);

    FILE* f = fopen(nodes_csv, "w");
    fprintf(f, "id,label\n");
    for (int i = 0; i < nnodes; i++)
        fprintf(f, "%d,n%d\n", i, i);
    fclose(f);
    f = fopen(edges_csv, "w");
    fprintf(f, "from,to,position\n");
    for (int i = 0; i < nedges; i++)
        fprintf(f, "%d,%d,%d\n", (i % 3 == 0) ? 0 : (i % nnodes), (i + 1) % nnodes, i);
    fclose(f);

    char path[600];
    snprintf(path, sizeof path, "%s/db", dir);
    lbug_system_config cfg = lbug_default_system_config();
    if (getenv("LBUG_THREADS"))
        cfg.max_num_threads = atoi(getenv("LBUG_THREADS"));
    lbug_database db;
    lbug_connection conn;
    lbug_database_init(path, cfg, &db);
    lbug_connection_init(&db, &conn);

    run(&conn, "CREATE NODE TABLE n(id INT64, label STRING, PRIMARY KEY(id));");
    char q[800];
    snprintf(q, sizeof q, "COPY n FROM '%s' (HEADER=true);", nodes_csv);
    run(&conn, q);
    run(&conn, "CREATE REL TABLE e(FROM n TO n, position INT64);");
    snprintf(q, sizeof q, "COPY e FROM '%s' (HEADER=true);", edges_csv);

    struct rusage r0, r1;
    struct timespec t0, t1;
    getrusage(RUSAGE_SELF, &r0);
    clock_gettime(CLOCK_MONOTONIC, &t0);
    run(&conn, q);
    clock_gettime(CLOCK_MONOTONIC, &t1);
    getrusage(RUSAGE_SELF, &r1);

    const double ms = (t1.tv_sec - t0.tv_sec) * 1e3 + (t1.tv_nsec - t0.tv_nsec) / 1e6;
    const double usr = (r1.ru_utime.tv_sec - r0.ru_utime.tv_sec) * 1e3 +
                       (r1.ru_utime.tv_usec - r0.ru_utime.tv_usec) / 1e3;
    const double sys = (r1.ru_stime.tv_sec - r0.ru_stime.tv_sec) * 1e3 +
                       (r1.ru_stime.tv_usec - r0.ru_stime.tv_usec) / 1e3;
    printf("%6d nodes %6d edges  wall=%7.2f  cpu=%7.2f (usr %6.2f sys %6.2f)  minflt=%8ld\n",
        nnodes, nedges, ms, usr + sys, usr, sys, r1.ru_minflt - r0.ru_minflt);

    lbug_connection_destroy(&conn);
    lbug_database_destroy(&db);
    snprintf(cmd, sizeof cmd, "rm -rf %s", dir);
    if (system(cmd) != 0)
        return 1;
    return 0;
}
```

</details>

<details>
<summary>count_rel_headers.gdb</summary>

```gdb
set confirm off
set pagination off
set breakpoint pending on
# One per worker before the patch, one per worker that receives a partition after it.
break lbug::storage::InMemChunkedCSRHeader::InMemChunkedCSRHeader(lbug::storage::MemoryManager&, bool, unsigned long)
ignore 1 1000000
# Only exists on the patched tree; stays pending and unhit on the unpatched one.
break lbug::processor::RelBatchInsert::initLocalStateForFirstPartition
ignore 2 1000000
run
info breakpoints
quit
```

</details>
