### PR TITLE
perf(ice-disk): replace per-row binary search with a monotonic CSR cursor

### DIFF
--- a/src/include/storage/table/ice_disk_rel_table.h
+++ b/src/include/storage/table/ice_disk_rel_table.h
@@ -29,6 +29,11 @@ struct IceDiskRelTableScanState final : RelTableScanState {
     std::unordered_map<common::offset_t, common::sel_t>
         boundNodeOffsets; // Map from bound node offset to selection vector index
 
+    // Monotonic cursor into the indptr array for CSR scans. Since rows are examined in
+    // increasing global (CSR) order, the source node of the current row is found by advancing
+    // this cursor (O(1) amortized) instead of a binary search per row.
+    common::offset_t csrSrcNodeIdx = 0;
+
     // Per-scan-state readers for thread safety
     std::unique_ptr<processor::ParquetReader> indicesReader;
     std::unique_ptr<processor::ParquetReader> indptrReader;
@@ -94,7 +99,6 @@ private:
     void initializeParquetReaders(transaction::Transaction* transaction) const;
     void initializeIndptrReader(transaction::Transaction* transaction) const;
     void loadIndptrData(transaction::Transaction* transaction) const;
-    common::offset_t findSourceNodeForRow(common::offset_t globalRowIdx) const;
     bool scanCSR(transaction::Transaction* transaction, IceDiskRelTableScanState& scanState);
     bool scanFlat(transaction::Transaction* transaction, IceDiskRelTableScanState& scanState);
 };

--- a/src/storage/table/ice_disk_rel_table.cpp
+++ b/src/storage/table/ice_disk_rel_table.cpp
@@ -206,6 +206,18 @@ void IceDiskRelTable::initScanState(Transaction* transaction, TableScanState& sc
         iceDiskScanState.indicesReader->initializeScan(*iceDiskScanState.parquetScanState,
             std::move(rowGroupsToProcess), vfs, 0, UINT64_MAX);
     }
+
+    // Re-anchor the monotonic CSR source-node cursor to the node that contains the first
+    // scanned row of this batch. scanCSR advances the cursor strictly forward while reading
+    // rows, which is only valid within a single batch because the underlying indices file is
+    // read strictly forward. Bound-node batches are NOT guaranteed to arrive in increasing
+    // offset order (hash joins and other reordered inputs feed arbitrary batches), so the
+    // cursor must be repositioned per batch rather than carried across the whole query.
+    if (layout == IceDiskRelTableLayout::CSR && !indptrData.empty() &&
+        iceDiskScanState.currentBatchStartOffset < indptrData.back()) {
+        iceDiskScanState.csrSrcNodeIdx =
+            findSourceNodeForRowInternal(iceDiskScanState.currentBatchStartOffset, indptrData);
+    }
 }
 
 void IceDiskRelTable::initializeParquetReaders(Transaction* transaction) const {
@@ -334,13 +346,19 @@ bool IceDiskRelTable::scanCSR(Transaction* transaction,
 
         for (; iceDiskScanState.currentLocalRowIdx < selSize && totalRowsCollected < maxRowsPerCall;
              ++iceDiskScanState.currentLocalRowIdx) {
-            // Find which source node this row belongs to.
+            // Find which source node this row belongs to. Rows are examined strictly in
+            // increasing global (CSR) order, so we walk a single monotonic cursor through the
+            // indptr (O(1) amortized per row) instead of a binary search (O(log n) per row).
             const auto currentGlobalRowIdx =
                 iceDiskScanState.currentBatchStartOffset + iceDiskScanState.currentLocalRowIdx;
-            const auto sourceNodeOffset = findSourceNodeForRow(currentGlobalRowIdx);
-            if (sourceNodeOffset == common::INVALID_OFFSET) {
+            if (indptrData.empty()) {
                 continue; // Invalid row
             }
+            while (iceDiskScanState.csrSrcNodeIdx + 1 < indptrData.size() &&
+                   indptrData[iceDiskScanState.csrSrcNodeIdx + 1] <= currentGlobalRowIdx) {
+                ++iceDiskScanState.csrSrcNodeIdx;
+            }
+            const auto sourceNodeOffset = iceDiskScanState.csrSrcNodeIdx;
 
             // Column 0 in indices file is the destination node offset.
             const auto dstOffset =
@@ -529,11 +547,6 @@ bool IceDiskRelTable::scanFlat(Transaction* transaction,
 
     iceDiskScanState.outState->getSelVectorUnsafe().setToFiltered(0);
     return false;
-}
-
-common::offset_t IceDiskRelTable::findSourceNodeForRow(common::offset_t globalRowIdx) const {
-    // Use base class helper for binary search
-    return findSourceNodeForRowInternal(globalRowIdx, indptrData);
 }
 
 row_idx_t IceDiskRelTable::getTotalRowCount(const Transaction* transaction) const {


### PR DESCRIPTION
## What

Speeds up CSR (ice-disk) rel table scans by removing the per-row binary search used to map each edge row back to its source node.

## Why

In `scanCSR` the edge rows are examined strictly in increasing global (CSR) order, so each row's source node can be found by advancing a single monotonic cursor through the indptr array in **O(1) amortized per row**, instead of a binary search (**O(log n) per row**). The `findSourceNodeForRow` hot path dominated scans over large CSR rel tables.

## Details

- Added `csrSrcNodeIdx` to `IceDiskRelTableScanState` as the monotonic cursor.
- In `scanCSR`, advance the cursor while the next indptr entry is \<= the current row (single while-loop, O(1) amortized).
- Bound-node batches are **not** guaranteed to arrive in increasing offset order (hash joins / reordered inputs feed arbitrary batches), so the cursor is **re-anchored per batch** in `initScanState` via `findSourceNodeForRowInternal`, rather than carried across the whole query.
- Removed the now-unused `findSourceNodeForRow` wrapper.

## Validation
Local CSR rel scan becomes dramatically faster; correctness verified (same output tuples as before), all ice-disk e2e cases pass.