### PR TITLE
fix: record rel change epoch even when CSR materialization fails

### DIFF
--- a/src/function/table/project_native_graph.cpp
+++ b/src/function/table/project_native_graph.cpp
@@ -95,8 +95,11 @@ static void materializeRelCsr(ParsedNativeGraphEntry& entry, main::ClientContext
             entry.relCsrEpochs.push_back(epoch);
         } else {
             // Shape not tracked (or scan failed): this rel stays unmaterialized.
+            // Record the captured epoch anyway — it is the table's change epoch at projection
+            // time, even without a materialized CSR. Consumers check relCsrResults[i] for null
+            // to decide whether to use the pinned CSR or fall back to scanning storage.
             entry.relCsrResults.push_back(nullptr);
-            entry.relCsrEpochs.push_back(0);
+            entry.relCsrEpochs.push_back(epoch);
         }
     }
 }


### PR DESCRIPTION
## Summary

The epoch capture in  correctly reads each rel table's storage changeEpoch before the materializing scan, but only stored it on the success path (). On Windows/MSVC, the inner query's scan can produce edges in an order that invalidates the per-batch CSR metadata, causing  to return false. When that happened, the else branch pushed  for the epoch instead of the captured value, making it appear as if no epoch was ever captured.

## Fix

Always push the captured epoch, regardless of whether CSR materialization succeeded. Consumers already check  for  to decide whether a pinned CSR is available; the epoch is still meaningful for staleness detection even without a materialized CSR.

## Testing

- Test passes on macOS (local), Linux (CI), and Windows (CI)
- Existing  now passes on Windows

Fixes: #814