### PR TITLE
add llm AI EXTRACT extension feature

### DIFF
--- a/src/common/task_system/task_scheduler.cpp
+++ b/src/common/task_system/task_scheduler.cpp
@@ -41,8 +41,13 @@ TaskScheduler::~TaskScheduler() {
 
 void TaskScheduler::scheduleTaskAndWaitOrError(const std::shared_ptr<Task>& task,
     processor::ExecutionContext* context, bool launchNewWorkerThread) {
+    scheduleTaskAndWaitOrError(task, context->clientContext, launchNewWorkerThread);
+}
+
+void TaskScheduler::scheduleTaskAndWaitOrError(const std::shared_ptr<Task>& task,
+    main::ClientContext* clientContext, bool launchNewWorkerThread) {
     for (auto& dependency : task->children) {
-        scheduleTaskAndWaitOrError(dependency, context);
+        scheduleTaskAndWaitOrError(dependency, clientContext);
         if (dependency->terminate()) {
             return;
         }
@@ -71,16 +76,16 @@ void TaskScheduler::scheduleTaskAndWaitOrError(const std::shared_ptr<Task>& task
             taskLck.unlock();
             break;
         }
-        if (context->clientContext->hasTimeout()) {
-            timeout = context->clientContext->getTimeoutRemainingInMS();
+        if (clientContext->hasTimeout()) {
+            timeout = clientContext->getTimeoutRemainingInMS();
             if (timeout == 0) {
-                context->clientContext->interrupt();
+                clientContext->interrupt();
             } else {
                 timedWait = true;
             }
         } else if (task->hasExceptionNoLock()) {
             // Interrupt tasks that errored, so other threads can stop working on them early.
-            context->clientContext->interrupt();
+            clientContext->interrupt();
         }
         if (timedWait) {
             task->cv.wait_for(taskLck, std::chrono::milliseconds(timeout));
@@ -152,9 +157,14 @@ TaskScheduler::~TaskScheduler() {
 }
 
 void TaskScheduler::scheduleTaskAndWaitOrError(const std::shared_ptr<Task>& task,
-    processor::ExecutionContext* context, bool) {
+    processor::ExecutionContext* context, bool launchNewWorkerThread) {
+    scheduleTaskAndWaitOrError(task, context->clientContext, launchNewWorkerThread);
+}
+
+void TaskScheduler::scheduleTaskAndWaitOrError(const std::shared_ptr<Task>& task,
+    main::ClientContext* clientContext, bool) {
     for (auto& dependency : task->children) {
-        scheduleTaskAndWaitOrError(dependency, context);
+        scheduleTaskAndWaitOrError(dependency, clientContext);
         if (dependency->terminate()) {
             return;
         }

--- a/src/include/common/task_system/task_scheduler.h
+++ b/src/include/common/task_system/task_scheduler.h
@@ -56,6 +56,8 @@ public:
     // thread will be working on the given task.
     void scheduleTaskAndWaitOrError(const std::shared_ptr<Task>& task,
         processor::ExecutionContext* context, bool launchNewWorkerThread = false);
+    void scheduleTaskAndWaitOrError(const std::shared_ptr<Task>& task,
+        main::ClientContext* clientContext, bool launchNewWorkerThread = false);
 
     static TaskScheduler* Get(const main::ClientContext& context);
 
@@ -90,6 +92,8 @@ public:
 
     void scheduleTaskAndWaitOrError(const std::shared_ptr<Task>& task,
         processor::ExecutionContext* context, bool launchNewWorkerThread = false);
+    void scheduleTaskAndWaitOrError(const std::shared_ptr<Task>& task,
+        main::ClientContext* clientContext, bool launchNewWorkerThread = false);
 
     static TaskScheduler* Get(const main::ClientContext& context);
 


### PR DESCRIPTION
  ## Refactor: add `ClientContext` overload of `TaskScheduler::scheduleTaskAndWaitOrError`

   ### Summary
   Adds a `scheduleTaskAndWaitOrError` overload that takes a `main::ClientContext*`
   directly, so task scheduling no longer requires a `processor::ExecutionContext`.
   The existing `ExecutionContext` overload now simply delegates to the new one.

   ### Motivation / Context
   Groundwork for the LLM "AI EXTRACT" extension: the extraction pipeline may need
   to schedule and await tasks extending beyond the regular execution context. Callers
   who only hold a `ClientContext` (no `ExecutionContext` in scope) can now use the
   scheduler without building a fake context. This is the groundwork refactor; the
   AI EXTRACT extension itself will land in a follow-up commit.
