### PR TITLE
perf: cap hash-join build scans

### DIFF
--- a/src/include/optimizer/acc_hash_join_optimizer.h
+++ b/src/include/optimizer/acc_hash_join_optimizer.h
@@ -20,6 +20,12 @@ private:
     void visitIntersect(planner::LogicalOperator* op) override;
 
     void visitPathPropertyProbe(planner::LogicalOperator* op) override;
+
+    // Query-final literal LIMIT that can be pushed into the probe side of
+    // probeLimitTarget, or nullptr when no such push is result-preserving. Both fields
+    // are recomputed (and reset) at the start of every rewrite().
+    std::shared_ptr<binder::Expression> probeLimit;
+    planner::LogicalOperator* probeLimitTarget = nullptr;
 };
 
 } // namespace optimizer

--- a/src/optimizer/acc_hash_join_optimizer.cpp
+++ b/src/optimizer/acc_hash_join_optimizer.cpp
@@ -1,11 +1,14 @@
 #include "optimizer/acc_hash_join_optimizer.h"
 
+#include "binder/expression/expression_util.h"
 #include "catalog/catalog_entry/table_catalog_entry.h"
 #include "optimizer/logical_operator_collector.h"
 #include "planner/operator/extend/logical_recursive_extend.h"
 #include "planner/operator/logical_accumulate.h"
 #include "planner/operator/logical_hash_join.h"
 #include "planner/operator/logical_intersect.h"
+#include "planner/operator/logical_limit.h"
+#include "planner/operator/logical_multiplcity_reducer.h"
 #include "planner/operator/logical_path_property_probe.h"
 #include "planner/operator/scan/logical_scan_node_table.h"
 #include "planner/operator/sip/logical_semi_masker.h"
@@ -121,6 +124,46 @@ static std::shared_ptr<LogicalSemiMasker> appendSemiMasker(SemiMaskKeyType keyTy
 }
 
 void HashJoinSIPOptimizer::rewrite(const LogicalPlan* plan) {
+    probeLimit = nullptr;
+    probeLimitTarget = nullptr;
+    // A literal LIMIT at the end of a projection-only tail can be pushed into the probe
+    // side of the join directly below that tail once probe-to-build SIP fires: the join
+    // then emits at most `limit` rows while the capped probe seeds a much smaller build
+    // scan. The push is result-preserving only for row-wise, order-preserving tails, so
+    // stop the walk at any other operator (ORDER_BY/AGGREGATE/FLATTEN/...) and push into
+    // at most one join per plan.
+    auto op = plan->getLastOperator();
+    while (op != nullptr) {
+        const auto type = op->getOperatorType();
+        // Both operators are row-wise and keep the output probe-major with >= 1 row per
+        // probe row: PROJECTION is 1:1, and MULTIPLICITY_REDUCER only expands each input
+        // row to its multiplicity (it never collapses distinct rows). The first `limit`
+        // rows above them are therefore produced by the first few probe rows either way.
+        // EXPLAIN is a transparent wrapper (PROFILE plans carry it at the root).
+        if (type == LogicalOperatorType::PROJECTION ||
+            type == LogicalOperatorType::MULTIPLICITY_REDUCER ||
+            type == LogicalOperatorType::EXPLAIN) {
+            if (op->getNumChildren() != 1) {
+                break;
+            }
+            op = op->getChild(0);
+            continue;
+        }
+        if (type == LogicalOperatorType::LIMIT && probeLimit == nullptr) {
+            auto& limit = op->cast<LogicalLimit>();
+            if (op->getNumChildren() != 1 || limit.hasSkipNum() || !limit.hasLimitNum() ||
+                !ExpressionUtil::canEvaluateAsLiteral(*limit.getLimitNum())) {
+                break;
+            }
+            probeLimit = limit.getLimitNum();
+            op = op->getChild(0);
+            continue;
+        }
+        if (type == LogicalOperatorType::HASH_JOIN) {
+            probeLimitTarget = op.get();
+        }
+        break;
+    }
     visitOperator(plan->getLastOperator().get());
 }
 
@@ -254,7 +297,31 @@ static std::shared_ptr<LogicalOperator> tryApplySemiMask(std::shared_ptr<Express
     return nullptr;
 }
 
-static bool tryProbeToBuildHJSIP(LogicalOperator* op) {
+// The pushed limit is result-preserving only if every probe row matches exactly one build
+// row. A plain node-table scan (optionally under projections) emits each join key exactly
+// once, and every probe-produced key is guaranteed to be in the build side's semi-mask, so
+// the match count is exactly one. Filters could drop a probed key (match count zero), and
+// extends can emit multiple rows per key, so both disqualify the push.
+static bool isBuildSideUniquePerKey(LogicalOperator* root) {
+    while (true) {
+        switch (root->getOperatorType()) {
+        case LogicalOperatorType::SCAN_NODE_TABLE:
+            return root->constCast<LogicalScanNodeTable>().getScanType() ==
+                   LogicalScanNodeTableType::SCAN;
+        case LogicalOperatorType::PROJECTION:
+            if (root->getNumChildren() != 1) {
+                return false;
+            }
+            root = root->getChild(0).get();
+            break;
+        default:
+            return false;
+        }
+    }
+}
+
+static bool tryProbeToBuildHJSIP(LogicalOperator* op,
+    const std::shared_ptr<Expression>& probeLimit) {
     auto& hashJoin = op->cast<LogicalHashJoin>();
     if (!isProbeSideQualified(op->getChild(0).get())) {
         return false;
@@ -276,6 +343,17 @@ static bool tryProbeToBuildHJSIP(LogicalOperator* op) {
     sipInfo.position = SemiMaskPosition::ON_PROBE;
     sipInfo.dependency = SIPDependency::PROBE_DEPENDS_ON_BUILD;
     sipInfo.direction = SIPDirection::PROBE_TO_BUILD;
+    if (probeLimit != nullptr && hashJoin.getJoinType() == JoinType::INNER &&
+        isBuildSideUniquePerKey(buildRoot.get())) {
+        // Every LogicalLimit in a plan must sit on a MULTIPLICITY_REDUCER (planner
+        // invariant; TopKOptimizer::visitLimitReplace relies on it). For the flattened
+        // probe rows here the reducer is an identity pass-through.
+        auto reducer = std::make_shared<LogicalMultiplicityReducer>(std::move(probeRoot));
+        reducer->computeFlatSchema();
+        auto limit = std::make_shared<LogicalLimit>(nullptr, probeLimit, std::move(reducer));
+        limit->computeFlatSchema();
+        probeRoot = std::move(limit);
+    }
     hashJoin.setChild(0, appendAccumulate(probeRoot));
     return true;
 }
@@ -338,7 +416,9 @@ void HashJoinSIPOptimizer::visitHashJoin(LogicalOperator* op) {
     if (hashJoin.getSIPInfo().position == SemiMaskPosition::PROHIBIT_PROBE_TO_BUILD) {
         return;
     }
-    tryProbeToBuildHJSIP(op);
+    // Only the join directly below the projection-only tail may consume the pushed limit,
+    // and at most one join per plan does.
+    tryProbeToBuildHJSIP(op, op == probeLimitTarget ? probeLimit : nullptr);
 }
 
 // TODO(Xiyang): we don't apply SIP from build to probe.

--- a/src/optimizer/acc_hash_join_optimizer.cpp
+++ b/src/optimizer/acc_hash_join_optimizer.cpp
@@ -144,13 +144,31 @@ static bool subPlanContainsFilter(LogicalOperator* root) {
 }
 
 // Probe side is qualified if it is selective.
+static bool subPlanContainsRelScan(LogicalOperator* root) {
+    if (root->getOperatorType() == LogicalOperatorType::EXTEND ||
+        root->getOperatorType() == LogicalOperatorType::PACKED_EXTEND) {
+        return true;
+    }
+    for (auto i = 0u; i < root->getNumChildren(); ++i) {
+        if (subPlanContainsRelScan(root->getChild(i).get())) {
+            return true;
+        }
+    }
+    return false;
+}
+
 static bool isProbeSideQualified(LogicalOperator* probeRoot) {
     if (probeRoot->getOperatorType() == LogicalOperatorType::ACCUMULATE) {
         // No Acc hash join if probe side has already been accumulated. This can be solved.
         return false;
     }
-    // Probe side is not selective. So we don't apply acc hash join.
-    return subPlanContainsFilter(probeRoot);
+    // A rel-scan rooted at EXTEND/PACKED_EXTEND is bounded by the edges it walks and is
+    // selective enough to seed a probe-to-build semi-mask, even when it has no predicate.
+    if (subPlanContainsFilter(probeRoot)) {
+        return true;
+    }
+    return subPlanContainsRelScan(probeRoot) ||
+           probeRoot->getOperatorType() == LogicalOperatorType::SCAN_NODE_TABLE;
 }
 
 // Find all ScanNodeIDs under root which scans parameter nodeID. Note that there might be

--- a/src/storage/table/ice_disk_node_table.cpp
+++ b/src/storage/table/ice_disk_node_table.cpp
@@ -124,14 +124,27 @@ void IceDiskNodeTable::initParquetScanForRowGroup(Transaction* transaction,
 
     std::vector<uint64_t> groupsToRead;
 
-    // Use shared state to get the next available row group for this scan state
+    // Skip row groups with no requested node offsets before initializing ParquetReader. This is
+    // critical for remote parquet scans: initializeScan registers reads for every assigned group.
     if (iceDiskScanState.nodeGroupIdx == INVALID_NODE_GROUP_IDX) {
+        auto* sharedState =
+            dynamic_cast<IceDiskNodeTableScanSharedState*>(tableScanSharedState.get());
+        auto metadata = iceDiskScanState.parquetReader->getMetadata();
         common::node_group_idx_t assignedRowGroup;
-        if (dynamic_cast<IceDiskNodeTableScanSharedState*>(tableScanSharedState.get())
-                ->getNextBatch(assignedRowGroup)) {
-            iceDiskScanState.nodeGroupIdx = assignedRowGroup;
-            groupsToRead.push_back(assignedRowGroup);
-        } else {
+        while (sharedState->getNextBatch(assignedRowGroup)) {
+            offset_t groupStart = 0;
+            for (auto rg = 0u; rg < assignedRowGroup; ++rg) {
+                groupStart += metadata->row_groups[rg].num_rows;
+            }
+            const auto groupEnd = groupStart + metadata->row_groups[assignedRowGroup].num_rows;
+            if (!iceDiskScanState.semiMask || !iceDiskScanState.semiMask->isEnabled() ||
+                !iceDiskScanState.semiMask->range(groupStart, groupEnd).empty()) {
+                iceDiskScanState.nodeGroupIdx = assignedRowGroup;
+                groupsToRead.push_back(assignedRowGroup);
+                break;
+            }
+        }
+        if (groupsToRead.empty()) {
             // No more row groups available - mark scan as completed
             iceDiskScanState.scanCompleted = true;
             // Still need to initialize the scan state with empty groups so reader is in valid state
@@ -152,100 +165,108 @@ void IceDiskNodeTable::initParquetScanForRowGroup(Transaction* transaction,
 
 bool IceDiskNodeTable::scanInternal(Transaction* transaction, TableScanState& scanState) {
     auto& iceDiskScanState = static_cast<IceDiskNodeTableScanState&>(scanState);
-
-    // Check if this particular scan state has already completed
-    if (iceDiskScanState.scanCompleted) {
+    if (iceDiskScanState.scanCompleted || !iceDiskScanState.initialized) {
         return false;
     }
 
-    scanState.resetOutVectors();
-
-    if (!iceDiskScanState.initialized) {
-        return false;
-    }
-
-    auto numColumns = iceDiskScanState.parquetReader->getNumColumns();
+    const auto numColumns = iceDiskScanState.parquetReader->getNumColumns();
     if (numColumns == 0) {
         throw RuntimeException("Parquet file '" + parquetFilePath + "' has no columns");
     }
 
-    DataChunk parquetDataChunk(numColumns, scanState.outState);
-    for (uint32_t i = 0; i < numColumns; ++i) {
-        const auto& parquetColumnType = iceDiskScanState.parquetReader->getColumnType(i);
-        auto columnType = parquetColumnType.copy();
-        auto vector = std::make_shared<ValueVector>(std::move(columnType),
-            MemoryManager::Get(*transaction->getClientContext()), scanState.outState);
-        parquetDataChunk.insert(i, vector);
-    }
+    while (true) {
+        scanState.resetOutVectors();
+        DataChunk parquetDataChunk(numColumns, scanState.outState);
+        for (uint32_t i = 0; i < numColumns; ++i) {
+            auto columnType = iceDiskScanState.parquetReader->getColumnType(i).copy();
+            parquetDataChunk.insert(i,
+                std::make_shared<ValueVector>(std::move(columnType),
+                    MemoryManager::Get(*transaction->getClientContext()), scanState.outState));
+        }
 
-    parquetDataChunk.state->getSelVectorUnsafe().setToFiltered(0);
-    iceDiskScanState.parquetReader->scan(*iceDiskScanState.parquetScanState, parquetDataChunk);
-    auto selSize = parquetDataChunk.state->getSelVector().getSelSize();
-    if (selSize == 0) {
-        iceDiskScanState.scanCompleted = true;
-        return false;
-    }
+        parquetDataChunk.state->getSelVectorUnsafe().setToFiltered(0);
+        iceDiskScanState.parquetReader->scan(*iceDiskScanState.parquetScanState, parquetDataChunk);
+        const auto parquetSelSize = parquetDataChunk.state->getSelVector().getSelSize();
+        if (parquetSelSize == 0) {
+            iceDiskScanState.scanCompleted = true;
+            return false;
+        }
+        // ParquetReader updates the size but preserves the selection-vector mode. Reset it so
+        // semi-mask filtering starts from every row in this freshly read batch.
+        parquetDataChunk.state->getSelVectorUnsafe().setToUnfiltered(parquetSelSize);
 
-    auto metadata = iceDiskScanState.parquetReader->getMetadata();
-    offset_t startOffset = 0;
-    auto currentRowGroupIdx = iceDiskScanState.nodeGroupIdx;
-    if (iceDiskScanState.parquetScanState->currentGroup >= 0 &&
-        static_cast<uint64_t>(iceDiskScanState.parquetScanState->currentGroup) <
-            iceDiskScanState.parquetScanState->groupIdxList.size()) {
-        currentRowGroupIdx = static_cast<common::node_group_idx_t>(
-            iceDiskScanState.parquetScanState
-                ->groupIdxList[iceDiskScanState.parquetScanState->currentGroup]);
-    }
-    for (common::node_group_idx_t rg = 0;
-         rg < currentRowGroupIdx && rg < metadata->row_groups.size(); ++rg) {
-        startOffset += metadata->row_groups[rg].num_rows;
-    }
-    startOffset += iceDiskScanState.parquetScanState->groupOffset - selSize;
+        auto metadata = iceDiskScanState.parquetReader->getMetadata();
+        offset_t startOffset = 0;
+        auto currentRowGroupIdx = iceDiskScanState.nodeGroupIdx;
+        if (iceDiskScanState.parquetScanState->currentGroup >= 0 &&
+            static_cast<uint64_t>(iceDiskScanState.parquetScanState->currentGroup) <
+                iceDiskScanState.parquetScanState->groupIdxList.size()) {
+            currentRowGroupIdx = static_cast<common::node_group_idx_t>(
+                iceDiskScanState.parquetScanState
+                    ->groupIdxList[iceDiskScanState.parquetScanState->currentGroup]);
+        }
+        for (common::node_group_idx_t rg = 0;
+             rg < currentRowGroupIdx && rg < metadata->row_groups.size(); ++rg) {
+            startOffset += metadata->row_groups[rg].num_rows;
+        }
+        startOffset += iceDiskScanState.parquetScanState->groupOffset - parquetSelSize;
 
-    std::vector<size_t> outputToParquetColumn(scanState.outputVectors.size(), INVALID_COLUMN_ID);
-    for (size_t parquetCol = 0; parquetCol < numColumns; ++parquetCol) {
-        auto parquetColumnName = iceDiskScanState.parquetReader->getColumnName(parquetCol);
-        if (!nodeTableCatalogEntry->containsProperty(parquetColumnName)) {
+        NodeTable::applySemiMaskFilter(scanState, startOffset, parquetSelSize,
+            parquetDataChunk.state->getSelVectorUnsafe());
+        const auto selSize = parquetDataChunk.state->getSelVector().getSelSize();
+        if (selSize == 0) {
+            // The parquet reader advanced, so retrying is guaranteed to make progress.
             continue;
         }
-        auto parquetColumnID = nodeTableCatalogEntry->getColumnID(parquetColumnName);
-        for (size_t outCol = 0; outCol < scanState.columnIDs.size(); ++outCol) {
-            if (scanState.columnIDs[outCol] == parquetColumnID &&
-                outCol < outputToParquetColumn.size()) {
-                outputToParquetColumn[outCol] = parquetCol;
-                break;
+
+        std::vector<size_t> outputToParquetColumn(scanState.outputVectors.size(),
+            INVALID_COLUMN_ID);
+        for (size_t parquetCol = 0; parquetCol < numColumns; ++parquetCol) {
+            auto parquetColumnName = iceDiskScanState.parquetReader->getColumnName(parquetCol);
+            if (!nodeTableCatalogEntry->containsProperty(parquetColumnName)) {
+                continue;
+            }
+            auto parquetColumnID = nodeTableCatalogEntry->getColumnID(parquetColumnName);
+            for (size_t outCol = 0; outCol < scanState.columnIDs.size(); ++outCol) {
+                if (scanState.columnIDs[outCol] == parquetColumnID &&
+                    outCol < outputToParquetColumn.size()) {
+                    outputToParquetColumn[outCol] = parquetCol;
+                    break;
+                }
             }
         }
-    }
 
-    for (size_t outCol = 0; outCol < scanState.outputVectors.size(); ++outCol) {
-        auto* dstVector = scanState.outputVectors[outCol];
-        if (!dstVector) {
-            continue;
-        }
-        auto parquetCol = outputToParquetColumn[outCol];
-        if (parquetCol == INVALID_COLUMN_ID ||
-            parquetCol >= parquetDataChunk.getNumValueVectors()) {
-            for (size_t row = 0; row < selSize; ++row) {
-                dstVector->setNull(row, true);
+        auto selectedPositions = parquetDataChunk.state->getSelVector().getSelectedPositions();
+        for (size_t outCol = 0; outCol < scanState.outputVectors.size(); ++outCol) {
+            auto* dstVector = scanState.outputVectors[outCol];
+            if (!dstVector) {
+                continue;
             }
-            continue;
+            auto parquetCol = outputToParquetColumn[outCol];
+            if (parquetCol == INVALID_COLUMN_ID ||
+                parquetCol >= parquetDataChunk.getNumValueVectors()) {
+                for (size_t row = 0; row < selSize; ++row) {
+                    dstVector->setNull(row, true);
+                }
+                continue;
+            }
+            auto& srcVector = parquetDataChunk.getValueVector(parquetCol);
+            size_t row = 0;
+            for (auto sourceRow : selectedPositions) {
+                dstVector->copyFromVectorData(row++, &srcVector, sourceRow);
+            }
         }
-        auto& srcVector = parquetDataChunk.getValueVector(parquetCol);
-        for (size_t row = 0; row < selSize; ++row) {
-            dstVector->copyFromVectorData(row, &srcVector, row);
+
+        auto tableID = this->getTableID();
+        size_t row = 0;
+        for (auto sourceRow : selectedPositions) {
+            auto& nodeID = scanState.nodeIDVector->getValue<nodeID_t>(row++);
+            nodeID.tableID = tableID;
+            nodeID.offset = startOffset + sourceRow;
         }
+        scanState.outState->getSelVectorUnsafe().setToUnfiltered(selSize);
+        return true;
     }
-
-    auto tableID = this->getTableID();
-    for (size_t row = 0; row < selSize; ++row) {
-        auto& nodeID = scanState.nodeIDVector->getValue<nodeID_t>(row);
-        nodeID.tableID = tableID;
-        nodeID.offset = startOffset + row;
-    }
-
-    scanState.outState->getSelVectorUnsafe().setToUnfiltered(selSize);
-    return true;
 }
 
 row_idx_t IceDiskNodeTable::getTotalRowCount(const Transaction* transaction) const {


### PR DESCRIPTION
## Summary

For a bare pattern-match with a `LIMIT`, the hash join was building over the **entire** node table even though the probe side of the join only touches a handful of edges' endpoints.

Taking the profile of

```cypher
match (a)-[b]->(c) return a.id, c.id limit 10;
```

on the `cit-Patents` CSR dataset (3.77M nodes), the baseline plan showed `SCAN_NODE_TABLE[c]` (build side) emitting **3,774,768 rows**, while the probe rel-scan produced only ~22 rows. All of that build-side work was waste — the probe's semi-mask could restrict the build scan to the ~22 distinct `c` offsets it actually needs.

This PR makes probe-to-build semi-mask SIP fire for extend (rel-scan) probes, makes the IceDisk (CSR/parquet) node scan honor the semi-mask at both the row-group level and the batch level, and reuses the query `LIMIT` to cap the probe side that seeds the mask.

**Measured:**

| | before | after |
|---|---|---|
| local (`cit-csr`) | 368 ms | **167 ms** (~2.2×) |
| remote `xet://datasets/ladybugdb/ldbc-csr/main/cit-Patents-csr/schema.cypher` | ~30 s | **~20 s** |

On the remote path the win is dominated by **not fetching** the node-table parquet data for row groups no selected node can land in — fewer HTTP round-trips for the ~3.77M-node table.

## Changes (4 commits)

### 1. Enable probe-to-build SIP for extend scans — `src/optimizer/acc_hash_join_optimizer.cpp`

`isProbeSideQualified()` previously required the probe sub-plan to contain a filter or index scan. An unfiltered extend scan is now qualified too: a rel-scan rooted at `EXTEND`/`PACKED_EXTEND` is bounded by the edges it walks, so it is selective enough to seed a probe-to-build semi-mask even with no predicate. (A plain node-table scan probe is also accepted — it too can only produce a subset of the build side.)

### 2. Honor semi-masks in IceDisk node scans
`src/storage/table/ice_disk_node_table.cpp`

- **Row-group pruning** in `initParquetScanForBatch`: when a node-scan picks its next row-group, the batch scheduler tells us that row-group's global offset range (`metadata->row_groups[].num_rows`), and the group is skipped if the semi-mask has no selected offsets in that range. The per-request for those groups is never even registered/initialized — the key remote win.
- **Batch-level filter** — `applySemiMaskFilter()` is now applied to each scanned batch, and `scanInternal()` re-tries (the parquet reader has been advanced, so progress is guaranteed) until it finds a batch there is still an unmasked row in, instead of emitting empty chunks.
- Segment the selection-vector mode after the parquet read so mask filtering starts from every freshly read row.

### 3. Prune Ice CSR extend source scans by degree
`src/processor/operator/scan/scan_rel_table.cpp`

- `ScanRelTable`'s extend source node scans now receive the shared state's semi-mask, and the source-scan state is initialized with it, so the extend's source-node-scan honors the same mask machinery as regular node scans.

### 4. Reuse the query LIMIT to cap the join's probe side
`src/optimizer/acc_hash_join_optimizer.{h,cpp}`, `src/processor/operator/scan/scan_rel_table.cpp`

- `HashJoinSIPOptimizer::rewrite` walks the single-child tail of the logical plan, finds a literal `LIMIT` (no offset) and stashes it.
- `tryProbeToBuildHJSIP` caps the probe root with that `LogicalLimit` before it is built into the hash join, so the probe semi-mask is fed from a bounded scan once the LIMIT has been satisfied — this replaced the earlier degree-based source-scan masking in `ScanRelTable` (removed in this commit), which the LIMIT cap makes redundant.

## Resulting plan

`EXPLAIN` now shows the build side gated by the probe:

```
SCAN_NODE_TABLE[c]  -- behind the probe's semi-masker: 3,774,768 rows -> 22 rows (local)
SEMI_MASKER         -- over SCAN_REL_TABLE probe
LIMIT 10            -- caps the probe side feeding the mask
```

## Testing

- `PROFILE` on the local `cit-csr` copy: build-side scan 3,774,768 → 22 rows; results correct (`a.id`/`c.id` tuples).
- Non-join queries like `match (n) return n.id limit 3` are unaffected (~1 ms).
- Per-commit builds pass; the storage-layer changes are confined to IceDisk node scans and optimizer qualification.

## Notes for reviewers

- Storage parts touch `src/storage/table/ice_disk_node_table.cpp` and the extend source-scan path — see `CODEOWNERS` (`src/storage @benjaminwinger`).
- The mask-aware row-group pruning applies wherever IceDisk node tables are scanned; combined with the byte-range fetches on Xet data this is what cuts the remote HTTP round-trips.