### PR TITLE
fix(simd): build NEON lane-mask weights without brace init on MSVC

### DIFF
--- a/src/function/simd_filter_neon.cpp
+++ b/src/function/simd_filter_neon.cpp
@@ -223,15 +223,20 @@ template<typename T, typename MASK>
 uint32_t toLaneMask(MASK mask) {
     if constexpr (sizeof(T) == 1) {
         const auto bits = vshrq_n_u8(mask, 7);
-        const uint8x8_t weights = {1, 2, 4, 8, 16, 32, 64, 128};
+        // MSVC ARM64 maps NEON vector types to __n64/__n128, which cannot take brace
+        // initializers (C2078), so build the {1, 2, 4, 8, 16, 32, 64, 128} lane weights
+        // from a bit pattern instead.
+        const auto weights = vcreate_u8(0x8040201008040201ULL);
         const auto low = vaddv_u8(vmul_u8(vget_low_u8(bits), weights));
         const auto high = vaddv_u8(vmul_u8(vget_high_u8(bits), weights));
         return static_cast<uint32_t>(low) | (static_cast<uint32_t>(high) << 8);
     } else if constexpr (sizeof(T) == 2) {
-        const uint16x8_t weights = {1, 2, 4, 8, 16, 32, 64, 128};
+        const auto weights =
+            vcombine_u16(vcreate_u16(0x0008000400020001ULL), vcreate_u16(0x0080004000200010ULL));
         return vaddvq_u16(vmulq_u16(vshrq_n_u16(mask, 15), weights));
     } else if constexpr (sizeof(T) == 4) {
-        const uint32x4_t weights = {1, 2, 4, 8};
+        const auto weights =
+            vcombine_u32(vcreate_u32(0x0000000200000001ULL), vcreate_u32(0x0000000800000004ULL));
         return vaddvq_u32(vmulq_u32(vshrq_n_u32(mask, 31), weights));
     } else {
         const auto bits = vshrq_n_u64(mask, 63);


### PR DESCRIPTION
## Problem

Recent SIMD filter kernels (`70f8828c5`, `d187dd03c`) break Windows ARM64 builds. MSVC fails compiling `src/function/simd_filter_neon.cpp`:

```
simd_filter_neon.cpp(226): error C2078: too many initializers
simd_filter_neon.cpp(231): error C2078: too many initializers
simd_filter_neon.cpp(234): error C2078: too many initializers
```

## Root cause

MSVC ARM64 maps the NEON vector types (`uint8x8_t`, `uint16x8_t`, `uint32x4_t`, ...) to the intrinsic `__n64`/`__n128` types, which cannot be initialized with scalar brace lists (same known issue as xtensor-stack/xsimd#611). The lane-mask weights `{1, 2, 4, 8, ...}` in `toLaneMask` were constructed with `= {...}` initializers.

## Fix

Build the weights from bit patterns using `vcreate_u8` / `vcreate_u16` / `vcreate_u32` + `vcombine`, which is portable across GCC, Clang, and MSVC:

- `uint8x8_t`: `vcreate_u8(0x8040201008040201ULL)` → `{1,2,4,8,16,32,64,128}`
- `uint16x8_t`: `vcombine_u16(vcreate_u16(...), vcreate_u16(...))` → `{1,...,128}`
- `uint32x4_t`: `vcombine_u32(vcreate_u32(...), vcreate_u32(...))` → `{1,2,4,8}`

## Verification

- Lane-mask extraction verified against scalar reference on ARM64 (all single-lane, full, and mixed patterns).
- `SIMDFilterTest.*` (4 tests) pass locally on ARM64.
- `ci-workflow.yml` with `platform=windows` — Build and Test steps pass on the Windows ARM64 runner.
- clang-format-18 clean.