### PR TITLE
fix: icebug disk can now read zstd + dictionary RLE compressed parquet

### DIFF
--- a/src/include/processor/operator/persistent/reader/parquet/parquet_reader.h
+++ b/src/include/processor/operator/persistent/reader/parquet/parquet_reader.h
@@ -29,6 +29,11 @@ struct ParquetReaderScanState {
 
     bool finished = false;
 
+    // Range-limited scan support: rows to skip at the start of the first scanned row
+    // group, and the total number of rows to emit (UINT64_MAX means "scan to end").
+    uint64_t rowsToSkip = 0;
+    uint64_t rowsRemaining = UINT64_MAX;
+
     ResizeableBuffer defineBuf;
     ResizeableBuffer repeatBuf;
 
@@ -43,7 +48,7 @@ public:
     ~ParquetReader() = default;
 
     void initializeScan(ParquetReaderScanState& state, std::vector<uint64_t> groups_to_read,
-        common::VirtualFileSystem* vfs);
+        common::VirtualFileSystem* vfs, uint64_t skipRows = 0, uint64_t numRows = UINT64_MAX);
     bool scanInternal(ParquetReaderScanState& state, common::DataChunk& result);
     void scan(ParquetReaderScanState& state, common::DataChunk& result);
     uint64_t getNumRowGroups() { return metadata->row_groups.size(); }

--- a/src/include/processor/operator/persistent/reader/parquet/struct_column_reader.h
+++ b/src/include/processor/operator/persistent/reader/parquet/struct_column_reader.h
@@ -20,11 +20,11 @@ public:
     uint64_t read(uint64_t num_values, parquet_filter_t& filter, uint8_t* define_out,
         uint8_t* repeat_out, common::ValueVector* result) override;
     ColumnReader* getChildReader(uint64_t childIdx);
+    void skip(uint64_t num_values) override;
 
 private:
     uint64_t getTotalCompressedSize() override;
     void registerPrefetch(ThriftFileTransport& transport, bool allow_merge) override;
-    void skip(uint64_t num_values) override;
     uint64_t getGroupRowsAvailable() override;
 
 private:

--- a/src/include/processor/operator/persistent/reader/parquet/templated_column_reader.h
+++ b/src/include/processor/operator/persistent/reader/parquet/templated_column_reader.h
@@ -55,11 +55,6 @@ public:
             result->setNull(rowIdx + resultOffset, false);
             if (filter[rowIdx + resultOffset]) {
                 VALUE_TYPE val = VALUE_CONVERSION::dictRead(*dict, offsets[offsetIdx++], *this);
-                if (rowIdx == 0 && resultOffset == 1048576 % numValues) {
-                    fprintf(stderr, "[DBG] offsets resultOffset=%lu off0=%u dict.ptr=%p val=%llu\n",
-                        (unsigned long)resultOffset, offsets[offsetIdx-1], (void*)dict->ptr,
-                        (unsigned long long)val);
-                }
                 result->setValue(rowIdx + resultOffset, val);
             } else {
                 offsetIdx++;
@@ -76,9 +71,6 @@ public:
     void dictionary(const std::shared_ptr<ResizeableBuffer>& data,
         uint64_t /*num_entries*/) override {
         dict = data;
-        fprintf(stderr, "[DBG] dictionary fileIdx=%lu dict.ptr=%p len=%lu firstval=%llu\n",
-            (unsigned long)fileIdx, (void*)dict->ptr, (unsigned long)dict->len,
-            (unsigned long long)((VALUE_TYPE*)dict->ptr)[0]);
     }
 };
 

--- a/src/include/processor/operator/persistent/reader/parquet/templated_column_reader.h
+++ b/src/include/processor/operator/persistent/reader/parquet/templated_column_reader.h
@@ -55,6 +55,11 @@ public:
             result->setNull(rowIdx + resultOffset, false);
             if (filter[rowIdx + resultOffset]) {
                 VALUE_TYPE val = VALUE_CONVERSION::dictRead(*dict, offsets[offsetIdx++], *this);
+                if (rowIdx == 0 && resultOffset == 1048576 % numValues) {
+                    fprintf(stderr, "[DBG] offsets resultOffset=%lu off0=%u dict.ptr=%p val=%llu\n",
+                        (unsigned long)resultOffset, offsets[offsetIdx-1], (void*)dict->ptr,
+                        (unsigned long long)val);
+                }
                 result->setValue(rowIdx + resultOffset, val);
             } else {
                 offsetIdx++;
@@ -71,6 +76,9 @@ public:
     void dictionary(const std::shared_ptr<ResizeableBuffer>& data,
         uint64_t /*num_entries*/) override {
         dict = data;
+        fprintf(stderr, "[DBG] dictionary fileIdx=%lu dict.ptr=%p len=%lu firstval=%llu\n",
+            (unsigned long)fileIdx, (void*)dict->ptr, (unsigned long)dict->len,
+            (unsigned long long)((VALUE_TYPE*)dict->ptr)[0]);
     }
 };
 

--- a/src/processor/operator/persistent/reader/parquet/column_reader.cpp
+++ b/src/processor/operator/persistent/reader/parquet/column_reader.cpp
@@ -62,9 +62,6 @@ void ColumnReader::initializeRead(uint64_t /*rowGroupIdx*/,
         chunkReadOffset = chunk->meta_data.dictionary_page_offset;
     }
     groupRowsAvailable = chunk->meta_data.num_values;
-    fprintf(stderr, "[DBG] initializeRead fileIdx=%lu groupRowsAvail=%lu pageRowsAvail=%lu chunkReadOff=%lu\n",
-        (unsigned long)fileIdx, (unsigned long)groupRowsAvailable,
-        (unsigned long)pageRowsAvailable, (unsigned long)chunkReadOffset);
 }
 
 void ColumnReader::registerPrefetch(ThriftFileTransport& transport, bool allowMerge) {
@@ -280,13 +277,8 @@ void ColumnReader::prepareRead(parquet_filter_t& /*filter*/) {
     dictDecoder.reset();
     defineDecoder.reset();
     block.reset();
-    auto beforeOff =
-        reinterpret_cast<ThriftFileTransport&>(*protocol->getTransport()).GetLocation();
     lbug_parquet::format::PageHeader pageHdr;
     pageHdr.read(protocol);
-    fprintf(stderr, "[DBG] prepareRead fileIdx=%lu off=%lu type=%d pageRowsAvail=%lu\n",
-        (unsigned long)fileIdx, (unsigned long)beforeOff, (int)pageHdr.type,
-        (unsigned long)pageRowsAvailable);
     switch (pageHdr.type) {
     case PageType::DATA_PAGE_V2:
         preparePageV2(pageHdr);

--- a/src/processor/operator/persistent/reader/parquet/column_reader.cpp
+++ b/src/processor/operator/persistent/reader/parquet/column_reader.cpp
@@ -35,7 +35,11 @@ ColumnReader::ColumnReader(ParquetReader& reader, LogicalType type,
     uint64_t maxRepeat)
     : schema{schema}, fileIdx{fileIdx}, maxDefine{maxDefinition}, maxRepeat{maxRepeat},
       reader{reader}, type{std::move(type)}, protocol(nullptr), pageRowsAvailable{0},
-      groupRowsAvailable(0), chunkReadOffset(0) {}
+      groupRowsAvailable(0), chunkReadOffset(0) {
+    // Buffers used by applyPendingSkips() (row skipping for range-limited scans).
+    dummyDefine.resize(DEFAULT_VECTOR_CAPACITY);
+    dummyRepeat.resize(DEFAULT_VECTOR_CAPACITY);
+}
 
 void ColumnReader::initializeRead(uint64_t /*rowGroupIdx*/,
     const std::vector<lbug_parquet::format::ColumnChunk>& columns,
@@ -58,6 +62,9 @@ void ColumnReader::initializeRead(uint64_t /*rowGroupIdx*/,
         chunkReadOffset = chunk->meta_data.dictionary_page_offset;
     }
     groupRowsAvailable = chunk->meta_data.num_values;
+    fprintf(stderr, "[DBG] initializeRead fileIdx=%lu groupRowsAvail=%lu pageRowsAvail=%lu chunkReadOff=%lu\n",
+        (unsigned long)fileIdx, (unsigned long)groupRowsAvailable,
+        (unsigned long)pageRowsAvailable, (unsigned long)chunkReadOffset);
 }
 
 void ColumnReader::registerPrefetch(ThriftFileTransport& transport, bool allowMerge) {
@@ -273,9 +280,13 @@ void ColumnReader::prepareRead(parquet_filter_t& /*filter*/) {
     dictDecoder.reset();
     defineDecoder.reset();
     block.reset();
+    auto beforeOff =
+        reinterpret_cast<ThriftFileTransport&>(*protocol->getTransport()).GetLocation();
     lbug_parquet::format::PageHeader pageHdr;
     pageHdr.read(protocol);
-
+    fprintf(stderr, "[DBG] prepareRead fileIdx=%lu off=%lu type=%d pageRowsAvail=%lu\n",
+        (unsigned long)fileIdx, (unsigned long)beforeOff, (int)pageHdr.type,
+        (unsigned long)pageRowsAvailable);
     switch (pageHdr.type) {
     case PageType::DATA_PAGE_V2:
         preparePageV2(pageHdr);

--- a/src/processor/operator/persistent/reader/parquet/parquet_reader.cpp
+++ b/src/processor/operator/persistent/reader/parquet/parquet_reader.cpp
@@ -30,11 +30,14 @@ ParquetReader::ParquetReader(std::string filePath, std::vector<bool> columnSkips
 }
 
 void ParquetReader::initializeScan(ParquetReaderScanState& state,
-    std::vector<uint64_t> groups_to_read, VirtualFileSystem* vfs) {
+    std::vector<uint64_t> groups_to_read, VirtualFileSystem* vfs, uint64_t skipRows,
+    uint64_t numRows) {
     state.currentGroup = -1;
     state.finished = false;
     state.groupOffset = 0;
     state.groupIdxList = std::move(groups_to_read);
+    state.rowsToSkip = skipRows;
+    state.rowsRemaining = numRows;
     if (!state.fileInfo || state.fileInfo->path != filePath) {
         state.prefetchMode = true;
         state.fileInfo =
@@ -121,11 +124,24 @@ bool ParquetReader::scanInternal(ParquetReaderScanState& state, DataChunk& resul
                 trans.PrefetchRegistered();
             }
         }
+
+        // Range-limited scans: skip rows at the start of the first scanned row group. The
+        // skip is queued on every column reader and consumed by the first read() call.
+        if (state.rowsToSkip > 0) {
+            auto& group = getGroup(state);
+            const auto skipNow = std::min<uint64_t>(state.rowsToSkip, group.num_rows);
+            auto rootReader = dynamic_cast_checked<StructColumnReader*>(state.rootReader.get());
+            rootReader->skip(skipNow);
+            state.groupOffset += skipNow;
+            state.rowsToSkip -= skipNow;
+        }
         return true;
     }
 
     auto thisOutputChunkRows =
         std::min<uint64_t>(DEFAULT_VECTOR_CAPACITY, getGroup(state).num_rows - state.groupOffset);
+    // Respect the range-limited scan's row budget.
+    thisOutputChunkRows = std::min<uint64_t>(thisOutputChunkRows, state.rowsRemaining);
     result.state->getSelVectorUnsafe().setSelSize(thisOutputChunkRows);
 
     if (thisOutputChunkRows == 0) {
@@ -169,6 +185,7 @@ bool ParquetReader::scanInternal(ParquetReaderScanState& state, DataChunk& resul
     }
 
     state.groupOffset += thisOutputChunkRows;
+    state.rowsRemaining -= thisOutputChunkRows;
     return true;
 }
 

--- a/src/processor/operator/persistent/reader/parquet/parquet_reader.cpp
+++ b/src/processor/operator/persistent/reader/parquet/parquet_reader.cpp
@@ -59,6 +59,9 @@ bool ParquetReader::scanInternal(ParquetReaderScanState& state, DataChunk& resul
     if (state.currentGroup < 0 || (int64_t)state.groupOffset >= getGroup(state).num_rows) {
         state.currentGroup++;
         state.groupOffset = 0;
+        // No rows are produced by a row-group switch; make sure callers do not see a stale
+        // selection size (and re-process the previous chunk's data).
+        result.state->getSelVectorUnsafe().setSelSize(0);
 
         auto& trans =
             dynamic_cast_checked<ThriftFileTransport&>(*state.thriftFileProto->getTransport());

--- a/src/storage/table/ice_disk_rel_table.cpp
+++ b/src/storage/table/ice_disk_rel_table.cpp
@@ -1,5 +1,6 @@
 #include "storage/table/ice_disk_rel_table.h"
 
+#include <algorithm>
 #include <filesystem>
 #include <queue>
 
@@ -150,8 +151,61 @@ void IceDiskRelTable::initScanState(Transaction* transaction, TableScanState& sc
     }
 
     iceDiskScanState.reset(std::move(boundNodeOffsets));
-    iceDiskScanState.indicesReader->initializeScan(*iceDiskScanState.parquetScanState,
-        rowGroupsToProcess, vfs);
+
+    // Range-limit the indices scan to the file rows that can possibly contain edges of this
+    // bound-node batch. The indices file is CSR-sorted by source node, so the edges of nodes
+    // [minNode, maxNode] live in rows [indptr[minNode], indptr[maxNode + 1]). Scanning only
+    // those rows turns a full-query scan from O(#batches * #edges) into O(#edges) total.
+    // This only applies in the FWD direction (for BWD the bound nodes are targets whose rows
+    // are scattered throughout the file) and when the indptr has been loaded.
+    bool rangeLimited = false;
+    uint64_t startRow = 0;
+    uint64_t numRows = UINT64_MAX;
+    if (layout == IceDiskRelTableLayout::CSR &&
+        iceDiskScanState.direction == RelDataDirection::FWD && !indptrData.empty() &&
+        !iceDiskScanState.boundNodeOffsets.empty()) {
+        common::offset_t minNode = std::numeric_limits<common::offset_t>::max();
+        common::offset_t maxNode = 0;
+        for (auto& entry : iceDiskScanState.boundNodeOffsets) {
+            minNode = std::min(minNode, entry.first);
+            maxNode = std::max(maxNode, entry.first);
+        }
+        // indptr has #nodes + 1 entries; node i's edges span [indptr[i], indptr[i + 1]).
+        if ((uint64_t)minNode + 1 < indptrData.size()) {
+            auto endIdx = std::min<uint64_t>((uint64_t)maxNode + 1, indptrData.size() - 1);
+            startRow = (uint64_t)indptrData[minNode];
+            numRows = (uint64_t)indptrData[endIdx] - startRow;
+            rangeLimited = true;
+        }
+    }
+
+    if (rangeLimited) {
+        // Select only the row groups overlapping [startRow, startRow + numRows).
+        std::vector<uint64_t> groups;
+        uint64_t running = 0;
+        uint64_t firstGroupStart = 0;
+        for (uint64_t i = 0; i < numRowGroups && running < startRow + numRows; ++i) {
+            auto groupNumRows =
+                (uint64_t)iceDiskScanState.indicesReader->getMetadata()->row_groups[i].num_rows;
+            if (startRow < running + groupNumRows && startRow + numRows > running) {
+                if (groups.empty()) {
+                    firstGroupStart = running;
+                }
+                groups.push_back(i);
+            }
+            running += groupNumRows;
+        }
+        auto skipRows = startRow > firstGroupStart ? startRow - firstGroupStart : 0;
+        // Global row indices of the first scanned row, used by scanCSR to map each edge row
+        // back to its source node via the indptr.
+        iceDiskScanState.currentBatchStartOffset = (common::offset_t)startRow;
+        iceDiskScanState.indicesReader->initializeScan(*iceDiskScanState.parquetScanState,
+            std::move(groups), vfs, skipRows, numRows);
+    } else {
+        iceDiskScanState.currentBatchStartOffset = 0;
+        iceDiskScanState.indicesReader->initializeScan(*iceDiskScanState.parquetScanState,
+            std::move(rowGroupsToProcess), vfs, 0, UINT64_MAX);
+    }
 }
 
 void IceDiskRelTable::initializeParquetReaders(Transaction* transaction) const {


### PR DESCRIPTION
Fixes: #820 