### PR TITLE
feat(parser): allow the graph-projection trio on read-only databases

### DIFF
--- a/src/include/parser/visitor/statement_read_write_analyzer.h
+++ b/src/include/parser/visitor/statement_read_write_analyzer.h
@@ -22,7 +22,7 @@ private:
     void visitAlter(const Statement& /*statement*/) override { readOnly = false; }
     void visitCopyFrom(const Statement& /*statement*/) override { readOnly = false; }
     void visitStandaloneCall(const Statement& /*statement*/) override { readOnly = true; }
-    void visitStandaloneCallFunction(const Statement& /*statement*/) override { readOnly = false; }
+    void visitStandaloneCallFunction(const Statement& statement) override;
     void visitCreateMacro(const Statement& /*statement*/) override { readOnly = false; }
     void visitCreateGraph(const Statement& /*statement*/) override { readOnly = false; }
     void visitExtension(const Statement& /*statement*/) override;

--- a/src/parser/visitor/statement_read_write_analyzer.cpp
+++ b/src/parser/visitor/statement_read_write_analyzer.cpp
@@ -1,13 +1,35 @@
 #include "parser/visitor/statement_read_write_analyzer.h"
 
+#include <algorithm>
+
+#include "common/string_utils.h"
 #include "main/client_context.h"
 #include "main/db_config.h"
 #include "parser/expression/parsed_expression_visitor.h"
+#include "parser/expression/parsed_function_expression.h"
 #include "parser/query/reading_clause/reading_clause.h"
 #include "parser/query/return_with_clause/with_clause.h"
+#include "parser/standalone_call_function.h"
 
 namespace lbug {
 namespace parser {
+
+void StatementReadWriteAnalyzer::visitStandaloneCallFunction(const Statement& statement) {
+    // Standalone CALL functions are write-classified by default: extensions can register
+    // storage-writing calls (e.g. index builds), and the analyzer runs before binding, so the
+    // name is all we have. The graph-projection trio only mutates the session-local
+    // GraphEntrySet — no storage is touched — so it is safe (and useful) on read-only
+    // databases: project + run GDS over a read-only replica. Names match
+    // function/table/standalone_call_function.h.
+    static constexpr std::string_view READ_ONLY_SAFE_FUNCS[] = {"PROJECT_GRAPH",
+        "PROJECT_GRAPH_CYPHER", "DROP_PROJECTED_GRAPH"};
+    const auto& funcExpr = statement.constCast<StandaloneCallFunction>()
+                               .getFunctionExpression()
+                               ->constCast<ParsedFunctionExpression>();
+    const auto name = common::StringUtils::getUpper(funcExpr.getFunctionName());
+    readOnly = std::find(std::begin(READ_ONLY_SAFE_FUNCS), std::end(READ_ONLY_SAFE_FUNCS), name) !=
+               std::end(READ_ONLY_SAFE_FUNCS);
+}
 
 void StatementReadWriteAnalyzer::visitExtension(const Statement& /*statement*/) {
     // We allow LOAD EXTENSION to run in read-only mode.

--- a/test/api/read_only_test.cpp
+++ b/test/api/read_only_test.cpp
@@ -1,6 +1,9 @@
 #include "api_test/api_test.h"
+#include "graph/graph_entry_set.h"
+#include "graph/parsed_graph_entry.h"
 
 using namespace lbug::common;
+using namespace lbug::graph;
 using namespace lbug::testing;
 
 class ReadOnlyTest : public ApiTest {};
@@ -17,4 +20,30 @@ TEST_F(ReadOnlyTest, Test) {
         conn->query("CALL CLEAR_WARNINGS()")->toString().c_str());
     ASSERT_STREQ("Connection exception: Cannot execute write operations in a read-only database!",
         conn->query("CALL _CACHE_ARRAY_COLUMN_LOCALLY('Test', 'arr')")->toString().c_str());
+}
+
+TEST_F(ReadOnlyTest, ProjectGraphOnReadOnlyDatabase) {
+    if (databasePath == "" || databasePath == ":memory:") {
+        return;
+    }
+    ASSERT_TRUE(conn->query("CREATE NODE TABLE RoNode(id INT64 PRIMARY KEY)")->isSuccess());
+    ASSERT_TRUE(conn->query("CREATE REL TABLE RoEdge(FROM RoNode TO RoNode)")->isSuccess());
+    ASSERT_TRUE(conn->query("CREATE (:RoNode {id:0}), (:RoNode {id:1})")->isSuccess());
+    ASSERT_TRUE(
+        conn->query("MATCH (a:RoNode {id:0}), (b:RoNode {id:1}) "
+                    "CREATE (a)-[:RoEdge]->(b)")
+            ->isSuccess());
+    systemConfig->readOnly = true;
+    createDBAndConn();
+    // The graph-projection trio only mutates the session-local GraphEntrySet — it must work on
+    // a read-only database (project + run GDS over a read-only replica).
+    ASSERT_TRUE(conn->query("CALL PROJECT_GRAPH('RoG', ['RoNode'], ['RoEdge'])")->isSuccess());
+    // Eager arrow-CSR materialization runs an internal read query; it must also succeed here.
+    auto* entrySet = GraphEntrySet::Get(*conn->getClientContext());
+    ASSERT_TRUE(entrySet->hasGraph("RoG"));
+    const auto& entry = entrySet->getEntry("RoG")->cast<ParsedNativeGraphEntry>();
+    ASSERT_EQ(entry.relCsrResults.size(), 1u);
+    ASSERT_NE(entry.relCsrResults[0], nullptr);
+    ASSERT_TRUE(conn->query("CALL DROP_PROJECTED_GRAPH('RoG')")->isSuccess());
+    ASSERT_FALSE(entrySet->hasGraph("RoG"));
 }

--- a/test/api/read_only_test.cpp
+++ b/test/api/read_only_test.cpp
@@ -29,10 +29,9 @@ TEST_F(ReadOnlyTest, ProjectGraphOnReadOnlyDatabase) {
     ASSERT_TRUE(conn->query("CREATE NODE TABLE RoNode(id INT64 PRIMARY KEY)")->isSuccess());
     ASSERT_TRUE(conn->query("CREATE REL TABLE RoEdge(FROM RoNode TO RoNode)")->isSuccess());
     ASSERT_TRUE(conn->query("CREATE (:RoNode {id:0}), (:RoNode {id:1})")->isSuccess());
-    ASSERT_TRUE(
-        conn->query("MATCH (a:RoNode {id:0}), (b:RoNode {id:1}) "
-                    "CREATE (a)-[:RoEdge]->(b)")
-            ->isSuccess());
+    ASSERT_TRUE(conn->query("MATCH (a:RoNode {id:0}), (b:RoNode {id:1}) "
+                            "CREATE (a)-[:RoEdge]->(b)")
+                    ->isSuccess());
     systemConfig->readOnly = true;
     createDBAndConn();
     // The graph-projection trio only mutates the session-local GraphEntrySet — it must work on


### PR DESCRIPTION
From the Discord thread: `PROJECT_GRAPH` couldn't run on a read-only database, which blocks the natural serving shape — project + run GDS over a read-only replica (and `pagerank.py` itself opens `read_only=True`).

**Cause:** the read-write analyzer blanket-classifies every standalone CALL function as a write. The projection trio (`PROJECT_GRAPH`, `PROJECT_GRAPH_CYPHER`, `DROP_PROJECTED_GRAPH`) only mutates the session-local `GraphEntrySet` — no storage is touched.

**Fix:** `visitStandaloneCallFunction` consults a per-function allowlist for the trio; everything else keeps the write default. Opt-in by name is the safe shape here: the analyzer runs before binding, and extensions can register storage-writing standalone calls (index builds etc.). `CLEAR_WARNINGS` deliberately stays write-classified (existing behavior + test).

**Empirical check, wikidata scale:** `lbug -r wikidata.lbdb` → `PROJECT_GRAPH` (eager arrow-CSR materialization, 766.5M edges) **6.8s** → `GDS_PAGE_RANK` (zero-copy) **131s**, peak RSS **28.9GB**, top-25 identical to the read-write run and to the precomputed `page_rank.lbdb` reference. The exact command that failed before this change.

Tests: `ReadOnlyTest.ProjectGraphOnReadOnlyDatabase` — project on a read-only DB, assert the pinned CSR materialized (the internal connection only runs read queries), drop; the existing blocked-call assertions are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)