### PR TITLE
Fix `LIMIT` in `HASH_JOIN` with recursive extend

### DIFF
--- a/src/include/optimizer/limit_push_down_optimizer.h
+++ b/src/include/optimizer/limit_push_down_optimizer.h
@@ -12,7 +12,7 @@ public:
     void rewrite(planner::LogicalPlan* plan);
 
 private:
-    void visitOperator(planner::LogicalOperator* op);
+    void visitOperator(planner::LogicalOperator* op, bool canPushLimitToHashJoin = true);
 
 private:
     common::offset_t skipNumber;

--- a/src/include/optimizer/limit_push_down_optimizer.h
+++ b/src/include/optimizer/limit_push_down_optimizer.h
@@ -9,24 +9,14 @@ class LimitPushDownOptimizer {
 public:
     LimitPushDownOptimizer() : skipNumber{0}, limitNumber{common::INVALID_LIMIT} {}
 
-    // Behavior toggle for FILTER handling. When true (default), a FILTER is a hard barrier: the
-    // push-down descent stops there, so nothing below the filter is ever capped. When false, the
-    // original behavior is restored -- the descent continues past FILTER while only suppressing
-    // the recursive-extend hash-join cap. Flip this to go back to the prior behavior without
-    // removing code.
-    explicit LimitPushDownOptimizer(bool treatFilterAsBarrier)
-        : skipNumber{0}, limitNumber{common::INVALID_LIMIT},
-          treatFilterAsBarrier{treatFilterAsBarrier} {}
-
     void rewrite(planner::LogicalPlan* plan);
 
 private:
-    void visitOperator(planner::LogicalOperator* op, bool canPushLimitToHashJoin = true);
+    void visitOperator(planner::LogicalOperator* op);
 
 private:
     common::offset_t skipNumber;
     common::offset_t limitNumber;
-    const bool treatFilterAsBarrier = true;
 };
 
 } // namespace optimizer

--- a/src/include/optimizer/limit_push_down_optimizer.h
+++ b/src/include/optimizer/limit_push_down_optimizer.h
@@ -9,6 +9,15 @@ class LimitPushDownOptimizer {
 public:
     LimitPushDownOptimizer() : skipNumber{0}, limitNumber{common::INVALID_LIMIT} {}
 
+    // Behavior toggle for FILTER handling. When true (default), a FILTER is a hard barrier: the
+    // push-down descent stops there, so nothing below the filter is ever capped. When false, the
+    // original behavior is restored -- the descent continues past FILTER while only suppressing
+    // the recursive-extend hash-join cap. Flip this to go back to the prior behavior without
+    // removing code.
+    explicit LimitPushDownOptimizer(bool treatFilterAsBarrier)
+        : skipNumber{0}, limitNumber{common::INVALID_LIMIT},
+          treatFilterAsBarrier{treatFilterAsBarrier} {}
+
     void rewrite(planner::LogicalPlan* plan);
 
 private:
@@ -17,6 +26,7 @@ private:
 private:
     common::offset_t skipNumber;
     common::offset_t limitNumber;
+    const bool treatFilterAsBarrier = true;
 };
 
 } // namespace optimizer

--- a/src/optimizer/limit_push_down_optimizer.cpp
+++ b/src/optimizer/limit_push_down_optimizer.cpp
@@ -14,6 +14,25 @@ using namespace lbug::planner;
 namespace lbug {
 namespace optimizer {
 
+// A LIMIT/SKIP cap may only be pushed through operators that never reduce the number of rows
+// they emit relative to their input (i.e. 1:1 or 1:many operators). Any operator that can
+// discard rows -- FILTER, DISTINCT, joins, aggregates, UNWIND of empty lists, etc. -- would
+// leave the parent LIMIT with too few surviving rows if a static cap were placed below it, so
+// those are hard barriers. The cap is instead applied directly to operators that support early
+// termination (TABLE_FUNCTION_CALL, DISTINCT, and the recursive extend behind its 1:1
+// property-probe join, see visitOperator below).
+static bool isPushDownSupported(planner::LogicalOperator* op) {
+    switch (op->getOperatorType()) {
+    case LogicalOperatorType::MULTIPLICITY_REDUCER:
+    case LogicalOperatorType::EXPLAIN:
+    case LogicalOperatorType::ACCUMULATE:
+    case LogicalOperatorType::PROJECTION:
+        return true;
+    default:
+        return false;
+    }
+}
+
 void LimitPushDownOptimizer::rewrite(LogicalPlan* plan) {
     visitOperator(plan->getLastOperator().get());
 }
@@ -31,20 +50,9 @@ void LimitPushDownOptimizer::visitOperator(planner::LogicalOperator* op) {
         visitOperator(limit.getChild(0).get());
         return;
     }
-    case LogicalOperatorType::MULTIPLICITY_REDUCER:
-    case LogicalOperatorType::EXPLAIN:
-    case LogicalOperatorType::ACCUMULATE:
-    case LogicalOperatorType::PROJECTION: {
-        visitOperator(op->getChild(0).get());
-        return;
-    }
-    case LogicalOperatorType::FILTER: {
-        // A filter can discard rows, so a static cap pushed below it could leave the parent LIMIT
-        // with too few surviving rows.
-        return;
-    }
     case LogicalOperatorType::TABLE_FUNCTION_CALL: {
-        if (limitNumber == INVALID_LIMIT && skipNumber == 0) {
+        // SKIP without LIMIT has no finite row demand and skip + limit may overflow.
+        if (limitNumber == INVALID_LIMIT || skipNumber >= INVALID_LIMIT - limitNumber) {
             return;
         }
         auto& tableFuncCall = op->cast<LogicalTableFunctionCall>();
@@ -54,6 +62,9 @@ void LimitPushDownOptimizer::visitOperator(planner::LogicalOperator* op) {
         return;
     }
     case LogicalOperatorType::DISTINCT: {
+        // The physical DISTINCT is capped at skip + limit distinct groups, after which the
+        // remaining LIMIT/SKIP operator on top selects the requested rows. SKIP without LIMIT
+        // must not cap DISTINCT, and skip + limit must not overflow.
         if (limitNumber == INVALID_LIMIT || skipNumber >= INVALID_LIMIT - limitNumber) {
             return;
         }
@@ -77,7 +88,7 @@ void LimitPushDownOptimizer::visitOperator(planner::LogicalOperator* op) {
         if (op->getChild(0)->getOperatorType() != LogicalOperatorType::PATH_PROPERTY_PROBE ||
             op->getChild(0)->getChild(0)->getOperatorType() !=
                 LogicalOperatorType::RECURSIVE_EXTEND ||
-            skipNumber > INVALID_LIMIT - limitNumber) {
+            skipNumber >= INVALID_LIMIT - limitNumber) {
             return;
         }
         auto& extend = op->getChild(0)->getChild(0)->cast<LogicalRecursiveExtend>();
@@ -91,8 +102,14 @@ void LimitPushDownOptimizer::visitOperator(planner::LogicalOperator* op) {
         }
         return;
     }
-    default:
+    default: {
+        // Only row-count-preserving operators let the cap pass through; FILTER and every
+        // other operator that can alter the number of rows is a barrier.
+        if (isPushDownSupported(op)) {
+            visitOperator(op->getChild(0).get());
+        }
         return;
+    }
     }
 }
 

--- a/src/optimizer/limit_push_down_optimizer.cpp
+++ b/src/optimizer/limit_push_down_optimizer.cpp
@@ -1,7 +1,6 @@
 #include "optimizer/limit_push_down_optimizer.h"
 
 #include "binder/expression/expression_util.h"
-#include "common/exception/runtime.h"
 #include "planner/operator/extend/logical_recursive_extend.h"
 #include "planner/operator/logical_distinct.h"
 #include "planner/operator/logical_hash_join.h"
@@ -19,7 +18,8 @@ void LimitPushDownOptimizer::rewrite(LogicalPlan* plan) {
     visitOperator(plan->getLastOperator().get());
 }
 
-void LimitPushDownOptimizer::visitOperator(planner::LogicalOperator* op) {
+void LimitPushDownOptimizer::visitOperator(planner::LogicalOperator* op,
+    bool canPushLimitToHashJoin) {
     switch (op->getOperatorType()) {
     case LogicalOperatorType::LIMIT: {
         auto& limit = op->constCast<LogicalLimit>();
@@ -35,9 +35,14 @@ void LimitPushDownOptimizer::visitOperator(planner::LogicalOperator* op) {
     case LogicalOperatorType::MULTIPLICITY_REDUCER:
     case LogicalOperatorType::EXPLAIN:
     case LogicalOperatorType::ACCUMULATE:
-    case LogicalOperatorType::FILTER:
     case LogicalOperatorType::PROJECTION: {
-        visitOperator(op->getChild(0).get());
+        visitOperator(op->getChild(0).get(), canPushLimitToHashJoin);
+        return;
+    }
+    case LogicalOperatorType::FILTER: {
+        // A filter between LIMIT and HASH_JOIN can reject rows after the join. A static
+        // pre-join cap could then leave the parent LIMIT with too few surviving rows.
+        visitOperator(op->getChild(0).get(), false);
         return;
     }
     case LogicalOperatorType::TABLE_FUNCTION_CALL: {
@@ -60,25 +65,24 @@ void LimitPushDownOptimizer::visitOperator(planner::LogicalOperator* op) {
         return;
     }
     case LogicalOperatorType::HASH_JOIN: {
-        if (limitNumber == INVALID_LIMIT && skipNumber == 0) {
+        if (limitNumber == INVALID_LIMIT || !canPushLimitToHashJoin) {
             return;
         }
-        if (op->getChild(0)->getOperatorType() == LogicalOperatorType::HASH_JOIN) {
-            op->ptrCast<LogicalHashJoin>()->getSIPInfoUnsafe().position = SemiMaskPosition::NONE;
-            // OP is the hash join reading destination node property. Continue push limit down.
-            op = op->getChild(0).get();
+        auto& hashJoin = op->cast<LogicalHashJoin>();
+        // The recursive-extend join created by Planner::appendRecursiveExtend is a 1:1 INNER
+        // join that reads the bound node properties back after path expansion. Only that direct
+        // shape is safe: nested joins, filtering joins, and multiplicative joins must remain
+        // barriers because their first N probe rows may produce fewer than N final rows.
+        if (hashJoin.getJoinType() != JoinType::INNER || hashJoin.requireFlatProbeKeys()) {
+            return;
         }
-        if (op->getChild(0)->getOperatorType() == LogicalOperatorType::PATH_PROPERTY_PROBE) {
-            // LCOV_EXCL_START
-            if (op->getChild(0)->getChild(0)->getOperatorType() !=
-                LogicalOperatorType::RECURSIVE_EXTEND) {
-                throw RuntimeException("Trying to push limit to a non RECURSIVE_EXTEND operator. "
-                                       "This should never happen.");
-            }
-            // LCOV_EXCL_STOP
-            auto& extend = op->getChild(0)->getChild(0)->cast<LogicalRecursiveExtend>();
-            extend.setLimitNum(skipNumber + limitNumber);
+        if (op->getChild(0)->getOperatorType() != LogicalOperatorType::PATH_PROPERTY_PROBE ||
+            op->getChild(0)->getChild(0)->getOperatorType() !=
+                LogicalOperatorType::RECURSIVE_EXTEND || skipNumber > INVALID_LIMIT - limitNumber) {
+            return;
         }
+        auto& extend = op->getChild(0)->getChild(0)->cast<LogicalRecursiveExtend>();
+        extend.setLimitNum(skipNumber + limitNumber);
         return;
     }
     case LogicalOperatorType::UNION_ALL: {

--- a/src/optimizer/limit_push_down_optimizer.cpp
+++ b/src/optimizer/limit_push_down_optimizer.cpp
@@ -78,7 +78,8 @@ void LimitPushDownOptimizer::visitOperator(planner::LogicalOperator* op,
         }
         if (op->getChild(0)->getOperatorType() != LogicalOperatorType::PATH_PROPERTY_PROBE ||
             op->getChild(0)->getChild(0)->getOperatorType() !=
-                LogicalOperatorType::RECURSIVE_EXTEND || skipNumber > INVALID_LIMIT - limitNumber) {
+                LogicalOperatorType::RECURSIVE_EXTEND ||
+            skipNumber > INVALID_LIMIT - limitNumber) {
             return;
         }
         auto& extend = op->getChild(0)->getChild(0)->cast<LogicalRecursiveExtend>();

--- a/src/optimizer/limit_push_down_optimizer.cpp
+++ b/src/optimizer/limit_push_down_optimizer.cpp
@@ -42,6 +42,12 @@ void LimitPushDownOptimizer::visitOperator(planner::LogicalOperator* op,
     case LogicalOperatorType::FILTER: {
         // A filter between LIMIT and HASH_JOIN can reject rows after the join. A static
         // pre-join cap could then leave the parent LIMIT with too few surviving rows.
+        if (treatFilterAsBarrier) {
+            // A filter can discard rows, so a static cap pushed beneath it could leave the parent
+            // LIMIT with too few surviving rows. Stop the descent: nothing below the filter is
+            // capped.
+            return;
+        }
         visitOperator(op->getChild(0).get(), false);
         return;
     }
@@ -88,7 +94,7 @@ void LimitPushDownOptimizer::visitOperator(planner::LogicalOperator* op,
     }
     case LogicalOperatorType::UNION_ALL: {
         for (auto i = 0u; i < op->getNumChildren(); ++i) {
-            auto optimizer = LimitPushDownOptimizer();
+            auto optimizer = LimitPushDownOptimizer(treatFilterAsBarrier);
             optimizer.visitOperator(op->getChild(i).get());
         }
         return;

--- a/src/optimizer/limit_push_down_optimizer.cpp
+++ b/src/optimizer/limit_push_down_optimizer.cpp
@@ -18,8 +18,7 @@ void LimitPushDownOptimizer::rewrite(LogicalPlan* plan) {
     visitOperator(plan->getLastOperator().get());
 }
 
-void LimitPushDownOptimizer::visitOperator(planner::LogicalOperator* op,
-    bool canPushLimitToHashJoin) {
+void LimitPushDownOptimizer::visitOperator(planner::LogicalOperator* op) {
     switch (op->getOperatorType()) {
     case LogicalOperatorType::LIMIT: {
         auto& limit = op->constCast<LogicalLimit>();
@@ -36,19 +35,12 @@ void LimitPushDownOptimizer::visitOperator(planner::LogicalOperator* op,
     case LogicalOperatorType::EXPLAIN:
     case LogicalOperatorType::ACCUMULATE:
     case LogicalOperatorType::PROJECTION: {
-        visitOperator(op->getChild(0).get(), canPushLimitToHashJoin);
+        visitOperator(op->getChild(0).get());
         return;
     }
     case LogicalOperatorType::FILTER: {
-        // A filter between LIMIT and HASH_JOIN can reject rows after the join. A static
-        // pre-join cap could then leave the parent LIMIT with too few surviving rows.
-        if (treatFilterAsBarrier) {
-            // A filter can discard rows, so a static cap pushed beneath it could leave the parent
-            // LIMIT with too few surviving rows. Stop the descent: nothing below the filter is
-            // capped.
-            return;
-        }
-        visitOperator(op->getChild(0).get(), false);
+        // A filter can discard rows, so a static cap pushed below it could leave the parent LIMIT
+        // with too few surviving rows.
         return;
     }
     case LogicalOperatorType::TABLE_FUNCTION_CALL: {
@@ -71,7 +63,7 @@ void LimitPushDownOptimizer::visitOperator(planner::LogicalOperator* op,
         return;
     }
     case LogicalOperatorType::HASH_JOIN: {
-        if (limitNumber == INVALID_LIMIT || !canPushLimitToHashJoin) {
+        if (limitNumber == INVALID_LIMIT) {
             return;
         }
         auto& hashJoin = op->cast<LogicalHashJoin>();
@@ -94,7 +86,7 @@ void LimitPushDownOptimizer::visitOperator(planner::LogicalOperator* op,
     }
     case LogicalOperatorType::UNION_ALL: {
         for (auto i = 0u; i < op->getNumChildren(); ++i) {
-            auto optimizer = LimitPushDownOptimizer(treatFilterAsBarrier);
+            auto optimizer = LimitPushDownOptimizer();
             optimizer.visitOperator(op->getChild(i).get());
         }
         return;

--- a/src/optimizer/limit_push_down_optimizer.cpp
+++ b/src/optimizer/limit_push_down_optimizer.cpp
@@ -54,7 +54,7 @@ void LimitPushDownOptimizer::visitOperator(planner::LogicalOperator* op) {
         return;
     }
     case LogicalOperatorType::DISTINCT: {
-        if (limitNumber == INVALID_LIMIT && skipNumber == 0) {
+        if (limitNumber == INVALID_LIMIT || skipNumber >= INVALID_LIMIT - limitNumber) {
             return;
         }
         auto& distinctOp = op->cast<LogicalDistinct>();

--- a/src/processor/map/map_distinct.cpp
+++ b/src/processor/map/map_distinct.cpp
@@ -14,15 +14,19 @@ std::unique_ptr<PhysicalOperator> PlanMapper::mapDistinct(const LogicalOperator*
     auto outSchema = distinct->getSchema();
     auto inSchema = child->getSchema();
     auto prevOperator = mapOperator(child);
-    uint64_t limitNum = 0;
+    uint64_t limitNum = UINT64_MAX;
     if (distinct->hasLimitNum()) {
-        limitNum += distinct->getLimitNum();
-    }
-    if (distinct->hasSkipNum()) {
-        limitNum += distinct->getSkipNum();
-    }
-    if (limitNum == 0) {
-        limitNum = UINT64_MAX;
+        limitNum = distinct->getLimitNum();
+        if (distinct->hasSkipNum()) {
+            if (distinct->getSkipNum() >= UINT64_MAX - limitNum) {
+                limitNum = UINT64_MAX;
+            } else {
+                limitNum += distinct->getSkipNum();
+            }
+        }
+        if (limitNum == 0) {
+            limitNum = UINT64_MAX;
+        }
     }
     auto op = createDistinctHashAggregate(distinct->getKeys(), distinct->getPayloads(), inSchema,
         outSchema, std::move(prevOperator));

--- a/test/test_files/generic_hash_join/limit.test
+++ b/test/test_files/generic_hash_join/limit.test
@@ -1,0 +1,45 @@
+-DATASET CSV empty
+
+--
+
+-CASE LimitHashJoinRecursiveExtend
+-STATEMENT CREATE NODE TABLE Frame(id INT64, PRIMARY KEY(id));
+---- ok
+-STATEMENT CREATE NODE TABLE Page(id INT64, PRIMARY KEY(id));
+---- ok
+-STATEMENT CREATE NODE TABLE Collection(id INT64, PRIMARY KEY(id));
+---- ok
+-STATEMENT CREATE REL TABLE Child(FROM Frame TO Page, FROM Frame TO Collection, FROM Collection TO Page);
+---- ok
+-STATEMENT UNWIND range(0, 9) AS id CREATE (:Frame {id: id});
+---- ok
+-STATEMENT UNWIND range(100, 109) AS id CREATE (:Frame {id: id});
+---- ok
+-STATEMENT CREATE (:Page {id: 1});
+---- ok
+-STATEMENT UNWIND range(0, 9) AS id CREATE (:Collection {id: id});
+---- ok
+-STATEMENT MATCH (f:Frame), (g:Collection) WHERE f.id = g.id CREATE (f)-[:Child]->(g);
+---- ok
+-STATEMENT MATCH (g:Collection), (p:Page {id: 1}) CREATE (g)-[:Child]->(p);
+---- ok
+-STATEMENT MATCH (f:Frame), (p:Page {id: 1}) WHERE f.id >= 100 CREATE (f)-[:Child]->(p);
+---- ok
+-STATEMENT MATCH (a:Frame)-[:Child]->(:Page), (a:Frame)-[:Child*1..]->(b) WITH a.id AS id LIMIT 5 RETURN count(*) AS rows;
+---- 1
+5
+-STATEMENT MATCH (a:Frame)-[r:Child*1..]->(b) WITH a.id AS id LIMIT 5 RETURN count(*) AS rows;
+---- 1
+5
+-STATEMENT MATCH (a:Frame)-[r:Child*1..]->(b) WITH a.id AS id SKIP 3 LIMIT 5 RETURN count(*) AS rows;
+---- 1
+5
+-STATEMENT MATCH (a:Frame)-[r:Child*1..]->(b) WITH a.id AS id SKIP 10 RETURN count(*) AS rows;
+---- 1
+20
+-STATEMENT MATCH (a:Frame) WHERE a.id >= 100 WITH a MATCH (a)-[r:Child*1..]->(b) WITH a.id AS id LIMIT 5 RETURN count(*) AS rows;
+---- 1
+5
+-STATEMENT MATCH (a:Frame)-[r:Child*1..]->(b) WHERE length(r) = 2 WITH a.id AS id LIMIT 5 RETURN count(*) AS rows;
+---- 1
+5

--- a/test/test_files/generic_hash_join/limit_tinysnb.test
+++ b/test/test_files/generic_hash_join/limit_tinysnb.test
@@ -1,0 +1,17 @@
+-DATASET CSV tinysnb
+--
+
+-CASE SkipOnlyMustNotCapRecursiveExtend
+-LOG SKIP without LIMIT has no finite row demand and must not cap recursive extend
+-STATEMENT MATCH (a:person)-[r:knows*1..2]->(b) RETURN CASE WHEN a.ID >= 0 THEN 1 ELSE 0 END AS marker SKIP 48;
+---- 2
+1
+1
+
+-CASE LimitAboveFilterMustNotCapRecursiveExtend
+-LOG Rows rejected by FILTER must not count toward the outer LIMIT
+-STATEMENT MATCH (a:person)-[r:knows*1..3]->(b) WHERE length(r) = 2 RETURN CASE WHEN a.ID >= 0 THEN 1 ELSE 0 END AS marker LIMIT 3;
+---- 3
+1
+1
+1

--- a/test/test_files/projection/limit_push_down.test
+++ b/test/test_files/projection/limit_push_down.test
@@ -1,0 +1,26 @@
+-DATASET CSV tinysnb
+--
+
+-CASE FilterMustBlockDistinctLimitPushDown
+-LOG Rows filtered after DISTINCT must not count toward the outer LIMIT
+-STATEMENT UNWIND [0, 1, 100, 101] AS age WITH DISTINCT age WHERE age >= 100 RETURN age LIMIT 2;
+---- 2
+100
+101
+
+-CASE DistinctWithSkipAndLimitReturnsRows
+-LOG DISTINCT with finite SKIP and LIMIT returns the requested rows
+-STATEMENT MATCH (a:person) WITH DISTINCT a.age AS age SKIP 2 LIMIT 2 RETURN CASE WHEN age >= 0 THEN 1 ELSE 0 END AS marker;
+---- 2
+1
+1
+
+-CASE SkipOnlyMustNotCapDistinct
+-LOG SKIP without LIMIT has no finite row demand and must not cap DISTINCT
+-STATEMENT MATCH (a:person) WITH DISTINCT a.age AS age SKIP 2 RETURN CASE WHEN age >= 0 THEN 1 ELSE 0 END AS marker;
+---- 5
+1
+1
+1
+1
+1


### PR DESCRIPTION
`LIMIT` pushdown can currently cross a query hash join above recursive extend without proving that rows can survive the join. A `LIMIT 5` might stop recursive expansion after five candidate rows, but if a hash join or filter rejects one of them, the query will return only four rows even though more matching rows exist. 

This PR pushes down a finite, overflow-safe `SKIP` + `LIMIT` only through the direct one-to-one inner rejoin generated for recursive extend. Intervening filters and all other hash joins block this pushdown, allowing recursion to continue until enough rows reach the outer limit. `SKIP` without `LIMIT` does not create a recursive cap.

I added several regression tests to cover the original join failure, filtered paths, and `SKIP` queries.

---

**Update**: Another test for a DISTINCT + SKIP case:

```cypher
MATCH (a:person)
WITH DISTINCT a.age AS age
SKIP 2
RETURN ...;
```
Tinysnb contains seven distinct ages, so the correct result contains five rows. However, the optimizer was doing this:

1. Read `SKIP 2`.
2. Leave limitNumber equal to `INVALID_LIMIT`.
3. Annotate `LogicalDistinct` with the skip value anyway.
4. Let `mapDistinct` calculate a physical cap from the available fields.

`mapDistinct` started its calculation at zero:
`cap = 0`
 no finite `LIMIT`, so add nothing
`SKIP` is 2, so `cap = 2`

The physical `DISTINCT` stopped after collecting two distinct values. The real outer SKIP then discarded those two values:

DISTINCT produces 2 rows + SKIP discards 2 rows => result contains 0 rows 💥




