### PR TITLE
fix(parser): collapse a doubled backtick in an escaped identifier

### DIFF
--- a/src/binder/bind/bind_export_database.cpp
+++ b/src/binder/bind/bind_export_database.cpp
@@ -58,14 +58,17 @@ void bindExportTableData(ExportedTableData& tableData, const std::string& query,
 }
 
 static std::string getExportNodeTableDataQuery(const TableCatalogEntry& entry) {
-    return std::format("match (a:`{}`) return a.*", entry.getName());
+    return std::format("match (a:{}) return a.*", StringUtils::quoteIdentifier(entry.getName()));
 }
 
 static std::string getExportRelTableDataQuery(const TableCatalogEntry& relGroupEntry,
     const NodeTableCatalogEntry& srcEntry, const NodeTableCatalogEntry& dstEntry) {
-    return std::format("match (a:`{}`)-[r:`{}`]->(b:`{}`) return a.{},b.{},r.*;",
-        srcEntry.getName(), relGroupEntry.getName(), dstEntry.getName(),
-        srcEntry.getPrimaryKeyName(), dstEntry.getPrimaryKeyName());
+    return std::format("match (a:{})-[r:{}]->(b:{}) return a.{},b.{},r.*;",
+        StringUtils::quoteIdentifier(srcEntry.getName()),
+        StringUtils::quoteIdentifier(relGroupEntry.getName()),
+        StringUtils::quoteIdentifier(dstEntry.getName()),
+        StringUtils::quoteIdentifier(srcEntry.getPrimaryKeyName()),
+        StringUtils::quoteIdentifier(dstEntry.getPrimaryKeyName()));
 }
 
 static std::vector<ExportedTableData> getExportInfo(const Catalog& catalog,

--- a/src/binder/bind/bind_import_database.cpp
+++ b/src/binder/bind/bind_import_database.cpp
@@ -3,6 +3,7 @@
 #include "common/copier_config/csv_reader_config.h"
 #include "common/exception/binder.h"
 #include "common/file_system/virtual_file_system.h"
+#include "common/string_utils.h"
 #include "main/client_context.h"
 #include "parser/copy.h"
 #include "parser/parser.h"
@@ -43,7 +44,7 @@ static std::string getColumnNamesToCopy(const CopyFrom& copyFrom) {
     std::string delimiter = "";
     for (auto& column : copyFrom.getCopyColumnInfo().columnNames) {
         columns += delimiter;
-        columns += "`" + column + "`";
+        columns += common::StringUtils::quoteIdentifier(column);
         if (delimiter == "") {
             delimiter = ",";
         }
@@ -126,13 +127,13 @@ std::unique_ptr<BoundStatement> Binder::bindImportDatabaseClause(const Statement
                 if (!copyFromOptions.empty()) {
                     optionsMap.insert(copyFromOptions.begin(), copyFromOptions.end());
                 }
-                query =
-                    std::format("COPY `{}` {} FROM \"{}\" {};", copyFromStatement.getTableName(),
-                        columnNames, copyFilePath, CSVOption::toCypher(optionsMap));
+                query = std::format("COPY {} {} FROM \"{}\" {};",
+                    StringUtils::quoteIdentifier(copyFromStatement.getTableName()), columnNames,
+                    copyFilePath, CSVOption::toCypher(optionsMap));
             } else {
-                query =
-                    std::format("COPY `{}` {} FROM \"{}\" {};", copyFromStatement.getTableName(),
-                        columnNames, copyFilePath, CSVOption::toCypher(copyFromOptions));
+                query = std::format("COPY {} {} FROM \"{}\" {};",
+                    StringUtils::quoteIdentifier(copyFromStatement.getTableName()), columnNames,
+                    copyFilePath, CSVOption::toCypher(copyFromOptions));
             }
             finalQueryStatements += query;
         }

--- a/src/catalog/catalog_entry/graph_catalog_entry.cpp
+++ b/src/catalog/catalog_entry/graph_catalog_entry.cpp
@@ -1,6 +1,7 @@
 #include "catalog/catalog_entry/graph_catalog_entry.h"
 
 #include "common/serializer/deserializer.h"
+#include "common/string_utils.h"
 #include <format>
 
 using namespace lbug::common;
@@ -25,9 +26,10 @@ std::unique_ptr<GraphCatalogEntry> GraphCatalogEntry::deserialize(Deserializer& 
 }
 
 std::string GraphCatalogEntry::toCypher(const ToCypherInfo& /* info */) const {
-    return std::format("DROP GRAPH IF EXISTS `{}`;\n"
-                       "CREATE GRAPH `{}` {};\n",
-        getName(), getName(), isAnyGraph ? "ANY" : "");
+    const auto name = common::StringUtils::quoteIdentifier(getName());
+    return std::format("DROP GRAPH IF EXISTS {};\n"
+                       "CREATE GRAPH {} {};\n",
+        name, name, isAnyGraph ? "ANY" : "");
 }
 
 } // namespace catalog

--- a/src/catalog/catalog_entry/index_catalog_entry.cpp
+++ b/src/catalog/catalog_entry/index_catalog_entry.cpp
@@ -4,6 +4,7 @@
 #include "catalog/catalog_entry/table_catalog_entry.h"
 #include "common/exception/runtime.h"
 #include "common/serializer/buffer_writer.h"
+#include "common/string_utils.h"
 #include "transaction/transaction.h"
 #include <format>
 
@@ -31,8 +32,10 @@ std::string BuiltinIndexAuxInfo::toCypher(const IndexCatalogEntry& indexEntry,
         return "";
     }
     auto propertyName = tableEntry->getProperty(propertyIDs[0]).getName();
-    return std::format("CREATE {} INDEX `{}` FOR (n:`{}`) ON (n.`{}`);", indexEntry.getIndexType(),
-        indexEntry.getIndexName(), tableEntry->getName(), propertyName);
+    return std::format("CREATE {} INDEX {} FOR (n:{}) ON (n.{});", indexEntry.getIndexType(),
+        common::StringUtils::quoteIdentifier(indexEntry.getIndexName()),
+        common::StringUtils::quoteIdentifier(tableEntry->getName()),
+        common::StringUtils::quoteIdentifier(propertyName));
 }
 
 bool IndexCatalogEntry::containsPropertyID(common::property_id_t propertyID) const {

--- a/src/catalog/catalog_entry/node_table_catalog_entry.cpp
+++ b/src/catalog/catalog_entry/node_table_catalog_entry.cpp
@@ -106,8 +106,9 @@ std::unique_ptr<NodeTableCatalogEntry> NodeTableCatalogEntry::deserialize(
 }
 
 std::string NodeTableCatalogEntry::toCypher(const ToCypherInfo& /*info*/) const {
-    return std::format("CREATE NODE TABLE `{}` ({} PRIMARY KEY(`{}`));", getName(),
-        propertyCollection.toCypher(), primaryKeyName);
+    return std::format("CREATE NODE TABLE {} ({} PRIMARY KEY({}));",
+        common::StringUtils::quoteIdentifier(getName()), propertyCollection.toCypher(),
+        common::StringUtils::quoteIdentifier(primaryKeyName));
 }
 
 std::optional<function::TableFunction> NodeTableCatalogEntry::getScanFunction() const {

--- a/src/catalog/catalog_entry/rel_group_catalog_entry.cpp
+++ b/src/catalog/catalog_entry/rel_group_catalog_entry.cpp
@@ -213,7 +213,8 @@ static std::string getFromToStr(const NodeTableIDPair& pair, const Catalog* cata
         srcTableName = catalog->getTableCatalogEntry(transaction, pair.srcTableID)->getName();
         dstTableName = catalog->getTableCatalogEntry(transaction, pair.dstTableID)->getName();
     }
-    return std::format("FROM `{}` TO `{}`", srcTableName, dstTableName);
+    return std::format("FROM {} TO {}", common::StringUtils::quoteIdentifier(srcTableName),
+        common::StringUtils::quoteIdentifier(dstTableName));
 }
 
 static std::string getMultiplicityStr(RelMultiplicity srcMultiplicity,
@@ -227,7 +228,7 @@ std::string RelGroupCatalogEntry::toCypher(const ToCypherInfo& info) const {
     auto catalog = Catalog::Get(*relGroupInfo.context);
     auto transaction = transaction::Transaction::Get(*relGroupInfo.context);
     std::stringstream ss;
-    ss << std::format("CREATE REL TABLE `{}` (", getName());
+    ss << std::format("CREATE REL TABLE {} (", common::StringUtils::quoteIdentifier(getName()));
     DASSERT(!relTableInfos.empty());
     ss << getFromToStr(relTableInfos[0].nodePair, catalog, transaction, storage);
     if (relTableInfos[0].srcMultiplicity != srcMultiplicity ||

--- a/src/catalog/catalog_entry/sequence_catalog_entry.cpp
+++ b/src/catalog/catalog_entry/sequence_catalog_entry.cpp
@@ -4,6 +4,7 @@
 #include "common/exception/catalog.h"
 #include "common/exception/overflow.h"
 #include "common/serializer/deserializer.h"
+#include "common/string_utils.h"
 #include "common/vector/value_vector.h"
 #include "function/arithmetic/add.h"
 #include "transaction/transaction.h"
@@ -156,11 +157,12 @@ std::unique_ptr<SequenceCatalogEntry> SequenceCatalogEntry::deserialize(
 }
 
 std::string SequenceCatalogEntry::toCypher(const ToCypherInfo& /* info */) const {
-    return std::format("DROP SEQUENCE IF EXISTS `{}`;\n"
-                       "CREATE SEQUENCE IF NOT EXISTS `{}` START {} INCREMENT {} MINVALUE {} "
+    const auto quotedName = common::StringUtils::quoteIdentifier(getName());
+    return std::format("DROP SEQUENCE IF EXISTS {};\n"
+                       "CREATE SEQUENCE IF NOT EXISTS {} START {} INCREMENT {} MINVALUE {} "
                        "MAXVALUE {} {} CYCLE;\n"
                        "RETURN nextval('{}');",
-        getName(), getName(), sequenceData.currVal, sequenceData.increment, sequenceData.minValue,
+        quotedName, quotedName, sequenceData.currVal, sequenceData.increment, sequenceData.minValue,
         sequenceData.maxValue, sequenceData.cycle ? "" : "NO", getName());
 }
 

--- a/src/catalog/property_definition_collection.cpp
+++ b/src/catalog/property_definition_collection.cpp
@@ -102,8 +102,7 @@ std::string PropertyDefinitionCollection::toCypher() const {
         if (typeStr.find("MAP") != std::string::npos) {
             StringUtils::replaceAll(typeStr, "  ", ",");
         }
-        ss << "`" << def.getName() << "`"
-           << " " << typeStr << ",";
+        ss << common::StringUtils::quoteIdentifier(def.getName()) << " " << typeStr << ",";
     }
     return ss.str();
 }

--- a/src/function/gds/gds.cpp
+++ b/src/function/gds/gds.cpp
@@ -6,6 +6,7 @@
 #include "catalog/catalog.h"
 #include "catalog/catalog_entry/rel_group_catalog_entry.h"
 #include "common/exception/binder.h"
+#include "common/string_utils.h"
 #include "function/table/bind_input.h"
 #include "graph/graph_entry_set.h"
 #include "graph/on_disk_graph.h"
@@ -83,12 +84,14 @@ static NativeGraphEntryTableInfo bindNodeEntry(ClientContext& context, const std
         throw BinderException(std::format("{} is not a NODE table.", tableName));
     }
     if (!predicate.empty()) {
-        auto cypher = std::format("MATCH (n:`{}`) RETURN n, {}", nodeEntry->getName(), predicate);
+        auto cypher = std::format("MATCH (n:{}) RETURN n, {}",
+            common::StringUtils::quoteIdentifier(nodeEntry->getName()), predicate);
         auto columns = getResultColumns(cypher, &context);
         DASSERT(columns.size() == 2);
         return {nodeEntry, columns[0], columns[1]};
     } else {
-        auto cypher = std::format("MATCH (n:`{}`) RETURN n", nodeEntry->getName());
+        auto cypher = std::format("MATCH (n:{}) RETURN n",
+            common::StringUtils::quoteIdentifier(nodeEntry->getName()));
         auto columns = getResultColumns(cypher, &context);
         DASSERT(columns.size() == 1);
         return {nodeEntry, columns[0], nullptr /* empty predicate */};
@@ -105,13 +108,14 @@ static NativeGraphEntryTableInfo bindRelEntry(ClientContext& context, const std:
             std::format("{} has catalog entry type. REL entry was expected.", tableName));
     }
     if (!predicate.empty()) {
-        auto cypher =
-            std::format("MATCH ()-[r:`{}`]->() RETURN r, {}", relEntry->getName(), predicate);
+        auto cypher = std::format("MATCH ()-[r:{}]->() RETURN r, {}",
+            common::StringUtils::quoteIdentifier(relEntry->getName()), predicate);
         auto columns = getResultColumns(cypher, &context);
         DASSERT(columns.size() == 2);
         return {relEntry, columns[0], columns[1]};
     } else {
-        auto cypher = std::format("MATCH ()-[r:`{}`]->() RETURN r", relEntry->getName());
+        auto cypher = std::format("MATCH ()-[r:{}]->() RETURN r",
+            common::StringUtils::quoteIdentifier(relEntry->getName()));
         auto columns = getResultColumns(cypher, &context);
         DASSERT(columns.size() == 1);
         return {relEntry, columns[0], nullptr /* empty predicate */};

--- a/src/function/scalar_macro_function.cpp
+++ b/src/function/scalar_macro_function.cpp
@@ -65,8 +65,8 @@ std::string ScalarMacroFunction::toCypher(const std::string& name) const {
     for (auto& defaultParam : defaultArgs) {
         paramStrings.push_back(defaultParam.first + ":=" + defaultParam.second->toString());
     }
-    return std::format("CREATE MACRO `{}` ({}) AS {};", name, StringUtils::join(paramStrings, ","),
-        expression->toString());
+    return std::format("CREATE MACRO {} ({}) AS {};", common::StringUtils::quoteIdentifier(name),
+        StringUtils::join(paramStrings, ","), expression->toString());
 }
 } // namespace function
 } // namespace lbug

--- a/src/function/table/project_native_graph.cpp
+++ b/src/function/table/project_native_graph.cpp
@@ -3,6 +3,7 @@
 #include "catalog/catalog.h"
 #include "catalog/catalog_entry/rel_group_catalog_entry.h"
 #include "common/exception/binder.h"
+#include "common/string_utils.h"
 #include "common/types/value/nested.h"
 #include "function/gds/gds.h"
 #include "function/table/bind_data.h"
@@ -83,8 +84,10 @@ static void materializeRelCsr(ParsedNativeGraphEntry& entry, main::ClientContext
                 epoch = relTable->getChangeEpoch();
             }
         }
-        auto query = std::format("MATCH (a:`{}`)-[r:`{}`]->(b:`{}`) RETURN a.rowid, b.rowid",
-            nodeTable, relInfo.tableName, nodeTable);
+        const auto quotedNodeTable = common::StringUtils::quoteIdentifier(nodeTable);
+        auto query =
+            std::format("MATCH (a:{})-[r:{}]->(b:{}) RETURN a.rowid, b.rowid", quotedNodeTable,
+                common::StringUtils::quoteIdentifier(relInfo.tableName), quotedNodeTable);
         auto result = conn.queryAsArrow(query, ARROW_CHUNK_SIZE);
         auto* arrowResult = dynamic_cast<main::ArrowQueryResult*>(result.get());
         if (arrowResult != nullptr && arrowResult->isSuccess() && arrowResult->hasCSRMetadata()) {

--- a/src/include/common/string_utils.h
+++ b/src/include/common/string_utils.h
@@ -30,6 +30,23 @@ public:
     static void toLower(std::string& input);
     static void toUpper(std::string& input);
 
+    // Wrap a name for use as an escaped identifier in generated Cypher. A backtick inside the
+    // name is doubled, which is the form the lexer reads as one identifier and the transformer
+    // collapses back to a single backtick.
+    static std::string quoteIdentifier(std::string_view name) {
+        std::string quoted;
+        quoted.reserve(name.size() + 2);
+        quoted += '`';
+        for (const char c : name) {
+            quoted += c;
+            if (c == '`') {
+                quoted += c;
+            }
+        }
+        quoted += '`';
+        return quoted;
+    }
+
     static bool isSpace(char c) {
         return c == ' ' || c == '\t' || c == '\n' || c == '\v' || c == '\f' || c == '\r';
     }

--- a/src/parser/transformer.cpp
+++ b/src/parser/transformer.cpp
@@ -211,10 +211,21 @@ std::string Transformer::transformVariable(CypherParser::OC_VariableContext& ctx
 }
 std::string Transformer::transformSymbolicName(CypherParser::OC_SymbolicNameContext& ctx) {
     if (ctx.EscapedSymbolicName()) {
-        std::string escapedSymbolName = ctx.EscapedSymbolicName()->getText();
-        // escapedSymbolName symbol will be of form "`Some.Value`". Therefore, we need to sanitize
-        // it such that we don't store the symbol with escape character.
-        return escapedSymbolName.substr(1, escapedSymbolName.size() - 2);
+        // The token spans one or more backtick-quoted groups, so `a``b` arrives here as the
+        // single text "`a``b`". Strip the outer pair, then collapse each doubled backtick into
+        // the one the name asked for, which is the escape the grammar's repetition encodes.
+        const std::string escapedSymbolName = ctx.EscapedSymbolicName()->getText();
+        const auto inner =
+            std::string_view(escapedSymbolName).substr(1, escapedSymbolName.size() - 2);
+        std::string name;
+        name.reserve(inner.size());
+        for (auto i = 0u; i < inner.size(); i++) {
+            name += inner[i];
+            if (inner[i] == '`' && i + 1 < inner.size() && inner[i + 1] == '`') {
+                i++;
+            }
+        }
+        return name;
     } else {
         DASSERT(ctx.HexLetter() || ctx.UnescapedSymbolicName() || ctx.iC_NonReservedKeywords());
         return ctx.getText();

--- a/src/processor/operator/simple/export_db.cpp
+++ b/src/processor/operator/simple/export_db.cpp
@@ -60,7 +60,7 @@ static std::string getTablePropertyDefinitions(const TableCatalogEntry* entry) {
         if (property.getType() == LogicalType::INTERNAL_ID()) {
             continue;
         }
-        columns += "`" + property.getName() + "`";
+        columns += common::StringUtils::quoteIdentifier(property.getName());
         columns += propertyIdx == properties.size() ? "" : ",";
     }
     return columns;
@@ -79,10 +79,11 @@ static void writeCopyNodeStatement(stringstream& ss, const TableCatalogEntry* en
     }
     auto copyOptionsCypher = CSVOption::toCypher(csvConfig.option.toOptionsMap(useParallelReader));
     if (columns.empty()) {
-        ss << std::format("COPY `{}` FROM \"{}\" {};\n", entry->getName(), fileName,
-            copyOptionsCypher);
+        ss << std::format("COPY {} FROM \"{}\" {};\n",
+            common::StringUtils::quoteIdentifier(entry->getName()), fileName, copyOptionsCypher);
     } else {
-        ss << std::format("COPY `{}` ({}) FROM \"{}\" {};\n", entry->getName(), columns, fileName,
+        ss << std::format("COPY {} ({}) FROM \"{}\" {};\n",
+            common::StringUtils::quoteIdentifier(entry->getName()), columns, fileName,
             copyOptionsCypher);
     }
 }
@@ -111,11 +112,12 @@ static void writeCopyRelStatement(stringstream& ss, const ClientContext* context
         copyOptionsMap["to"] = std::format("'{}'", toTableName);
         auto copyOptions = CSVOption::toCypher(copyOptionsMap);
         if (columns.empty()) {
-            ss << std::format("COPY `{}` FROM \"{}\" {};\n", entry->getName(), fileName,
-                copyOptions);
+            ss << std::format("COPY {} FROM \"{}\" {};\n",
+                common::StringUtils::quoteIdentifier(entry->getName()), fileName, copyOptions);
         } else {
-            ss << std::format("COPY `{}` ({}) FROM \"{}\" {};\n", entry->getName(), columns,
-                fileName, copyOptions);
+            ss << std::format("COPY {} ({}) FROM \"{}\" {};\n",
+                common::StringUtils::quoteIdentifier(entry->getName()), columns, fileName,
+                copyOptions);
         }
     }
 }

--- a/src/storage/table/arrow_table_support.cpp
+++ b/src/storage/table/arrow_table_support.cpp
@@ -5,6 +5,7 @@
 
 #include "common/arrow/arrow_converter.h"
 #include "common/exception/runtime.h"
+#include "common/string_utils.h"
 #include "main/database.h"
 
 namespace lbug {
@@ -46,7 +47,7 @@ static int64_t findArrowColumnByName(const ArrowSchemaWrapper& schema, const std
 // names are arbitrary strings, and many ordinary ones (`index`, `order`, `group`, names with a
 // space or a leading digit) are not valid unquoted Cypher identifiers.
 std::string quoteIdent(const std::string& name) {
-    return "`" + name + "`";
+    return common::StringUtils::quoteIdentifier(name);
 }
 
 std::string ArrowTableSupport::registerArrowData(ArrowSchemaWrapper schema,

--- a/test/test_files/ddl/ddl_empty.test
+++ b/test/test_files/ddl/ddl_empty.test
@@ -424,3 +424,42 @@ Adam|2020|Karissa
 Adam|2020|Zhang
 Karissa|2021|Zhang
 Zhang|2022|Noura
+
+-CASE EscapedIdentifierCollapsesDoubledBacktick
+-STATEMENT CREATE NODE TABLE `a``b` (id INT64, `c``d` INT64, PRIMARY KEY(id));
+---- 1
+Table a`b has been created.
+-STATEMENT CALL SHOW_TABLES() RETURN name;
+---- 1
+a`b
+-STATEMENT CREATE (:`a``b` {id: 1, `c``d`: 2});
+---- ok
+-STATEMENT MATCH (n:`a``b`) RETURN n.`c``d`;
+---- 1
+2
+-STATEMENT CALL TABLE_INFO('a`b') RETURN name;
+---- 2
+c`d
+id
+
+-CASE EscapedIdentifierSurvivesExportImport
+-SKIP_WASM
+-STATEMENT CREATE NODE TABLE `x``y` (id INT64, `p``q` INT64, PRIMARY KEY(id));
+---- 1
+Table x`y has been created.
+-STATEMENT CREATE (:`x``y` {id: 1, `p``q`: 2});
+---- ok
+-STATEMENT EXPORT DATABASE "${LBUG_EXPORT_DB_DIRECTORY}_backtick/db";
+---- 1
+Exported database successfully.
+-IMPORT_DATABASE "${LBUG_EXPORT_DB_DIRECTORY}_backtick/db"
+-STATEMENT IMPORT DATABASE "${LBUG_EXPORT_DB_DIRECTORY}_backtick/db";
+---- 1
+Imported database successfully.
+-STATEMENT CALL SHOW_TABLES() RETURN name;
+---- 1
+x`y
+-STATEMENT MATCH (n:`x``y`) RETURN n.`p``q`;
+---- 1
+2
+

--- a/test/test_runner/fsm_leak_checker.cpp
+++ b/test/test_runner/fsm_leak_checker.cpp
@@ -7,6 +7,7 @@
 
 #include "catalog/catalog.h"
 #include "catalog/catalog_entry/table_catalog_entry.h"
+#include "common/string_utils.h"
 #include "gtest/gtest.h"
 #include "main/connection.h"
 #include "processor/result/flat_tuple.h"
@@ -92,13 +93,15 @@ void FSMLeakChecker::checkForLeakedPages(main::Connection* conn) {
     // Drop rel tables first
     for (const auto& [name, type] : tableNames) {
         if (type == common::TableTypeUtils::toString(common::TableType::REL)) {
-            ASSERT_TRUE(conn->query(std::format("drop table `{}`", name))->isSuccess());
+            ASSERT_TRUE(conn->query("drop table " + common::StringUtils::quoteIdentifier(name))
+                            ->isSuccess());
         }
     }
     // Then non-rel
     for (const auto& [name, type] : tableNames) {
         if (type != common::TableTypeUtils::toString(common::TableType::REL)) {
-            ASSERT_TRUE(conn->query(std::format("drop table `{}`", name))->isSuccess());
+            ASSERT_TRUE(conn->query("drop table " + common::StringUtils::quoteIdentifier(name))
+                            ->isSuccess());
         }
     }
 


### PR DESCRIPTION
_This work was produced with the help of language models._

Fixes #770.

The lexer reads a whole escaped name, doublings included, as one token:

    EscapedSymbolicName : ( '`' ( ~[`] )* '`' )+ ;

`Transformer::transformSymbolicName` strips the outer pair and stores what is left, which keeps the doubling. The name a writer asks for and the name the catalogue holds differ:

    written in Cypher   `a``b`
    stored on main      a``b
    stored here         a`b

The stored form on `main` is self-consistent for a caller who only types the name. It breaks the moment a name makes the round trip, because a writer that quotes by wrapping in backticks then emits Cypher the lexer reads as a different name. That is how the Arrow DDL generator fails on a field whose name contains a backtick, which is where this was found.

The issue offers three options and asks for a decision. This takes the first with the third, because that pair is the only combination under which a generated name survives the trip.

## The parser collapses the doubling

`transformSymbolicName` walks the inner text and emits one backtick for each doubled pair, which is the escape the grammar's repetition encodes. Every other identifier form keeps its old path.

## Every writer of generated Cypher doubles what it writes

`common::StringUtils::quoteIdentifier` wraps a name and doubles any backtick inside it. Seventeen call sites that interpolate a catalogue name into Cypher now go through it:

| file | what it writes |
|---|---|
| `catalog/catalog_entry/node_table_catalog_entry.cpp` | `CREATE NODE TABLE`, and its primary key name |
| `catalog/catalog_entry/rel_group_catalog_entry.cpp` | `CREATE REL TABLE`, and its `FROM` and `TO` names |
| `catalog/catalog_entry/index_catalog_entry.cpp` | `CREATE INDEX`, its table and its property |
| `catalog/catalog_entry/sequence_catalog_entry.cpp` | `CREATE SEQUENCE` and `DROP SEQUENCE` |
| `catalog/catalog_entry/graph_catalog_entry.cpp` | `CREATE GRAPH` and `DROP GRAPH` |
| `catalog/property_definition_collection.cpp` | the property list inside those statements |
| `binder/bind/bind_export_database.cpp` | the `MATCH` that reads each table out |
| `processor/operator/simple/export_db.cpp` | the `COPY` statements in the exported script |
| `binder/bind/bind_import_database.cpp` | the `COPY` statements it re-binds on import |
| `function/scalar_macro_function.cpp` | `CREATE MACRO` |
| `function/gds/gds.cpp` | the projection queries behind the graph functions |
| `function/table/project_native_graph.cpp` | the projection query for a native graph |
| `storage/table/arrow_table_support.cpp` | the DDL for an Arrow-backed table |
| `test/test_runner/fsm_leak_checker.cpp` | the `DROP TABLE` the harness runs between cases |

The last one is a test file, and it is in the list because it failed first: with the parser fixed and the writer naive, the harness could no longer drop the table the new test creates.

The one place that keeps its bare backticks is the type-mismatch message in `reader_bind_utils.cpp`, where they are decoration in prose rather than an identifier the parser will read.

## The behaviour change

The catalogue holds a different name after this patch, for names that contain a backtick:

    CREATE NODE TABLE `a``b` (...)   ->  a`b   here
                                     ->  a``b  on main

A database written by an older build therefore reports one name and a new build reports another. Names without a backtick are unaffected.

## Tests

Both cases are in `test/test_files/ddl/ddl_empty.test`, and both fail on `main` at `41f704d05`.

`EscapedIdentifierCollapsesDoubledBacktick` creates a node table and a property whose names contain a backtick, reads both back through `SHOW_TABLES` and `TABLE_INFO`, then quotes them again in a `CREATE` and a `MATCH`. On `main` the first row reads:

    Table a``b has been created.

`EscapedIdentifierSurvivesExportImport` runs the same schema through `EXPORT DATABASE` and `IMPORT DATABASE` and reads the name and the property back. On this branch before the writers were converted, the export failed inside its own generated query:

    Parser exception: Invalid input <match (a:`x`y>: expected rule oC_SingleQuery (line: 1, offset: 12)

which is the round trip this pair of options is for.

`make test NUM_THREADS=14 TEST_JOBS=8`: 2672 passed and 4 failed out of 2676, on the rebase onto `41f704d05`. The four are `dictionary_bug~orb383_relationship_projection_obfuscated.AnonymousParquetDeleteReload`, which needs a gitignored Parquet fixture, and three `extension` cases that download from `extension.ladybugdb.com`. The same four fail on `main` on this host.
