### PR TITLE
Namespace-wrap vendored mbedtls to avoid clashes with statically-linked duckdb

### DIFF
--- a/third_party/mbedtls/include/mbedtls/aes.h
+++ b/third_party/mbedtls/include/mbedtls/aes.h
@@ -64,9 +64,6 @@
 #define inline __inline
 #endif
 
-#ifdef __cplusplus
-extern "C" {
-#endif
 
 #if !defined(MBEDTLS_AES_ALT)
 // Regular implementation
@@ -75,6 +72,7 @@ extern "C" {
 /**
  * \brief The AES context-type definition.
  */
+namespace lbug_mbedtls {
 typedef struct mbedtls_aes_context {
     int MBEDTLS_PRIVATE(nr);           /*!< The number of rounds. */
     uint32_t* MBEDTLS_PRIVATE(rk);     /*!< AES round keys. */
@@ -88,16 +86,19 @@ typedef struct mbedtls_aes_context {
                      </li></ul> */
 } mbedtls_aes_context;
 
+} // namespace lbug_mbedtls
 #if defined(MBEDTLS_CIPHER_MODE_XTS)
 /**
  * \brief The AES XTS context-type definition.
  */
+namespace lbug_mbedtls {
 typedef struct mbedtls_aes_xts_context {
     mbedtls_aes_context MBEDTLS_PRIVATE(crypt); /*!< The AES context to use for AES block
                                         encryption or decryption. */
     mbedtls_aes_context MBEDTLS_PRIVATE(tweak); /*!< The AES context used for tweak
                                         computation. */
 } mbedtls_aes_xts_context;
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_CIPHER_MODE_XTS */
 
 #else /* MBEDTLS_AES_ALT */
@@ -112,6 +113,7 @@ typedef struct mbedtls_aes_xts_context {
  *
  * \param ctx      The AES context to initialize. This must not be \c NULL.
  */
+namespace lbug_mbedtls {
 void mbedtls_aes_init(mbedtls_aes_context* ctx);
 
 /**
@@ -123,6 +125,7 @@ void mbedtls_aes_init(mbedtls_aes_context* ctx);
  */
 void mbedtls_aes_free(mbedtls_aes_context* ctx);
 
+} // namespace lbug_mbedtls
 #if defined(MBEDTLS_CIPHER_MODE_XTS)
 /**
  * \brief          This function initializes the specified AES XTS context.
@@ -132,6 +135,7 @@ void mbedtls_aes_free(mbedtls_aes_context* ctx);
  *
  * \param ctx      The AES XTS context to initialize. This must not be \c NULL.
  */
+namespace lbug_mbedtls {
 void mbedtls_aes_xts_init(mbedtls_aes_xts_context* ctx);
 
 /**
@@ -142,6 +146,7 @@ void mbedtls_aes_xts_init(mbedtls_aes_xts_context* ctx);
  *                 Otherwise, the context must have been at least initialized.
  */
 void mbedtls_aes_xts_free(mbedtls_aes_xts_context* ctx);
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_CIPHER_MODE_XTS */
 
 /**
@@ -159,6 +164,7 @@ void mbedtls_aes_xts_free(mbedtls_aes_xts_context* ctx);
  * \return         \c 0 on success.
  * \return         #MBEDTLS_ERR_AES_INVALID_KEY_LENGTH on failure.
  */
+namespace lbug_mbedtls {
 MBEDTLS_CHECK_RETURN_TYPICAL
 int mbedtls_aes_setkey_enc(mbedtls_aes_context* ctx, const unsigned char* key,
     unsigned int keybits);
@@ -182,6 +188,7 @@ MBEDTLS_CHECK_RETURN_TYPICAL
 int mbedtls_aes_setkey_dec(mbedtls_aes_context* ctx, const unsigned char* key,
     unsigned int keybits);
 
+} // namespace lbug_mbedtls
 #if defined(MBEDTLS_CIPHER_MODE_XTS)
 /**
  * \brief          This function prepares an XTS context for encryption and
@@ -199,6 +206,7 @@ int mbedtls_aes_setkey_dec(mbedtls_aes_context* ctx, const unsigned char* key,
  * \return         \c 0 on success.
  * \return         #MBEDTLS_ERR_AES_INVALID_KEY_LENGTH on failure.
  */
+namespace lbug_mbedtls {
 MBEDTLS_CHECK_RETURN_TYPICAL
 int mbedtls_aes_xts_setkey_enc(mbedtls_aes_xts_context* ctx, const unsigned char* key,
     unsigned int keybits);
@@ -222,6 +230,7 @@ int mbedtls_aes_xts_setkey_enc(mbedtls_aes_xts_context* ctx, const unsigned char
 MBEDTLS_CHECK_RETURN_TYPICAL
 int mbedtls_aes_xts_setkey_dec(mbedtls_aes_xts_context* ctx, const unsigned char* key,
     unsigned int keybits);
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_CIPHER_MODE_XTS */
 
 /**
@@ -247,10 +256,12 @@ int mbedtls_aes_xts_setkey_dec(mbedtls_aes_xts_context* ctx, const unsigned char
 
 * \return         \c 0 on success.
 */
+namespace lbug_mbedtls {
 MBEDTLS_CHECK_RETURN_TYPICAL
 int mbedtls_aes_crypt_ecb(mbedtls_aes_context* ctx, int mode, const unsigned char input[16],
     unsigned char output[16]);
 
+} // namespace lbug_mbedtls
 #if defined(MBEDTLS_CIPHER_MODE_CBC)
 /**
  * \brief  This function performs an AES-CBC encryption or decryption operation
@@ -293,9 +304,11 @@ int mbedtls_aes_crypt_ecb(mbedtls_aes_context* ctx, int mode, const unsigned cha
  * \return         #MBEDTLS_ERR_AES_INVALID_INPUT_LENGTH
  *                 on failure.
  */
+namespace lbug_mbedtls {
 MBEDTLS_CHECK_RETURN_TYPICAL
 int mbedtls_aes_crypt_cbc(mbedtls_aes_context* ctx, int mode, size_t length, unsigned char iv[16],
     const unsigned char* input, unsigned char* output);
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_CIPHER_MODE_CBC */
 
 #if defined(MBEDTLS_CIPHER_MODE_XTS)
@@ -334,9 +347,11 @@ int mbedtls_aes_crypt_cbc(mbedtls_aes_context* ctx, int mode, size_t length, uns
  *                     smaller than an AES block in size (16 Bytes) or if \p
  *                     length is larger than 2^20 blocks (16 MiB).
  */
+namespace lbug_mbedtls {
 MBEDTLS_CHECK_RETURN_TYPICAL
 int mbedtls_aes_crypt_xts(mbedtls_aes_xts_context* ctx, int mode, size_t length,
     const unsigned char data_unit[16], const unsigned char* input, unsigned char* output);
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_CIPHER_MODE_XTS */
 
 #if defined(MBEDTLS_CIPHER_MODE_CFB)
@@ -379,6 +394,7 @@ int mbedtls_aes_crypt_xts(mbedtls_aes_xts_context* ctx, int mode, size_t length,
  *
  * \return         \c 0 on success.
  */
+namespace lbug_mbedtls {
 MBEDTLS_CHECK_RETURN_TYPICAL
 int mbedtls_aes_crypt_cfb128(mbedtls_aes_context* ctx, int mode, size_t length, size_t* iv_off,
     unsigned char iv[16], const unsigned char* input, unsigned char* output);
@@ -422,6 +438,7 @@ int mbedtls_aes_crypt_cfb128(mbedtls_aes_context* ctx, int mode, size_t length, 
 MBEDTLS_CHECK_RETURN_TYPICAL
 int mbedtls_aes_crypt_cfb8(mbedtls_aes_context* ctx, int mode, size_t length, unsigned char iv[16],
     const unsigned char* input, unsigned char* output);
+} // namespace lbug_mbedtls
 #endif /*MBEDTLS_CIPHER_MODE_CFB */
 
 #if defined(MBEDTLS_CIPHER_MODE_OFB)
@@ -470,10 +487,12 @@ int mbedtls_aes_crypt_cfb8(mbedtls_aes_context* ctx, int mode, size_t length, un
  *
  * \return         \c 0 on success.
  */
+namespace lbug_mbedtls {
 MBEDTLS_CHECK_RETURN_TYPICAL
 int mbedtls_aes_crypt_ofb(mbedtls_aes_context* ctx, size_t length, size_t* iv_off,
     unsigned char iv[16], const unsigned char* input, unsigned char* output);
 
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_CIPHER_MODE_OFB */
 
 #if defined(MBEDTLS_CIPHER_MODE_CTR)
@@ -549,10 +568,12 @@ int mbedtls_aes_crypt_ofb(mbedtls_aes_context* ctx, size_t length, size_t* iv_of
  *
  * \return                 \c 0 on success.
  */
+namespace lbug_mbedtls {
 MBEDTLS_CHECK_RETURN_TYPICAL
 int mbedtls_aes_crypt_ctr(mbedtls_aes_context* ctx, size_t length, size_t* nc_off,
     unsigned char nonce_counter[16], unsigned char stream_block[16], const unsigned char* input,
     unsigned char* output);
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_CIPHER_MODE_CTR */
 
 /**
@@ -566,6 +587,7 @@ int mbedtls_aes_crypt_ctr(mbedtls_aes_context* ctx, size_t length, size_t* nc_of
  *
  * \return          \c 0 on success.
  */
+namespace lbug_mbedtls {
 MBEDTLS_CHECK_RETURN_TYPICAL
 int mbedtls_internal_aes_encrypt(mbedtls_aes_context* ctx, const unsigned char input[16],
     unsigned char output[16]);
@@ -585,6 +607,7 @@ MBEDTLS_CHECK_RETURN_TYPICAL
 int mbedtls_internal_aes_decrypt(mbedtls_aes_context* ctx, const unsigned char input[16],
     unsigned char output[16]);
 
+} // namespace lbug_mbedtls
 #if defined(MBEDTLS_SELF_TEST)
 /**
  * \brief          Checkup routine.
@@ -592,13 +615,14 @@ int mbedtls_internal_aes_decrypt(mbedtls_aes_context* ctx, const unsigned char i
  * \return         \c 0 on success.
  * \return         \c 1 on failure.
  */
+namespace lbug_mbedtls {
 MBEDTLS_CHECK_RETURN_CRITICAL
 int mbedtls_aes_self_test(int verbose);
 
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_SELF_TEST */
 
-#ifdef __cplusplus
-}
-#endif
 
 #endif /* aes.h */
+
+using namespace lbug_mbedtls; // keep unqualified names for in-tree consumers

--- a/third_party/mbedtls/include/mbedtls/aria.h
+++ b/third_party/mbedtls/include/mbedtls/aria.h
@@ -48,9 +48,6 @@
 /** Invalid data input length. */
 #define MBEDTLS_ERR_ARIA_INVALID_INPUT_LENGTH -0x005E
 
-#ifdef __cplusplus
-extern "C" {
-#endif
 
 #if !defined(MBEDTLS_ARIA_ALT)
 // Regular implementation
@@ -59,12 +56,14 @@ extern "C" {
 /**
  * \brief The ARIA context-type definition.
  */
+namespace lbug_mbedtls {
 typedef struct mbedtls_aria_context {
     unsigned char MBEDTLS_PRIVATE(nr); /*!< The number of rounds (12, 14 or 16) */
     /*! The ARIA round keys. */
     uint32_t MBEDTLS_PRIVATE(rk)[MBEDTLS_ARIA_MAX_ROUNDS + 1][MBEDTLS_ARIA_BLOCKSIZE / 4];
 } mbedtls_aria_context;
 
+} // namespace lbug_mbedtls
 #else /* MBEDTLS_ARIA_ALT */
 #include "mbedtls/aria_alt.h"
 #endif /* MBEDTLS_ARIA_ALT */
@@ -77,6 +76,7 @@ typedef struct mbedtls_aria_context {
  *
  * \param ctx      The ARIA context to initialize. This must not be \c NULL.
  */
+namespace lbug_mbedtls {
 void mbedtls_aria_init(mbedtls_aria_context* ctx);
 
 /**
@@ -148,6 +148,7 @@ int mbedtls_aria_crypt_ecb(mbedtls_aria_context* ctx,
     const unsigned char input[MBEDTLS_ARIA_BLOCKSIZE],
     unsigned char output[MBEDTLS_ARIA_BLOCKSIZE]);
 
+} // namespace lbug_mbedtls
 #if defined(MBEDTLS_CIPHER_MODE_CBC)
 /**
  * \brief  This function performs an ARIA-CBC encryption or decryption operation
@@ -190,8 +191,10 @@ int mbedtls_aria_crypt_ecb(mbedtls_aria_context* ctx,
  * \return         \c 0 on success.
  * \return         A negative error code on failure.
  */
+namespace lbug_mbedtls {
 int mbedtls_aria_crypt_cbc(mbedtls_aria_context* ctx, int mode, size_t length,
     unsigned char iv[MBEDTLS_ARIA_BLOCKSIZE], const unsigned char* input, unsigned char* output);
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_CIPHER_MODE_CBC */
 
 #if defined(MBEDTLS_CIPHER_MODE_CFB)
@@ -236,8 +239,10 @@ int mbedtls_aria_crypt_cbc(mbedtls_aria_context* ctx, int mode, size_t length,
  * \return         \c 0 on success.
  * \return         A negative error code on failure.
  */
+namespace lbug_mbedtls {
 int mbedtls_aria_crypt_cfb128(mbedtls_aria_context* ctx, int mode, size_t length, size_t* iv_off,
     unsigned char iv[MBEDTLS_ARIA_BLOCKSIZE], const unsigned char* input, unsigned char* output);
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_CIPHER_MODE_CFB */
 
 #if defined(MBEDTLS_CIPHER_MODE_CTR)
@@ -318,10 +323,12 @@ int mbedtls_aria_crypt_cfb128(mbedtls_aria_context* ctx, int mode, size_t length
  * \return                 \c 0 on success.
  * \return                 A negative error code on failure.
  */
+namespace lbug_mbedtls {
 int mbedtls_aria_crypt_ctr(mbedtls_aria_context* ctx, size_t length, size_t* nc_off,
     unsigned char nonce_counter[MBEDTLS_ARIA_BLOCKSIZE],
     unsigned char stream_block[MBEDTLS_ARIA_BLOCKSIZE], const unsigned char* input,
     unsigned char* output);
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_CIPHER_MODE_CTR */
 
 #if defined(MBEDTLS_SELF_TEST)
@@ -330,11 +337,12 @@ int mbedtls_aria_crypt_ctr(mbedtls_aria_context* ctx, size_t length, size_t* nc_
  *
  * \return         \c 0 on success, or \c 1 on failure.
  */
+namespace lbug_mbedtls {
 int mbedtls_aria_self_test(int verbose);
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_SELF_TEST */
 
-#ifdef __cplusplus
-}
-#endif
 
 #endif /* aria.h */
+
+using namespace lbug_mbedtls; // keep unqualified names for in-tree consumers

--- a/third_party/mbedtls/include/mbedtls/asn1.h
+++ b/third_party/mbedtls/include/mbedtls/asn1.h
@@ -135,9 +135,6 @@
     ((MBEDTLS_OID_SIZE(oid_str) != (oid_buf_len)) ||                                               \
         memcmp((oid_str), (oid_buf), (oid_buf_len)) != 0)
 
-#ifdef __cplusplus
-extern "C" {
-#endif
 
 /**
  * \name Functions to parse ASN.1 data structures
@@ -147,6 +144,7 @@ extern "C" {
 /**
  * Type-length-value structure that allows for ASN1 using DER.
  */
+namespace lbug_mbedtls {
 typedef struct mbedtls_asn1_buf {
     int tag;          /**< ASN1 type, e.g. MBEDTLS_ASN1_UTF8_STRING. */
     size_t len;       /**< ASN1 length, in octets. */
@@ -502,6 +500,7 @@ int mbedtls_asn1_traverse_sequence_of(unsigned char** p, const unsigned char* en
     unsigned char tag_may_val, int (*cb)(void* ctx, int tag, unsigned char* start, size_t len),
     void* ctx);
 
+} // namespace lbug_mbedtls
 #if defined(MBEDTLS_BIGNUM_C)
 /**
  * \brief       Retrieve an integer ASN.1 tag and its value.
@@ -521,7 +520,9 @@ int mbedtls_asn1_traverse_sequence_of(unsigned char** p, const unsigned char* en
  *              not fit in an \c int.
  * \return      An MPI error code if the parsed value is too large.
  */
+namespace lbug_mbedtls {
 int mbedtls_asn1_get_mpi(unsigned char** p, const unsigned char* end, mbedtls_mpi* X);
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_BIGNUM_C */
 
 /**
@@ -540,6 +541,7 @@ int mbedtls_asn1_get_mpi(unsigned char** p, const unsigned char* end, mbedtls_mp
  *
  * \return      0 if successful or a specific ASN.1 or MPI error code.
  */
+namespace lbug_mbedtls {
 int mbedtls_asn1_get_alg(unsigned char** p, const unsigned char* end, mbedtls_asn1_buf* alg,
     mbedtls_asn1_buf* params);
 
@@ -592,8 +594,8 @@ void mbedtls_asn1_free_named_data(mbedtls_asn1_named_data* entry);
  */
 void mbedtls_asn1_free_named_data_list(mbedtls_asn1_named_data** head);
 
-#ifdef __cplusplus
-}
-#endif
 
+} // namespace lbug_mbedtls
 #endif /* asn1.h */
+
+using namespace lbug_mbedtls; // keep unqualified names for in-tree consumers

--- a/third_party/mbedtls/include/mbedtls/base64.h
+++ b/third_party/mbedtls/include/mbedtls/base64.h
@@ -31,9 +31,6 @@
 /** Invalid character in input. */
 #define MBEDTLS_ERR_BASE64_INVALID_CHARACTER -0x002C
 
-#ifdef __cplusplus
-extern "C" {
-#endif
 
 /**
  * \brief          Encode a buffer into base64 format
@@ -54,6 +51,7 @@ extern "C" {
  * \note           Call this function with dlen = 0 to obtain the
  *                 required buffer size in *olen
  */
+namespace lbug_mbedtls {
 int mbedtls_base64_encode(unsigned char* dst, size_t dlen, size_t* olen, const unsigned char* src,
     size_t slen);
 
@@ -77,18 +75,20 @@ int mbedtls_base64_encode(unsigned char* dst, size_t dlen, size_t* olen, const u
 int mbedtls_base64_decode(unsigned char* dst, size_t dlen, size_t* olen, const unsigned char* src,
     size_t slen);
 
+} // namespace lbug_mbedtls
 #if defined(MBEDTLS_SELF_TEST)
 /**
  * \brief          Checkup routine
  *
  * \return         0 if successful, or 1 if the test failed
  */
+namespace lbug_mbedtls {
 int mbedtls_base64_self_test(int verbose);
 
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_SELF_TEST */
 
-#ifdef __cplusplus
-}
-#endif
 
 #endif /* base64.h */
+
+using namespace lbug_mbedtls; // keep unqualified names for in-tree consumers

--- a/third_party/mbedtls/include/mbedtls/bignum.h
+++ b/third_party/mbedtls/include/mbedtls/bignum.h
@@ -127,8 +127,10 @@
 #if !defined(MBEDTLS_HAVE_INT64)
 #define MBEDTLS_HAVE_INT64
 #endif /* !MBEDTLS_HAVE_INT64 */
+namespace lbug_mbedtls {
 typedef int64_t mbedtls_mpi_sint;
 typedef uint64_t mbedtls_mpi_uint;
+} // namespace lbug_mbedtls
 #elif defined(__GNUC__) &&                                                                         \
     (defined(__amd64__) || defined(__x86_64__) || defined(__ppc64__) || defined(__powerpc64__) ||  \
         defined(__ia64__) || defined(__alpha__) || (defined(__sparc__) && defined(__arch64__)) ||  \
@@ -136,12 +138,16 @@ typedef uint64_t mbedtls_mpi_uint;
 #if !defined(MBEDTLS_HAVE_INT64)
 #define MBEDTLS_HAVE_INT64
 #endif /* MBEDTLS_HAVE_INT64 */
+namespace lbug_mbedtls {
 typedef int64_t mbedtls_mpi_sint;
 typedef uint64_t mbedtls_mpi_uint;
+} // namespace lbug_mbedtls
 #if !defined(MBEDTLS_NO_UDBL_DIVISION)
 /* mbedtls_t_udbl defined as 128-bit unsigned int */
+namespace lbug_mbedtls {
 typedef unsigned int mbedtls_t_udbl __attribute__((mode(TI)));
 #define MBEDTLS_HAVE_UDBL
+} // namespace lbug_mbedtls
 #endif /* !MBEDTLS_NO_UDBL_DIVISION */
 #elif defined(__ARMCC_VERSION) && defined(__aarch64__)
 /*
@@ -151,17 +157,23 @@ typedef unsigned int mbedtls_t_udbl __attribute__((mode(TI)));
 #if !defined(MBEDTLS_HAVE_INT64)
 #define MBEDTLS_HAVE_INT64
 #endif /* !MBEDTLS_HAVE_INT64 */
+namespace lbug_mbedtls {
 typedef int64_t mbedtls_mpi_sint;
 typedef uint64_t mbedtls_mpi_uint;
+} // namespace lbug_mbedtls
 #if !defined(MBEDTLS_NO_UDBL_DIVISION)
 /* mbedtls_t_udbl defined as 128-bit unsigned int */
+namespace lbug_mbedtls {
 typedef __uint128_t mbedtls_t_udbl;
 #define MBEDTLS_HAVE_UDBL
+} // namespace lbug_mbedtls
 #endif /* !MBEDTLS_NO_UDBL_DIVISION */
 #elif defined(MBEDTLS_HAVE_INT64)
 /* Force 64-bit integers with unknown compiler */
+namespace lbug_mbedtls {
 typedef int64_t mbedtls_mpi_sint;
 typedef uint64_t mbedtls_mpi_uint;
+} // namespace lbug_mbedtls
 #endif
 #endif /* !MBEDTLS_HAVE_INT32 */
 
@@ -170,21 +182,23 @@ typedef uint64_t mbedtls_mpi_uint;
 #if !defined(MBEDTLS_HAVE_INT32)
 #define MBEDTLS_HAVE_INT32
 #endif /* !MBEDTLS_HAVE_INT32 */
+namespace lbug_mbedtls {
 typedef int32_t mbedtls_mpi_sint;
 typedef uint32_t mbedtls_mpi_uint;
+} // namespace lbug_mbedtls
 #if !defined(MBEDTLS_NO_UDBL_DIVISION)
+namespace lbug_mbedtls {
 typedef uint64_t mbedtls_t_udbl;
 #define MBEDTLS_HAVE_UDBL
+} // namespace lbug_mbedtls
 #endif /* !MBEDTLS_NO_UDBL_DIVISION */
 #endif /* !MBEDTLS_HAVE_INT64 */
 
-#ifdef __cplusplus
-extern "C" {
-#endif
 
 /**
  * \brief          MPI structure
  */
+namespace lbug_mbedtls {
 typedef struct mbedtls_mpi {
     int MBEDTLS_PRIVATE(s);               /*!<  Sign: -1 if the mpi is negative, 1 otherwise */
     size_t MBEDTLS_PRIVATE(n);            /*!<  total # of limbs  */
@@ -437,6 +451,7 @@ int mbedtls_mpi_read_string(mbedtls_mpi* X, int radix, const char* s);
 int mbedtls_mpi_write_string(const mbedtls_mpi* X, int radix, char* buf, size_t buflen,
     size_t* olen);
 
+} // namespace lbug_mbedtls
 #if defined(MBEDTLS_FS_IO)
 /**
  * \brief          Read an MPI from a line in an opened file.
@@ -459,6 +474,7 @@ int mbedtls_mpi_write_string(const mbedtls_mpi* X, int radix, char* buf, size_t 
  *                 is too small.
  * \return         Another negative error code on failure.
  */
+namespace lbug_mbedtls {
 int mbedtls_mpi_read_file(mbedtls_mpi* X, int radix, FILE* fin);
 
 /**
@@ -477,6 +493,7 @@ int mbedtls_mpi_read_file(mbedtls_mpi* X, int radix, FILE* fin);
  * \return         A negative error code on failure.
  */
 int mbedtls_mpi_write_file(const char* p, const mbedtls_mpi* X, int radix, FILE* fout);
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_FS_IO */
 
 /**
@@ -491,6 +508,7 @@ int mbedtls_mpi_write_file(const char* p, const mbedtls_mpi* X, int radix, FILE*
  * \return         #MBEDTLS_ERR_MPI_ALLOC_FAILED if memory allocation failed.
  * \return         Another negative error code on different kinds of failure.
  */
+namespace lbug_mbedtls {
 int mbedtls_mpi_read_binary(mbedtls_mpi* X, const unsigned char* buf, size_t buflen);
 
 /**
@@ -982,6 +1000,7 @@ typedef enum {
 int mbedtls_mpi_gen_prime(mbedtls_mpi* X, size_t nbits, int flags,
     int (*f_rng)(void*, unsigned char*, size_t), void* p_rng);
 
+} // namespace lbug_mbedtls
 #if defined(MBEDTLS_SELF_TEST)
 
 /**
@@ -989,12 +1008,13 @@ int mbedtls_mpi_gen_prime(mbedtls_mpi* X, size_t nbits, int flags,
  *
  * \return         0 if successful, or 1 if the test failed
  */
+namespace lbug_mbedtls {
 int mbedtls_mpi_self_test(int verbose);
 
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_SELF_TEST */
 
-#ifdef __cplusplus
-}
-#endif
 
 #endif /* bignum.h */
+
+using namespace lbug_mbedtls; // keep unqualified names for in-tree consumers

--- a/third_party/mbedtls/include/mbedtls/camellia.h
+++ b/third_party/mbedtls/include/mbedtls/camellia.h
@@ -37,9 +37,6 @@
 /** Invalid data input length. */
 #define MBEDTLS_ERR_CAMELLIA_INVALID_INPUT_LENGTH -0x0026
 
-#ifdef __cplusplus
-extern "C" {
-#endif
 
 #if !defined(MBEDTLS_CAMELLIA_ALT)
 // Regular implementation
@@ -48,11 +45,13 @@ extern "C" {
 /**
  * \brief          CAMELLIA context structure
  */
+namespace lbug_mbedtls {
 typedef struct mbedtls_camellia_context {
     int MBEDTLS_PRIVATE(nr);          /*!<  number of rounds  */
     uint32_t MBEDTLS_PRIVATE(rk)[68]; /*!<  CAMELLIA round keys    */
 } mbedtls_camellia_context;
 
+} // namespace lbug_mbedtls
 #else /* MBEDTLS_CAMELLIA_ALT */
 #include "mbedtls/camellia_alt.h"
 #endif /* MBEDTLS_CAMELLIA_ALT */
@@ -63,6 +62,7 @@ typedef struct mbedtls_camellia_context {
  * \param ctx      The CAMELLIA context to be initialized.
  *                 This must not be \c NULL.
  */
+namespace lbug_mbedtls {
 void mbedtls_camellia_init(mbedtls_camellia_context* ctx);
 
 /**
@@ -122,6 +122,7 @@ int mbedtls_camellia_setkey_dec(mbedtls_camellia_context* ctx, const unsigned ch
 int mbedtls_camellia_crypt_ecb(mbedtls_camellia_context* ctx, int mode,
     const unsigned char input[16], unsigned char output[16]);
 
+} // namespace lbug_mbedtls
 #if defined(MBEDTLS_CIPHER_MODE_CBC)
 /**
  * \brief          Perform a CAMELLIA-CBC buffer encryption/decryption operation.
@@ -151,8 +152,10 @@ int mbedtls_camellia_crypt_ecb(mbedtls_camellia_context* ctx, int mode,
  * \return         \c 0 if successful.
  * \return         A negative error code on failure.
  */
+namespace lbug_mbedtls {
 int mbedtls_camellia_crypt_cbc(mbedtls_camellia_context* ctx, int mode, size_t length,
     unsigned char iv[16], const unsigned char* input, unsigned char* output);
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_CIPHER_MODE_CBC */
 
 #if defined(MBEDTLS_CIPHER_MODE_CFB)
@@ -193,8 +196,10 @@ int mbedtls_camellia_crypt_cbc(mbedtls_camellia_context* ctx, int mode, size_t l
  * \return         \c 0 if successful.
  * \return         A negative error code on failure.
  */
+namespace lbug_mbedtls {
 int mbedtls_camellia_crypt_cfb128(mbedtls_camellia_context* ctx, int mode, size_t length,
     size_t* iv_off, unsigned char iv[16], const unsigned char* input, unsigned char* output);
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_CIPHER_MODE_CFB */
 
 #if defined(MBEDTLS_CIPHER_MODE_CTR)
@@ -272,9 +277,11 @@ int mbedtls_camellia_crypt_cfb128(mbedtls_camellia_context* ctx, int mode, size_
  * \return              \c 0 if successful.
  * \return              A negative error code on failure.
  */
+namespace lbug_mbedtls {
 int mbedtls_camellia_crypt_ctr(mbedtls_camellia_context* ctx, size_t length, size_t* nc_off,
     unsigned char nonce_counter[16], unsigned char stream_block[16], const unsigned char* input,
     unsigned char* output);
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_CIPHER_MODE_CTR */
 
 #if defined(MBEDTLS_SELF_TEST)
@@ -284,12 +291,13 @@ int mbedtls_camellia_crypt_ctr(mbedtls_camellia_context* ctx, size_t length, siz
  *
  * \return         0 if successful, or 1 if the test failed
  */
+namespace lbug_mbedtls {
 int mbedtls_camellia_self_test(int verbose);
 
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_SELF_TEST */
 
-#ifdef __cplusplus
-}
-#endif
 
 #endif /* camellia.h */
+
+using namespace lbug_mbedtls; // keep unqualified names for in-tree consumers

--- a/third_party/mbedtls/include/mbedtls/ccm.h
+++ b/third_party/mbedtls/include/mbedtls/ccm.h
@@ -60,9 +60,6 @@
 /** Authenticated decryption failed. */
 #define MBEDTLS_ERR_CCM_AUTH_FAILED -0x000F
 
-#ifdef __cplusplus
-extern "C" {
-#endif
 
 #if !defined(MBEDTLS_CCM_ALT)
 // Regular implementation
@@ -72,6 +69,7 @@ extern "C" {
  * \brief    The CCM context-type definition. The CCM context is passed
  *           to the APIs called.
  */
+namespace lbug_mbedtls {
 typedef struct mbedtls_ccm_context {
     unsigned char MBEDTLS_PRIVATE(y)[16];                 /*!< The Y working buffer */
     unsigned char MBEDTLS_PRIVATE(ctr)[16];               /*!< The counter buffer */
@@ -96,6 +94,7 @@ typedef struct mbedtls_ccm_context {
                                                                input */
 } mbedtls_ccm_context;
 
+} // namespace lbug_mbedtls
 #else /* MBEDTLS_CCM_ALT */
 #include "mbedtls/ccm_alt.h"
 #endif /* MBEDTLS_CCM_ALT */
@@ -107,6 +106,7 @@ typedef struct mbedtls_ccm_context {
  *
  * \param ctx       The CCM context to initialize. This must not be \c NULL.
  */
+namespace lbug_mbedtls {
 void mbedtls_ccm_init(mbedtls_ccm_context* ctx);
 
 /**
@@ -491,6 +491,7 @@ int mbedtls_ccm_update(mbedtls_ccm_context* ctx, const unsigned char* input, siz
  */
 int mbedtls_ccm_finish(mbedtls_ccm_context* ctx, unsigned char* tag, size_t tag_len);
 
+} // namespace lbug_mbedtls
 #if defined(MBEDTLS_SELF_TEST) && defined(MBEDTLS_AES_C)
 /**
  * \brief          The CCM checkup routine.
@@ -498,11 +499,12 @@ int mbedtls_ccm_finish(mbedtls_ccm_context* ctx, unsigned char* tag, size_t tag_
  * \return         \c 0 on success.
  * \return         \c 1 on failure.
  */
+namespace lbug_mbedtls {
 int mbedtls_ccm_self_test(int verbose);
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_SELF_TEST && MBEDTLS_AES_C */
 
-#ifdef __cplusplus
-}
-#endif
 
 #endif /* MBEDTLS_CCM_H */
+
+using namespace lbug_mbedtls; // keep unqualified names for in-tree consumers

--- a/third_party/mbedtls/include/mbedtls/cipher.h
+++ b/third_party/mbedtls/include/mbedtls/cipher.h
@@ -66,9 +66,6 @@
 #define MBEDTLS_CIPHER_VARIABLE_IV_LEN 0x01  /**< Cipher accepts IVs of variable length. */
 #define MBEDTLS_CIPHER_VARIABLE_KEY_LEN 0x02 /**< Cipher accepts keys of variable length. */
 
-#ifdef __cplusplus
-extern "C" {
-#endif
 
 /**
  * \brief     Supported cipher types.
@@ -77,6 +74,7 @@ extern "C" {
  *            constitutes a security risk. Arm recommends considering stronger
  *            ciphers instead.
  */
+namespace lbug_mbedtls {
 typedef enum {
     MBEDTLS_CIPHER_ID_NONE = 0, /**< Placeholder to mark the end of cipher ID lists. */
     MBEDTLS_CIPHER_ID_NULL,     /**< The identity cipher, treated as a stream cipher. */
@@ -252,6 +250,7 @@ enum {
  * This should be kept in sync with MBEDTLS_SSL_MAX_BLOCK_LENGTH defined
  * in library/ssl_misc.h, which however deliberately ignores the case of XTS
  * since the latter isn't used in SSL/TLS. */
+} // namespace lbug_mbedtls
 #if defined(MBEDTLS_CIPHER_MODE_XTS)
 #define MBEDTLS_MAX_KEY_LENGTH 64
 #else
@@ -261,6 +260,7 @@ enum {
 /**
  * Base cipher information (opaque struct).
  */
+namespace lbug_mbedtls {
 typedef struct mbedtls_cipher_base_t mbedtls_cipher_base_t;
 
 /**
@@ -627,6 +627,7 @@ void mbedtls_cipher_free(mbedtls_cipher_context_t* ctx);
  */
 int mbedtls_cipher_setup(mbedtls_cipher_context_t* ctx, const mbedtls_cipher_info_t* cipher_info);
 
+} // namespace lbug_mbedtls
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
 /**
  * \brief               This function initializes a cipher context for
@@ -649,8 +650,10 @@ int mbedtls_cipher_setup(mbedtls_cipher_context_t* ctx, const mbedtls_cipher_inf
  * \return              #MBEDTLS_ERR_CIPHER_ALLOC_FAILED if allocation of the
  *                      cipher-specific context fails.
  */
+namespace lbug_mbedtls {
 int mbedtls_cipher_setup_psa(mbedtls_cipher_context_t* ctx,
     const mbedtls_cipher_info_t* cipher_info, size_t taglen);
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_USE_PSA_CRYPTO */
 
 /**
@@ -663,6 +666,7 @@ int mbedtls_cipher_setup_psa(mbedtls_cipher_context_t* ctx,
  * \return       \c 1 if the cipher is a stream cipher.
  * \return       \c 0 if \p ctx has not been initialized.
  */
+namespace lbug_mbedtls {
 static inline unsigned int mbedtls_cipher_get_block_size(const mbedtls_cipher_context_t* ctx) {
     MBEDTLS_INTERNAL_VALIDATE_RET(ctx != NULL, 0);
     if (ctx->MBEDTLS_PRIVATE(cipher_info) == NULL)
@@ -809,6 +813,7 @@ static inline unsigned int mbedtls_cipher_get_block_size(const mbedtls_cipher_co
 int mbedtls_cipher_setkey(mbedtls_cipher_context_t* ctx, const unsigned char* key, int key_bitlen,
     const mbedtls_operation_t operation);
 
+} // namespace lbug_mbedtls
 #if defined(MBEDTLS_CIPHER_MODE_WITH_PADDING)
 /**
  * \brief               This function sets the padding mode, for cipher modes
@@ -826,7 +831,9 @@ int mbedtls_cipher_setkey(mbedtls_cipher_context_t* ctx, const unsigned char* ke
  * \return              #MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA if the cipher mode
  *                      does not support padding.
  */
+namespace lbug_mbedtls {
 int mbedtls_cipher_set_padding_mode(mbedtls_cipher_context_t* ctx, mbedtls_cipher_padding_t mode);
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_CIPHER_MODE_WITH_PADDING */
 
 /**
@@ -847,6 +854,7 @@ int mbedtls_cipher_set_padding_mode(mbedtls_cipher_context_t* ctx, mbedtls_ciphe
  * \return          #MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA on
  *                  parameter-verification failure.
  */
+namespace lbug_mbedtls {
 int mbedtls_cipher_set_iv(mbedtls_cipher_context_t* ctx, const unsigned char* iv, size_t iv_len);
 
 /**
@@ -883,6 +891,7 @@ int mbedtls_cipher_set_iv(mbedtls_cipher_context_t* ctx, const unsigned char* iv
  */
 int mbedtls_cipher_reset(mbedtls_cipher_context_t* ctx);
 
+} // namespace lbug_mbedtls
 #if defined(MBEDTLS_GCM_C) || defined(MBEDTLS_CHACHAPOLY_C)
 /**
  * \brief               This function adds additional data for AEAD ciphers.
@@ -896,7 +905,9 @@ int mbedtls_cipher_reset(mbedtls_cipher_context_t* ctx);
  * \return              \c 0 on success.
  * \return              A specific error code on failure.
  */
+namespace lbug_mbedtls {
 int mbedtls_cipher_update_ad(mbedtls_cipher_context_t* ctx, const unsigned char* ad, size_t ad_len);
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_GCM_C || MBEDTLS_CHACHAPOLY_C */
 
 /**
@@ -928,6 +939,7 @@ int mbedtls_cipher_update_ad(mbedtls_cipher_context_t* ctx, const unsigned char*
  *                      unsupported mode for a cipher.
  * \return              A cipher-specific error code on failure.
  */
+namespace lbug_mbedtls {
 int mbedtls_cipher_update(mbedtls_cipher_context_t* ctx, const unsigned char* input, size_t ilen,
     unsigned char* output, size_t* olen);
 
@@ -955,6 +967,7 @@ int mbedtls_cipher_update(mbedtls_cipher_context_t* ctx, const unsigned char* in
  */
 int mbedtls_cipher_finish(mbedtls_cipher_context_t* ctx, unsigned char* output, size_t* olen);
 
+} // namespace lbug_mbedtls
 #if defined(MBEDTLS_GCM_C) || defined(MBEDTLS_CHACHAPOLY_C)
 /**
  * \brief               This function writes a tag for AEAD ciphers.
@@ -972,6 +985,7 @@ int mbedtls_cipher_finish(mbedtls_cipher_context_t* ctx, unsigned char* output, 
  * \return              \c 0 on success.
  * \return              A specific error code on failure.
  */
+namespace lbug_mbedtls {
 int mbedtls_cipher_write_tag(mbedtls_cipher_context_t* ctx, unsigned char* tag, size_t tag_len);
 
 /**
@@ -989,6 +1003,7 @@ int mbedtls_cipher_write_tag(mbedtls_cipher_context_t* ctx, unsigned char* tag, 
  */
 int mbedtls_cipher_check_tag(mbedtls_cipher_context_t* ctx, const unsigned char* tag,
     size_t tag_len);
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_GCM_C || MBEDTLS_CHACHAPOLY_C */
 
 /**
@@ -1024,9 +1039,11 @@ int mbedtls_cipher_check_tag(mbedtls_cipher_context_t* ctx, const unsigned char*
  *                      while decrypting.
  * \return              A cipher-specific error code on failure.
  */
+namespace lbug_mbedtls {
 int mbedtls_cipher_crypt(mbedtls_cipher_context_t* ctx, const unsigned char* iv, size_t iv_len,
     const unsigned char* input, size_t ilen, unsigned char* output, size_t* olen);
 
+} // namespace lbug_mbedtls
 #if defined(MBEDTLS_CIPHER_MODE_AEAD) || defined(MBEDTLS_NIST_KW_C)
 /**
  * \brief               The authenticated encryption (AEAD/NIST_KW) function.
@@ -1072,6 +1089,7 @@ int mbedtls_cipher_crypt(mbedtls_cipher_context_t* ctx, const unsigned char* iv,
  *                      parameter-verification failure.
  * \return              A cipher-specific error code on failure.
  */
+namespace lbug_mbedtls {
 int mbedtls_cipher_auth_encrypt_ext(mbedtls_cipher_context_t* ctx, const unsigned char* iv,
     size_t iv_len, const unsigned char* ad, size_t ad_len, const unsigned char* input, size_t ilen,
     unsigned char* output, size_t output_len, size_t* olen, size_t tag_len);
@@ -1128,9 +1146,9 @@ int mbedtls_cipher_auth_encrypt_ext(mbedtls_cipher_context_t* ctx, const unsigne
 int mbedtls_cipher_auth_decrypt_ext(mbedtls_cipher_context_t* ctx, const unsigned char* iv,
     size_t iv_len, const unsigned char* ad, size_t ad_len, const unsigned char* input, size_t ilen,
     unsigned char* output, size_t output_len, size_t* olen, size_t tag_len);
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_CIPHER_MODE_AEAD || MBEDTLS_NIST_KW_C */
-#ifdef __cplusplus
-}
-#endif
 
 #endif /* MBEDTLS_CIPHER_H */
+
+using namespace lbug_mbedtls; // keep unqualified names for in-tree consumers

--- a/third_party/mbedtls/include/mbedtls/constant_time.h
+++ b/third_party/mbedtls/include/mbedtls/constant_time.h
@@ -37,6 +37,10 @@
  * \return      Zero if the content of the two buffer is the same,
  *              otherwise non-zero.
  */
+namespace lbug_mbedtls {
 int mbedtls_ct_memcmp(const void* a, const void* b, size_t n);
 
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_CONSTANT_TIME_H */
+
+using namespace lbug_mbedtls; // keep unqualified names for in-tree consumers

--- a/third_party/mbedtls/include/mbedtls/des.h
+++ b/third_party/mbedtls/include/mbedtls/des.h
@@ -41,9 +41,6 @@
 
 #define MBEDTLS_DES_KEY_SIZE 8
 
-#ifdef __cplusplus
-extern "C" {
-#endif
 
 #if !defined(MBEDTLS_DES_ALT)
 // Regular implementation
@@ -56,6 +53,7 @@ extern "C" {
  *                 security risk. We recommend considering stronger ciphers
  *                 instead.
  */
+namespace lbug_mbedtls {
 typedef struct mbedtls_des_context {
     uint32_t MBEDTLS_PRIVATE(sk)[32]; /*!<  DES subkeys       */
 } mbedtls_des_context;
@@ -67,6 +65,7 @@ typedef struct mbedtls_des3_context {
     uint32_t MBEDTLS_PRIVATE(sk)[96]; /*!<  3DES subkeys      */
 } mbedtls_des3_context;
 
+} // namespace lbug_mbedtls
 #else /* MBEDTLS_DES_ALT */
 #include "des_alt.h"
 #endif /* MBEDTLS_DES_ALT */
@@ -80,6 +79,7 @@ typedef struct mbedtls_des3_context {
  *                 security risk. We recommend considering stronger ciphers
  *                 instead.
  */
+namespace lbug_mbedtls {
 void mbedtls_des_init(mbedtls_des_context* ctx);
 
 /**
@@ -247,6 +247,7 @@ MBEDTLS_CHECK_RETURN_TYPICAL
 int mbedtls_des_crypt_ecb(mbedtls_des_context* ctx, const unsigned char input[8],
     unsigned char output[8]);
 
+} // namespace lbug_mbedtls
 #if defined(MBEDTLS_CIPHER_MODE_CBC)
 /**
  * \brief          DES-CBC buffer encryption/decryption
@@ -270,9 +271,11 @@ int mbedtls_des_crypt_ecb(mbedtls_des_context* ctx, const unsigned char input[8]
  *                 security risk. We recommend considering stronger ciphers
  *                 instead.
  */
+namespace lbug_mbedtls {
 MBEDTLS_CHECK_RETURN_TYPICAL
 int mbedtls_des_crypt_cbc(mbedtls_des_context* ctx, int mode, size_t length, unsigned char iv[8],
     const unsigned char* input, unsigned char* output);
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_CIPHER_MODE_CBC */
 
 /**
@@ -284,10 +287,12 @@ int mbedtls_des_crypt_cbc(mbedtls_des_context* ctx, int mode, size_t length, uns
  *
  * \return         0 if successful
  */
+namespace lbug_mbedtls {
 MBEDTLS_CHECK_RETURN_TYPICAL
 int mbedtls_des3_crypt_ecb(mbedtls_des3_context* ctx, const unsigned char input[8],
     unsigned char output[8]);
 
+} // namespace lbug_mbedtls
 #if defined(MBEDTLS_CIPHER_MODE_CBC)
 /**
  * \brief          3DES-CBC buffer encryption/decryption
@@ -309,9 +314,11 @@ int mbedtls_des3_crypt_ecb(mbedtls_des3_context* ctx, const unsigned char input[
  *
  * \return         0 if successful, or MBEDTLS_ERR_DES_INVALID_INPUT_LENGTH
  */
+namespace lbug_mbedtls {
 MBEDTLS_CHECK_RETURN_TYPICAL
 int mbedtls_des3_crypt_cbc(mbedtls_des3_context* ctx, int mode, size_t length, unsigned char iv[8],
     const unsigned char* input, unsigned char* output);
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_CIPHER_MODE_CBC */
 
 /**
@@ -326,8 +333,10 @@ int mbedtls_des3_crypt_cbc(mbedtls_des3_context* ctx, int mode, size_t length, u
  *                 security risk. We recommend considering stronger ciphers
  *                 instead.
  */
+namespace lbug_mbedtls {
 void mbedtls_des_setkey(uint32_t SK[32], const unsigned char key[MBEDTLS_DES_KEY_SIZE]);
 
+} // namespace lbug_mbedtls
 #if defined(MBEDTLS_SELF_TEST)
 
 /**
@@ -335,13 +344,14 @@ void mbedtls_des_setkey(uint32_t SK[32], const unsigned char key[MBEDTLS_DES_KEY
  *
  * \return         0 if successful, or 1 if the test failed
  */
+namespace lbug_mbedtls {
 MBEDTLS_CHECK_RETURN_CRITICAL
 int mbedtls_des_self_test(int verbose);
 
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_SELF_TEST */
 
-#ifdef __cplusplus
-}
-#endif
 
 #endif /* des.h */
+
+using namespace lbug_mbedtls; // keep unqualified names for in-tree consumers

--- a/third_party/mbedtls/include/mbedtls/entropy.h
+++ b/third_party/mbedtls/include/mbedtls/entropy.h
@@ -81,9 +81,6 @@
 #define MBEDTLS_ENTROPY_SOURCE_STRONG 1 /**< Entropy source is strong   */
 #define MBEDTLS_ENTROPY_SOURCE_WEAK 0   /**< Entropy source is weak     */
 
-#ifdef __cplusplus
-extern "C" {
-#endif
 
 /**
  * \brief           Entropy poll callback pointer
@@ -96,6 +93,7 @@ extern "C" {
  * \return          0 if no critical failures occurred,
  *                  MBEDTLS_ERR_ENTROPY_SOURCE_FAILED otherwise
  */
+namespace lbug_mbedtls {
 typedef int (
     *mbedtls_entropy_f_source_ptr)(void* data, unsigned char* output, size_t len, size_t* olen);
 
@@ -132,11 +130,14 @@ typedef struct mbedtls_entropy_context {
 #endif
 } mbedtls_entropy_context;
 
+} // namespace lbug_mbedtls
 #if !defined(MBEDTLS_NO_PLATFORM_ENTROPY)
 /**
  * \brief           Platform-specific entropy poll callback
  */
+namespace lbug_mbedtls {
 int mbedtls_platform_entropy_poll(void* data, unsigned char* output, size_t len, size_t* olen);
+} // namespace lbug_mbedtls
 #endif
 
 /**
@@ -144,6 +145,7 @@ int mbedtls_platform_entropy_poll(void* data, unsigned char* output, size_t len,
  *
  * \param ctx       Entropy context to initialize
  */
+namespace lbug_mbedtls {
 void mbedtls_entropy_init(mbedtls_entropy_context* ctx);
 
 /**
@@ -209,6 +211,7 @@ int mbedtls_entropy_func(void* data, unsigned char* output, size_t len);
 int mbedtls_entropy_update_manual(mbedtls_entropy_context* ctx, const unsigned char* data,
     size_t len);
 
+} // namespace lbug_mbedtls
 #if defined(MBEDTLS_ENTROPY_NV_SEED)
 /**
  * \brief           Trigger an update of the seed file in NV by using the
@@ -218,7 +221,9 @@ int mbedtls_entropy_update_manual(mbedtls_entropy_context* ctx, const unsigned c
  *
  * \return          0 if successful
  */
+namespace lbug_mbedtls {
 int mbedtls_entropy_update_nv_seed(mbedtls_entropy_context* ctx);
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_ENTROPY_NV_SEED */
 
 #if defined(MBEDTLS_FS_IO)
@@ -232,6 +237,7 @@ int mbedtls_entropy_update_nv_seed(mbedtls_entropy_context* ctx);
  *                      MBEDTLS_ERR_ENTROPY_FILE_IO_ERROR on file error, or
  *                      MBEDTLS_ERR_ENTROPY_SOURCE_FAILED
  */
+namespace lbug_mbedtls {
 int mbedtls_entropy_write_seed_file(mbedtls_entropy_context* ctx, const char* path);
 
 /**
@@ -247,6 +253,7 @@ int mbedtls_entropy_write_seed_file(mbedtls_entropy_context* ctx, const char* pa
  *                      MBEDTLS_ERR_ENTROPY_SOURCE_FAILED
  */
 int mbedtls_entropy_update_seed_file(mbedtls_entropy_context* ctx, const char* path);
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_FS_IO */
 
 #if defined(MBEDTLS_SELF_TEST)
@@ -258,8 +265,10 @@ int mbedtls_entropy_update_seed_file(mbedtls_entropy_context* ctx, const char* p
  *
  * \return         0 if successful, or 1 if a test failed
  */
+namespace lbug_mbedtls {
 int mbedtls_entropy_self_test(int verbose);
 
+} // namespace lbug_mbedtls
 #if defined(MBEDTLS_ENTROPY_HARDWARE_ALT)
 /**
  * \brief          Checkup routine
@@ -274,12 +283,13 @@ int mbedtls_entropy_self_test(int verbose);
  *
  * \return         0 if successful, or 1 if a test failed
  */
+namespace lbug_mbedtls {
 int mbedtls_entropy_source_self_test(int verbose);
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_ENTROPY_HARDWARE_ALT */
 #endif /* MBEDTLS_SELF_TEST */
 
-#ifdef __cplusplus
-}
-#endif
 
 #endif /* entropy.h */
+
+using namespace lbug_mbedtls; // keep unqualified names for in-tree consumers

--- a/third_party/mbedtls/include/mbedtls/error.h
+++ b/third_party/mbedtls/include/mbedtls/error.h
@@ -103,9 +103,6 @@
  * Module dependent error code (5 bits 0x.00.-0x.F8.)
  */
 
-#ifdef __cplusplus
-extern "C" {
-#endif
 
 /** Generic error */
 #define MBEDTLS_ERR_ERROR_GENERIC_ERROR -0x0001
@@ -130,7 +127,9 @@ extern "C" {
  * \brief Testing hook called before adding/combining two error codes together.
  *        Only used when invasive testing is enabled via MBEDTLS_TEST_HOOKS.
  */
+namespace lbug_mbedtls {
 extern void (*mbedtls_test_hook_error_add)(int, int, const char*, int);
+} // namespace lbug_mbedtls
 #endif
 
 /**
@@ -151,6 +150,7 @@ extern void (*mbedtls_test_hook_error_add)(int, int, const char*, int);
  * \param file      file where this error code addition occurred.
  * \param line      line where this error code addition occurred.
  */
+namespace lbug_mbedtls {
 static inline int mbedtls_error_add(int high, int low, const char* file, int line) {
 #if defined(MBEDTLS_TEST_HOOKS)
     if (*mbedtls_test_hook_error_add != NULL)
@@ -203,8 +203,8 @@ const char* mbedtls_high_level_strerr(int error_code);
  */
 const char* mbedtls_low_level_strerr(int error_code);
 
-#ifdef __cplusplus
-}
-#endif
 
+} // namespace lbug_mbedtls
 #endif /* error.h */
+
+using namespace lbug_mbedtls; // keep unqualified names for in-tree consumers

--- a/third_party/mbedtls/include/mbedtls/gcm.h
+++ b/third_party/mbedtls/include/mbedtls/gcm.h
@@ -46,15 +46,13 @@
 /** An output buffer is too small. */
 #define MBEDTLS_ERR_GCM_BUFFER_TOO_SMALL -0x0016
 
-#ifdef __cplusplus
-extern "C" {
-#endif
 
 #if !defined(MBEDTLS_GCM_ALT)
 
 /**
  * \brief          The GCM context structure.
  */
+namespace lbug_mbedtls {
 typedef struct mbedtls_gcm_context {
     mbedtls_cipher_context_t MBEDTLS_PRIVATE(cipher_ctx); /*!< The cipher context used. */
     uint64_t MBEDTLS_PRIVATE(HL)[16];                     /*!< Precalculated HTable low. */
@@ -69,6 +67,7 @@ typedef struct mbedtls_gcm_context {
                                       #MBEDTLS_GCM_DECRYPT. */
 } mbedtls_gcm_context;
 
+} // namespace lbug_mbedtls
 #else /* !MBEDTLS_GCM_ALT */
 #include "mbedtls/gcm_alt.h"
 #endif /* !MBEDTLS_GCM_ALT */
@@ -84,6 +83,7 @@ typedef struct mbedtls_gcm_context {
  *
  * \param ctx       The GCM context to initialize. This must not be \c NULL.
  */
+namespace lbug_mbedtls {
 void mbedtls_gcm_init(mbedtls_gcm_context* ctx);
 
 /**
@@ -333,6 +333,7 @@ int mbedtls_gcm_finish(mbedtls_gcm_context* ctx, unsigned char* output, size_t o
  */
 void mbedtls_gcm_free(mbedtls_gcm_context* ctx);
 
+} // namespace lbug_mbedtls
 #if defined(MBEDTLS_SELF_TEST)
 
 /**
@@ -341,12 +342,13 @@ void mbedtls_gcm_free(mbedtls_gcm_context* ctx);
  * \return         \c 0 on success.
  * \return         \c 1 on failure.
  */
+namespace lbug_mbedtls {
 int mbedtls_gcm_self_test(int verbose);
 
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_SELF_TEST */
 
-#ifdef __cplusplus
-}
-#endif
 
 #endif /* gcm.h */
+
+using namespace lbug_mbedtls; // keep unqualified names for in-tree consumers

--- a/third_party/mbedtls/include/mbedtls/md.h
+++ b/third_party/mbedtls/include/mbedtls/md.h
@@ -39,9 +39,6 @@
 /** Opening or reading of file failed. */
 #define MBEDTLS_ERR_MD_FILE_IO_ERROR -0x5200
 
-#ifdef __cplusplus
-extern "C" {
-#endif
 
 /**
  * \brief     Supported message digests.
@@ -51,6 +48,7 @@ extern "C" {
  *            stronger message digests instead.
  *
  */
+namespace lbug_mbedtls {
 typedef enum {
     MBEDTLS_MD_NONE = 0,  /**< None. */
     MBEDTLS_MD_MD5,       /**< The MD5 message digest. */
@@ -62,6 +60,7 @@ typedef enum {
     MBEDTLS_MD_RIPEMD160, /**< The RIPEMD-160 message digest. */
 } mbedtls_md_type_t;
 
+} // namespace lbug_mbedtls
 #if defined(MBEDTLS_SHA512_C)
 #define MBEDTLS_MD_MAX_SIZE 64 /* longest known is SHA512 */
 #else
@@ -84,6 +83,7 @@ typedef enum {
  * #mbedtls_md_get_type and #mbedtls_md_get_name.
  */
 /* Defined internally in library/md_wrap.h. */
+namespace lbug_mbedtls {
 typedef struct mbedtls_md_info_t mbedtls_md_info_t;
 
 /**
@@ -315,6 +315,7 @@ MBEDTLS_CHECK_RETURN_TYPICAL
 int mbedtls_md(const mbedtls_md_info_t* md_info, const unsigned char* input, size_t ilen,
     unsigned char* output);
 
+} // namespace lbug_mbedtls
 #if defined(MBEDTLS_FS_IO)
 /**
  * \brief          This function calculates the message-digest checksum
@@ -333,8 +334,10 @@ int mbedtls_md(const mbedtls_md_info_t* md_info, const unsigned char* input, siz
  *                 the file pointed by \p path.
  * \return         #MBEDTLS_ERR_MD_BAD_INPUT_DATA if \p md_info was NULL.
  */
+namespace lbug_mbedtls {
 MBEDTLS_CHECK_RETURN_TYPICAL
 int mbedtls_md_file(const mbedtls_md_info_t* md_info, const char* path, unsigned char* output);
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_FS_IO */
 
 /**
@@ -355,6 +358,7 @@ int mbedtls_md_file(const mbedtls_md_info_t* md_info, const char* path, unsigned
  * \return          #MBEDTLS_ERR_MD_BAD_INPUT_DATA on parameter-verification
  *                  failure.
  */
+namespace lbug_mbedtls {
 MBEDTLS_CHECK_RETURN_TYPICAL
 int mbedtls_md_hmac_starts(mbedtls_md_context_t* ctx, const unsigned char* key, size_t keylen);
 
@@ -449,8 +453,8 @@ int mbedtls_md_hmac(const mbedtls_md_info_t* md_info, const unsigned char* key, 
 MBEDTLS_CHECK_RETURN_TYPICAL
 int mbedtls_md_process(mbedtls_md_context_t* ctx, const unsigned char* data);
 
-#ifdef __cplusplus
-}
-#endif
 
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_MD_H */
+
+using namespace lbug_mbedtls; // keep unqualified names for in-tree consumers

--- a/third_party/mbedtls/include/mbedtls/memory_buffer_alloc.h
+++ b/third_party/mbedtls/include/mbedtls/memory_buffer_alloc.h
@@ -45,9 +45,6 @@
 #define MBEDTLS_MEMORY_VERIFY_FREE (1 << 1)
 #define MBEDTLS_MEMORY_VERIFY_ALWAYS (MBEDTLS_MEMORY_VERIFY_ALLOC | MBEDTLS_MEMORY_VERIFY_FREE)
 
-#ifdef __cplusplus
-extern "C" {
-#endif
 
 /**
  * \brief   Initialize use of stack-based memory allocator.
@@ -64,6 +61,7 @@ extern "C" {
  * \param buf   buffer to use as heap
  * \param len   size of the buffer
  */
+namespace lbug_mbedtls {
 void mbedtls_memory_buffer_alloc_init(unsigned char* buf, size_t len);
 
 /**
@@ -81,6 +79,7 @@ void mbedtls_memory_buffer_alloc_free(void);
  */
 void mbedtls_memory_buffer_set_verify(int verify);
 
+} // namespace lbug_mbedtls
 #if defined(MBEDTLS_MEMORY_DEBUG)
 /**
  * \brief   Print out the status of the allocated memory (primarily for use
@@ -88,6 +87,7 @@ void mbedtls_memory_buffer_set_verify(int verify);
  *          Prints out a list of 'still allocated' blocks and their stack
  *          trace if MBEDTLS_MEMORY_BACKTRACE is defined.
  */
+namespace lbug_mbedtls {
 void mbedtls_memory_buffer_alloc_status(void);
 
 /**
@@ -114,6 +114,7 @@ void mbedtls_memory_buffer_alloc_max_reset(void);
  * \param cur_blocks    Current number of blocks in use, including free and used
  */
 void mbedtls_memory_buffer_alloc_cur_get(size_t* cur_used, size_t* cur_blocks);
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_MEMORY_DEBUG */
 
 /**
@@ -127,19 +128,22 @@ void mbedtls_memory_buffer_alloc_cur_get(size_t* cur_used, size_t* cur_blocks);
  *
  * \return             0 if verified, 1 otherwise
  */
+namespace lbug_mbedtls {
 int mbedtls_memory_buffer_alloc_verify(void);
 
+} // namespace lbug_mbedtls
 #if defined(MBEDTLS_SELF_TEST)
 /**
  * \brief          Checkup routine
  *
  * \return         0 if successful, or 1 if a test failed
  */
+namespace lbug_mbedtls {
 int mbedtls_memory_buffer_alloc_self_test(int verbose);
+} // namespace lbug_mbedtls
 #endif
 
-#ifdef __cplusplus
-}
-#endif
 
 #endif /* memory_buffer_alloc.h */
+
+using namespace lbug_mbedtls; // keep unqualified names for in-tree consumers

--- a/third_party/mbedtls/include/mbedtls/oid.h
+++ b/third_party/mbedtls/include/mbedtls/oid.h
@@ -573,13 +573,11 @@
  *   ecdsa-with-SHA2(3) 4 } */
 #define MBEDTLS_OID_ECDSA_SHA512 MBEDTLS_OID_ANSI_X9_62_SIG_SHA2 "\x04"
 
-#ifdef __cplusplus
-extern "C" {
-#endif
 
 /**
  * \brief Base OID descriptor structure
  */
+namespace lbug_mbedtls {
 typedef struct mbedtls_oid_descriptor_t {
     const char* MBEDTLS_PRIVATE(asn1); /*!< OID ASN.1 representation       */
     size_t MBEDTLS_PRIVATE(asn1_len);  /*!< length of asn1                 */
@@ -644,6 +642,7 @@ int mbedtls_oid_get_pk_alg(const mbedtls_asn1_buf* oid, mbedtls_pk_type_t* pk_al
  */
 int mbedtls_oid_get_oid_by_pk_alg(mbedtls_pk_type_t pk_alg, const char** oid, size_t* olen);
 
+} // namespace lbug_mbedtls
 #if defined(MBEDTLS_ECP_C)
 /**
  * \brief          Translate NamedCurve OID into an EC group identifier
@@ -653,6 +652,7 @@ int mbedtls_oid_get_oid_by_pk_alg(mbedtls_pk_type_t pk_alg, const char** oid, si
  *
  * \return         0 if successful, or MBEDTLS_ERR_OID_NOT_FOUND
  */
+namespace lbug_mbedtls {
 int mbedtls_oid_get_ec_grp(const mbedtls_asn1_buf* oid, mbedtls_ecp_group_id* grp_id);
 
 /**
@@ -665,6 +665,7 @@ int mbedtls_oid_get_ec_grp(const mbedtls_asn1_buf* oid, mbedtls_ecp_group_id* gr
  * \return         0 if successful, or MBEDTLS_ERR_OID_NOT_FOUND
  */
 int mbedtls_oid_get_oid_by_ec_grp(mbedtls_ecp_group_id grp_id, const char** oid, size_t* olen);
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_ECP_C */
 
 #if defined(MBEDTLS_MD_C)
@@ -677,6 +678,7 @@ int mbedtls_oid_get_oid_by_ec_grp(mbedtls_ecp_group_id grp_id, const char** oid,
  *
  * \return         0 if successful, or MBEDTLS_ERR_OID_NOT_FOUND
  */
+namespace lbug_mbedtls {
 int mbedtls_oid_get_sig_alg(const mbedtls_asn1_buf* oid, mbedtls_md_type_t* md_alg,
     mbedtls_pk_type_t* pk_alg);
 
@@ -722,6 +724,7 @@ int mbedtls_oid_get_md_alg(const mbedtls_asn1_buf* oid, mbedtls_md_type_t* md_al
  * \return         0 if successful, or MBEDTLS_ERR_OID_NOT_FOUND
  */
 int mbedtls_oid_get_md_hmac(const mbedtls_asn1_buf* oid, mbedtls_md_type_t* md_hmac);
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_MD_C */
 
 #if !defined(MBEDTLS_X509_REMOVE_INFO)
@@ -733,7 +736,9 @@ int mbedtls_oid_get_md_hmac(const mbedtls_asn1_buf* oid, mbedtls_md_type_t* md_h
  *
  * \return         0 if successful, or MBEDTLS_ERR_OID_NOT_FOUND
  */
+namespace lbug_mbedtls {
 int mbedtls_oid_get_extended_key_usage(const mbedtls_asn1_buf* oid, const char** desc);
+} // namespace lbug_mbedtls
 #endif
 
 /**
@@ -744,6 +749,7 @@ int mbedtls_oid_get_extended_key_usage(const mbedtls_asn1_buf* oid, const char**
  *
  * \return         0 if successful, or MBEDTLS_ERR_OID_NOT_FOUND
  */
+namespace lbug_mbedtls {
 int mbedtls_oid_get_certificate_policies(const mbedtls_asn1_buf* oid, const char** desc);
 
 /**
@@ -757,6 +763,7 @@ int mbedtls_oid_get_certificate_policies(const mbedtls_asn1_buf* oid, const char
  */
 int mbedtls_oid_get_oid_by_md(mbedtls_md_type_t md_alg, const char** oid, size_t* olen);
 
+} // namespace lbug_mbedtls
 #if defined(MBEDTLS_CIPHER_C)
 /**
  * \brief          Translate encryption algorithm OID into cipher_type
@@ -766,7 +773,9 @@ int mbedtls_oid_get_oid_by_md(mbedtls_md_type_t md_alg, const char** oid, size_t
  *
  * \return         0 if successful, or MBEDTLS_ERR_OID_NOT_FOUND
  */
+namespace lbug_mbedtls {
 int mbedtls_oid_get_cipher_alg(const mbedtls_asn1_buf* oid, mbedtls_cipher_type_t* cipher_alg);
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_CIPHER_C */
 
 #if defined(MBEDTLS_PKCS12_C)
@@ -780,12 +789,13 @@ int mbedtls_oid_get_cipher_alg(const mbedtls_asn1_buf* oid, mbedtls_cipher_type_
  *
  * \return         0 if successful, or MBEDTLS_ERR_OID_NOT_FOUND
  */
+namespace lbug_mbedtls {
 int mbedtls_oid_get_pkcs12_pbe_alg(const mbedtls_asn1_buf* oid, mbedtls_md_type_t* md_alg,
     mbedtls_cipher_type_t* cipher_alg);
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_PKCS12_C */
 
-#ifdef __cplusplus
-}
-#endif
 
 #endif /* oid.h */
+
+using namespace lbug_mbedtls; // keep unqualified names for in-tree consumers

--- a/third_party/mbedtls/include/mbedtls/pem.h
+++ b/third_party/mbedtls/include/mbedtls/pem.h
@@ -52,14 +52,12 @@
 #define MBEDTLS_ERR_PEM_BAD_INPUT_DATA -0x1480
 /* \} name */
 
-#ifdef __cplusplus
-extern "C" {
-#endif
 
 #if defined(MBEDTLS_PEM_PARSE_C)
 /**
  * \brief       PEM context structure
  */
+namespace lbug_mbedtls {
 typedef struct mbedtls_pem_context {
     unsigned char* MBEDTLS_PRIVATE(buf);  /*!< buffer for decoded data             */
     size_t MBEDTLS_PRIVATE(buflen);       /*!< length of the buffer                */
@@ -104,6 +102,7 @@ int mbedtls_pem_read_buffer(mbedtls_pem_context* ctx, const char* header, const 
  * \param ctx   context to be freed
  */
 void mbedtls_pem_free(mbedtls_pem_context* ctx);
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_PEM_PARSE_C */
 
 #if defined(MBEDTLS_PEM_WRITE_C)
@@ -133,12 +132,13 @@ void mbedtls_pem_free(mbedtls_pem_context* ctx);
  *                  the required minimum size of \p buf.
  * \return          Another PEM or BASE64 error code on other kinds of failure.
  */
+namespace lbug_mbedtls {
 int mbedtls_pem_write_buffer(const char* header, const char* footer, const unsigned char* der_data,
     size_t der_len, unsigned char* buf, size_t buf_len, size_t* olen);
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_PEM_WRITE_C */
 
-#ifdef __cplusplus
-}
-#endif
 
 #endif /* pem.h */
+
+using namespace lbug_mbedtls; // keep unqualified names for in-tree consumers

--- a/third_party/mbedtls/include/mbedtls/pk.h
+++ b/third_party/mbedtls/include/mbedtls/pk.h
@@ -77,13 +77,11 @@
 /** The output buffer is too small. */
 #define MBEDTLS_ERR_PK_BUFFER_TOO_SMALL -0x3880
 
-#ifdef __cplusplus
-extern "C" {
-#endif
 
 /**
  * \brief          Public key types
  */
+namespace lbug_mbedtls {
 typedef enum {
     MBEDTLS_PK_NONE = 0,
     MBEDTLS_PK_RSA,
@@ -119,6 +117,7 @@ typedef struct mbedtls_pk_rsassa_pss_options {
  */
 #define MBEDTLS_PK_SIGNATURE_MAX_SIZE 0
 
+} // namespace lbug_mbedtls
 #if (defined(MBEDTLS_RSA_C) || defined(MBEDTLS_PK_RSA_ALT_SUPPORT)) &&                             \
     MBEDTLS_MPI_MAX_SIZE > MBEDTLS_PK_SIGNATURE_MAX_SIZE
 /* For RSA, the signature can be as large as the bignum module allows.
@@ -159,6 +158,7 @@ typedef struct mbedtls_pk_rsassa_pss_options {
 /**
  * \brief           Types for interfacing with the debug module
  */
+namespace lbug_mbedtls {
 typedef enum {
     MBEDTLS_PK_DEBUG_NONE = 0,
     MBEDTLS_PK_DEBUG_MPI,
@@ -194,17 +194,22 @@ typedef struct mbedtls_pk_context {
     void* MBEDTLS_PRIVATE(pk_ctx);                     /**< Underlying public key context  */
 } mbedtls_pk_context;
 
+} // namespace lbug_mbedtls
 #if defined(MBEDTLS_ECDSA_C) && defined(MBEDTLS_ECP_RESTARTABLE)
 /**
  * \brief           Context for resuming operations
  */
+namespace lbug_mbedtls {
 typedef struct {
     const mbedtls_pk_info_t* MBEDTLS_PRIVATE(pk_info); /**< Public key information         */
     void* MBEDTLS_PRIVATE(rs_ctx);                     /**< Underlying restart context     */
 } mbedtls_pk_restart_ctx;
+} // namespace lbug_mbedtls
 #else  /* MBEDTLS_ECDSA_C && MBEDTLS_ECP_RESTARTABLE */
 /* Now we can declare functions that take a pointer to that */
+namespace lbug_mbedtls {
 typedef void mbedtls_pk_restart_ctx;
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_ECDSA_C && MBEDTLS_ECP_RESTARTABLE */
 
 #if defined(MBEDTLS_RSA_C)
@@ -214,9 +219,11 @@ typedef void mbedtls_pk_restart_ctx;
  * \warning You must make sure the PK context actually holds an RSA context
  * before using this function!
  */
+namespace lbug_mbedtls {
 static inline mbedtls_rsa_context* mbedtls_pk_rsa(const mbedtls_pk_context pk) {
     return ((mbedtls_rsa_context*)(pk).MBEDTLS_PRIVATE(pk_ctx));
 }
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_RSA_C */
 
 #if defined(MBEDTLS_ECP_C)
@@ -226,21 +233,25 @@ static inline mbedtls_rsa_context* mbedtls_pk_rsa(const mbedtls_pk_context pk) {
  * \warning You must make sure the PK context actually holds an EC context
  * before using this function!
  */
+namespace lbug_mbedtls {
 static inline mbedtls_ecp_keypair* mbedtls_pk_ec(const mbedtls_pk_context pk) {
     return ((mbedtls_ecp_keypair*)(pk).MBEDTLS_PRIVATE(pk_ctx));
 }
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_ECP_C */
 
 #if defined(MBEDTLS_PK_RSA_ALT_SUPPORT)
 /**
  * \brief           Types for RSA-alt abstraction
  */
+namespace lbug_mbedtls {
 typedef int (*mbedtls_pk_rsa_alt_decrypt_func)(void* ctx, size_t* olen, const unsigned char* input,
     unsigned char* output, size_t output_max_len);
 typedef int (*mbedtls_pk_rsa_alt_sign_func)(void* ctx, int (*f_rng)(void*, unsigned char*, size_t),
     void* p_rng, mbedtls_md_type_t md_alg, unsigned int hashlen, const unsigned char* hash,
     unsigned char* sig);
 typedef size_t (*mbedtls_pk_rsa_alt_key_len_func)(void* ctx);
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_PK_RSA_ALT_SUPPORT */
 
 /**
@@ -250,6 +261,7 @@ typedef size_t (*mbedtls_pk_rsa_alt_key_len_func)(void* ctx);
  *
  * \return          The PK info associated with the type or NULL if not found.
  */
+namespace lbug_mbedtls {
 const mbedtls_pk_info_t* mbedtls_pk_info_from_type(mbedtls_pk_type_t pk_type);
 
 /**
@@ -273,6 +285,7 @@ void mbedtls_pk_init(mbedtls_pk_context* ctx);
  */
 void mbedtls_pk_free(mbedtls_pk_context* ctx);
 
+} // namespace lbug_mbedtls
 #if defined(MBEDTLS_ECDSA_C) && defined(MBEDTLS_ECP_RESTARTABLE)
 /**
  * \brief           Initialize a restart context
@@ -280,6 +293,7 @@ void mbedtls_pk_free(mbedtls_pk_context* ctx);
  * \param ctx       The context to initialize.
  *                  This must not be \c NULL.
  */
+namespace lbug_mbedtls {
 void mbedtls_pk_restart_init(mbedtls_pk_restart_ctx* ctx);
 
 /**
@@ -289,6 +303,7 @@ void mbedtls_pk_restart_init(mbedtls_pk_restart_ctx* ctx);
  *                  If this is \c NULL, this function does nothing.
  */
 void mbedtls_pk_restart_free(mbedtls_pk_restart_ctx* ctx);
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_ECDSA_C && MBEDTLS_ECP_RESTARTABLE */
 
 /**
@@ -306,8 +321,10 @@ void mbedtls_pk_restart_free(mbedtls_pk_restart_ctx* ctx);
  * \note            For contexts holding an RSA-alt key, use
  *                  \c mbedtls_pk_setup_rsa_alt() instead.
  */
+namespace lbug_mbedtls {
 int mbedtls_pk_setup(mbedtls_pk_context* ctx, const mbedtls_pk_info_t* info);
 
+} // namespace lbug_mbedtls
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
 /**
  * \brief           Initialize a PK context to wrap a PSA key.
@@ -337,7 +354,9 @@ int mbedtls_pk_setup(mbedtls_pk_context* ctx, const mbedtls_pk_info_t* info);
  *                  ECC key pair.
  * \return          #MBEDTLS_ERR_PK_ALLOC_FAILED on allocation failure.
  */
+namespace lbug_mbedtls {
 int mbedtls_pk_setup_opaque(mbedtls_pk_context* ctx, const psa_key_id_t key);
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_USE_PSA_CRYPTO */
 
 #if defined(MBEDTLS_PK_RSA_ALT_SUPPORT)
@@ -356,9 +375,11 @@ int mbedtls_pk_setup_opaque(mbedtls_pk_context* ctx, const psa_key_id_t key);
  *
  * \note            This function replaces \c mbedtls_pk_setup() for RSA-alt.
  */
+namespace lbug_mbedtls {
 int mbedtls_pk_setup_rsa_alt(mbedtls_pk_context* ctx, void* key,
     mbedtls_pk_rsa_alt_decrypt_func decrypt_func, mbedtls_pk_rsa_alt_sign_func sign_func,
     mbedtls_pk_rsa_alt_key_len_func key_len_func);
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_PK_RSA_ALT_SUPPORT */
 
 /**
@@ -368,6 +389,7 @@ int mbedtls_pk_setup_rsa_alt(mbedtls_pk_context* ctx, void* key,
  *
  * \return          Key size in bits, or 0 on error
  */
+namespace lbug_mbedtls {
 size_t mbedtls_pk_get_bitlen(const mbedtls_pk_context* ctx);
 
 ///**
@@ -638,6 +660,7 @@ const char* mbedtls_pk_get_name(const mbedtls_pk_context* ctx);
  */
 mbedtls_pk_type_t mbedtls_pk_get_type(const mbedtls_pk_context* ctx);
 
+} // namespace lbug_mbedtls
 #if defined(MBEDTLS_PK_PARSE_C)
 /** \ingroup pk_module */
 /**
@@ -670,6 +693,7 @@ mbedtls_pk_type_t mbedtls_pk_get_type(const mbedtls_pk_context* ctx);
  *
  * \return          0 if successful, or a specific PK or PEM error code
  */
+namespace lbug_mbedtls {
 int mbedtls_pk_parse_key(mbedtls_pk_context* ctx, const unsigned char* key, size_t keylen,
     const unsigned char* pwd, size_t pwdlen, int (*f_rng)(void*, unsigned char*, size_t),
     void* p_rng);
@@ -698,6 +722,7 @@ int mbedtls_pk_parse_key(mbedtls_pk_context* ctx, const unsigned char* key, size
  */
 int mbedtls_pk_parse_public_key(mbedtls_pk_context* ctx, const unsigned char* key, size_t keylen);
 
+} // namespace lbug_mbedtls
 #if defined(MBEDTLS_FS_IO)
 /** \ingroup pk_module */
 /**
@@ -722,6 +747,7 @@ int mbedtls_pk_parse_public_key(mbedtls_pk_context* ctx, const unsigned char* ke
  *
  * \return          0 if successful, or a specific PK or PEM error code
  */
+namespace lbug_mbedtls {
 int mbedtls_pk_parse_keyfile(mbedtls_pk_context* ctx, const char* path, const char* password,
     int (*f_rng)(void*, unsigned char*, size_t), void* p_rng);
 
@@ -743,6 +769,7 @@ int mbedtls_pk_parse_keyfile(mbedtls_pk_context* ctx, const char* path, const ch
  * \return          0 if successful, or a specific PK or PEM error code
  */
 int mbedtls_pk_parse_public_keyfile(mbedtls_pk_context* ctx, const char* path);
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_FS_IO */
 #endif /* MBEDTLS_PK_PARSE_C */
 
@@ -760,6 +787,7 @@ int mbedtls_pk_parse_public_keyfile(mbedtls_pk_context* ctx, const char* path);
  * \return          length of data written if successful, or a specific
  *                  error code
  */
+namespace lbug_mbedtls {
 int mbedtls_pk_write_key_der(const mbedtls_pk_context* ctx, unsigned char* buf, size_t size);
 
 /**
@@ -777,6 +805,7 @@ int mbedtls_pk_write_key_der(const mbedtls_pk_context* ctx, unsigned char* buf, 
  */
 int mbedtls_pk_write_pubkey_der(const mbedtls_pk_context* ctx, unsigned char* buf, size_t size);
 
+} // namespace lbug_mbedtls
 #if defined(MBEDTLS_PEM_WRITE_C)
 /**
  * \brief           Write a public key to a PEM string
@@ -788,6 +817,7 @@ int mbedtls_pk_write_pubkey_der(const mbedtls_pk_context* ctx, unsigned char* bu
  *
  * \return          0 if successful, or a specific error code
  */
+namespace lbug_mbedtls {
 int mbedtls_pk_write_pubkey_pem(const mbedtls_pk_context* ctx, unsigned char* buf, size_t size);
 
 /**
@@ -801,6 +831,7 @@ int mbedtls_pk_write_pubkey_pem(const mbedtls_pk_context* ctx, unsigned char* bu
  * \return          0 if successful, or a specific error code
  */
 int mbedtls_pk_write_key_pem(const mbedtls_pk_context* ctx, unsigned char* buf, size_t size);
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_PEM_WRITE_C */
 #endif /* MBEDTLS_PK_WRITE_C */
 
@@ -820,7 +851,9 @@ int mbedtls_pk_write_key_pem(const mbedtls_pk_context* ctx, unsigned char* buf, 
  *
  * \return          0 if successful, or a specific PK error code
  */
+namespace lbug_mbedtls {
 int mbedtls_pk_parse_subpubkey(unsigned char** p, const unsigned char* end, mbedtls_pk_context* pk);
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_PK_PARSE_C */
 
 #if defined(MBEDTLS_PK_WRITE_C)
@@ -834,7 +867,9 @@ int mbedtls_pk_parse_subpubkey(unsigned char** p, const unsigned char* end, mbed
  *
  * \return          the length written or a negative error code
  */
+namespace lbug_mbedtls {
 int mbedtls_pk_write_pubkey(unsigned char** p, unsigned char* start, const mbedtls_pk_context* key);
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_PK_WRITE_C */
 
 /*
@@ -842,7 +877,9 @@ int mbedtls_pk_write_pubkey(unsigned char** p, unsigned char* start, const mbedt
  * know you do.
  */
 #if defined(MBEDTLS_FS_IO)
+namespace lbug_mbedtls {
 int mbedtls_pk_load_file(const char* path, unsigned char** buf, size_t* n);
+} // namespace lbug_mbedtls
 #endif
 
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
@@ -866,11 +903,12 @@ int mbedtls_pk_load_file(const char* path, unsigned char** buf, size_t* n);
  * \return          \c 0 if successful.
  * \return          An Mbed TLS error code otherwise.
  */
+namespace lbug_mbedtls {
 int mbedtls_pk_wrap_as_opaque(mbedtls_pk_context* pk, psa_key_id_t* key, psa_algorithm_t hash_alg);
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_USE_PSA_CRYPTO */
 
-#ifdef __cplusplus
-}
-#endif
 
 #endif /* MBEDTLS_PK_H */
+
+using namespace lbug_mbedtls; // keep unqualified names for in-tree consumers

--- a/third_party/mbedtls/include/mbedtls/platform.h
+++ b/third_party/mbedtls/include/mbedtls/platform.h
@@ -37,9 +37,6 @@
 #include "mbedtls/platform_time.h"
 #endif
 
-#ifdef __cplusplus
-extern "C" {
-#endif
 
 /**
  * \name SECTION: Module settings
@@ -131,6 +128,7 @@ extern "C" {
 #else
 /* For size_t */
 #include <stddef.h>
+namespace lbug_mbedtls {
 extern void* mbedtls_calloc(size_t n, size_t size);
 extern void mbedtls_free(void* ptr);
 
@@ -145,6 +143,7 @@ extern void mbedtls_free(void* ptr);
  */
 int mbedtls_platform_set_calloc_free(void* (*calloc_func)(size_t, size_t),
     void (*free_func)(void*));
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_PLATFORM_FREE_MACRO && MBEDTLS_PLATFORM_CALLOC_MACRO */
 #else  /* !MBEDTLS_PLATFORM_MEMORY */
 #define mbedtls_free free
@@ -157,6 +156,7 @@ int mbedtls_platform_set_calloc_free(void* (*calloc_func)(size_t, size_t),
 #if defined(MBEDTLS_PLATFORM_FPRINTF_ALT)
 /* We need FILE * */
 #include <stdio.h>
+namespace lbug_mbedtls {
 extern int (*mbedtls_fprintf)(FILE* stream, const char* format, ...);
 
 /**
@@ -169,6 +169,7 @@ extern int (*mbedtls_fprintf)(FILE* stream, const char* format, ...);
  * \return               \c 0.
  */
 int mbedtls_platform_set_fprintf(int (*fprintf_func)(FILE* stream, const char*, ...));
+} // namespace lbug_mbedtls
 #else
 #if defined(MBEDTLS_PLATFORM_FPRINTF_MACRO)
 #define mbedtls_fprintf MBEDTLS_PLATFORM_FPRINTF_MACRO
@@ -181,6 +182,7 @@ int mbedtls_platform_set_fprintf(int (*fprintf_func)(FILE* stream, const char*, 
  * The function pointers for printf
  */
 #if defined(MBEDTLS_PLATFORM_PRINTF_ALT)
+namespace lbug_mbedtls {
 extern int (*mbedtls_printf)(const char* format, ...);
 
 /**
@@ -193,6 +195,7 @@ extern int (*mbedtls_printf)(const char* format, ...);
  * \return              \c 0 on success.
  */
 int mbedtls_platform_set_printf(int (*printf_func)(const char*, ...));
+} // namespace lbug_mbedtls
 #else /* !MBEDTLS_PLATFORM_PRINTF_ALT */
 #if defined(MBEDTLS_PLATFORM_PRINTF_MACRO)
 #define mbedtls_printf MBEDTLS_PLATFORM_PRINTF_MACRO
@@ -212,10 +215,13 @@ int mbedtls_platform_set_printf(int (*printf_func)(const char*, ...));
  */
 #if defined(MBEDTLS_PLATFORM_HAS_NON_CONFORMING_SNPRINTF)
 /* For Windows (inc. MSYS2), we provide our own fixed implementation */
+namespace lbug_mbedtls {
 int mbedtls_platform_win32_snprintf(char* s, size_t n, const char* fmt, ...);
+} // namespace lbug_mbedtls
 #endif
 
 #if defined(MBEDTLS_PLATFORM_SNPRINTF_ALT)
+namespace lbug_mbedtls {
 extern int (*mbedtls_snprintf)(char* s, size_t n, const char* format, ...);
 
 /**
@@ -227,6 +233,7 @@ extern int (*mbedtls_snprintf)(char* s, size_t n, const char* format, ...);
  * \return                \c 0 on success.
  */
 int mbedtls_platform_set_snprintf(int (*snprintf_func)(char* s, size_t n, const char* format, ...));
+} // namespace lbug_mbedtls
 #else /* MBEDTLS_PLATFORM_SNPRINTF_ALT */
 #if defined(MBEDTLS_PLATFORM_SNPRINTF_MACRO)
 #define mbedtls_snprintf MBEDTLS_PLATFORM_SNPRINTF_MACRO
@@ -247,11 +254,14 @@ int mbedtls_platform_set_snprintf(int (*snprintf_func)(char* s, size_t n, const 
 #if defined(MBEDTLS_PLATFORM_HAS_NON_CONFORMING_VSNPRINTF)
 #include <stdarg.h>
 /* For Older Windows (inc. MSYS2), we provide our own fixed implementation */
+namespace lbug_mbedtls {
 int mbedtls_platform_win32_vsnprintf(char* s, size_t n, const char* fmt, va_list arg);
+} // namespace lbug_mbedtls
 #endif
 
 #if defined(MBEDTLS_PLATFORM_VSNPRINTF_ALT)
 #include <stdarg.h>
+namespace lbug_mbedtls {
 extern int (*mbedtls_vsnprintf)(char* s, size_t n, const char* format, va_list arg);
 
 /**
@@ -263,6 +273,7 @@ extern int (*mbedtls_vsnprintf)(char* s, size_t n, const char* format, va_list a
  */
 int mbedtls_platform_set_vsnprintf(
     int (*vsnprintf_func)(char* s, size_t n, const char* format, va_list arg));
+} // namespace lbug_mbedtls
 #else /* MBEDTLS_PLATFORM_VSNPRINTF_ALT */
 #if defined(MBEDTLS_PLATFORM_VSNPRINTF_MACRO)
 #define mbedtls_vsnprintf MBEDTLS_PLATFORM_VSNPRINTF_MACRO
@@ -275,6 +286,7 @@ int mbedtls_platform_set_vsnprintf(
  * The function pointers for exit
  */
 #if defined(MBEDTLS_PLATFORM_EXIT_ALT)
+namespace lbug_mbedtls {
 extern void (*mbedtls_exit)(int status);
 
 /**
@@ -287,6 +299,7 @@ extern void (*mbedtls_exit)(int status);
  * \return            \c 0 on success.
  */
 int mbedtls_platform_set_exit(void (*exit_func)(int status));
+} // namespace lbug_mbedtls
 #else
 #if defined(MBEDTLS_PLATFORM_EXIT_MACRO)
 #define mbedtls_exit MBEDTLS_PLATFORM_EXIT_MACRO
@@ -318,11 +331,14 @@ int mbedtls_platform_set_exit(void (*exit_func)(int status));
 #if defined(MBEDTLS_ENTROPY_NV_SEED)
 #if !defined(MBEDTLS_PLATFORM_NO_STD_FUNCTIONS) && defined(MBEDTLS_FS_IO)
 /* Internal standard platform definitions */
+namespace lbug_mbedtls {
 int mbedtls_platform_std_nv_seed_read(unsigned char* buf, size_t buf_len);
 int mbedtls_platform_std_nv_seed_write(unsigned char* buf, size_t buf_len);
+} // namespace lbug_mbedtls
 #endif
 
 #if defined(MBEDTLS_PLATFORM_NV_SEED_ALT)
+namespace lbug_mbedtls {
 extern int (*mbedtls_nv_seed_read)(unsigned char* buf, size_t buf_len);
 extern int (*mbedtls_nv_seed_write)(unsigned char* buf, size_t buf_len);
 
@@ -337,6 +353,7 @@ extern int (*mbedtls_nv_seed_write)(unsigned char* buf, size_t buf_len);
  */
 int mbedtls_platform_set_nv_seed(int (*nv_seed_read_func)(unsigned char* buf, size_t buf_len),
     int (*nv_seed_write_func)(unsigned char* buf, size_t buf_len));
+} // namespace lbug_mbedtls
 #else
 #if defined(MBEDTLS_PLATFORM_NV_SEED_READ_MACRO) && defined(MBEDTLS_PLATFORM_NV_SEED_WRITE_MACRO)
 #define mbedtls_nv_seed_read MBEDTLS_PLATFORM_NV_SEED_READ_MACRO
@@ -356,10 +373,12 @@ int mbedtls_platform_set_nv_seed(int (*nv_seed_read_func)(unsigned char* buf, si
  * \note    This structure may be used to assist platform-specific
  *          setup or teardown operations.
  */
+namespace lbug_mbedtls {
 typedef struct mbedtls_platform_context {
     char MBEDTLS_PRIVATE(dummy); /**< A placeholder member, as empty structs are not portable. */
 } mbedtls_platform_context;
 
+} // namespace lbug_mbedtls
 #else
 #include "platform_alt.h"
 #endif /* !MBEDTLS_PLATFORM_SETUP_TEARDOWN_ALT */
@@ -379,6 +398,7 @@ typedef struct mbedtls_platform_context {
  *
  * \return  \c 0 on success.
  */
+namespace lbug_mbedtls {
 int mbedtls_platform_setup(mbedtls_platform_context* ctx);
 /**
  * \brief   This function performs any platform teardown operations.
@@ -396,8 +416,8 @@ int mbedtls_platform_setup(mbedtls_platform_context* ctx);
  */
 void mbedtls_platform_teardown(mbedtls_platform_context* ctx);
 
-#ifdef __cplusplus
-}
-#endif
 
+} // namespace lbug_mbedtls
 #endif /* platform.h */
+
+using namespace lbug_mbedtls; // keep unqualified names for in-tree consumers

--- a/third_party/mbedtls/include/mbedtls/platform_time.h
+++ b/third_party/mbedtls/include/mbedtls/platform_time.h
@@ -24,9 +24,6 @@
 
 #include "mbedtls/build_info.h"
 
-#ifdef __cplusplus
-extern "C" {
-#endif
 
 /**
  * \name SECTION: Module settings
@@ -40,17 +37,22 @@ extern "C" {
  * The time_t datatype
  */
 #if defined(MBEDTLS_PLATFORM_TIME_TYPE_MACRO)
+namespace lbug_mbedtls {
 typedef MBEDTLS_PLATFORM_TIME_TYPE_MACRO mbedtls_time_t;
+} // namespace lbug_mbedtls
 #else
 /* For time_t */
 #include <time.h>
+namespace lbug_mbedtls {
 typedef time_t mbedtls_time_t;
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_PLATFORM_TIME_TYPE_MACRO */
 
 /*
  * The function pointers for time
  */
 #if defined(MBEDTLS_PLATFORM_TIME_ALT)
+namespace lbug_mbedtls {
 extern mbedtls_time_t (*mbedtls_time)(mbedtls_time_t* time);
 
 /**
@@ -61,6 +63,7 @@ extern mbedtls_time_t (*mbedtls_time)(mbedtls_time_t* time);
  * \return              0
  */
 int mbedtls_platform_set_time(mbedtls_time_t (*time_func)(mbedtls_time_t* time));
+} // namespace lbug_mbedtls
 #else
 #if defined(MBEDTLS_PLATFORM_TIME_MACRO)
 #define mbedtls_time MBEDTLS_PLATFORM_TIME_MACRO
@@ -69,8 +72,7 @@ int mbedtls_platform_set_time(mbedtls_time_t (*time_func)(mbedtls_time_t* time))
 #endif /* MBEDTLS_PLATFORM_TIME_MACRO */
 #endif /* MBEDTLS_PLATFORM_TIME_ALT */
 
-#ifdef __cplusplus
-}
-#endif
 
 #endif /* platform_time.h */
+
+using namespace lbug_mbedtls; // keep unqualified names for in-tree consumers

--- a/third_party/mbedtls/include/mbedtls/platform_util.h
+++ b/third_party/mbedtls/include/mbedtls/platform_util.h
@@ -32,9 +32,6 @@
 #include "mbedtls/platform_time.h"
 #endif /* MBEDTLS_HAVE_TIME_DATE */
 
-#ifdef __cplusplus
-extern "C" {
-#endif
 
 /* Internal macros meant to be called only from within the library. */
 #define MBEDTLS_INTERNAL_VALIDATE_RET(cond, ret)                                                   \
@@ -48,10 +45,12 @@ extern "C" {
 #if !defined(MBEDTLS_DEPRECATED_REMOVED)
 #if defined(MBEDTLS_DEPRECATED_WARNING)
 #define MBEDTLS_DEPRECATED __attribute__((deprecated))
+namespace lbug_mbedtls {
 MBEDTLS_DEPRECATED typedef char const* mbedtls_deprecated_string_constant_t;
 #define MBEDTLS_DEPRECATED_STRING_CONSTANT(VAL) ((mbedtls_deprecated_string_constant_t)(VAL))
 MBEDTLS_DEPRECATED typedef int mbedtls_deprecated_numeric_constant_t;
 #define MBEDTLS_DEPRECATED_NUMERIC_CONSTANT(VAL) ((mbedtls_deprecated_numeric_constant_t)(VAL))
+} // namespace lbug_mbedtls
 #else /* MBEDTLS_DEPRECATED_WARNING */
 #define MBEDTLS_DEPRECATED
 #define MBEDTLS_DEPRECATED_STRING_CONSTANT(VAL) VAL
@@ -170,8 +169,10 @@ MBEDTLS_DEPRECATED typedef int mbedtls_deprecated_numeric_constant_t;
  * \param len   Length of the buffer in bytes
  *
  */
+namespace lbug_mbedtls {
 void mbedtls_platform_zeroize(void* buf, size_t len);
 
+} // namespace lbug_mbedtls
 #if defined(MBEDTLS_HAVE_TIME_DATE)
 /**
  * \brief      Platform-specific implementation of gmtime_r()
@@ -199,11 +200,12 @@ void mbedtls_platform_zeroize(void* buf, size_t len);
  * \return      Pointer to an object of type struct tm on success, otherwise
  *              NULL
  */
+namespace lbug_mbedtls {
 struct tm* mbedtls_platform_gmtime_r(const mbedtls_time_t* tt, struct tm* tm_buf);
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_HAVE_TIME_DATE */
 
-#ifdef __cplusplus
-}
-#endif
 
 #endif /* MBEDTLS_PLATFORM_UTIL_H */
+
+using namespace lbug_mbedtls; // keep unqualified names for in-tree consumers

--- a/third_party/mbedtls/include/mbedtls/rsa.h
+++ b/third_party/mbedtls/include/mbedtls/rsa.h
@@ -75,9 +75,6 @@
  * eg for alternative (PKCS#11) RSA implemenations in the PK layers.
  */
 
-#ifdef __cplusplus
-extern "C" {
-#endif
 
 #if !defined(MBEDTLS_RSA_ALT)
 // Regular implementation
@@ -86,6 +83,7 @@ extern "C" {
 /**
  * \brief   The RSA context structure.
  */
+namespace lbug_mbedtls {
 typedef struct mbedtls_rsa_context {
     int MBEDTLS_PRIVATE(ver);    /*!<  Reserved for internal purposes.
                                   *    Do not set this field in application
@@ -125,6 +123,7 @@ typedef struct mbedtls_rsa_context {
 #endif
 } mbedtls_rsa_context;
 
+} // namespace lbug_mbedtls
 #else /* MBEDTLS_RSA_ALT */
 #include "rsa_alt.h"
 #endif /* MBEDTLS_RSA_ALT */
@@ -139,6 +138,7 @@ typedef struct mbedtls_rsa_context {
  *
  * \param ctx      The RSA context to initialize. This must not be \c NULL.
  */
+namespace lbug_mbedtls {
 void mbedtls_rsa_init(mbedtls_rsa_context* ctx);
 
 /**
@@ -1034,6 +1034,7 @@ int mbedtls_rsa_copy(mbedtls_rsa_context* dst, const mbedtls_rsa_context* src);
  */
 void mbedtls_rsa_free(mbedtls_rsa_context* ctx);
 
+} // namespace lbug_mbedtls
 #if defined(MBEDTLS_SELF_TEST)
 
 /**
@@ -1042,12 +1043,13 @@ void mbedtls_rsa_free(mbedtls_rsa_context* ctx);
  * \return         \c 0 on success.
  * \return         \c 1 on failure.
  */
+namespace lbug_mbedtls {
 int mbedtls_rsa_self_test(int verbose);
 
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_SELF_TEST */
 
-#ifdef __cplusplus
-}
-#endif
 
 #endif /* rsa.h */
+
+using namespace lbug_mbedtls; // keep unqualified names for in-tree consumers

--- a/third_party/mbedtls/include/mbedtls/sha1.h
+++ b/third_party/mbedtls/include/mbedtls/sha1.h
@@ -37,9 +37,6 @@
 /** SHA-1 input data was malformed. */
 #define MBEDTLS_ERR_SHA1_BAD_INPUT_DATA -0x0073
 
-#ifdef __cplusplus
-extern "C" {
-#endif
 
 #if !defined(MBEDTLS_SHA1_ALT)
 // Regular implementation
@@ -53,12 +50,14 @@ extern "C" {
  *                 stronger message digests instead.
  *
  */
+namespace lbug_mbedtls {
 typedef struct mbedtls_sha1_context {
     uint32_t MBEDTLS_PRIVATE(total)[2];        /*!< The number of Bytes processed.  */
     uint32_t MBEDTLS_PRIVATE(state)[5];        /*!< The intermediate digest state.  */
     unsigned char MBEDTLS_PRIVATE(buffer)[64]; /*!< The data block being processed. */
 } mbedtls_sha1_context;
 
+} // namespace lbug_mbedtls
 #else /* MBEDTLS_SHA1_ALT */
 #include "sha1_alt.h"
 #endif /* MBEDTLS_SHA1_ALT */
@@ -74,6 +73,7 @@ typedef struct mbedtls_sha1_context {
  *                 This must not be \c NULL.
  *
  */
+namespace lbug_mbedtls {
 void mbedtls_sha1_init(mbedtls_sha1_context* ctx);
 
 /**
@@ -198,6 +198,7 @@ int mbedtls_internal_sha1_process(mbedtls_sha1_context* ctx, const unsigned char
  */
 int mbedtls_sha1(const unsigned char* input, size_t ilen, unsigned char output[20]);
 
+} // namespace lbug_mbedtls
 #if defined(MBEDTLS_SELF_TEST)
 
 /**
@@ -211,12 +212,13 @@ int mbedtls_sha1(const unsigned char* input, size_t ilen, unsigned char output[2
  * \return         \c 1 on failure.
  *
  */
+namespace lbug_mbedtls {
 int mbedtls_sha1_self_test(int verbose);
 
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_SELF_TEST */
 
-#ifdef __cplusplus
-}
-#endif
 
 #endif /* mbedtls_sha1.h */
+
+using namespace lbug_mbedtls; // keep unqualified names for in-tree consumers

--- a/third_party/mbedtls/include/mbedtls/sha256.h
+++ b/third_party/mbedtls/include/mbedtls/sha256.h
@@ -33,9 +33,6 @@
 /** SHA-256 input data was malformed. */
 #define MBEDTLS_ERR_SHA256_BAD_INPUT_DATA -0x0074
 
-#ifdef __cplusplus
-extern "C" {
-#endif
 
 #if !defined(MBEDTLS_SHA256_ALT)
 // Regular implementation
@@ -48,6 +45,7 @@ extern "C" {
  *                 checksum calculations. The choice between these two is
  *                 made in the call to mbedtls_sha256_starts().
  */
+namespace lbug_mbedtls {
 typedef struct mbedtls_sha256_context {
     uint32_t MBEDTLS_PRIVATE(total)[2];        /*!< The number of Bytes processed.  */
     uint32_t MBEDTLS_PRIVATE(state)[8];        /*!< The intermediate digest state.  */
@@ -56,6 +54,7 @@ typedef struct mbedtls_sha256_context {
                                    0: Use SHA-256, or 1: Use SHA-224. */
 } mbedtls_sha256_context;
 
+} // namespace lbug_mbedtls
 #else /* MBEDTLS_SHA256_ALT */
 #include "sha256_alt.h"
 #endif /* MBEDTLS_SHA256_ALT */
@@ -65,6 +64,7 @@ typedef struct mbedtls_sha256_context {
  *
  * \param ctx      The SHA-256 context to initialize. This must not be \c NULL.
  */
+namespace lbug_mbedtls {
 void mbedtls_sha256_init(mbedtls_sha256_context* ctx);
 
 /**
@@ -165,6 +165,7 @@ int mbedtls_internal_sha256_process(mbedtls_sha256_context* ctx, const unsigned 
  */
 int mbedtls_sha256(const unsigned char* input, size_t ilen, unsigned char* output, int is224);
 
+} // namespace lbug_mbedtls
 #if defined(MBEDTLS_SELF_TEST)
 
 /**
@@ -173,12 +174,13 @@ int mbedtls_sha256(const unsigned char* input, size_t ilen, unsigned char* outpu
  * \return         \c 0 on success.
  * \return         \c 1 on failure.
  */
+namespace lbug_mbedtls {
 int mbedtls_sha256_self_test(int verbose);
 
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_SELF_TEST */
 
-#ifdef __cplusplus
-}
-#endif
 
 #endif /* mbedtls_sha256.h */
+
+using namespace lbug_mbedtls; // keep unqualified names for in-tree consumers

--- a/third_party/mbedtls/include/mbedtls/sha512.h
+++ b/third_party/mbedtls/include/mbedtls/sha512.h
@@ -32,9 +32,6 @@
 /** SHA-512 input data was malformed. */
 #define MBEDTLS_ERR_SHA512_BAD_INPUT_DATA -0x0075
 
-#ifdef __cplusplus
-extern "C" {
-#endif
 
 #if !defined(MBEDTLS_SHA512_ALT)
 // Regular implementation
@@ -47,6 +44,7 @@ extern "C" {
  *                 checksum calculations. The choice between these two is
  *                 made in the call to mbedtls_sha512_starts().
  */
+namespace lbug_mbedtls {
 typedef struct mbedtls_sha512_context {
     uint64_t MBEDTLS_PRIVATE(total)[2];         /*!< The number of Bytes processed. */
     uint64_t MBEDTLS_PRIVATE(state)[8];         /*!< The intermediate digest state. */
@@ -57,6 +55,7 @@ typedef struct mbedtls_sha512_context {
 #endif
 } mbedtls_sha512_context;
 
+} // namespace lbug_mbedtls
 #else /* MBEDTLS_SHA512_ALT */
 #include "sha512_alt.h"
 #endif /* MBEDTLS_SHA512_ALT */
@@ -67,6 +66,7 @@ typedef struct mbedtls_sha512_context {
  * \param ctx      The SHA-512 context to initialize. This must
  *                 not be \c NULL.
  */
+namespace lbug_mbedtls {
 void mbedtls_sha512_init(mbedtls_sha512_context* ctx);
 
 /**
@@ -176,6 +176,7 @@ int mbedtls_internal_sha512_process(mbedtls_sha512_context* ctx, const unsigned 
  */
 int mbedtls_sha512(const unsigned char* input, size_t ilen, unsigned char* output, int is384);
 
+} // namespace lbug_mbedtls
 #if defined(MBEDTLS_SELF_TEST)
 
 /**
@@ -184,11 +185,12 @@ int mbedtls_sha512(const unsigned char* input, size_t ilen, unsigned char* outpu
  * \return         \c 0 on success.
  * \return         \c 1 on failure.
  */
+namespace lbug_mbedtls {
 int mbedtls_sha512_self_test(int verbose);
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_SELF_TEST */
 
-#ifdef __cplusplus
-}
-#endif
 
 #endif /* mbedtls_sha512.h */
+
+using namespace lbug_mbedtls; // keep unqualified names for in-tree consumers

--- a/third_party/mbedtls/library/aes.cpp
+++ b/third_party/mbedtls/library/aes.cpp
@@ -56,13 +56,16 @@
 #define AES_VALIDATE(cond) MBEDTLS_INTERNAL_VALIDATE(cond)
 
 #if defined(MBEDTLS_PADLOCK_C) && (defined(MBEDTLS_HAVE_X86) || defined(MBEDTLS_PADLOCK_ALIGN16))
+namespace lbug_mbedtls {
 static int aes_padlock_ace = -1;
+} // namespace lbug_mbedtls
 #endif
 
 #if defined(MBEDTLS_AES_ROM_TABLES)
 /*
  * Forward S-box
  */
+namespace lbug_mbedtls {
 static const unsigned char AESFSb[256] = {0x63, 0x7C, 0x77, 0x7B, 0xF2, 0x6B, 0x6F, 0xC5, 0x30,
     0x01, 0x67, 0x2B, 0xFE, 0xD7, 0xAB, 0x76, 0xCA, 0x82, 0xC9, 0x7D, 0xFA, 0x59, 0x47, 0xF0, 0xAD,
     0xD4, 0xA2, 0xAF, 0x9C, 0xA4, 0x72, 0xC0, 0xB7, 0xFD, 0x93, 0x26, 0x36, 0x3F, 0xF7, 0xCC, 0x34,
@@ -155,9 +158,11 @@ static const unsigned char AESFSb[256] = {0x63, 0x7C, 0x77, 0x7B, 0xF2, 0x6B, 0x
 static const uint32_t FT0[256] = {FT};
 #undef V
 
+} // namespace lbug_mbedtls
 #if !defined(MBEDTLS_AES_FEWER_TABLES)
 
 #define V(a, b, c, d) 0x##b##c##d##a
+namespace lbug_mbedtls {
 static const uint32_t FT1[256] = {FT};
 #undef V
 
@@ -169,6 +174,7 @@ static const uint32_t FT2[256] = {FT};
 static const uint32_t FT3[256] = {FT};
 #undef V
 
+} // namespace lbug_mbedtls
 #endif /* !MBEDTLS_AES_FEWER_TABLES */
 
 #undef FT
@@ -176,6 +182,7 @@ static const uint32_t FT3[256] = {FT};
 /*
  * Reverse S-box
  */
+namespace lbug_mbedtls {
 static const unsigned char RSb[256] = {0x52, 0x09, 0x6A, 0xD5, 0x30, 0x36, 0xA5, 0x38, 0xBF, 0x40,
     0xA3, 0x9E, 0x81, 0xF3, 0xD7, 0xFB, 0x7C, 0xE3, 0x39, 0x82, 0x9B, 0x2F, 0xFF, 0x87, 0x34, 0x8E,
     0x43, 0x44, 0xC4, 0xDE, 0xE9, 0xCB, 0x54, 0x7B, 0x94, 0x32, 0xA6, 0xC2, 0x23, 0x3D, 0xEE, 0x4C,
@@ -268,9 +275,11 @@ static const unsigned char RSb[256] = {0x52, 0x09, 0x6A, 0xD5, 0x30, 0x36, 0xA5,
 static const uint32_t RT0[256] = {RT};
 #undef V
 
+} // namespace lbug_mbedtls
 #if !defined(MBEDTLS_AES_FEWER_TABLES)
 
 #define V(a, b, c, d) 0x##b##c##d##a
+namespace lbug_mbedtls {
 static const uint32_t RT1[256] = {RT};
 #undef V
 
@@ -282,6 +291,7 @@ static const uint32_t RT2[256] = {RT};
 static const uint32_t RT3[256] = {RT};
 #undef V
 
+} // namespace lbug_mbedtls
 #endif /* !MBEDTLS_AES_FEWER_TABLES */
 
 #undef RT
@@ -289,36 +299,47 @@ static const uint32_t RT3[256] = {RT};
 /*
  * Round constants
  */
+namespace lbug_mbedtls {
 static const uint32_t RCON[10] = {0x00000001, 0x00000002, 0x00000004, 0x00000008, 0x00000010,
     0x00000020, 0x00000040, 0x00000080, 0x0000001B, 0x00000036};
 
+} // namespace lbug_mbedtls
 #else /* MBEDTLS_AES_ROM_TABLES */
 
 /*
  * Forward S-box & tables
  */
+namespace lbug_mbedtls {
 static unsigned char AESFSb[256];
 static uint32_t FT0[256];
+} // namespace lbug_mbedtls
 #if !defined(MBEDTLS_AES_FEWER_TABLES)
+namespace lbug_mbedtls {
 static uint32_t FT1[256];
 static uint32_t FT2[256];
 static uint32_t FT3[256];
+} // namespace lbug_mbedtls
 #endif /* !MBEDTLS_AES_FEWER_TABLES */
 
 /*
  * Reverse S-box & tables
  */
+namespace lbug_mbedtls {
 static unsigned char RSb[256];
 static uint32_t RT0[256];
+} // namespace lbug_mbedtls
 #if !defined(MBEDTLS_AES_FEWER_TABLES)
+namespace lbug_mbedtls {
 static uint32_t RT1[256];
 static uint32_t RT2[256];
 static uint32_t RT3[256];
+} // namespace lbug_mbedtls
 #endif /* !MBEDTLS_AES_FEWER_TABLES */
 
 /*
  * Round constants
  */
+namespace lbug_mbedtls {
 static uint32_t RCON[10];
 
 /*
@@ -406,6 +427,7 @@ static void aes_gen_tables(void) {
 
 #undef ROTL8
 
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_AES_ROM_TABLES */
 
 #if defined(MBEDTLS_AES_FEWER_TABLES)
@@ -438,6 +460,7 @@ static void aes_gen_tables(void) {
 
 #endif /* MBEDTLS_AES_FEWER_TABLES */
 
+namespace lbug_mbedtls {
 void mbedtls_aes_init(mbedtls_aes_context* ctx) {
     AES_VALIDATE(ctx != NULL);
 
@@ -451,7 +474,9 @@ void mbedtls_aes_free(mbedtls_aes_context* ctx) {
     mbedtls_platform_zeroize(ctx, sizeof(mbedtls_aes_context));
 }
 
+} // namespace lbug_mbedtls
 #if defined(MBEDTLS_CIPHER_MODE_XTS)
+namespace lbug_mbedtls {
 void mbedtls_aes_xts_init(mbedtls_aes_xts_context* ctx) {
     AES_VALIDATE(ctx != NULL);
 
@@ -466,12 +491,14 @@ void mbedtls_aes_xts_free(mbedtls_aes_xts_context* ctx) {
     mbedtls_aes_free(&ctx->crypt);
     mbedtls_aes_free(&ctx->tweak);
 }
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_CIPHER_MODE_XTS */
 
 /*
  * AES key schedule (encryption)
  */
 #if !defined(MBEDTLS_AES_SETKEY_ENC_ALT)
+namespace lbug_mbedtls {
 int mbedtls_aes_setkey_enc(mbedtls_aes_context* ctx, const unsigned char* key,
     unsigned int keybits) {
     unsigned int i;
@@ -577,12 +604,14 @@ int mbedtls_aes_setkey_enc(mbedtls_aes_context* ctx, const unsigned char* key,
 
     return (0);
 }
+} // namespace lbug_mbedtls
 #endif /* !MBEDTLS_AES_SETKEY_ENC_ALT */
 
 /*
  * AES key schedule (decryption)
  */
 #if !defined(MBEDTLS_AES_SETKEY_DEC_ALT)
+namespace lbug_mbedtls {
 int mbedtls_aes_setkey_dec(mbedtls_aes_context* ctx, const unsigned char* key,
     unsigned int keybits) {
     int i, j, ret;
@@ -642,9 +671,11 @@ exit:
 
     return (ret);
 }
+} // namespace lbug_mbedtls
 #endif /* !MBEDTLS_AES_SETKEY_DEC_ALT */
 
 #if defined(MBEDTLS_CIPHER_MODE_XTS)
+namespace lbug_mbedtls {
 static int mbedtls_aes_xts_decode_keys(const unsigned char* key, unsigned int keybits,
     const unsigned char** key1, unsigned int* key1bits, const unsigned char** key2,
     unsigned int* key2bits) {
@@ -711,6 +742,7 @@ int mbedtls_aes_xts_setkey_dec(mbedtls_aes_xts_context* ctx, const unsigned char
     /* Set crypt key for decryption. */
     return mbedtls_aes_setkey_dec(&ctx->crypt, key1, key1bits);
 }
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_CIPHER_MODE_XTS */
 
 #define AES_FROUND(X0, X1, X2, X3, Y0, Y1, Y2, Y3)                                                 \
@@ -747,6 +779,7 @@ int mbedtls_aes_xts_setkey_dec(mbedtls_aes_xts_context* ctx, const unsigned char
  * AES-ECB block encryption
  */
 #if !defined(MBEDTLS_AES_ENCRYPT_ALT)
+namespace lbug_mbedtls {
 int mbedtls_internal_aes_encrypt(mbedtls_aes_context* ctx, const unsigned char input[16],
     unsigned char output[16]) {
     int i;
@@ -801,12 +834,14 @@ int mbedtls_internal_aes_encrypt(mbedtls_aes_context* ctx, const unsigned char i
 
     return (0);
 }
+} // namespace lbug_mbedtls
 #endif /* !MBEDTLS_AES_ENCRYPT_ALT */
 
 /*
  * AES-ECB block decryption
  */
 #if !defined(MBEDTLS_AES_DECRYPT_ALT)
+namespace lbug_mbedtls {
 int mbedtls_internal_aes_decrypt(mbedtls_aes_context* ctx, const unsigned char input[16],
     unsigned char output[16]) {
     int i;
@@ -861,11 +896,13 @@ int mbedtls_internal_aes_decrypt(mbedtls_aes_context* ctx, const unsigned char i
 
     return (0);
 }
+} // namespace lbug_mbedtls
 #endif /* !MBEDTLS_AES_DECRYPT_ALT */
 
 /*
  * AES-ECB block encryption/decryption
  */
+namespace lbug_mbedtls {
 int mbedtls_aes_crypt_ecb(mbedtls_aes_context* ctx, int mode, const unsigned char input[16],
     unsigned char output[16]) {
     AES_VALIDATE_RET(ctx != NULL);
@@ -895,10 +932,12 @@ int mbedtls_aes_crypt_ecb(mbedtls_aes_context* ctx, int mode, const unsigned cha
         return (mbedtls_internal_aes_decrypt(ctx, input, output));
 }
 
+} // namespace lbug_mbedtls
 #if defined(MBEDTLS_CIPHER_MODE_CBC)
 /*
  * AES-CBC buffer encryption/decryption
  */
+namespace lbug_mbedtls {
 int mbedtls_aes_crypt_cbc(mbedtls_aes_context* ctx, int mode, size_t length, unsigned char iv[16],
     const unsigned char* input, unsigned char* output) {
     int i;
@@ -961,10 +1000,12 @@ int mbedtls_aes_crypt_cbc(mbedtls_aes_context* ctx, int mode, size_t length, uns
 exit:
     return (ret);
 }
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_CIPHER_MODE_CBC */
 
 #if defined(MBEDTLS_CIPHER_MODE_XTS)
 
+namespace lbug_mbedtls {
 typedef unsigned char mbedtls_be128[16];
 
 /*
@@ -1085,12 +1126,14 @@ int mbedtls_aes_crypt_xts(mbedtls_aes_xts_context* ctx, int mode, size_t length,
 
     return (0);
 }
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_CIPHER_MODE_XTS */
 
 #if defined(MBEDTLS_CIPHER_MODE_CFB)
 /*
  * AES-CFB128 buffer encryption/decryption
  */
+namespace lbug_mbedtls {
 int mbedtls_aes_crypt_cfb128(mbedtls_aes_context* ctx, int mode, size_t length, size_t* iv_off,
     unsigned char iv[16], const unsigned char* input, unsigned char* output) {
     int c;
@@ -1179,12 +1222,14 @@ int mbedtls_aes_crypt_cfb8(mbedtls_aes_context* ctx, int mode, size_t length, un
 exit:
     return (ret);
 }
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_CIPHER_MODE_CFB */
 
 #if defined(MBEDTLS_CIPHER_MODE_OFB)
 /*
  * AES-OFB (Output Feedback Mode) buffer encryption/decryption
  */
+namespace lbug_mbedtls {
 int mbedtls_aes_crypt_ofb(mbedtls_aes_context* ctx, size_t length, size_t* iv_off,
     unsigned char iv[16], const unsigned char* input, unsigned char* output) {
     int ret = 0;
@@ -1217,12 +1262,14 @@ int mbedtls_aes_crypt_ofb(mbedtls_aes_context* ctx, size_t length, size_t* iv_of
 exit:
     return (ret);
 }
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_CIPHER_MODE_OFB */
 
 #if defined(MBEDTLS_CIPHER_MODE_CTR)
 /*
  * AES-CTR buffer encryption/decryption
  */
+namespace lbug_mbedtls {
 int mbedtls_aes_crypt_ctr(mbedtls_aes_context* ctx, size_t length, size_t* nc_off,
     unsigned char nonce_counter[16], unsigned char stream_block[16], const unsigned char* input,
     unsigned char* output) {
@@ -1264,6 +1311,7 @@ int mbedtls_aes_crypt_ctr(mbedtls_aes_context* ctx, size_t length, size_t* nc_of
 exit:
     return (ret);
 }
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_CIPHER_MODE_CTR */
 
 #endif /* !MBEDTLS_AES_ALT */
@@ -1274,6 +1322,7 @@ exit:
  *
  * http://csrc.nist.gov/archive/aes/rijndael/rijndael-vals.zip
  */
+namespace lbug_mbedtls {
 static const unsigned char aes_test_ecb_dec[3][16] = {{0x44, 0x41, 0x6A, 0xC2, 0xD1, 0xF5, 0x3C,
                                                           0x58, 0x33, 0x03, 0x91, 0x7E, 0x6B, 0xE9,
                                                           0xEB, 0xE0},
@@ -1290,7 +1339,9 @@ static const unsigned char aes_test_ecb_enc[3][16] = {{0xC3, 0x4C, 0x05, 0x2C, 0
     {0x8B, 0x79, 0xEE, 0xCC, 0x93, 0xA0, 0xEE, 0x5D, 0xFF, 0x30, 0xB4, 0xEA, 0x21, 0x63, 0x6D,
         0xA4}};
 
+} // namespace lbug_mbedtls
 #if defined(MBEDTLS_CIPHER_MODE_CBC)
+namespace lbug_mbedtls {
 static const unsigned char aes_test_cbc_dec[3][16] = {{0xFA, 0xCA, 0x37, 0xE0, 0xB0, 0xC8, 0x53,
                                                           0x73, 0xDF, 0x70, 0x6E, 0x73, 0xF7, 0xC9,
                                                           0xAF, 0x86},
@@ -1306,6 +1357,7 @@ static const unsigned char aes_test_cbc_enc[3][16] = {{0x8A, 0x05, 0xFC, 0x5E, 0
         0x04},
     {0xFE, 0x3C, 0x53, 0x65, 0x3E, 0x2F, 0x45, 0xB5, 0x6F, 0xCD, 0x88, 0xB2, 0xCC, 0x89, 0x8F,
         0xF0}};
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_CIPHER_MODE_CBC */
 
 #if defined(MBEDTLS_CIPHER_MODE_CFB)
@@ -1314,6 +1366,7 @@ static const unsigned char aes_test_cbc_enc[3][16] = {{0x8A, 0x05, 0xFC, 0x5E, 0
  *
  * http://csrc.nist.gov/publications/nistpubs/800-38a/sp800-38a.pdf
  */
+namespace lbug_mbedtls {
 static const unsigned char aes_test_cfb128_key[3][32] = {{0x2B, 0x7E, 0x15, 0x16, 0x28, 0xAE, 0xD2,
                                                              0xA6, 0xAB, 0xF7, 0x15, 0x88, 0x09,
                                                              0xCF, 0x4F, 0x3C},
@@ -1348,6 +1401,7 @@ static const unsigned char aes_test_cfb128_ct[3][64] = {
         0x7B, 0xDF, 0x10, 0x13, 0x24, 0x15, 0xE5, 0x4B, 0x92, 0xA1, 0x3E, 0xD0, 0xA8, 0x26, 0x7A,
         0xE2, 0xF9, 0x75, 0xA3, 0x85, 0x74, 0x1A, 0xB9, 0xCE, 0xF8, 0x20, 0x31, 0x62, 0x3D, 0x55,
         0xB1, 0xE4, 0x71}};
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_CIPHER_MODE_CFB */
 
 #if defined(MBEDTLS_CIPHER_MODE_OFB)
@@ -1356,6 +1410,7 @@ static const unsigned char aes_test_cfb128_ct[3][64] = {
  *
  * https://csrc.nist.gov/publications/detail/sp/800-38a/final
  */
+namespace lbug_mbedtls {
 static const unsigned char aes_test_ofb_key[3][32] = {{0x2B, 0x7E, 0x15, 0x16, 0x28, 0xAE, 0xD2,
                                                           0xA6, 0xAB, 0xF7, 0x15, 0x88, 0x09, 0xCF,
                                                           0x4F, 0x3C},
@@ -1390,6 +1445,7 @@ static const unsigned char aes_test_ofb_ct[3][64] = {
         0x8d, 0x71, 0xab, 0x47, 0xa0, 0x86, 0xe8, 0x6e, 0xed, 0xf3, 0x9d, 0x1c, 0x5b, 0xba, 0x97,
         0xc4, 0x08, 0x01, 0x26, 0x14, 0x1d, 0x67, 0xf3, 0x7b, 0xe8, 0x53, 0x8f, 0x5a, 0x8b, 0xe7,
         0x40, 0xe4, 0x84}};
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_CIPHER_MODE_OFB */
 
 #if defined(MBEDTLS_CIPHER_MODE_CTR)
@@ -1399,6 +1455,7 @@ static const unsigned char aes_test_ofb_ct[3][64] = {
  * http://www.faqs.org/rfcs/rfc3686.html
  */
 
+namespace lbug_mbedtls {
 static const unsigned char aes_test_ctr_key[3][16] = {{0xAE, 0x68, 0x52, 0xF8, 0x12, 0x10, 0x67,
                                                           0xCC, 0x4B, 0xF7, 0xA5, 0x76, 0x55, 0x77,
                                                           0xF3, 0x9E},
@@ -1438,6 +1495,7 @@ static const unsigned char aes_test_ctr_ct[3][48] = {{0xE4, 0x09, 0x5D, 0x4F, 0x
         0x53, 0x25, 0xB2, 0x07, 0x2F}};
 
 static const int aes_test_ctr_len[3] = {16, 32, 36};
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_CIPHER_MODE_CTR */
 
 #if defined(MBEDTLS_CIPHER_MODE_XTS)
@@ -1448,6 +1506,7 @@ static const int aes_test_ctr_len[3] = {16, 32, 36};
  * https://web.archive.org/web/20150629024421/http://grouper.ieee.org/groups/1619/email/pdf00086.pdf
  * (Archived from original at http://grouper.ieee.org/groups/1619/email/pdf00086.pdf)
  */
+namespace lbug_mbedtls {
 static const unsigned char aes_test_xts_key[][32] = {
     {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
         0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
@@ -1493,11 +1552,13 @@ static const unsigned char aes_test_xts_data_unit[][16] = {
         0x00},
 };
 
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_CIPHER_MODE_XTS */
 
 /*
  * Checkup routine
  */
+namespace lbug_mbedtls {
 int mbedtls_aes_self_test(int verbose) {
     int ret = 0, i, j, u, mode;
     unsigned int keybits;
@@ -1867,6 +1928,7 @@ exit:
     return (ret);
 }
 
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_SELF_TEST */
 
 #endif /* MBEDTLS_AES_C */

--- a/third_party/mbedtls/library/aria.cpp
+++ b/third_party/mbedtls/library/aria.cpp
@@ -65,20 +65,24 @@
 /* armcc5 --gnu defines __GNUC__ but doesn't support GNU's extended asm */
 #if defined(__GNUC__) && (!defined(__ARMCC_VERSION) || __ARMCC_VERSION >= 6000000) &&              \
     __ARM_ARCH >= 6
+namespace lbug_mbedtls {
 static inline uint32_t aria_p1(uint32_t x) {
     uint32_t r;
     __asm("rev16 %0, %1" : "=l"(r) : "l"(x));
     return (r);
 }
 #define ARIA_P1 aria_p1
+} // namespace lbug_mbedtls
 #elif defined(__ARMCC_VERSION) && __ARMCC_VERSION < 6000000 &&                                     \
     (__TARGET_ARCH_ARM >= 6 || __TARGET_ARCH_THUMB >= 3)
+namespace lbug_mbedtls {
 static inline uint32_t aria_p1(uint32_t x) {
     uint32_t r;
     __asm("rev16 r, x");
     return (r);
 }
 #define ARIA_P1 aria_p1
+} // namespace lbug_mbedtls
 #endif
 #endif /* arm */
 #if defined(__GNUC__) && defined(__i386__) || defined(__amd64__) || defined(__x86_64__)
@@ -112,28 +116,34 @@ static inline uint32_t aria_p1(uint32_t x) {
 /* armcc5 --gnu defines __GNUC__ but doesn't support GNU's extended asm */
 #if defined(__GNUC__) && (!defined(__ARMCC_VERSION) || __ARMCC_VERSION >= 6000000) &&              \
     __ARM_ARCH >= 6
+namespace lbug_mbedtls {
 static inline uint32_t aria_p3(uint32_t x) {
     uint32_t r;
     __asm("rev %0, %1" : "=l"(r) : "l"(x));
     return (r);
 }
 #define ARIA_P3 aria_p3
+} // namespace lbug_mbedtls
 #elif defined(__ARMCC_VERSION) && __ARMCC_VERSION < 6000000 &&                                     \
     (__TARGET_ARCH_ARM >= 6 || __TARGET_ARCH_THUMB >= 3)
+namespace lbug_mbedtls {
 static inline uint32_t aria_p3(uint32_t x) {
     uint32_t r;
     __asm("rev r, x");
     return (r);
 }
 #define ARIA_P3 aria_p3
+} // namespace lbug_mbedtls
 #endif
 #endif /* arm */
 #if defined(__GNUC__) && defined(__i386__) || defined(__amd64__) || defined(__x86_64__)
+namespace lbug_mbedtls {
 static inline uint32_t aria_p3(uint32_t x) {
     __asm("bswap %0" : "=r"(x) : "0"(x));
     return (x);
 }
 #define ARIA_P3 aria_p3
+} // namespace lbug_mbedtls
 #endif /* x86 gnuc */
 #endif /* MBEDTLS_HAVE_ASM && GNUC */
 #if !defined(ARIA_P3)
@@ -163,6 +173,7 @@ static inline uint32_t aria_p3(uint32_t x) {
  * half of App. B.1 in [1] in terms of 4-byte operators P1, P2, P3 and P4.
  * The implementation below uses only P1 and P2 as they are sufficient.
  */
+namespace lbug_mbedtls {
 static inline void aria_a(uint32_t* a, uint32_t* b, uint32_t* c, uint32_t* d) {
     uint32_t ta, tb, tc;
     ta = *b;                    // 4567
@@ -507,10 +518,12 @@ void mbedtls_aria_free(mbedtls_aria_context* ctx) {
     mbedtls_platform_zeroize(ctx, sizeof(mbedtls_aria_context));
 }
 
+} // namespace lbug_mbedtls
 #if defined(MBEDTLS_CIPHER_MODE_CBC)
 /*
  * ARIA-CBC buffer encryption/decryption
  */
+namespace lbug_mbedtls {
 int mbedtls_aria_crypt_cbc(mbedtls_aria_context* ctx, int mode, size_t length,
     unsigned char iv[MBEDTLS_ARIA_BLOCKSIZE], const unsigned char* input, unsigned char* output) {
     int i;
@@ -555,12 +568,14 @@ int mbedtls_aria_crypt_cbc(mbedtls_aria_context* ctx, int mode, size_t length,
 
     return (0);
 }
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_CIPHER_MODE_CBC */
 
 #if defined(MBEDTLS_CIPHER_MODE_CFB)
 /*
  * ARIA-CFB128 buffer encryption/decryption
  */
+namespace lbug_mbedtls {
 int mbedtls_aria_crypt_cfb128(mbedtls_aria_context* ctx, int mode, size_t length, size_t* iv_off,
     unsigned char iv[MBEDTLS_ARIA_BLOCKSIZE], const unsigned char* input, unsigned char* output) {
     unsigned char c;
@@ -607,12 +622,14 @@ int mbedtls_aria_crypt_cfb128(mbedtls_aria_context* ctx, int mode, size_t length
 
     return (0);
 }
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_CIPHER_MODE_CFB */
 
 #if defined(MBEDTLS_CIPHER_MODE_CTR)
 /*
  * ARIA-CTR buffer encryption/decryption
  */
+namespace lbug_mbedtls {
 int mbedtls_aria_crypt_ctr(mbedtls_aria_context* ctx, size_t length, size_t* nc_off,
     unsigned char nonce_counter[MBEDTLS_ARIA_BLOCKSIZE],
     unsigned char stream_block[MBEDTLS_ARIA_BLOCKSIZE], const unsigned char* input,
@@ -652,6 +669,7 @@ int mbedtls_aria_crypt_ctr(mbedtls_aria_context* ctx, size_t length, size_t* nc_
 
     return (0);
 }
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_CIPHER_MODE_CTR */
 #endif /* !MBEDTLS_ARIA_ALT */
 
@@ -660,6 +678,7 @@ int mbedtls_aria_crypt_ctr(mbedtls_aria_context* ctx, size_t length, size_t* nc_
 /*
  * Basic ARIA ECB test vectors from RFC 5794
  */
+namespace lbug_mbedtls {
 static const uint8_t aria_test1_ecb_key[32] = // test key
     {
         0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, // 128 bit
@@ -686,8 +705,10 @@ static const uint8_t aria_test1_ecb_ct[3][MBEDTLS_ARIA_BLOCKSIZE] = // ciphertex
  * Mode tests from "Test Vectors for ARIA"  Version 1.0
  * http://210.104.33.10/ARIA/doc/ARIA-testvector-e.pdf
  */
+} // namespace lbug_mbedtls
 #if (defined(MBEDTLS_CIPHER_MODE_CBC) || defined(MBEDTLS_CIPHER_MODE_CFB) ||                       \
      defined(MBEDTLS_CIPHER_MODE_CTR))
+namespace lbug_mbedtls {
 static const uint8_t aria_test2_key[32] = {
     0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, // 128 bit
     0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff, 0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66,
@@ -745,16 +766,20 @@ static const uint8_t aria_test2_pt[48] = {
     0xbb,
     0xbb,
 };
+} // namespace lbug_mbedtls
 #endif
 
 #if (defined(MBEDTLS_CIPHER_MODE_CBC) || defined(MBEDTLS_CIPHER_MODE_CFB))
+namespace lbug_mbedtls {
 static const uint8_t aria_test2_iv[MBEDTLS_ARIA_BLOCKSIZE] = {
     0x0f, 0x1e, 0x2d, 0x3c, 0x4b, 0x5a, 0x69, 0x78, // same for CBC, CFB
     0x87, 0x96, 0xa5, 0xb4, 0xc3, 0xd2, 0xe1, 0xf0  // CTR has zero IV
 };
+} // namespace lbug_mbedtls
 #endif
 
 #if defined(MBEDTLS_CIPHER_MODE_CBC)
+namespace lbug_mbedtls {
 static const uint8_t aria_test2_cbc_ct[3][48] =       // CBC ciphertext
     {{0x49, 0xd6, 0x18, 0x60, 0xb1, 0x49, 0x09, 0x10, // 128-bit key
          0x9c, 0xef, 0x0d, 0x22, 0xa9, 0x26, 0x81, 0x34, 0xfa, 0xdf, 0x9f, 0xb2, 0x31, 0x51, 0xe9,
@@ -768,9 +793,11 @@ static const uint8_t aria_test2_cbc_ct[3][48] =       // CBC ciphertext
             0x55, 0xfd, 0xd2, 0x8d, 0xbc, 0x34, 0xe1, 0xab, 0x7b, 0x9b, 0x42, 0x43, 0x2a, 0xd8,
             0xb2, 0xef, 0xb9, 0x6e, 0x23, 0xb1, 0x3f, 0x0a, 0x6e, 0x52, 0xf3, 0x61, 0x85, 0xd5,
             0x0a, 0xd0, 0x02, 0xc5, 0xf6, 0x01, 0xbe, 0xe5, 0x49, 0x3f, 0x11, 0x8b}};
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_CIPHER_MODE_CBC */
 
 #if defined(MBEDTLS_CIPHER_MODE_CFB)
+namespace lbug_mbedtls {
 static const uint8_t aria_test2_cfb_ct[3][48] =       // CFB ciphertext
     {{0x37, 0x20, 0xe5, 0x3b, 0xa7, 0xd6, 0x15, 0x38, // 128-bit key
          0x34, 0x06, 0xb0, 0x9f, 0x0a, 0x05, 0xa2, 0x00, 0xc0, 0x7c, 0x21, 0xe6, 0x37, 0x0f, 0x41,
@@ -784,9 +811,11 @@ static const uint8_t aria_test2_cfb_ct[3][48] =       // CFB ciphertext
             0x58, 0x8d, 0x4a, 0x7f, 0x09, 0x00, 0x96, 0x35, 0xf2, 0x8b, 0xb9, 0x3d, 0x8c, 0x31,
             0xf8, 0x70, 0xec, 0x1e, 0x0b, 0xdb, 0x08, 0x2b, 0x66, 0xfa, 0x40, 0x2d, 0xd9, 0xc2,
             0x02, 0xbe, 0x30, 0x0c, 0x45, 0x17, 0xd1, 0x96, 0xb1, 0x4d, 0x4c, 0xe1}};
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_CIPHER_MODE_CFB */
 
 #if defined(MBEDTLS_CIPHER_MODE_CTR)
+namespace lbug_mbedtls {
 static const uint8_t aria_test2_ctr_ct[3][48] =       // CTR ciphertext
     {{0xac, 0x5d, 0x7d, 0xe8, 0x05, 0xa0, 0xbf, 0x1c, // 128-bit key
          0x57, 0xc8, 0x54, 0x50, 0x1a, 0xf6, 0x0f, 0xa1, 0x14, 0x97, 0xe2, 0xa3, 0x45, 0x19, 0xde,
@@ -800,6 +829,7 @@ static const uint8_t aria_test2_ctr_ct[3][48] =       // CTR ciphertext
             0x21, 0x17, 0x8b, 0x99, 0xc0, 0xa1, 0xf1, 0xb2, 0xf0, 0x69, 0x40, 0x25, 0x3f, 0x7b,
             0x30, 0x89, 0xe2, 0xa3, 0x0e, 0xa8, 0x6a, 0xa3, 0xc8, 0x8f, 0x59, 0x40, 0xf0, 0x5a,
             0xd7, 0xee, 0x41, 0xd7, 0x13, 0x47, 0xbb, 0x72, 0x61, 0xe3, 0x48, 0xf1}};
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_CIPHER_MODE_CFB */
 
 #define ARIA_SELF_TEST_IF_FAIL                                                                     \
@@ -816,6 +846,7 @@ static const uint8_t aria_test2_ctr_ct[3][48] =       // CTR ciphertext
 /*
  * Checkup routine
  */
+namespace lbug_mbedtls {
 int mbedtls_aria_self_test(int verbose) {
     int i;
     uint8_t blk[MBEDTLS_ARIA_BLOCKSIZE];
@@ -950,6 +981,7 @@ exit:
     return (ret);
 }
 
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_SELF_TEST */
 
 #endif /* MBEDTLS_ARIA_C */

--- a/third_party/mbedtls/library/asn1parse.cpp
+++ b/third_party/mbedtls/library/asn1parse.cpp
@@ -42,6 +42,7 @@
 /*
  * ASN.1 DER decoding routines
  */
+namespace lbug_mbedtls {
 int mbedtls_asn1_get_len(unsigned char** p, const unsigned char* end, size_t* len) {
     if ((end - *p) < 1)
         return (MBEDTLS_ERR_ASN1_OUT_OF_DATA);
@@ -169,7 +170,9 @@ int mbedtls_asn1_get_enum(unsigned char** p, const unsigned char* end, int* val)
     return (asn1_get_tagged_int(p, end, MBEDTLS_ASN1_ENUMERATED, val));
 }
 
+} // namespace lbug_mbedtls
 #if defined(MBEDTLS_BIGNUM_C)
+namespace lbug_mbedtls {
 int mbedtls_asn1_get_mpi(unsigned char** p, const unsigned char* end, mbedtls_mpi* X) {
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
     size_t len;
@@ -183,8 +186,10 @@ int mbedtls_asn1_get_mpi(unsigned char** p, const unsigned char* end, mbedtls_mp
 
     return (ret);
 }
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_BIGNUM_C */
 
+namespace lbug_mbedtls {
 int mbedtls_asn1_get_bitstring(unsigned char** p, const unsigned char* end,
     mbedtls_asn1_bitstring* bs) {
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
@@ -412,4 +417,5 @@ const mbedtls_asn1_named_data* mbedtls_asn1_find_named_data(const mbedtls_asn1_n
     return (list);
 }
 
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_ASN1_PARSE_C */

--- a/third_party/mbedtls/library/base64.cpp
+++ b/third_party/mbedtls/library/base64.cpp
@@ -41,6 +41,7 @@
 /*
  * Encode a buffer into base64 format
  */
+namespace lbug_mbedtls {
 int mbedtls_base64_encode(unsigned char* dst, size_t dlen, size_t* olen, const unsigned char* src,
     size_t slen) {
     size_t i, n;
@@ -194,8 +195,10 @@ int mbedtls_base64_decode(unsigned char* dst, size_t dlen, size_t* olen, const u
     return (0);
 }
 
+} // namespace lbug_mbedtls
 #if defined(MBEDTLS_SELF_TEST)
 
+namespace lbug_mbedtls {
 static const unsigned char base64_test_dec[64] = {0x24, 0x48, 0x6E, 0x56, 0x87, 0x62, 0x5A, 0xBD,
     0xBF, 0x17, 0xD9, 0xA2, 0xC4, 0x17, 0x1A, 0x01, 0x94, 0xED, 0x8F, 0x1E, 0x11, 0xB3, 0xD7, 0x09,
     0x0C, 0xB6, 0xE9, 0x10, 0x6F, 0x22, 0xEE, 0x13, 0xCA, 0xB3, 0x07, 0x05, 0x76, 0xC9, 0xFA, 0x31,
@@ -245,6 +248,7 @@ int mbedtls_base64_self_test(int verbose) {
     return (0);
 }
 
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_SELF_TEST */
 
 #endif /* MBEDTLS_BASE64_C */

--- a/third_party/mbedtls/library/bignum.cpp
+++ b/third_party/mbedtls/library/bignum.cpp
@@ -73,6 +73,7 @@
 #define CHARS_TO_LIMBS(i) ((i) / ciL + ((i) % ciL != 0))
 
 /* Implementation that should never be optimized out by the compiler */
+namespace lbug_mbedtls {
 static void mbedtls_mpi_zeroize(mbedtls_mpi_uint* v, size_t n) {
     mbedtls_platform_zeroize(v, ciL * n);
 }
@@ -560,10 +561,12 @@ cleanup:
     return (ret);
 }
 
+} // namespace lbug_mbedtls
 #if defined(MBEDTLS_FS_IO)
 /*
  * Read X from an opened file
  */
+namespace lbug_mbedtls {
 int mbedtls_mpi_read_file(mbedtls_mpi* X, int radix, FILE* fin) {
     mbedtls_mpi_uint d;
     size_t slen;
@@ -643,11 +646,13 @@ cleanup:
 
     return (ret);
 }
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_FS_IO */
 
 /* Convert a big-endian byte array aligned to the size of mbedtls_mpi_uint
  * into the storage form used by mbedtls_mpi. */
 
+namespace lbug_mbedtls {
 static mbedtls_mpi_uint mpi_uint_bigendian_to_host_c(mbedtls_mpi_uint x) {
     uint8_t i;
     unsigned char* x_ptr;
@@ -2890,3 +2895,4 @@ cleanup:
 #endif /* MBEDTLS_SELF_TEST */
 
 #endif /* MBEDTLS_BIGNUM_C */
+} // namespace lbug_mbedtls

--- a/third_party/mbedtls/library/camellia.cpp
+++ b/third_party/mbedtls/library/camellia.cpp
@@ -48,6 +48,7 @@
     MBEDTLS_INTERNAL_VALIDATE_RET(cond, MBEDTLS_ERR_CAMELLIA_BAD_INPUT_DATA)
 #define CAMELLIA_VALIDATE(cond) MBEDTLS_INTERNAL_VALIDATE(cond)
 
+namespace lbug_mbedtls {
 static const unsigned char SIGMA_CHARS[6][8] = {{0xa0, 0x9e, 0x66, 0x7f, 0x3b, 0xcc, 0x90, 0x8b},
     {0xb6, 0x7a, 0xe8, 0x58, 0x4c, 0xaa, 0x73, 0xb2},
     {0xc6, 0xef, 0x37, 0x2f, 0xe9, 0x4f, 0x82, 0xbe},
@@ -55,8 +56,10 @@ static const unsigned char SIGMA_CHARS[6][8] = {{0xa0, 0x9e, 0x66, 0x7f, 0x3b, 0
     {0x10, 0xe5, 0x27, 0xfa, 0xde, 0x68, 0x2d, 0x1d},
     {0xb0, 0x56, 0x88, 0xc2, 0xb3, 0xe6, 0xc1, 0xfd}};
 
+} // namespace lbug_mbedtls
 #if defined(MBEDTLS_CAMELLIA_SMALL_MEMORY)
 
+namespace lbug_mbedtls {
 static const unsigned char FSb[256] = {112, 130, 44, 236, 179, 39, 192, 229, 228, 133, 87, 53, 234,
     12, 174, 65, 35, 239, 107, 147, 69, 25, 165, 33, 237, 14, 79, 78, 29, 101, 146, 189, 134, 184,
     175, 143, 124, 235, 31, 206, 62, 48, 220, 95, 94, 197, 11, 26, 166, 225, 57, 202, 213, 71, 93,
@@ -76,8 +79,10 @@ static const unsigned char FSb[256] = {112, 130, 44, 236, 179, 39, 192, 229, 228
 #define SBOX3(n) (unsigned char)((FSb[(n)] >> 1 ^ FSb[(n)] << 7) & 0xff)
 #define SBOX4(n) FSb[((n) << 1 ^ (n) >> 7) & 0xff]
 
+} // namespace lbug_mbedtls
 #else /* MBEDTLS_CAMELLIA_SMALL_MEMORY */
 
+namespace lbug_mbedtls {
 static const unsigned char FSb[256] = {112, 130, 44, 236, 179, 39, 192, 229, 228, 133, 87, 53, 234,
     12, 174, 65, 35, 239, 107, 147, 69, 25, 165, 33, 237, 14, 79, 78, 29, 101, 146, 189, 134, 184,
     175, 143, 124, 235, 31, 206, 62, 48, 220, 95, 94, 197, 11, 26, 166, 225, 57, 202, 213, 71, 93,
@@ -139,8 +144,10 @@ static const unsigned char FSb4[256] = {112, 44, 179, 192, 228, 87, 234, 174, 35
 #define SBOX3(n) FSb3[(n)]
 #define SBOX4(n) FSb4[(n)]
 
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_CAMELLIA_SMALL_MEMORY */
 
+namespace lbug_mbedtls {
 static const unsigned char shifts[2][4][4] = {{
                                                   {1, 1, 1, 1}, /* KL */
                                                   {0, 0, 0, 0}, /* KR */
@@ -469,10 +476,12 @@ int mbedtls_camellia_crypt_ecb(mbedtls_camellia_context* ctx, int mode,
     return (0);
 }
 
+} // namespace lbug_mbedtls
 #if defined(MBEDTLS_CIPHER_MODE_CBC)
 /*
  * Camellia-CBC buffer encryption/decryption
  */
+namespace lbug_mbedtls {
 int mbedtls_camellia_crypt_cbc(mbedtls_camellia_context* ctx, int mode, size_t length,
     unsigned char iv[16], const unsigned char* input, unsigned char* output) {
     int i;
@@ -516,12 +525,14 @@ int mbedtls_camellia_crypt_cbc(mbedtls_camellia_context* ctx, int mode, size_t l
 
     return (0);
 }
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_CIPHER_MODE_CBC */
 
 #if defined(MBEDTLS_CIPHER_MODE_CFB)
 /*
  * Camellia-CFB128 buffer encryption/decryption
  */
+namespace lbug_mbedtls {
 int mbedtls_camellia_crypt_cfb128(mbedtls_camellia_context* ctx, int mode, size_t length,
     size_t* iv_off, unsigned char iv[16], const unsigned char* input, unsigned char* output) {
     int c;
@@ -563,12 +574,14 @@ int mbedtls_camellia_crypt_cfb128(mbedtls_camellia_context* ctx, int mode, size_
 
     return (0);
 }
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_CIPHER_MODE_CFB */
 
 #if defined(MBEDTLS_CIPHER_MODE_CTR)
 /*
  * Camellia-CTR buffer encryption/decryption
  */
+namespace lbug_mbedtls {
 int mbedtls_camellia_crypt_ctr(mbedtls_camellia_context* ctx, size_t length, size_t* nc_off,
     unsigned char nonce_counter[16], unsigned char stream_block[16], const unsigned char* input,
     unsigned char* output) {
@@ -603,6 +616,7 @@ int mbedtls_camellia_crypt_ctr(mbedtls_camellia_context* ctx, size_t length, siz
 
     return (0);
 }
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_CIPHER_MODE_CTR */
 #endif /* !MBEDTLS_CAMELLIA_ALT */
 
@@ -618,6 +632,7 @@ int mbedtls_camellia_crypt_ctr(mbedtls_camellia_context* ctx, size_t length, siz
  */
 #define CAMELLIA_TESTS_ECB 2
 
+namespace lbug_mbedtls {
 static const unsigned char camellia_test_ecb_key[3][CAMELLIA_TESTS_ECB][32] = {
     {{0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef, 0xfe, 0xdc, 0xba, 0x98, 0x76, 0x54, 0x32,
          0x10},
@@ -655,9 +670,11 @@ static const unsigned char camellia_test_ecb_cipher[3][CAMELLIA_TESTS_ECB][16] =
         {0x05, 0x03, 0xFB, 0x10, 0xAB, 0x24, 0x1E, 0x7C, 0xF4, 0x5D, 0x8C, 0xDE, 0xEE, 0x47, 0x43,
             0x35}}};
 
+} // namespace lbug_mbedtls
 #if defined(MBEDTLS_CIPHER_MODE_CBC)
 #define CAMELLIA_TESTS_CBC 3
 
+namespace lbug_mbedtls {
 static const unsigned char camellia_test_cbc_key[3][32] = {{0x2B, 0x7E, 0x15, 0x16, 0x28, 0xAE,
                                                                0xD2, 0xA6, 0xAB, 0xF7, 0x15, 0x88,
                                                                0x09, 0xCF, 0x4F, 0x3C},
@@ -700,6 +717,7 @@ static const unsigned char camellia_test_cbc_cipher[3][CAMELLIA_TESTS_CBC][16] =
             0x50},
         {0xE3, 0x1A, 0x60, 0x55, 0x29, 0x7D, 0x96, 0xCA, 0x33, 0x30, 0xCD, 0xF1, 0xB1, 0x86, 0x0A,
             0x83}}};
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_CIPHER_MODE_CBC */
 
 #if defined(MBEDTLS_CIPHER_MODE_CTR)
@@ -709,6 +727,7 @@ static const unsigned char camellia_test_cbc_cipher[3][CAMELLIA_TESTS_CBC][16] =
  * http://www.faqs.org/rfcs/rfc5528.html
  */
 
+namespace lbug_mbedtls {
 static const unsigned char camellia_test_ctr_key[3][16] = {{0xAE, 0x68, 0x52, 0xF8, 0x12, 0x10,
                                                                0x67, 0xCC, 0x4B, 0xF7, 0xA5, 0x76,
                                                                0x55, 0x77, 0xF3, 0x9E},
@@ -748,11 +767,13 @@ static const unsigned char camellia_test_ctr_ct[3][48] = {{0xD0, 0x9D, 0xC2, 0x9
         0xCD, 0xDF, 0x50, 0x86, 0x96}};
 
 static const int camellia_test_ctr_len[3] = {16, 32, 36};
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_CIPHER_MODE_CTR */
 
 /*
  * Checkup routine
  */
+namespace lbug_mbedtls {
 int mbedtls_camellia_self_test(int verbose) {
     int i, j, u, v;
     unsigned char key[32];
@@ -919,6 +940,7 @@ exit:
     return (ret);
 }
 
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_SELF_TEST */
 
 #endif /* MBEDTLS_CAMELLIA_C */

--- a/third_party/mbedtls/library/cipher.cpp
+++ b/third_party/mbedtls/library/cipher.cpp
@@ -74,6 +74,7 @@
     MBEDTLS_INTERNAL_VALIDATE_RET(cond, MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA)
 #define CIPHER_VALIDATE(cond) MBEDTLS_INTERNAL_VALIDATE(cond)
 
+namespace lbug_mbedtls {
 static int supported_init = 0;
 
 const int* mbedtls_cipher_list(void) {
@@ -199,7 +200,9 @@ int mbedtls_cipher_setup(mbedtls_cipher_context_t* ctx, const mbedtls_cipher_inf
     return (0);
 }
 
+} // namespace lbug_mbedtls
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
+namespace lbug_mbedtls {
 int mbedtls_cipher_setup_psa(mbedtls_cipher_context_t* ctx,
     const mbedtls_cipher_info_t* cipher_info, size_t taglen) {
     psa_algorithm_t alg;
@@ -227,8 +230,10 @@ int mbedtls_cipher_setup_psa(mbedtls_cipher_context_t* ctx,
     ctx->psa_enabled = 1;
     return (0);
 }
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_USE_PSA_CRYPTO */
 
+namespace lbug_mbedtls {
 int mbedtls_cipher_setkey(mbedtls_cipher_context_t* ctx, const unsigned char* key, int key_bitlen,
     const mbedtls_operation_t operation) {
     CIPHER_VALIDATE_RET(ctx != NULL);
@@ -407,7 +412,9 @@ int mbedtls_cipher_reset(mbedtls_cipher_context_t* ctx) {
     return (0);
 }
 
+} // namespace lbug_mbedtls
 #if defined(MBEDTLS_GCM_C) || defined(MBEDTLS_CHACHAPOLY_C)
+namespace lbug_mbedtls {
 int mbedtls_cipher_update_ad(mbedtls_cipher_context_t* ctx, const unsigned char* ad,
     size_t ad_len) {
     CIPHER_VALIDATE_RET(ctx != NULL);
@@ -450,8 +457,10 @@ int mbedtls_cipher_update_ad(mbedtls_cipher_context_t* ctx, const unsigned char*
 
     return (0);
 }
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_GCM_C || MBEDTLS_CHACHAPOLY_C */
 
+namespace lbug_mbedtls {
 int mbedtls_cipher_update(mbedtls_cipher_context_t* ctx, const unsigned char* input, size_t ilen,
     unsigned char* output, size_t* olen) {
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
@@ -667,11 +676,13 @@ int mbedtls_cipher_update(mbedtls_cipher_context_t* ctx, const unsigned char* in
     return (MBEDTLS_ERR_CIPHER_FEATURE_UNAVAILABLE);
 }
 
+} // namespace lbug_mbedtls
 #if defined(MBEDTLS_CIPHER_MODE_WITH_PADDING)
 #if defined(MBEDTLS_CIPHER_PADDING_PKCS7)
 /*
  * PKCS7 (and PKCS5) padding: fill with ll bytes, with ll = padding_len
  */
+namespace lbug_mbedtls {
 static void add_pkcs_padding(unsigned char* output, size_t output_len, size_t data_len) {
     size_t padding_len = output_len - data_len;
     unsigned char i;
@@ -702,12 +713,14 @@ static int get_pkcs_padding(unsigned char* input, size_t input_len, size_t* data
 
     return (MBEDTLS_ERR_CIPHER_INVALID_PADDING * (bad != 0));
 }
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_CIPHER_PADDING_PKCS7 */
 
 #if defined(MBEDTLS_CIPHER_PADDING_ONE_AND_ZEROS)
 /*
  * One and zeros padding: fill with 80 00 ... 00
  */
+namespace lbug_mbedtls {
 static void add_one_and_zeros_padding(unsigned char* output, size_t output_len, size_t data_len) {
     size_t padding_len = output_len - data_len;
     unsigned char i = 0;
@@ -735,12 +748,14 @@ static int get_one_and_zeros_padding(unsigned char* input, size_t input_len, siz
 
     return (MBEDTLS_ERR_CIPHER_INVALID_PADDING * (bad != 0));
 }
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_CIPHER_PADDING_ONE_AND_ZEROS */
 
 #if defined(MBEDTLS_CIPHER_PADDING_ZEROS_AND_LEN)
 /*
  * Zeros and len padding: fill with 00 ... 00 ll, where ll is padding length
  */
+namespace lbug_mbedtls {
 static void add_zeros_and_len_padding(unsigned char* output, size_t output_len, size_t data_len) {
     size_t padding_len = output_len - data_len;
     unsigned char i = 0;
@@ -771,12 +786,14 @@ static int get_zeros_and_len_padding(unsigned char* input, size_t input_len, siz
 
     return (MBEDTLS_ERR_CIPHER_INVALID_PADDING * (bad != 0));
 }
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_CIPHER_PADDING_ZEROS_AND_LEN */
 
 #if defined(MBEDTLS_CIPHER_PADDING_ZEROS)
 /*
  * Zero padding: fill with 00 ... 00
  */
+namespace lbug_mbedtls {
 static void add_zeros_padding(unsigned char* output, size_t output_len, size_t data_len) {
     size_t i;
 
@@ -800,6 +817,7 @@ static int get_zeros_padding(unsigned char* input, size_t input_len, size_t* dat
 
     return (0);
 }
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_CIPHER_PADDING_ZEROS */
 
 /*
@@ -808,6 +826,7 @@ static int get_zeros_padding(unsigned char* input, size_t input_len, size_t* dat
  * There is no add_padding function (check for NULL in mbedtls_cipher_finish)
  * but a trivial get_padding function
  */
+namespace lbug_mbedtls {
 static int get_no_padding(unsigned char* input, size_t input_len, size_t* data_len) {
     if (NULL == input || NULL == data_len)
         return (MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA);
@@ -816,8 +835,10 @@ static int get_no_padding(unsigned char* input, size_t input_len, size_t* data_l
 
     return (0);
 }
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_CIPHER_MODE_WITH_PADDING */
 
+namespace lbug_mbedtls {
 int mbedtls_cipher_finish(mbedtls_cipher_context_t* ctx, unsigned char* output, size_t* olen) {
     CIPHER_VALIDATE_RET(ctx != NULL);
     CIPHER_VALIDATE_RET(output != NULL);
@@ -904,7 +925,9 @@ int mbedtls_cipher_finish(mbedtls_cipher_context_t* ctx, unsigned char* output, 
     return (MBEDTLS_ERR_CIPHER_FEATURE_UNAVAILABLE);
 }
 
+} // namespace lbug_mbedtls
 #if defined(MBEDTLS_CIPHER_MODE_WITH_PADDING)
+namespace lbug_mbedtls {
 int mbedtls_cipher_set_padding_mode(mbedtls_cipher_context_t* ctx, mbedtls_cipher_padding_t mode) {
     CIPHER_VALIDATE_RET(ctx != NULL);
 
@@ -960,9 +983,11 @@ int mbedtls_cipher_set_padding_mode(mbedtls_cipher_context_t* ctx, mbedtls_ciphe
 
     return (0);
 }
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_CIPHER_MODE_WITH_PADDING */
 
 #if defined(MBEDTLS_GCM_C) || defined(MBEDTLS_CHACHAPOLY_C)
+namespace lbug_mbedtls {
 int mbedtls_cipher_write_tag(mbedtls_cipher_context_t* ctx, unsigned char* tag, size_t tag_len) {
     CIPHER_VALIDATE_RET(ctx != NULL);
     CIPHER_VALIDATE_RET(tag_len == 0 || tag != NULL);
@@ -1078,11 +1103,13 @@ exit:
     mbedtls_platform_zeroize(check_tag, tag_len);
     return (ret);
 }
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_GCM_C || MBEDTLS_CHACHAPOLY_C */
 
 /*
  * Packet-oriented wrapper for non-AEAD modes
  */
+namespace lbug_mbedtls {
 int mbedtls_cipher_crypt(mbedtls_cipher_context_t* ctx, const unsigned char* iv, size_t iv_len,
     const unsigned char* input, size_t ilen, unsigned char* output, size_t* olen) {
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
@@ -1157,11 +1184,13 @@ int mbedtls_cipher_crypt(mbedtls_cipher_context_t* ctx, const unsigned char* iv,
     return (0);
 }
 
+} // namespace lbug_mbedtls
 #if defined(MBEDTLS_CIPHER_MODE_AEAD)
 /*
  * Packet-oriented encryption for AEAD modes: internal function used by
  * mbedtls_cipher_auth_encrypt_ext().
  */
+namespace lbug_mbedtls {
 static int mbedtls_cipher_aead_encrypt(mbedtls_cipher_context_t* ctx, const unsigned char* iv,
     size_t iv_len, const unsigned char* ad, size_t ad_len, const unsigned char* input, size_t ilen,
     unsigned char* output, size_t* olen, unsigned char* tag, size_t tag_len) {
@@ -1305,12 +1334,14 @@ static int mbedtls_cipher_aead_decrypt(mbedtls_cipher_context_t* ctx, const unsi
 
     return (MBEDTLS_ERR_CIPHER_FEATURE_UNAVAILABLE);
 }
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_CIPHER_MODE_AEAD */
 
 #if defined(MBEDTLS_CIPHER_MODE_AEAD) || defined(MBEDTLS_NIST_KW_C)
 /*
  * Packet-oriented encryption for AEAD/NIST_KW: public function.
  */
+namespace lbug_mbedtls {
 int mbedtls_cipher_auth_encrypt_ext(mbedtls_cipher_context_t* ctx, const unsigned char* iv,
     size_t iv_len, const unsigned char* ad, size_t ad_len, const unsigned char* input, size_t ilen,
     unsigned char* output, size_t output_len, size_t* olen, size_t tag_len) {
@@ -1402,6 +1433,7 @@ int mbedtls_cipher_auth_decrypt_ext(mbedtls_cipher_context_t* ctx, const unsigne
     return (MBEDTLS_ERR_CIPHER_FEATURE_UNAVAILABLE);
 #endif /* MBEDTLS_CIPHER_MODE_AEAD */
 }
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_CIPHER_MODE_AEAD || MBEDTLS_NIST_KW_C */
 
 #endif /* MBEDTLS_CIPHER_C */

--- a/third_party/mbedtls/library/cipher_wrap.cpp
+++ b/third_party/mbedtls/library/cipher_wrap.cpp
@@ -78,6 +78,7 @@
 
 #if defined(MBEDTLS_GCM_C)
 /* shared by all GCM ciphers */
+namespace lbug_mbedtls {
 static void* gcm_ctx_alloc(void) {
     void* ctx = mbedtls_calloc(1, sizeof(mbedtls_gcm_context));
 
@@ -91,10 +92,12 @@ static void gcm_ctx_free(void* ctx) {
     mbedtls_gcm_free((mbedtls_gcm_context*)ctx);
     mbedtls_free(ctx);
 }
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_GCM_C */
 
 #if defined(MBEDTLS_CCM_C)
 /* shared by all CCM ciphers */
+namespace lbug_mbedtls {
 static void* ccm_ctx_alloc(void) {
     void* ctx = mbedtls_calloc(1, sizeof(mbedtls_ccm_context));
 
@@ -108,47 +111,59 @@ static void ccm_ctx_free(void* ctx) {
     mbedtls_ccm_free(ctx);
     mbedtls_free(ctx);
 }
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_CCM_C */
 
 #if defined(MBEDTLS_AES_C)
 
+namespace lbug_mbedtls {
 static int aes_crypt_ecb_wrap(void* ctx, mbedtls_operation_t operation, const unsigned char* input,
     unsigned char* output) {
     return mbedtls_aes_crypt_ecb((mbedtls_aes_context*)ctx, operation, input, output);
 }
 
+} // namespace lbug_mbedtls
 #if defined(MBEDTLS_CIPHER_MODE_CBC)
+namespace lbug_mbedtls {
 static int aes_crypt_cbc_wrap(void* ctx, mbedtls_operation_t operation, size_t length,
     unsigned char* iv, const unsigned char* input, unsigned char* output) {
     return mbedtls_aes_crypt_cbc((mbedtls_aes_context*)ctx, operation, length, iv, input, output);
 }
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_CIPHER_MODE_CBC */
 
 #if defined(MBEDTLS_CIPHER_MODE_CFB)
+namespace lbug_mbedtls {
 static int aes_crypt_cfb128_wrap(void* ctx, mbedtls_operation_t operation, size_t length,
     size_t* iv_off, unsigned char* iv, const unsigned char* input, unsigned char* output) {
     return mbedtls_aes_crypt_cfb128((mbedtls_aes_context*)ctx, operation, length, iv_off, iv, input,
         output);
 }
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_CIPHER_MODE_CFB */
 
 #if defined(MBEDTLS_CIPHER_MODE_OFB)
+namespace lbug_mbedtls {
 static int aes_crypt_ofb_wrap(void* ctx, size_t length, size_t* iv_off, unsigned char* iv,
     const unsigned char* input, unsigned char* output) {
     return mbedtls_aes_crypt_ofb((mbedtls_aes_context*)ctx, length, iv_off, iv, input, output);
 }
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_CIPHER_MODE_OFB */
 
 #if defined(MBEDTLS_CIPHER_MODE_CTR)
+namespace lbug_mbedtls {
 static int aes_crypt_ctr_wrap(void* ctx, size_t length, size_t* nc_off,
     unsigned char* nonce_counter, unsigned char* stream_block, const unsigned char* input,
     unsigned char* output) {
     return mbedtls_aes_crypt_ctr((mbedtls_aes_context*)ctx, length, nc_off, nonce_counter,
         stream_block, input, output);
 }
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_CIPHER_MODE_CTR */
 
 #if defined(MBEDTLS_CIPHER_MODE_XTS)
+namespace lbug_mbedtls {
 static int aes_crypt_xts_wrap(void* ctx, mbedtls_operation_t operation, size_t length,
     const unsigned char data_unit[16], const unsigned char* input, unsigned char* output) {
     mbedtls_aes_xts_context* xts_ctx = ctx;
@@ -167,8 +182,10 @@ static int aes_crypt_xts_wrap(void* ctx, mbedtls_operation_t operation, size_t l
 
     return mbedtls_aes_crypt_xts(xts_ctx, mode, length, data_unit, input, output);
 }
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_CIPHER_MODE_XTS */
 
+namespace lbug_mbedtls {
 static int aes_setkey_dec_wrap(void* ctx, const unsigned char* key, unsigned int key_bitlen) {
     return mbedtls_aes_setkey_dec((mbedtls_aes_context*)ctx, key, key_bitlen);
 }
@@ -223,7 +240,9 @@ static const mbedtls_cipher_info_t aes_192_ecb_info = {MBEDTLS_CIPHER_AES_192_EC
 static const mbedtls_cipher_info_t aes_256_ecb_info = {MBEDTLS_CIPHER_AES_256_ECB, MBEDTLS_MODE_ECB,
     256, "AES-256-ECB", 0, 0, 16, &aes_info};
 
+} // namespace lbug_mbedtls
 #if defined(MBEDTLS_CIPHER_MODE_CBC)
+namespace lbug_mbedtls {
 static const mbedtls_cipher_info_t aes_128_cbc_info = {MBEDTLS_CIPHER_AES_128_CBC, MBEDTLS_MODE_CBC,
     128, "AES-128-CBC", 16, 0, 16, &aes_info};
 
@@ -232,9 +251,11 @@ static const mbedtls_cipher_info_t aes_192_cbc_info = {MBEDTLS_CIPHER_AES_192_CB
 
 static const mbedtls_cipher_info_t aes_256_cbc_info = {MBEDTLS_CIPHER_AES_256_CBC, MBEDTLS_MODE_CBC,
     256, "AES-256-CBC", 16, 0, 16, &aes_info};
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_CIPHER_MODE_CBC */
 
 #if defined(MBEDTLS_CIPHER_MODE_CFB)
+namespace lbug_mbedtls {
 static const mbedtls_cipher_info_t aes_128_cfb128_info = {MBEDTLS_CIPHER_AES_128_CFB128,
     MBEDTLS_MODE_CFB, 128, "AES-128-CFB128", 16, 0, 16, &aes_info};
 
@@ -243,9 +264,11 @@ static const mbedtls_cipher_info_t aes_192_cfb128_info = {MBEDTLS_CIPHER_AES_192
 
 static const mbedtls_cipher_info_t aes_256_cfb128_info = {MBEDTLS_CIPHER_AES_256_CFB128,
     MBEDTLS_MODE_CFB, 256, "AES-256-CFB128", 16, 0, 16, &aes_info};
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_CIPHER_MODE_CFB */
 
 #if defined(MBEDTLS_CIPHER_MODE_OFB)
+namespace lbug_mbedtls {
 static const mbedtls_cipher_info_t aes_128_ofb_info = {MBEDTLS_CIPHER_AES_128_OFB, MBEDTLS_MODE_OFB,
     128, "AES-128-OFB", 16, 0, 16, &aes_info};
 
@@ -254,9 +277,11 @@ static const mbedtls_cipher_info_t aes_192_ofb_info = {MBEDTLS_CIPHER_AES_192_OF
 
 static const mbedtls_cipher_info_t aes_256_ofb_info = {MBEDTLS_CIPHER_AES_256_OFB, MBEDTLS_MODE_OFB,
     256, "AES-256-OFB", 16, 0, 16, &aes_info};
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_CIPHER_MODE_OFB */
 
 #if defined(MBEDTLS_CIPHER_MODE_CTR)
+namespace lbug_mbedtls {
 static const mbedtls_cipher_info_t aes_128_ctr_info = {MBEDTLS_CIPHER_AES_128_CTR, MBEDTLS_MODE_CTR,
     128, "AES-128-CTR", 16, 0, 16, &aes_info};
 
@@ -265,9 +290,11 @@ static const mbedtls_cipher_info_t aes_192_ctr_info = {MBEDTLS_CIPHER_AES_192_CT
 
 static const mbedtls_cipher_info_t aes_256_ctr_info = {MBEDTLS_CIPHER_AES_256_CTR, MBEDTLS_MODE_CTR,
     256, "AES-256-CTR", 16, 0, 16, &aes_info};
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_CIPHER_MODE_CTR */
 
 #if defined(MBEDTLS_CIPHER_MODE_XTS)
+namespace lbug_mbedtls {
 static int xts_aes_setkey_enc_wrap(void* ctx, const unsigned char* key, unsigned int key_bitlen) {
     mbedtls_aes_xts_context* xts_ctx = ctx;
     return (mbedtls_aes_xts_setkey_enc(xts_ctx, key, key_bitlen));
@@ -323,9 +350,11 @@ static const mbedtls_cipher_info_t aes_128_xts_info = {MBEDTLS_CIPHER_AES_128_XT
 
 static const mbedtls_cipher_info_t aes_256_xts_info = {MBEDTLS_CIPHER_AES_256_XTS, MBEDTLS_MODE_XTS,
     512, "AES-256-XTS", 16, 0, 16, &xts_aes_info};
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_CIPHER_MODE_XTS */
 
 #if defined(MBEDTLS_GCM_C)
+namespace lbug_mbedtls {
 static int gcm_aes_setkey_wrap(void* ctx, const unsigned char* key, unsigned int key_bitlen) {
     return mbedtls_gcm_setkey((mbedtls_gcm_context*)ctx, MBEDTLS_CIPHER_ID_AES, key, key_bitlen);
 }
@@ -365,9 +394,11 @@ static const mbedtls_cipher_info_t aes_192_gcm_info = {MBEDTLS_CIPHER_AES_192_GC
 
 static const mbedtls_cipher_info_t aes_256_gcm_info = {MBEDTLS_CIPHER_AES_256_GCM, MBEDTLS_MODE_GCM,
     256, "AES-256-GCM", 12, MBEDTLS_CIPHER_VARIABLE_IV_LEN, 16, &gcm_aes_info};
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_GCM_C */
 
 #if defined(MBEDTLS_CCM_C)
+namespace lbug_mbedtls {
 static int ccm_aes_setkey_wrap(void* ctx, const unsigned char* key, unsigned int key_bitlen) {
     return mbedtls_ccm_setkey((mbedtls_ccm_context*)ctx, MBEDTLS_CIPHER_ID_AES, key, key_bitlen);
 }
@@ -419,42 +450,52 @@ static const mbedtls_cipher_info_t aes_192_ccm_star_no_tag_info = {
 static const mbedtls_cipher_info_t aes_256_ccm_star_no_tag_info = {
     MBEDTLS_CIPHER_AES_256_CCM_STAR_NO_TAG, MBEDTLS_MODE_CCM_STAR_NO_TAG, 256,
     "AES-256-CCM*-NO-TAG", 12, MBEDTLS_CIPHER_VARIABLE_IV_LEN, 16, &ccm_aes_info};
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_CCM_C */
 
 #endif /* MBEDTLS_AES_C */
 
 #if defined(MBEDTLS_CAMELLIA_C)
 
+namespace lbug_mbedtls {
 static int camellia_crypt_ecb_wrap(void* ctx, mbedtls_operation_t operation,
     const unsigned char* input, unsigned char* output) {
     return mbedtls_camellia_crypt_ecb((mbedtls_camellia_context*)ctx, operation, input, output);
 }
 
+} // namespace lbug_mbedtls
 #if defined(MBEDTLS_CIPHER_MODE_CBC)
+namespace lbug_mbedtls {
 static int camellia_crypt_cbc_wrap(void* ctx, mbedtls_operation_t operation, size_t length,
     unsigned char* iv, const unsigned char* input, unsigned char* output) {
     return mbedtls_camellia_crypt_cbc((mbedtls_camellia_context*)ctx, operation, length, iv, input,
         output);
 }
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_CIPHER_MODE_CBC */
 
 #if defined(MBEDTLS_CIPHER_MODE_CFB)
+namespace lbug_mbedtls {
 static int camellia_crypt_cfb128_wrap(void* ctx, mbedtls_operation_t operation, size_t length,
     size_t* iv_off, unsigned char* iv, const unsigned char* input, unsigned char* output) {
     return mbedtls_camellia_crypt_cfb128((mbedtls_camellia_context*)ctx, operation, length, iv_off,
         iv, input, output);
 }
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_CIPHER_MODE_CFB */
 
 #if defined(MBEDTLS_CIPHER_MODE_CTR)
+namespace lbug_mbedtls {
 static int camellia_crypt_ctr_wrap(void* ctx, size_t length, size_t* nc_off,
     unsigned char* nonce_counter, unsigned char* stream_block, const unsigned char* input,
     unsigned char* output) {
     return mbedtls_camellia_crypt_ctr((mbedtls_camellia_context*)ctx, length, nc_off, nonce_counter,
         stream_block, input, output);
 }
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_CIPHER_MODE_CTR */
 
+namespace lbug_mbedtls {
 static int camellia_setkey_dec_wrap(void* ctx, const unsigned char* key, unsigned int key_bitlen) {
     return mbedtls_camellia_setkey_dec((mbedtls_camellia_context*)ctx, key, key_bitlen);
 }
@@ -511,7 +552,9 @@ static const mbedtls_cipher_info_t camellia_192_ecb_info = {MBEDTLS_CIPHER_CAMEL
 static const mbedtls_cipher_info_t camellia_256_ecb_info = {MBEDTLS_CIPHER_CAMELLIA_256_ECB,
     MBEDTLS_MODE_ECB, 256, "CAMELLIA-256-ECB", 0, 0, 16, &camellia_info};
 
+} // namespace lbug_mbedtls
 #if defined(MBEDTLS_CIPHER_MODE_CBC)
+namespace lbug_mbedtls {
 static const mbedtls_cipher_info_t camellia_128_cbc_info = {MBEDTLS_CIPHER_CAMELLIA_128_CBC,
     MBEDTLS_MODE_CBC, 128, "CAMELLIA-128-CBC", 16, 0, 16, &camellia_info};
 
@@ -520,9 +563,11 @@ static const mbedtls_cipher_info_t camellia_192_cbc_info = {MBEDTLS_CIPHER_CAMEL
 
 static const mbedtls_cipher_info_t camellia_256_cbc_info = {MBEDTLS_CIPHER_CAMELLIA_256_CBC,
     MBEDTLS_MODE_CBC, 256, "CAMELLIA-256-CBC", 16, 0, 16, &camellia_info};
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_CIPHER_MODE_CBC */
 
 #if defined(MBEDTLS_CIPHER_MODE_CFB)
+namespace lbug_mbedtls {
 static const mbedtls_cipher_info_t camellia_128_cfb128_info = {MBEDTLS_CIPHER_CAMELLIA_128_CFB128,
     MBEDTLS_MODE_CFB, 128, "CAMELLIA-128-CFB128", 16, 0, 16, &camellia_info};
 
@@ -531,9 +576,11 @@ static const mbedtls_cipher_info_t camellia_192_cfb128_info = {MBEDTLS_CIPHER_CA
 
 static const mbedtls_cipher_info_t camellia_256_cfb128_info = {MBEDTLS_CIPHER_CAMELLIA_256_CFB128,
     MBEDTLS_MODE_CFB, 256, "CAMELLIA-256-CFB128", 16, 0, 16, &camellia_info};
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_CIPHER_MODE_CFB */
 
 #if defined(MBEDTLS_CIPHER_MODE_CTR)
+namespace lbug_mbedtls {
 static const mbedtls_cipher_info_t camellia_128_ctr_info = {MBEDTLS_CIPHER_CAMELLIA_128_CTR,
     MBEDTLS_MODE_CTR, 128, "CAMELLIA-128-CTR", 16, 0, 16, &camellia_info};
 
@@ -542,9 +589,11 @@ static const mbedtls_cipher_info_t camellia_192_ctr_info = {MBEDTLS_CIPHER_CAMEL
 
 static const mbedtls_cipher_info_t camellia_256_ctr_info = {MBEDTLS_CIPHER_CAMELLIA_256_CTR,
     MBEDTLS_MODE_CTR, 256, "CAMELLIA-256-CTR", 16, 0, 16, &camellia_info};
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_CIPHER_MODE_CTR */
 
 #if defined(MBEDTLS_GCM_C)
+namespace lbug_mbedtls {
 static int gcm_camellia_setkey_wrap(void* ctx, const unsigned char* key, unsigned int key_bitlen) {
     return mbedtls_gcm_setkey((mbedtls_gcm_context*)ctx, MBEDTLS_CIPHER_ID_CAMELLIA, key,
         key_bitlen);
@@ -588,9 +637,11 @@ static const mbedtls_cipher_info_t camellia_192_gcm_info = {MBEDTLS_CIPHER_CAMEL
 static const mbedtls_cipher_info_t camellia_256_gcm_info = {MBEDTLS_CIPHER_CAMELLIA_256_GCM,
     MBEDTLS_MODE_GCM, 256, "CAMELLIA-256-GCM", 12, MBEDTLS_CIPHER_VARIABLE_IV_LEN, 16,
     &gcm_camellia_info};
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_GCM_C */
 
 #if defined(MBEDTLS_CCM_C)
+namespace lbug_mbedtls {
 static int ccm_camellia_setkey_wrap(void* ctx, const unsigned char* key, unsigned int key_bitlen) {
     return mbedtls_ccm_setkey((mbedtls_ccm_context*)ctx, MBEDTLS_CIPHER_ID_CAMELLIA, key,
         key_bitlen);
@@ -646,42 +697,52 @@ static const mbedtls_cipher_info_t camellia_192_ccm_star_no_tag_info = {
 static const mbedtls_cipher_info_t camellia_256_ccm_star_no_tag_info = {
     MBEDTLS_CIPHER_CAMELLIA_256_CCM_STAR_NO_TAG, MBEDTLS_MODE_CCM_STAR_NO_TAG, 256,
     "CAMELLIA-256-CCM*-NO-TAG", 12, MBEDTLS_CIPHER_VARIABLE_IV_LEN, 16, &ccm_camellia_info};
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_CCM_C */
 
 #endif /* MBEDTLS_CAMELLIA_C */
 
 #if defined(MBEDTLS_ARIA_C)
 
+namespace lbug_mbedtls {
 static int aria_crypt_ecb_wrap(void* ctx, mbedtls_operation_t operation, const unsigned char* input,
     unsigned char* output) {
     (void)operation;
     return mbedtls_aria_crypt_ecb((mbedtls_aria_context*)ctx, input, output);
 }
 
+} // namespace lbug_mbedtls
 #if defined(MBEDTLS_CIPHER_MODE_CBC)
+namespace lbug_mbedtls {
 static int aria_crypt_cbc_wrap(void* ctx, mbedtls_operation_t operation, size_t length,
     unsigned char* iv, const unsigned char* input, unsigned char* output) {
     return mbedtls_aria_crypt_cbc((mbedtls_aria_context*)ctx, operation, length, iv, input, output);
 }
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_CIPHER_MODE_CBC */
 
 #if defined(MBEDTLS_CIPHER_MODE_CFB)
+namespace lbug_mbedtls {
 static int aria_crypt_cfb128_wrap(void* ctx, mbedtls_operation_t operation, size_t length,
     size_t* iv_off, unsigned char* iv, const unsigned char* input, unsigned char* output) {
     return mbedtls_aria_crypt_cfb128((mbedtls_aria_context*)ctx, operation, length, iv_off, iv,
         input, output);
 }
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_CIPHER_MODE_CFB */
 
 #if defined(MBEDTLS_CIPHER_MODE_CTR)
+namespace lbug_mbedtls {
 static int aria_crypt_ctr_wrap(void* ctx, size_t length, size_t* nc_off,
     unsigned char* nonce_counter, unsigned char* stream_block, const unsigned char* input,
     unsigned char* output) {
     return mbedtls_aria_crypt_ctr((mbedtls_aria_context*)ctx, length, nc_off, nonce_counter,
         stream_block, input, output);
 }
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_CIPHER_MODE_CTR */
 
+namespace lbug_mbedtls {
 static int aria_setkey_dec_wrap(void* ctx, const unsigned char* key, unsigned int key_bitlen) {
     return mbedtls_aria_setkey_dec((mbedtls_aria_context*)ctx, key, key_bitlen);
 }
@@ -737,7 +798,9 @@ static const mbedtls_cipher_info_t aria_192_ecb_info = {MBEDTLS_CIPHER_ARIA_192_
 static const mbedtls_cipher_info_t aria_256_ecb_info = {MBEDTLS_CIPHER_ARIA_256_ECB,
     MBEDTLS_MODE_ECB, 256, "ARIA-256-ECB", 0, 0, 16, &aria_info};
 
+} // namespace lbug_mbedtls
 #if defined(MBEDTLS_CIPHER_MODE_CBC)
+namespace lbug_mbedtls {
 static const mbedtls_cipher_info_t aria_128_cbc_info = {MBEDTLS_CIPHER_ARIA_128_CBC,
     MBEDTLS_MODE_CBC, 128, "ARIA-128-CBC", 16, 0, 16, &aria_info};
 
@@ -746,9 +809,11 @@ static const mbedtls_cipher_info_t aria_192_cbc_info = {MBEDTLS_CIPHER_ARIA_192_
 
 static const mbedtls_cipher_info_t aria_256_cbc_info = {MBEDTLS_CIPHER_ARIA_256_CBC,
     MBEDTLS_MODE_CBC, 256, "ARIA-256-CBC", 16, 0, 16, &aria_info};
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_CIPHER_MODE_CBC */
 
 #if defined(MBEDTLS_CIPHER_MODE_CFB)
+namespace lbug_mbedtls {
 static const mbedtls_cipher_info_t aria_128_cfb128_info = {MBEDTLS_CIPHER_ARIA_128_CFB128,
     MBEDTLS_MODE_CFB, 128, "ARIA-128-CFB128", 16, 0, 16, &aria_info};
 
@@ -757,9 +822,11 @@ static const mbedtls_cipher_info_t aria_192_cfb128_info = {MBEDTLS_CIPHER_ARIA_1
 
 static const mbedtls_cipher_info_t aria_256_cfb128_info = {MBEDTLS_CIPHER_ARIA_256_CFB128,
     MBEDTLS_MODE_CFB, 256, "ARIA-256-CFB128", 16, 0, 16, &aria_info};
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_CIPHER_MODE_CFB */
 
 #if defined(MBEDTLS_CIPHER_MODE_CTR)
+namespace lbug_mbedtls {
 static const mbedtls_cipher_info_t aria_128_ctr_info = {MBEDTLS_CIPHER_ARIA_128_CTR,
     MBEDTLS_MODE_CTR, 128, "ARIA-128-CTR", 16, 0, 16, &aria_info};
 
@@ -768,9 +835,11 @@ static const mbedtls_cipher_info_t aria_192_ctr_info = {MBEDTLS_CIPHER_ARIA_192_
 
 static const mbedtls_cipher_info_t aria_256_ctr_info = {MBEDTLS_CIPHER_ARIA_256_CTR,
     MBEDTLS_MODE_CTR, 256, "ARIA-256-CTR", 16, 0, 16, &aria_info};
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_CIPHER_MODE_CTR */
 
 #if defined(MBEDTLS_GCM_C)
+namespace lbug_mbedtls {
 static int gcm_aria_setkey_wrap(void* ctx, const unsigned char* key, unsigned int key_bitlen) {
     return mbedtls_gcm_setkey((mbedtls_gcm_context*)ctx, MBEDTLS_CIPHER_ID_ARIA, key, key_bitlen);
 }
@@ -810,9 +879,11 @@ static const mbedtls_cipher_info_t aria_192_gcm_info = {MBEDTLS_CIPHER_ARIA_192_
 
 static const mbedtls_cipher_info_t aria_256_gcm_info = {MBEDTLS_CIPHER_ARIA_256_GCM,
     MBEDTLS_MODE_GCM, 256, "ARIA-256-GCM", 12, MBEDTLS_CIPHER_VARIABLE_IV_LEN, 16, &gcm_aria_info};
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_GCM_C */
 
 #if defined(MBEDTLS_CCM_C)
+namespace lbug_mbedtls {
 static int ccm_aria_setkey_wrap(void* ctx, const unsigned char* key, unsigned int key_bitlen) {
     return mbedtls_ccm_setkey((mbedtls_ccm_context*)ctx, MBEDTLS_CIPHER_ID_ARIA, key, key_bitlen);
 }
@@ -864,12 +935,14 @@ static const mbedtls_cipher_info_t aria_192_ccm_star_no_tag_info = {
 static const mbedtls_cipher_info_t aria_256_ccm_star_no_tag_info = {
     MBEDTLS_CIPHER_ARIA_256_CCM_STAR_NO_TAG, MBEDTLS_MODE_CCM_STAR_NO_TAG, 256,
     "ARIA-256-CCM*-NO-TAG", 12, MBEDTLS_CIPHER_VARIABLE_IV_LEN, 16, &ccm_aria_info};
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_CCM_C */
 
 #endif /* MBEDTLS_ARIA_C */
 
 #if defined(MBEDTLS_DES_C)
 
+namespace lbug_mbedtls {
 static int des_crypt_ecb_wrap(void* ctx, mbedtls_operation_t operation, const unsigned char* input,
     unsigned char* output) {
     ((void)operation);
@@ -882,20 +955,26 @@ static int des3_crypt_ecb_wrap(void* ctx, mbedtls_operation_t operation, const u
     return mbedtls_des3_crypt_ecb((mbedtls_des3_context*)ctx, input, output);
 }
 
+} // namespace lbug_mbedtls
 #if defined(MBEDTLS_CIPHER_MODE_CBC)
+namespace lbug_mbedtls {
 static int des_crypt_cbc_wrap(void* ctx, mbedtls_operation_t operation, size_t length,
     unsigned char* iv, const unsigned char* input, unsigned char* output) {
     return mbedtls_des_crypt_cbc((mbedtls_des_context*)ctx, operation, length, iv, input, output);
 }
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_CIPHER_MODE_CBC */
 
 #if defined(MBEDTLS_CIPHER_MODE_CBC)
+namespace lbug_mbedtls {
 static int des3_crypt_cbc_wrap(void* ctx, mbedtls_operation_t operation, size_t length,
     unsigned char* iv, const unsigned char* input, unsigned char* output) {
     return mbedtls_des3_crypt_cbc((mbedtls_des3_context*)ctx, operation, length, iv, input, output);
 }
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_CIPHER_MODE_CBC */
 
+namespace lbug_mbedtls {
 static int des_setkey_dec_wrap(void* ctx, const unsigned char* key, unsigned int key_bitlen) {
     ((void)key_bitlen);
 
@@ -989,11 +1068,15 @@ static const mbedtls_cipher_base_t des_info = {MBEDTLS_CIPHER_ID_DES, des_crypt_
 static const mbedtls_cipher_info_t des_ecb_info = {MBEDTLS_CIPHER_DES_ECB, MBEDTLS_MODE_ECB,
     MBEDTLS_KEY_LENGTH_DES, "DES-ECB", 0, 0, 8, &des_info};
 
+} // namespace lbug_mbedtls
 #if defined(MBEDTLS_CIPHER_MODE_CBC)
+namespace lbug_mbedtls {
 static const mbedtls_cipher_info_t des_cbc_info = {MBEDTLS_CIPHER_DES_CBC, MBEDTLS_MODE_CBC,
     MBEDTLS_KEY_LENGTH_DES, "DES-CBC", 8, 0, 8, &des_info};
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_CIPHER_MODE_CBC */
 
+namespace lbug_mbedtls {
 static const mbedtls_cipher_base_t des_ede_info = {MBEDTLS_CIPHER_ID_DES, des3_crypt_ecb_wrap,
 #if defined(MBEDTLS_CIPHER_MODE_CBC)
     des3_crypt_cbc_wrap,
@@ -1018,11 +1101,15 @@ static const mbedtls_cipher_base_t des_ede_info = {MBEDTLS_CIPHER_ID_DES, des3_c
 static const mbedtls_cipher_info_t des_ede_ecb_info = {MBEDTLS_CIPHER_DES_EDE_ECB, MBEDTLS_MODE_ECB,
     MBEDTLS_KEY_LENGTH_DES_EDE, "DES-EDE-ECB", 0, 0, 8, &des_ede_info};
 
+} // namespace lbug_mbedtls
 #if defined(MBEDTLS_CIPHER_MODE_CBC)
+namespace lbug_mbedtls {
 static const mbedtls_cipher_info_t des_ede_cbc_info = {MBEDTLS_CIPHER_DES_EDE_CBC, MBEDTLS_MODE_CBC,
     MBEDTLS_KEY_LENGTH_DES_EDE, "DES-EDE-CBC", 8, 0, 8, &des_ede_info};
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_CIPHER_MODE_CBC */
 
+namespace lbug_mbedtls {
 static const mbedtls_cipher_base_t des_ede3_info = {MBEDTLS_CIPHER_ID_3DES, des3_crypt_ecb_wrap,
 #if defined(MBEDTLS_CIPHER_MODE_CBC)
     des3_crypt_cbc_wrap,
@@ -1046,14 +1133,18 @@ static const mbedtls_cipher_base_t des_ede3_info = {MBEDTLS_CIPHER_ID_3DES, des3
 
 static const mbedtls_cipher_info_t des_ede3_ecb_info = {MBEDTLS_CIPHER_DES_EDE3_ECB,
     MBEDTLS_MODE_ECB, MBEDTLS_KEY_LENGTH_DES_EDE3, "DES-EDE3-ECB", 0, 0, 8, &des_ede3_info};
+} // namespace lbug_mbedtls
 #if defined(MBEDTLS_CIPHER_MODE_CBC)
+namespace lbug_mbedtls {
 static const mbedtls_cipher_info_t des_ede3_cbc_info = {MBEDTLS_CIPHER_DES_EDE3_CBC,
     MBEDTLS_MODE_CBC, MBEDTLS_KEY_LENGTH_DES_EDE3, "DES-EDE3-CBC", 8, 0, 8, &des_ede3_info};
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_CIPHER_MODE_CBC */
 #endif /* MBEDTLS_DES_C */
 
 #if defined(MBEDTLS_CHACHA20_C)
 
+namespace lbug_mbedtls {
 static int chacha20_setkey_wrap(void* ctx, const unsigned char* key, unsigned int key_bitlen) {
     if (key_bitlen != 256U)
         return (MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA);
@@ -1114,10 +1205,12 @@ static const mbedtls_cipher_base_t chacha20_base_info = {MBEDTLS_CIPHER_ID_CHACH
     chacha20_setkey_wrap, chacha20_setkey_wrap, chacha20_ctx_alloc, chacha20_ctx_free};
 static const mbedtls_cipher_info_t chacha20_info = {MBEDTLS_CIPHER_CHACHA20, MBEDTLS_MODE_STREAM,
     256, "CHACHA20", 12, 0, 1, &chacha20_base_info};
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_CHACHA20_C */
 
 #if defined(MBEDTLS_CHACHAPOLY_C)
 
+namespace lbug_mbedtls {
 static int chachapoly_setkey_wrap(void* ctx, const unsigned char* key, unsigned int key_bitlen) {
     if (key_bitlen != 256U)
         return (MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA);
@@ -1167,9 +1260,11 @@ static const mbedtls_cipher_base_t chachapoly_base_info = {MBEDTLS_CIPHER_ID_CHA
     chachapoly_setkey_wrap, chachapoly_setkey_wrap, chachapoly_ctx_alloc, chachapoly_ctx_free};
 static const mbedtls_cipher_info_t chachapoly_info = {MBEDTLS_CIPHER_CHACHA20_POLY1305,
     MBEDTLS_MODE_CHACHAPOLY, 256, "CHACHA20-POLY1305", 12, 0, 1, &chachapoly_base_info};
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_CHACHAPOLY_C */
 
 #if defined(MBEDTLS_CIPHER_NULL_CIPHER)
+namespace lbug_mbedtls {
 static int null_crypt_stream(void* ctx, size_t length, const unsigned char* input,
     unsigned char* output) {
     ((void)ctx);
@@ -1216,9 +1311,11 @@ static const mbedtls_cipher_base_t null_base_info = {MBEDTLS_CIPHER_ID_NULL, NUL
 
 static const mbedtls_cipher_info_t null_cipher_info = {MBEDTLS_CIPHER_NULL, MBEDTLS_MODE_STREAM, 0,
     "NULL", 0, 0, 1, &null_base_info};
+} // namespace lbug_mbedtls
 #endif /* defined(MBEDTLS_CIPHER_NULL_CIPHER) */
 
 #if defined(MBEDTLS_NIST_KW_C)
+namespace lbug_mbedtls {
 static void* kw_ctx_alloc(void) {
     void* ctx = mbedtls_calloc(1, sizeof(mbedtls_nist_kw_context));
 
@@ -1287,8 +1384,10 @@ static const mbedtls_cipher_info_t aes_192_nist_kwp_info = {MBEDTLS_CIPHER_AES_1
 
 static const mbedtls_cipher_info_t aes_256_nist_kwp_info = {MBEDTLS_CIPHER_AES_256_KWP,
     MBEDTLS_MODE_KWP, 256, "AES-256-KWP", 0, 0, 16, &kw_aes_info};
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_NIST_KW_C */
 
+namespace lbug_mbedtls {
 const mbedtls_cipher_definition_t mbedtls_cipher_definitions[] = {
 #if defined(MBEDTLS_AES_C)
     {MBEDTLS_CIPHER_AES_128_ECB, &aes_128_ecb_info},
@@ -1436,4 +1535,5 @@ const mbedtls_cipher_definition_t mbedtls_cipher_definitions[] = {
 #define NUM_CIPHERS (sizeof(mbedtls_cipher_definitions) / sizeof(mbedtls_cipher_definitions[0]))
 int mbedtls_cipher_supported[NUM_CIPHERS];
 
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_CIPHER_C */

--- a/third_party/mbedtls/library/cipher_wrap.h
+++ b/third_party/mbedtls/library/cipher_wrap.h
@@ -31,13 +31,11 @@
 #include "psa/crypto.h"
 #endif /* MBEDTLS_USE_PSA_CRYPTO */
 
-#ifdef __cplusplus
-extern "C" {
-#endif
 
 /**
  * Base cipher information. The non-mode specific functions and values.
  */
+namespace lbug_mbedtls {
 struct mbedtls_cipher_base_t {
     /** Base Cipher type (e.g. MBEDTLS_CIPHER_ID_AES) */
     mbedtls_cipher_id_t cipher;
@@ -99,7 +97,9 @@ typedef struct {
     const mbedtls_cipher_info_t* info;
 } mbedtls_cipher_definition_t;
 
+} // namespace lbug_mbedtls
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
+namespace lbug_mbedtls {
 typedef enum {
     MBEDTLS_CIPHER_PSA_KEY_UNSET = 0,
     MBEDTLS_CIPHER_PSA_KEY_OWNED,     /* Used for PSA-based cipher contexts which */
@@ -118,14 +118,14 @@ typedef struct {
     psa_key_id_t slot;
     mbedtls_cipher_psa_key_ownership slot_state;
 } mbedtls_cipher_context_psa;
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_USE_PSA_CRYPTO */
 
+namespace lbug_mbedtls {
 extern const mbedtls_cipher_definition_t mbedtls_cipher_definitions[];
 
 extern int mbedtls_cipher_supported[];
 
-#ifdef __cplusplus
-}
-#endif
 
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_CIPHER_WRAP_H */

--- a/third_party/mbedtls/library/common.h
+++ b/third_party/mbedtls/library/common.h
@@ -49,6 +49,7 @@
 #endif
 
 #if defined(MBEDTLS_TEST_HOOKS)
+namespace lbug_mbedtls {
 extern void (*mbedtls_test_hook_test_fail)(const char* test, int line, const char* file);
 #define MBEDTLS_TEST_HOOK_TEST_ASSERT(TEST)                                                        \
     do {                                                                                           \
@@ -56,6 +57,7 @@ extern void (*mbedtls_test_hook_test_fail)(const char* test, int line, const cha
             (*mbedtls_test_hook_test_fail)(#TEST, __LINE__, __FILE__);                             \
         }                                                                                          \
     } while (0)
+} // namespace lbug_mbedtls
 #else
 #define MBEDTLS_TEST_HOOK_TEST_ASSERT(TEST)
 #endif /* defined(MBEDTLS_TEST_HOOKS) */

--- a/third_party/mbedtls/library/constant_time.cpp
+++ b/third_party/mbedtls/library/constant_time.cpp
@@ -47,6 +47,7 @@
 
 #include <string.h>
 
+namespace lbug_mbedtls {
 int mbedtls_ct_memcmp(const void* a, const void* b, size_t n) {
     size_t i;
     volatile const unsigned char* A = (volatile const unsigned char*)a;
@@ -84,8 +85,10 @@ unsigned mbedtls_ct_uint_mask(unsigned value) {
 #endif
 }
 
+} // namespace lbug_mbedtls
 #if defined(MBEDTLS_SSL_SOME_SUITES_USE_TLS_CBC)
 
+namespace lbug_mbedtls {
 size_t mbedtls_ct_size_mask(size_t value) {
     /* MSVC has a warning about unary minus on unsigned integer types,
      * but this is well-defined and precisely what we want to do here. */
@@ -99,10 +102,12 @@ size_t mbedtls_ct_size_mask(size_t value) {
 #endif
 }
 
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_SSL_SOME_SUITES_USE_TLS_CBC */
 
 #if defined(MBEDTLS_BIGNUM_C)
 
+namespace lbug_mbedtls {
 mbedtls_mpi_uint mbedtls_ct_mpi_uint_mask(mbedtls_mpi_uint value) {
     /* MSVC has a warning about unary minus on unsigned, but this is
      * well-defined and precisely what we want to do here */
@@ -116,6 +121,7 @@ mbedtls_mpi_uint mbedtls_ct_mpi_uint_mask(mbedtls_mpi_uint value) {
 #endif
 }
 
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_BIGNUM_C */
 
 #if defined(MBEDTLS_SSL_SOME_SUITES_USE_TLS_CBC)
@@ -132,6 +138,7 @@ mbedtls_mpi_uint mbedtls_ct_mpi_uint_mask(mbedtls_mpi_uint value) {
  *
  * \return      All-bits-one if \p x is less than \p y, otherwise zero.
  */
+namespace lbug_mbedtls {
 static size_t mbedtls_ct_size_mask_lt(size_t x, size_t y) {
     /* This has the most significant bit set if and only if x < y */
     const size_t sub = x - y;
@@ -149,6 +156,7 @@ size_t mbedtls_ct_size_mask_ge(size_t x, size_t y) {
     return (~mbedtls_ct_size_mask_lt(x, y));
 }
 
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_SSL_SOME_SUITES_USE_TLS_CBC */
 
 #if defined(MBEDTLS_BASE64_C)
@@ -157,6 +165,7 @@ size_t mbedtls_ct_size_mask_ge(size_t x, size_t y) {
  *
  * Constant flow with respect to c.
  */
+namespace lbug_mbedtls {
 MBEDTLS_STATIC_TESTABLE
 unsigned char mbedtls_ct_uchar_mask_of_range(unsigned char low, unsigned char high,
     unsigned char c) {
@@ -167,8 +176,10 @@ unsigned char mbedtls_ct_uchar_mask_of_range(unsigned char low, unsigned char hi
     return (~(low_mask | high_mask) & 0xff);
 }
 
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_BASE64_C */
 
+namespace lbug_mbedtls {
 unsigned mbedtls_ct_size_bool_eq(size_t x, size_t y) {
     /* diff = 0 if x == y, non-zero otherwise */
     const size_t diff = x ^ y;
@@ -193,6 +204,7 @@ unsigned mbedtls_ct_size_bool_eq(size_t x, size_t y) {
     return (1 ^ diff1);
 }
 
+} // namespace lbug_mbedtls
 #if defined(MBEDTLS_PKCS1_V15) && defined(MBEDTLS_RSA_C) && !defined(MBEDTLS_RSA_ALT)
 
 /** Constant-flow "greater than" comparison:
@@ -206,15 +218,18 @@ unsigned mbedtls_ct_size_bool_eq(size_t x, size_t y) {
  *
  * \return      1 if \p x greater than \p y, otherwise 0.
  */
+namespace lbug_mbedtls {
 static unsigned mbedtls_ct_size_gt(size_t x, size_t y) {
     /* Return the sign bit (1 for negative) of (y - x). */
     return ((y - x) >> (sizeof(size_t) * 8 - 1));
 }
 
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_PKCS1_V15 && MBEDTLS_RSA_C && ! MBEDTLS_RSA_ALT */
 
 #if defined(MBEDTLS_BIGNUM_C)
 
+namespace lbug_mbedtls {
 unsigned mbedtls_ct_mpi_uint_lt(const mbedtls_mpi_uint x, const mbedtls_mpi_uint y) {
     mbedtls_mpi_uint ret;
     mbedtls_mpi_uint cond;
@@ -240,13 +255,16 @@ unsigned mbedtls_ct_mpi_uint_lt(const mbedtls_mpi_uint x, const mbedtls_mpi_uint
     return (unsigned)ret;
 }
 
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_BIGNUM_C */
 
+namespace lbug_mbedtls {
 unsigned mbedtls_ct_uint_if(unsigned condition, unsigned if1, unsigned if0) {
     unsigned mask = mbedtls_ct_uint_mask(condition);
     return ((mask & if1) | (~mask & if0));
 }
 
+} // namespace lbug_mbedtls
 #if defined(MBEDTLS_BIGNUM_C)
 
 /** Select between two sign values without branches.
@@ -263,6 +281,7 @@ unsigned mbedtls_ct_uint_if(unsigned condition, unsigned if1, unsigned if0) {
  *
  * \return  \c if1 if \p condition is nonzero, otherwise \c if0.
  * */
+namespace lbug_mbedtls {
 static int mbedtls_ct_cond_select_sign(unsigned char condition, int if1, int if0) {
     /* In order to avoid questions about what we can reasonably assume about
      * the representations of signed integers, move everything to unsigned
@@ -302,10 +321,12 @@ void mbedtls_ct_mpi_uint_cond_assign(size_t n, mbedtls_mpi_uint* dest, const mbe
         dest[i] = (src[i] & mask) | (dest[i] & ~mask);
 }
 
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_BIGNUM_C */
 
 #if defined(MBEDTLS_BASE64_C)
 
+namespace lbug_mbedtls {
 unsigned char mbedtls_ct_base64_enc_char(unsigned char value) {
     unsigned char digit = 0;
     /* For each range of values, if value is in that range, mask digit with
@@ -335,6 +356,7 @@ signed char mbedtls_ct_base64_dec_value(unsigned char c) {
     return (val - 1);
 }
 
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_BASE64_C */
 
 #if defined(MBEDTLS_PKCS1_V15) && defined(MBEDTLS_RSA_C) && !defined(MBEDTLS_RSA_ALT)
@@ -355,6 +377,7 @@ signed char mbedtls_ct_base64_dec_value(unsigned char c) {
  * \param total     Total size of the buffer.
  * \param offset    Offset from which to copy \p total - \p offset bytes.
  */
+namespace lbug_mbedtls {
 static void mbedtls_ct_mem_move_to_left(void* start, size_t total, size_t offset) {
     volatile unsigned char* buf = (volatile unsigned char*)start;
     size_t i, n;
@@ -374,10 +397,12 @@ static void mbedtls_ct_mem_move_to_left(void* start, size_t total, size_t offset
     }
 }
 
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_PKCS1_V15 && MBEDTLS_RSA_C && ! MBEDTLS_RSA_ALT */
 
 #if defined(MBEDTLS_SSL_SOME_SUITES_USE_TLS_CBC)
 
+namespace lbug_mbedtls {
 void mbedtls_ct_memcpy_if_eq(unsigned char* dest, const unsigned char* src, size_t len, size_t c1,
     size_t c2) {
     /* mask = c1 == c2 ? 0xff : 0x00 */
@@ -474,6 +499,7 @@ cleanup:
     return (ret);
 }
 
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_SSL_SOME_SUITES_USE_TLS_CBC */
 
 #if defined(MBEDTLS_BIGNUM_C)
@@ -485,6 +511,7 @@ cleanup:
  * about whether the assignment was made or not.
  * (Leaking information about the respective sizes of X and Y is ok however.)
  */
+namespace lbug_mbedtls {
 int mbedtls_mpi_safe_cond_assign(mbedtls_mpi* X, const mbedtls_mpi* Y, unsigned char assign) {
     int ret = 0;
     size_t i;
@@ -609,10 +636,12 @@ int mbedtls_mpi_lt_mpi_ct(const mbedtls_mpi* X, const mbedtls_mpi* Y, unsigned* 
     return (0);
 }
 
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_BIGNUM_C */
 
 #if defined(MBEDTLS_PKCS1_V15) && defined(MBEDTLS_RSA_C) && !defined(MBEDTLS_RSA_ALT)
 
+namespace lbug_mbedtls {
 int mbedtls_ct_rsaes_pkcs1_v15_unpadding(unsigned char* input, size_t ilen, unsigned char* output,
     size_t output_max_len, size_t* olen) {
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
@@ -724,4 +753,5 @@ int mbedtls_ct_rsaes_pkcs1_v15_unpadding(unsigned char* input, size_t ilen, unsi
     return (ret);
 }
 
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_PKCS1_V15 && MBEDTLS_RSA_C && ! MBEDTLS_RSA_ALT */

--- a/third_party/mbedtls/library/constant_time_internal.h
+++ b/third_party/mbedtls/library/constant_time_internal.h
@@ -43,8 +43,10 @@
  *
  * \return          Zero if \p value is zero, otherwise all-bits-one.
  */
+namespace lbug_mbedtls {
 unsigned mbedtls_ct_uint_mask(unsigned value);
 
+} // namespace lbug_mbedtls
 #if defined(MBEDTLS_SSL_SOME_SUITES_USE_TLS_CBC)
 
 /** Turn a value into a mask:
@@ -58,8 +60,10 @@ unsigned mbedtls_ct_uint_mask(unsigned value);
  *
  * \return          Zero if \p value is zero, otherwise all-bits-one.
  */
+namespace lbug_mbedtls {
 size_t mbedtls_ct_size_mask(size_t value);
 
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_SSL_SOME_SUITES_USE_TLS_CBC */
 
 #if defined(MBEDTLS_BIGNUM_C)
@@ -75,8 +79,10 @@ size_t mbedtls_ct_size_mask(size_t value);
  *
  * \return          Zero if \p value is zero, otherwise all-bits-one.
  */
+namespace lbug_mbedtls {
 mbedtls_mpi_uint mbedtls_ct_mpi_uint_mask(mbedtls_mpi_uint value);
 
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_BIGNUM_C */
 
 #if defined(MBEDTLS_SSL_SOME_SUITES_USE_TLS_CBC)
@@ -94,8 +100,10 @@ mbedtls_mpi_uint mbedtls_ct_mpi_uint_mask(mbedtls_mpi_uint value);
  * \return      All-bits-one if \p x is greater or equal than \p y,
  *              otherwise zero.
  */
+namespace lbug_mbedtls {
 size_t mbedtls_ct_size_mask_ge(size_t x, size_t y);
 
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_SSL_SOME_SUITES_USE_TLS_CBC */
 
 /** Constant-flow boolean "equal" comparison:
@@ -109,8 +117,10 @@ size_t mbedtls_ct_size_mask_ge(size_t x, size_t y);
  *
  * \return      1 if \p x equals to \p y, otherwise 0.
  */
+namespace lbug_mbedtls {
 unsigned mbedtls_ct_size_bool_eq(size_t x, size_t y);
 
+} // namespace lbug_mbedtls
 #if defined(MBEDTLS_BIGNUM_C)
 
 /** Decide if an integer is less than the other, without branches.
@@ -123,8 +133,10 @@ unsigned mbedtls_ct_size_bool_eq(size_t x, size_t y);
  *
  * \return      1 if \p x is less than \p y, otherwise 0.
  */
+namespace lbug_mbedtls {
 unsigned mbedtls_ct_mpi_uint_lt(const mbedtls_mpi_uint x, const mbedtls_mpi_uint y);
 
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_BIGNUM_C */
 
 /** Choose between two integer values without branches.
@@ -138,8 +150,10 @@ unsigned mbedtls_ct_mpi_uint_lt(const mbedtls_mpi_uint x, const mbedtls_mpi_uint
  *
  * \return  \c if1 if \p condition is nonzero, otherwise \c if0.
  */
+namespace lbug_mbedtls {
 unsigned mbedtls_ct_uint_if(unsigned condition, unsigned if1, unsigned if0);
 
+} // namespace lbug_mbedtls
 #if defined(MBEDTLS_BIGNUM_C)
 
 /** Conditionally assign a value without branches.
@@ -154,9 +168,11 @@ unsigned mbedtls_ct_uint_if(unsigned condition, unsigned if1, unsigned if0);
  *                      initialized MPI.
  * \param condition     Condition to test, must be 0 or 1.
  */
+namespace lbug_mbedtls {
 void mbedtls_ct_mpi_uint_cond_assign(size_t n, mbedtls_mpi_uint* dest, const mbedtls_mpi_uint* src,
     unsigned char condition);
 
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_BIGNUM_C */
 
 #if defined(MBEDTLS_BASE64_C)
@@ -170,6 +186,7 @@ void mbedtls_ct_mpi_uint_cond_assign(size_t n, mbedtls_mpi_uint* dest, const mbe
  *
  * \return          A base64 digit converted from \p value.
  */
+namespace lbug_mbedtls {
 unsigned char mbedtls_ct_base64_enc_char(unsigned char value);
 
 /** Given a Base64 digit, return its value.
@@ -186,6 +203,7 @@ unsigned char mbedtls_ct_base64_enc_char(unsigned char value);
  */
 signed char mbedtls_ct_base64_dec_value(unsigned char c);
 
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_BASE64_C */
 
 #if defined(MBEDTLS_SSL_SOME_SUITES_USE_TLS_CBC)
@@ -201,6 +219,7 @@ signed char mbedtls_ct_base64_dec_value(unsigned char c);
  * \param c1        The first value to analyze in the condition.
  * \param c2        The second value to analyze in the condition.
  */
+namespace lbug_mbedtls {
 void mbedtls_ct_memcpy_if_eq(unsigned char* dest, const unsigned char* src, size_t len, size_t c1,
     size_t c2);
 
@@ -266,6 +285,7 @@ int mbedtls_ct_hmac(mbedtls_md_context_t* ctx, const unsigned char* add_data, si
     const unsigned char* data, size_t data_len_secret, size_t min_data_len, size_t max_data_len,
     unsigned char* output);
 
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_SSL_SOME_SUITES_USE_TLS_CBC */
 
 #if defined(MBEDTLS_PKCS1_V15) && defined(MBEDTLS_RSA_C) && !defined(MBEDTLS_RSA_ALT)
@@ -296,9 +316,11 @@ int mbedtls_ct_hmac(mbedtls_md_context_t* ctx, const unsigned char* add_data, si
  * \return      #MBEDTLS_ERR_RSA_INVALID_PADDING
  *              The input doesn't contain properly formatted padding.
  */
+namespace lbug_mbedtls {
 int mbedtls_ct_rsaes_pkcs1_v15_unpadding(unsigned char* input, size_t ilen, unsigned char* output,
     size_t output_max_len, size_t* olen);
 
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_PKCS1_V15 && MBEDTLS_RSA_C && ! MBEDTLS_RSA_ALT */
 
 #endif /* MBEDTLS_CONSTANT_TIME_INTERNAL_H */

--- a/third_party/mbedtls/library/constant_time_invasive.h
+++ b/third_party/mbedtls/library/constant_time_invasive.h
@@ -42,9 +42,11 @@
  *
  * \return      All-bits-one if \p low <= \p c <= \p high, otherwise zero.
  */
+namespace lbug_mbedtls {
 unsigned char mbedtls_ct_uchar_mask_of_range(unsigned char low, unsigned char high,
     unsigned char c);
 
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_TEST_HOOKS */
 
 #endif /* MBEDTLS_CONSTANT_TIME_INVASIVE_H */

--- a/third_party/mbedtls/library/entropy.cpp
+++ b/third_party/mbedtls/library/entropy.cpp
@@ -47,6 +47,7 @@
 
 #define ENTROPY_MAX_LOOP 256 /**< Maximum amount to loop before error */
 
+namespace lbug_mbedtls {
 void mbedtls_entropy_init(mbedtls_entropy_context* ctx) {
     ctx->source_count = 0;
     memset(ctx->source, 0, sizeof(ctx->source));
@@ -387,7 +388,9 @@ exit:
     return (ret);
 }
 
+} // namespace lbug_mbedtls
 #if defined(MBEDTLS_ENTROPY_NV_SEED)
+namespace lbug_mbedtls {
 int mbedtls_entropy_update_nv_seed(mbedtls_entropy_context* ctx) {
     int ret = MBEDTLS_ERR_ENTROPY_FILE_IO_ERROR;
     unsigned char buf[MBEDTLS_ENTROPY_BLOCK_SIZE];
@@ -405,9 +408,11 @@ int mbedtls_entropy_update_nv_seed(mbedtls_entropy_context* ctx) {
 
     return (ret);
 }
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_ENTROPY_NV_SEED */
 
 #if defined(MBEDTLS_FS_IO)
+namespace lbug_mbedtls {
 int mbedtls_entropy_write_seed_file(mbedtls_entropy_context* ctx, const char* path) {
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
     FILE* f = NULL;
@@ -469,12 +474,14 @@ int mbedtls_entropy_update_seed_file(mbedtls_entropy_context* ctx, const char* p
 
     return (mbedtls_entropy_write_seed_file(ctx, path));
 }
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_FS_IO */
 
 #if defined(MBEDTLS_SELF_TEST)
 /*
  * Dummy source function
  */
+namespace lbug_mbedtls {
 static int entropy_dummy_source(void* data, unsigned char* output, size_t len, size_t* olen) {
     ((void)data);
 
@@ -484,8 +491,10 @@ static int entropy_dummy_source(void* data, unsigned char* output, size_t len, s
     return (0);
 }
 
+} // namespace lbug_mbedtls
 #if defined(MBEDTLS_ENTROPY_HARDWARE_ALT)
 
+namespace lbug_mbedtls {
 static int mbedtls_entropy_source_self_test_gather(unsigned char* buf, size_t buf_len) {
     int ret = 0;
     size_t entropy_len = 0;
@@ -571,6 +580,7 @@ cleanup:
     return (ret != 0);
 }
 
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_ENTROPY_HARDWARE_ALT */
 
 /*
@@ -578,6 +588,7 @@ cleanup:
  * test that the functions don't cause errors and write the correct
  * amount of data to buffers.
  */
+namespace lbug_mbedtls {
 int mbedtls_entropy_self_test(int verbose) {
     int ret = 1;
     mbedtls_entropy_context ctx;
@@ -644,6 +655,7 @@ cleanup:
 
     return (ret != 0);
 }
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_SELF_TEST */
 
 #endif /* MBEDTLS_ENTROPY_C */

--- a/third_party/mbedtls/library/entropy_poll.cpp
+++ b/third_party/mbedtls/library/entropy_poll.cpp
@@ -55,6 +55,7 @@
 #include <wincrypt.h>
 #include <windows.h>
 
+namespace lbug_mbedtls {
 int mbedtls_platform_entropy_poll(void* data, unsigned char* output, size_t len, size_t* olen) {
     HCRYPTPROV provider;
     ((void)data);
@@ -74,6 +75,7 @@ int mbedtls_platform_entropy_poll(void* data, unsigned char* output, size_t len,
 
     return (0);
 }
+} // namespace lbug_mbedtls
 #else /* _WIN32 && !EFIX64 && !EFI32 */
 
 /*
@@ -89,6 +91,7 @@ int mbedtls_platform_entropy_poll(void* data, unsigned char* output, size_t len,
 #define HAVE_GETRANDOM
 #include <errno.h>
 
+namespace lbug_mbedtls {
 static int getrandom_wrapper(void* buf, size_t buflen, unsigned int flags) {
     /* MemSan cannot understand that the syscall writes to the buffer */
 #if defined(__has_feature)
@@ -98,6 +101,7 @@ static int getrandom_wrapper(void* buf, size_t buflen, unsigned int flags) {
 #endif
     return (syscall(SYS_getrandom, buf, buflen, flags));
 }
+} // namespace lbug_mbedtls
 #endif /* SYS_getrandom */
 #endif /* __linux__ || __midipix__ */
 
@@ -109,9 +113,11 @@ static int getrandom_wrapper(void* buf, size_t buflen, unsigned int flags) {
 
 #include <sys/random.h>
 #define HAVE_GETRANDOM
+namespace lbug_mbedtls {
 static int getrandom_wrapper(void* buf, size_t buflen, unsigned int flags) {
     return getrandom(buf, buflen, flags);
 }
+} // namespace lbug_mbedtls
 #endif /* (__FreeBSD__ && __FreeBSD_version >= 1200000) ||                                         \
           (__DragonFly__ && __DragonFly_version >= 500700) */
 #endif /* __FreeBSD__ || __DragonFly__ */
@@ -130,6 +136,7 @@ static int getrandom_wrapper(void* buf, size_t buflen, unsigned int flags) {
 #if defined(KERN_ARND)
 #define HAVE_SYSCTL_ARND
 
+namespace lbug_mbedtls {
 static int sysctl_arnd_wrapper(unsigned char* buf, size_t buflen) {
     int name[2];
     size_t len;
@@ -146,11 +153,13 @@ static int sysctl_arnd_wrapper(unsigned char* buf, size_t buflen) {
     }
     return (0);
 }
+} // namespace lbug_mbedtls
 #endif /* KERN_ARND */
 #endif /* __FreeBSD__ || __NetBSD__ */
 
 #include <stdio.h>
 
+namespace lbug_mbedtls {
 int mbedtls_platform_entropy_poll(void* data, unsigned char* output, size_t len, size_t* olen) {
     FILE* file;
     size_t read_len;
@@ -196,10 +205,12 @@ int mbedtls_platform_entropy_poll(void* data, unsigned char* output, size_t len,
     return (0);
 #endif /* HAVE_SYSCTL_ARND */
 }
+} // namespace lbug_mbedtls
 #endif /* _WIN32 && !EFIX64 && !EFI32 */
 #endif /* !MBEDTLS_NO_PLATFORM_ENTROPY */
 
 #if defined(MBEDTLS_ENTROPY_NV_SEED)
+namespace lbug_mbedtls {
 int mbedtls_nv_seed_poll(void* data, unsigned char* output, size_t len, size_t* olen) {
     unsigned char buf[MBEDTLS_ENTROPY_BLOCK_SIZE];
     size_t use_len = MBEDTLS_ENTROPY_BLOCK_SIZE;
@@ -218,6 +229,7 @@ int mbedtls_nv_seed_poll(void* data, unsigned char* output, size_t len, size_t* 
 
     return (0);
 }
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_ENTROPY_NV_SEED */
 
 #endif /* MBEDTLS_ENTROPY_C */

--- a/third_party/mbedtls/library/entropy_poll.h
+++ b/third_party/mbedtls/library/entropy_poll.h
@@ -26,9 +26,6 @@
 
 #include "mbedtls/build_info.h"
 
-#ifdef __cplusplus
-extern "C" {
-#endif
 
 /*
  * Default thresholds for built-in sources, in bytes
@@ -42,7 +39,9 @@ extern "C" {
 /**
  * \brief           Platform-specific entropy poll callback
  */
+namespace lbug_mbedtls {
 int mbedtls_platform_entropy_poll(void* data, unsigned char* output, size_t len, size_t* olen);
+} // namespace lbug_mbedtls
 #endif
 
 #if defined(MBEDTLS_ENTROPY_HARDWARE_ALT)
@@ -54,7 +53,9 @@ int mbedtls_platform_entropy_poll(void* data, unsigned char* output, size_t len,
  *
  * \note            This must accept NULL as its first argument.
  */
+namespace lbug_mbedtls {
 int mbedtls_hardware_poll(void* data, unsigned char* output, size_t len, size_t* olen);
+} // namespace lbug_mbedtls
 #endif
 
 #if defined(MBEDTLS_ENTROPY_NV_SEED)
@@ -63,11 +64,10 @@ int mbedtls_hardware_poll(void* data, unsigned char* output, size_t len, size_t*
  *
  * \note            This must accept NULL as its first argument.
  */
+namespace lbug_mbedtls {
 int mbedtls_nv_seed_poll(void* data, unsigned char* output, size_t len, size_t* olen);
+} // namespace lbug_mbedtls
 #endif
 
-#ifdef __cplusplus
-}
-#endif
 
 #endif /* entropy_poll.h */

--- a/third_party/mbedtls/library/gcm.cpp
+++ b/third_party/mbedtls/library/gcm.cpp
@@ -59,6 +59,7 @@
 /*
  * Initialize a context
  */
+namespace lbug_mbedtls {
 void mbedtls_gcm_init(mbedtls_gcm_context* ctx) {
     GCM_VALIDATE(ctx != NULL);
     memset(ctx, 0, sizeof(mbedtls_gcm_context));
@@ -574,6 +575,7 @@ void mbedtls_gcm_free(mbedtls_gcm_context* ctx) {
     mbedtls_platform_zeroize(ctx, sizeof(mbedtls_gcm_context));
 }
 
+} // namespace lbug_mbedtls
 #endif /* !MBEDTLS_GCM_ALT */
 
 #if defined(MBEDTLS_SELF_TEST) && defined(MBEDTLS_AES_C)
@@ -584,6 +586,7 @@ void mbedtls_gcm_free(mbedtls_gcm_context* ctx) {
  */
 #define MAX_TESTS 6
 
+namespace lbug_mbedtls {
 static const int key_index_test_data[MAX_TESTS] = {0, 0, 1, 1, 1, 1};
 
 static const unsigned char key_test_data[MAX_TESTS][32] = {
@@ -949,6 +952,7 @@ exit:
     return (ret);
 }
 
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_SELF_TEST && MBEDTLS_AES_C */
 
 #endif /* MBEDTLS_GCM_C */

--- a/third_party/mbedtls/library/md.cpp
+++ b/third_party/mbedtls/library/md.cpp
@@ -61,71 +61,86 @@
 #endif
 
 #if defined(MBEDTLS_MD5_C)
+namespace lbug_mbedtls {
 const mbedtls_md_info_t mbedtls_md5_info = {
     "MD5",
     MBEDTLS_MD_MD5,
     16,
     64,
 };
+} // namespace lbug_mbedtls
 #endif
 
 #if defined(MBEDTLS_RIPEMD160_C)
+namespace lbug_mbedtls {
 const mbedtls_md_info_t mbedtls_ripemd160_info = {
     "RIPEMD160",
     MBEDTLS_MD_RIPEMD160,
     20,
     64,
 };
+} // namespace lbug_mbedtls
 #endif
 
 #if defined(MBEDTLS_SHA1_C)
+namespace lbug_mbedtls {
 const mbedtls_md_info_t mbedtls_sha1_info = {
     "SHA1",
     MBEDTLS_MD_SHA1,
     20,
     64,
 };
+} // namespace lbug_mbedtls
 #endif
 
 #if defined(MBEDTLS_SHA224_C)
+namespace lbug_mbedtls {
 const mbedtls_md_info_t mbedtls_sha224_info = {
     "SHA224",
     MBEDTLS_MD_SHA224,
     28,
     64,
 };
+} // namespace lbug_mbedtls
 #endif
 
 #if defined(MBEDTLS_SHA256_C)
+namespace lbug_mbedtls {
 const mbedtls_md_info_t mbedtls_sha256_info = {
     "SHA256",
     MBEDTLS_MD_SHA256,
     32,
     64,
 };
+} // namespace lbug_mbedtls
 #endif
 
 #if defined(MBEDTLS_SHA384_C)
+namespace lbug_mbedtls {
 const mbedtls_md_info_t mbedtls_sha384_info = {
     "SHA384",
     MBEDTLS_MD_SHA384,
     48,
     128,
 };
+} // namespace lbug_mbedtls
 #endif
 
 #if defined(MBEDTLS_SHA512_C)
+namespace lbug_mbedtls {
 const mbedtls_md_info_t mbedtls_sha512_info = {
     "SHA512",
     MBEDTLS_MD_SHA512,
     64,
     128,
 };
+} // namespace lbug_mbedtls
 #endif
 
 /*
  * Reminder: update profiles in x509_crt.c when adding a new hash!
  */
+namespace lbug_mbedtls {
 static const int supported_digests[] = {
 
 #if defined(MBEDTLS_SHA512_C)
@@ -566,7 +581,9 @@ int mbedtls_md(const mbedtls_md_info_t* md_info, const unsigned char* input, siz
     }
 }
 
+} // namespace lbug_mbedtls
 #if defined(MBEDTLS_FS_IO)
+namespace lbug_mbedtls {
 int mbedtls_md_file(const mbedtls_md_info_t* md_info, const char* path, unsigned char* output) {
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
     FILE* f;
@@ -604,8 +621,10 @@ cleanup:
 
     return (ret);
 }
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_FS_IO */
 
+namespace lbug_mbedtls {
 int mbedtls_md_hmac_starts(mbedtls_md_context_t* ctx, const unsigned char* key, size_t keylen) {
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
     unsigned char sum[MBEDTLS_MD_MAX_SIZE];
@@ -776,4 +795,5 @@ const char* mbedtls_md_get_name(const mbedtls_md_info_t* md_info) {
     return md_info->name;
 }
 
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_MD_C */

--- a/third_party/mbedtls/library/md_wrap.h
+++ b/third_party/mbedtls/library/md_wrap.h
@@ -29,14 +29,12 @@
 #include "mbedtls/build_info.h"
 #include "mbedtls/md.h"
 
-#ifdef __cplusplus
-extern "C" {
-#endif
 
 /**
  * Message digest information.
  * Allows message digest functions to be called in a generic way.
  */
+namespace lbug_mbedtls {
 struct mbedtls_md_info_t {
     /** Name of the message digest */
     const char* name;
@@ -51,30 +49,42 @@ struct mbedtls_md_info_t {
     unsigned char block_size;
 };
 
+} // namespace lbug_mbedtls
 #if defined(MBEDTLS_MD5_C)
+namespace lbug_mbedtls {
 extern const mbedtls_md_info_t mbedtls_md5_info;
+} // namespace lbug_mbedtls
 #endif
 #if defined(MBEDTLS_RIPEMD160_C)
+namespace lbug_mbedtls {
 extern const mbedtls_md_info_t mbedtls_ripemd160_info;
+} // namespace lbug_mbedtls
 #endif
 #if defined(MBEDTLS_SHA1_C)
+namespace lbug_mbedtls {
 extern const mbedtls_md_info_t mbedtls_sha1_info;
+} // namespace lbug_mbedtls
 #endif
 #if defined(MBEDTLS_SHA224_C)
+namespace lbug_mbedtls {
 extern const mbedtls_md_info_t mbedtls_sha224_info;
+} // namespace lbug_mbedtls
 #endif
 #if defined(MBEDTLS_SHA256_C)
+namespace lbug_mbedtls {
 extern const mbedtls_md_info_t mbedtls_sha256_info;
+} // namespace lbug_mbedtls
 #endif
 #if defined(MBEDTLS_SHA384_C)
+namespace lbug_mbedtls {
 extern const mbedtls_md_info_t mbedtls_sha384_info;
+} // namespace lbug_mbedtls
 #endif
 #if defined(MBEDTLS_SHA512_C)
+namespace lbug_mbedtls {
 extern const mbedtls_md_info_t mbedtls_sha512_info;
+} // namespace lbug_mbedtls
 #endif
 
-#ifdef __cplusplus
-}
-#endif
 
 #endif /* MBEDTLS_MD_WRAP_H */

--- a/third_party/mbedtls/library/oid.cpp
+++ b/third_party/mbedtls/library/oid.cpp
@@ -157,6 +157,7 @@
 /*
  * For X520 attribute types
  */
+namespace lbug_mbedtls {
 typedef struct {
     mbedtls_oid_descriptor_t descriptor;
     const char* short_name;
@@ -300,7 +301,9 @@ static const oid_x509_ext_t oid_x509_ext[] = {
 FN_OID_TYPED_FROM_ASN1(oid_x509_ext_t, x509_ext, oid_x509_ext)
 FN_OID_GET_ATTR1(mbedtls_oid_get_x509_ext_type, oid_x509_ext_t, x509_ext, int, ext_type)
 
+} // namespace lbug_mbedtls
 #if !defined(MBEDTLS_X509_REMOVE_INFO)
+namespace lbug_mbedtls {
 static const mbedtls_oid_descriptor_t oid_ext_key_usage[] = {
     OID_DESCRIPTOR(MBEDTLS_OID_SERVER_AUTH, "id-kp-serverAuth", "TLS Web Server Authentication"),
     OID_DESCRIPTOR(MBEDTLS_OID_CLIENT_AUTH, "id-kp-clientAuth", "TLS Web Client Authentication"),
@@ -325,12 +328,14 @@ static const mbedtls_oid_descriptor_t oid_certificate_policies[] = {
 FN_OID_TYPED_FROM_ASN1(mbedtls_oid_descriptor_t, certificate_policies, oid_certificate_policies)
 FN_OID_GET_ATTR1(mbedtls_oid_get_certificate_policies, mbedtls_oid_descriptor_t,
     certificate_policies, const char*, description)
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_X509_REMOVE_INFO */
 
 #if defined(MBEDTLS_MD_C)
 /*
  * For SignatureAlgorithmIdentifier
  */
+namespace lbug_mbedtls {
 typedef struct {
     mbedtls_oid_descriptor_t descriptor;
     mbedtls_md_type_t md_alg;
@@ -442,20 +447,26 @@ static const oid_sig_alg_t oid_sig_alg[] = {
 
 FN_OID_TYPED_FROM_ASN1(oid_sig_alg_t, sig_alg, oid_sig_alg)
 
+} // namespace lbug_mbedtls
 #if !defined(MBEDTLS_X509_REMOVE_INFO)
+namespace lbug_mbedtls {
 FN_OID_GET_DESCRIPTOR_ATTR1(mbedtls_oid_get_sig_alg_desc, oid_sig_alg_t, sig_alg, const char*,
     description)
+} // namespace lbug_mbedtls
 #endif
 
+namespace lbug_mbedtls {
 FN_OID_GET_ATTR2(mbedtls_oid_get_sig_alg, oid_sig_alg_t, sig_alg, mbedtls_md_type_t, md_alg,
     mbedtls_pk_type_t, pk_alg)
 FN_OID_GET_OID_BY_ATTR2(mbedtls_oid_get_oid_by_sig_alg, oid_sig_alg_t, oid_sig_alg,
     mbedtls_pk_type_t, pk_alg, mbedtls_md_type_t, md_alg)
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_MD_C */
 
 /*
  * For PublicKeyInfo (PKCS1, RFC 5480)
  */
+namespace lbug_mbedtls {
 typedef struct {
     mbedtls_oid_descriptor_t descriptor;
     mbedtls_pk_type_t pk_alg;
@@ -485,10 +496,12 @@ FN_OID_GET_ATTR1(mbedtls_oid_get_pk_alg, oid_pk_alg_t, pk_alg, mbedtls_pk_type_t
 FN_OID_GET_OID_BY_ATTR1(mbedtls_oid_get_oid_by_pk_alg, oid_pk_alg_t, oid_pk_alg, mbedtls_pk_type_t,
     pk_alg)
 
+} // namespace lbug_mbedtls
 #if defined(MBEDTLS_ECP_C)
 /*
  * For namedCurve (RFC 5480)
  */
+namespace lbug_mbedtls {
 typedef struct {
     mbedtls_oid_descriptor_t descriptor;
     mbedtls_ecp_group_id grp_id;
@@ -571,12 +584,14 @@ FN_OID_TYPED_FROM_ASN1(oid_ecp_grp_t, grp_id, oid_ecp_grp)
 FN_OID_GET_ATTR1(mbedtls_oid_get_ec_grp, oid_ecp_grp_t, grp_id, mbedtls_ecp_group_id, grp_id)
 FN_OID_GET_OID_BY_ATTR1(mbedtls_oid_get_oid_by_ec_grp, oid_ecp_grp_t, oid_ecp_grp,
     mbedtls_ecp_group_id, grp_id)
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_ECP_C */
 
 #if defined(MBEDTLS_CIPHER_C)
 /*
  * For PKCS#5 PBES2 encryption algorithm
  */
+namespace lbug_mbedtls {
 typedef struct {
     mbedtls_oid_descriptor_t descriptor;
     mbedtls_cipher_type_t cipher_alg;
@@ -600,12 +615,14 @@ static const oid_cipher_alg_t oid_cipher_alg[] = {
 FN_OID_TYPED_FROM_ASN1(oid_cipher_alg_t, cipher_alg, oid_cipher_alg)
 FN_OID_GET_ATTR1(mbedtls_oid_get_cipher_alg, oid_cipher_alg_t, cipher_alg, mbedtls_cipher_type_t,
     cipher_alg)
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_CIPHER_C */
 
 #if defined(MBEDTLS_MD_C)
 /*
  * For digestAlgorithm
  */
+namespace lbug_mbedtls {
 typedef struct {
     mbedtls_oid_descriptor_t descriptor;
     mbedtls_md_type_t md_alg;
@@ -712,12 +729,14 @@ static const oid_md_hmac_t oid_md_hmac[] = {
 
 FN_OID_TYPED_FROM_ASN1(oid_md_hmac_t, md_hmac, oid_md_hmac)
 FN_OID_GET_ATTR1(mbedtls_oid_get_md_hmac, oid_md_hmac_t, md_hmac, mbedtls_md_type_t, md_hmac)
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_MD_C */
 
 #if defined(MBEDTLS_PKCS12_C)
 /*
  * For PKCS#12 PBEs
  */
+namespace lbug_mbedtls {
 typedef struct {
     mbedtls_oid_descriptor_t descriptor;
     mbedtls_md_type_t md_alg;
@@ -747,6 +766,7 @@ static const oid_pkcs12_pbe_alg_t oid_pkcs12_pbe_alg[] = {
 FN_OID_TYPED_FROM_ASN1(oid_pkcs12_pbe_alg_t, pkcs12_pbe_alg, oid_pkcs12_pbe_alg)
 FN_OID_GET_ATTR2(mbedtls_oid_get_pkcs12_pbe_alg, oid_pkcs12_pbe_alg_t, pkcs12_pbe_alg,
     mbedtls_md_type_t, md_alg, mbedtls_cipher_type_t, cipher_alg)
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_PKCS12_C */
 
 #define OID_SAFE_SNPRINTF                                                                          \
@@ -759,9 +779,11 @@ FN_OID_GET_ATTR2(mbedtls_oid_get_pkcs12_pbe_alg, oid_pkcs12_pbe_alg_t, pkcs12_pb
     } while (0)
 
 /* Return the x.y.z.... style numeric string for the given OID */
+namespace lbug_mbedtls {
 int mbedtls_oid_get_numeric_string(char*, size_t, const mbedtls_asn1_buf*) {
     return MBEDTLS_ERR_ERROR_GENERIC_ERROR; // patched because it used to require printf which would
                                             // fail on Windows
 }
 
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_OID_C */

--- a/third_party/mbedtls/library/pem.cpp
+++ b/third_party/mbedtls/library/pem.cpp
@@ -45,15 +45,18 @@
 #endif
 
 #if defined(MBEDTLS_PEM_PARSE_C)
+namespace lbug_mbedtls {
 void mbedtls_pem_init(mbedtls_pem_context* ctx) {
     memset(ctx, 0, sizeof(mbedtls_pem_context));
 }
 
+} // namespace lbug_mbedtls
 #if defined(MBEDTLS_MD5_C) && defined(MBEDTLS_CIPHER_MODE_CBC) &&                                  \
     (defined(MBEDTLS_DES_C) || defined(MBEDTLS_AES_C))
 /*
  * Read a 16-byte hex string and convert it to binary
  */
+namespace lbug_mbedtls {
 static int pem_get_iv(const unsigned char* s, unsigned char* iv, size_t iv_len) {
     size_t i, j, k;
 
@@ -132,10 +135,12 @@ exit:
     return (ret);
 }
 
+} // namespace lbug_mbedtls
 #if defined(MBEDTLS_DES_C)
 /*
  * Decrypt with DES-CBC, using PBKDF1 for key derivation
  */
+namespace lbug_mbedtls {
 static int pem_des_decrypt(unsigned char des_iv[8], unsigned char* buf, size_t buflen,
     const unsigned char* pwd, size_t pwdlen) {
     mbedtls_des_context des_ctx;
@@ -182,12 +187,14 @@ exit:
 
     return (ret);
 }
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_DES_C */
 
 #if defined(MBEDTLS_AES_C)
 /*
  * Decrypt with AES-XXX-CBC, using PBKDF1 for key derivation
  */
+namespace lbug_mbedtls {
 static int pem_aes_decrypt(unsigned char aes_iv[16], unsigned int keylen, unsigned char* buf,
     size_t buflen, const unsigned char* pwd, size_t pwdlen) {
     mbedtls_aes_context aes_ctx;
@@ -209,11 +216,13 @@ exit:
 
     return (ret);
 }
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_AES_C */
 
 #endif /* MBEDTLS_MD5_C && MBEDTLS_CIPHER_MODE_CBC &&                                              \
           ( MBEDTLS_AES_C || MBEDTLS_DES_C ) */
 
+namespace lbug_mbedtls {
 int mbedtls_pem_read_buffer(mbedtls_pem_context* ctx, const char* header, const char* footer,
     const unsigned char* data, const unsigned char* pwd, size_t pwdlen, size_t* use_len) {
     int ret, enc;
@@ -417,9 +426,11 @@ void mbedtls_pem_free(mbedtls_pem_context* ctx) {
 
     mbedtls_platform_zeroize(ctx, sizeof(mbedtls_pem_context));
 }
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_PEM_PARSE_C */
 
 #if defined(MBEDTLS_PEM_WRITE_C)
+namespace lbug_mbedtls {
 int mbedtls_pem_write_buffer(const char* header, const char* footer, const unsigned char* der_data,
     size_t der_len, unsigned char* buf, size_t buf_len, size_t* olen) {
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
@@ -467,5 +478,6 @@ int mbedtls_pem_write_buffer(const char* header, const char* footer, const unsig
     mbedtls_free(encode_buf);
     return (0);
 }
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_PEM_WRITE_C */
 #endif /* MBEDTLS_PEM_PARSE_C || MBEDTLS_PEM_WRITE_C */

--- a/third_party/mbedtls/library/pk.cpp
+++ b/third_party/mbedtls/library/pk.cpp
@@ -49,6 +49,7 @@
 /*
  * Initialise a mbedtls_pk_context
  */
+namespace lbug_mbedtls {
 void mbedtls_pk_init(mbedtls_pk_context* ctx) {
     PK_VALIDATE(ctx != NULL);
 
@@ -69,10 +70,12 @@ void mbedtls_pk_free(mbedtls_pk_context* ctx) {
     mbedtls_platform_zeroize(ctx, sizeof(mbedtls_pk_context));
 }
 
+} // namespace lbug_mbedtls
 #if defined(MBEDTLS_ECDSA_C) && defined(MBEDTLS_ECP_RESTARTABLE)
 /*
  * Initialize a restart context
  */
+namespace lbug_mbedtls {
 void mbedtls_pk_restart_init(mbedtls_pk_restart_ctx* ctx) {
     PK_VALIDATE(ctx != NULL);
     ctx->pk_info = NULL;
@@ -92,11 +95,13 @@ void mbedtls_pk_restart_free(mbedtls_pk_restart_ctx* ctx) {
     ctx->pk_info = NULL;
     ctx->rs_ctx = NULL;
 }
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_ECDSA_C && MBEDTLS_ECP_RESTARTABLE */
 
 /*
  * Get pk_info structure from type
  */
+namespace lbug_mbedtls {
 const mbedtls_pk_info_t* mbedtls_pk_info_from_type(mbedtls_pk_type_t pk_type) {
     switch (pk_type) {
 #if defined(MBEDTLS_RSA_C)
@@ -135,10 +140,12 @@ int mbedtls_pk_setup(mbedtls_pk_context* ctx, const mbedtls_pk_info_t* info) {
     return (0);
 }
 
+} // namespace lbug_mbedtls
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
 /*
  * Initialise a PSA-wrapping context
  */
+namespace lbug_mbedtls {
 int mbedtls_pk_setup_opaque(mbedtls_pk_context* ctx, const psa_key_id_t key) {
     const mbedtls_pk_info_t* const info = &mbedtls_pk_opaque_info;
     psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
@@ -167,12 +174,14 @@ int mbedtls_pk_setup_opaque(mbedtls_pk_context* ctx, const psa_key_id_t key) {
 
     return (0);
 }
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_USE_PSA_CRYPTO */
 
 #if defined(MBEDTLS_PK_RSA_ALT_SUPPORT)
 /*
  * Initialize an RSA-alt context
  */
+namespace lbug_mbedtls {
 int mbedtls_pk_setup_rsa_alt(mbedtls_pk_context* ctx, void* key,
     mbedtls_pk_rsa_alt_decrypt_func decrypt_func, mbedtls_pk_rsa_alt_sign_func sign_func,
     mbedtls_pk_rsa_alt_key_len_func key_len_func) {
@@ -197,11 +206,13 @@ int mbedtls_pk_setup_rsa_alt(mbedtls_pk_context* ctx, void* key,
 
     return (0);
 }
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_PK_RSA_ALT_SUPPORT */
 
 /*
  * Tell if a PK can do the operations of the given type
  */
+namespace lbug_mbedtls {
 int mbedtls_pk_can_do(const mbedtls_pk_context* ctx, mbedtls_pk_type_t type) {
     /* A context with null pk_info is not set up yet and can't do anything.
      * For backward compatibility, also accept NULL instead of a context
@@ -228,10 +239,12 @@ static inline int pk_hashlen_helper(mbedtls_md_type_t md_alg, size_t* hash_len) 
     return (0);
 }
 
+} // namespace lbug_mbedtls
 #if defined(MBEDTLS_ECDSA_C) && defined(MBEDTLS_ECP_RESTARTABLE)
 /*
  * Helper to set up a restart context if needed
  */
+namespace lbug_mbedtls {
 static int pk_restart_setup(mbedtls_pk_restart_ctx* ctx, const mbedtls_pk_info_t* info) {
     /* Don't do anything if already set up or invalid */
     if (ctx == NULL || ctx->pk_info != NULL)
@@ -248,11 +261,13 @@ static int pk_restart_setup(mbedtls_pk_restart_ctx* ctx, const mbedtls_pk_info_t
 
     return (0);
 }
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_ECDSA_C && MBEDTLS_ECP_RESTARTABLE */
 
 /*
  * Verify a signature (restartable)
  */
+namespace lbug_mbedtls {
 int mbedtls_pk_verify_restartable(mbedtls_pk_context* ctx, mbedtls_md_type_t md_alg,
     const unsigned char* hash, size_t hash_len, const unsigned char* sig, size_t sig_len,
     mbedtls_pk_restart_ctx* rs_ctx) {
@@ -522,6 +537,7 @@ mbedtls_pk_type_t mbedtls_pk_get_type(const mbedtls_pk_context* ctx) {
     return (ctx->pk_info->type);
 }
 
+} // namespace lbug_mbedtls
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
 /*
  * Load the key to a PSA key slot,
@@ -529,6 +545,7 @@ mbedtls_pk_type_t mbedtls_pk_get_type(const mbedtls_pk_context* ctx) {
  *
  * Currently only works for EC private keys.
  */
+namespace lbug_mbedtls {
 int mbedtls_pk_wrap_as_opaque(mbedtls_pk_context* pk, psa_key_id_t* key, psa_algorithm_t hash_alg) {
 #if !defined(MBEDTLS_ECP_C)
     ((void)pk);
@@ -574,5 +591,6 @@ int mbedtls_pk_wrap_as_opaque(mbedtls_pk_context* pk, psa_key_id_t* key, psa_alg
     return (mbedtls_pk_setup_opaque(pk, *key));
 #endif /* MBEDTLS_ECP_C */
 }
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_USE_PSA_CRYPTO */
 #endif /* MBEDTLS_PK_C */

--- a/third_party/mbedtls/library/pk_wrap.cpp
+++ b/third_party/mbedtls/library/pk_wrap.cpp
@@ -62,6 +62,7 @@
 #include <stdint.h>
 
 #if defined(MBEDTLS_RSA_C)
+namespace lbug_mbedtls {
 static int rsa_can_do(mbedtls_pk_type_t type) {
     return (type == MBEDTLS_PK_RSA || type == MBEDTLS_PK_RSASSA_PSS);
 }
@@ -201,12 +202,14 @@ const mbedtls_pk_info_t mbedtls_rsa_info = {
 #endif
     rsa_debug,
 };
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_RSA_C */
 
 #if defined(MBEDTLS_ECP_C)
 /*
  * Generic EC key
  */
+namespace lbug_mbedtls {
 static int eckey_can_do(mbedtls_pk_type_t type) {
     return (type == MBEDTLS_PK_ECKEY || type == MBEDTLS_PK_ECKEY_DH || type == MBEDTLS_PK_ECDSA);
 }
@@ -215,8 +218,10 @@ static size_t eckey_get_bitlen(const void* ctx) {
     return (((mbedtls_ecp_keypair*)ctx)->grp.pbits);
 }
 
+} // namespace lbug_mbedtls
 #if defined(MBEDTLS_ECDSA_C)
 /* Forward declarations */
+namespace lbug_mbedtls {
 static int ecdsa_verify_wrap(void* ctx, mbedtls_md_type_t md_alg, const unsigned char* hash,
     size_t hash_len, const unsigned char* sig, size_t sig_len);
 
@@ -255,8 +260,10 @@ static int eckey_sign_wrap(void* ctx, mbedtls_md_type_t md_alg, const unsigned c
     return (ret);
 }
 
+} // namespace lbug_mbedtls
 #if defined(MBEDTLS_ECP_RESTARTABLE)
 /* Forward declarations */
+namespace lbug_mbedtls {
 static int ecdsa_verify_rs_wrap(void* ctx, mbedtls_md_type_t md_alg, const unsigned char* hash,
     size_t hash_len, const unsigned char* sig, size_t sig_len, void* rs_ctx);
 
@@ -342,9 +349,11 @@ static int eckey_sign_rs_wrap(void* ctx, mbedtls_md_type_t md_alg, const unsigne
 cleanup:
     return (ret);
 }
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_ECP_RESTARTABLE */
 #endif /* MBEDTLS_ECDSA_C */
 
+namespace lbug_mbedtls {
 static int eckey_check_pair(const void* pub, const void* prv,
     int (*f_rng)(void*, unsigned char*, size_t), void* p_rng) {
     return (mbedtls_ecp_check_pub_priv((const mbedtls_ecp_keypair*)pub,
@@ -419,18 +428,22 @@ const mbedtls_pk_info_t mbedtls_eckeydh_info = {
 #endif
     eckey_debug, /* Same underlying key structure */
 };
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_ECP_C */
 
 #if defined(MBEDTLS_ECDSA_C)
+namespace lbug_mbedtls {
 static int ecdsa_can_do(mbedtls_pk_type_t type) {
     return (type == MBEDTLS_PK_ECDSA);
 }
 
+} // namespace lbug_mbedtls
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
 /*
  * An ASN.1 encoded signature is a sequence of two ASN.1 integers. Parse one of
  * those integers and convert it to the fixed-length encoding expected by PSA.
  */
+namespace lbug_mbedtls {
 static int extract_ecdsa_sig_int(unsigned char** from, const unsigned char* end, unsigned char* to,
     size_t to_len) {
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
@@ -549,7 +562,9 @@ cleanup:
     psa_destroy_key(key_id);
     return (ret);
 }
+} // namespace lbug_mbedtls
 #else  /* MBEDTLS_USE_PSA_CRYPTO */
+namespace lbug_mbedtls {
 static int ecdsa_verify_wrap(void* ctx, mbedtls_md_type_t md_alg, const unsigned char* hash,
     size_t hash_len, const unsigned char* sig, size_t sig_len) {
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
@@ -562,8 +577,10 @@ static int ecdsa_verify_wrap(void* ctx, mbedtls_md_type_t md_alg, const unsigned
 
     return (ret);
 }
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_USE_PSA_CRYPTO */
 
+namespace lbug_mbedtls {
 static int ecdsa_sign_wrap(void* ctx, mbedtls_md_type_t md_alg, const unsigned char* hash,
     size_t hash_len, unsigned char* sig, size_t sig_size, size_t* sig_len,
     int (*f_rng)(void*, unsigned char*, size_t), void* p_rng) {
@@ -571,7 +588,9 @@ static int ecdsa_sign_wrap(void* ctx, mbedtls_md_type_t md_alg, const unsigned c
         sig_size, sig_len, f_rng, p_rng));
 }
 
+} // namespace lbug_mbedtls
 #if defined(MBEDTLS_ECP_RESTARTABLE)
+namespace lbug_mbedtls {
 static int ecdsa_verify_rs_wrap(void* ctx, mbedtls_md_type_t md_alg, const unsigned char* hash,
     size_t hash_len, const unsigned char* sig, size_t sig_len, void* rs_ctx) {
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
@@ -592,8 +611,10 @@ static int ecdsa_sign_rs_wrap(void* ctx, mbedtls_md_type_t md_alg, const unsigne
     return (mbedtls_ecdsa_write_signature_restartable((mbedtls_ecdsa_context*)ctx, md_alg, hash,
         hash_len, sig, sig_size, sig_len, f_rng, p_rng, (mbedtls_ecdsa_restart_ctx*)rs_ctx));
 }
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_ECP_RESTARTABLE */
 
+namespace lbug_mbedtls {
 static void* ecdsa_alloc_wrap(void) {
     void* ctx = mbedtls_calloc(1, sizeof(mbedtls_ecdsa_context));
 
@@ -608,7 +629,9 @@ static void ecdsa_free_wrap(void* ctx) {
     mbedtls_free(ctx);
 }
 
+} // namespace lbug_mbedtls
 #if defined(MBEDTLS_ECP_RESTARTABLE)
+namespace lbug_mbedtls {
 static void* ecdsa_rs_alloc(void) {
     void* ctx = mbedtls_calloc(1, sizeof(mbedtls_ecdsa_restart_ctx));
 
@@ -622,8 +645,10 @@ static void ecdsa_rs_free(void* ctx) {
     mbedtls_ecdsa_restart_free(ctx);
     mbedtls_free(ctx);
 }
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_ECP_RESTARTABLE */
 
+namespace lbug_mbedtls {
 const mbedtls_pk_info_t mbedtls_ecdsa_info = {
     MBEDTLS_PK_ECDSA, "ECDSA", eckey_get_bitlen, /* Compatible key structures */
     ecdsa_can_do, ecdsa_verify_wrap, ecdsa_sign_wrap,
@@ -637,6 +662,7 @@ const mbedtls_pk_info_t mbedtls_ecdsa_info = {
 #endif
     eckey_debug, /* Compatible key structures */
 };
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_ECDSA_C */
 
 #if defined(MBEDTLS_PK_RSA_ALT_SUPPORT)
@@ -644,6 +670,7 @@ const mbedtls_pk_info_t mbedtls_ecdsa_info = {
  * Support for alternative RSA-private implementations
  */
 
+namespace lbug_mbedtls {
 static int rsa_alt_can_do(mbedtls_pk_type_t type) {
     return (type == MBEDTLS_PK_RSA);
 }
@@ -688,7 +715,9 @@ static int rsa_alt_decrypt_wrap(void* ctx, const unsigned char* input, size_t il
     return (rsa_alt->decrypt_func(rsa_alt->key, olen, input, output, osize));
 }
 
+} // namespace lbug_mbedtls
 #if defined(MBEDTLS_RSA_C)
+namespace lbug_mbedtls {
 static int rsa_alt_check_pair(const void* pub, const void* prv,
     int (*f_rng)(void*, unsigned char*, size_t), void* p_rng) {
     unsigned char sig[MBEDTLS_MPI_MAX_SIZE];
@@ -712,8 +741,10 @@ static int rsa_alt_check_pair(const void* pub, const void* prv,
 
     return (0);
 }
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_RSA_C */
 
+namespace lbug_mbedtls {
 static void* rsa_alt_alloc_wrap(void) {
     void* ctx = mbedtls_calloc(1, sizeof(mbedtls_rsa_alt_context));
 
@@ -755,10 +786,12 @@ const mbedtls_pk_info_t mbedtls_rsa_alt_info = {
     NULL,
 };
 
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_PK_RSA_ALT_SUPPORT */
 
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
 
+namespace lbug_mbedtls {
 static void* pk_opaque_alloc_wrap(void) {
     void* ctx = mbedtls_calloc(1, sizeof(psa_key_id_t));
 
@@ -792,6 +825,7 @@ static int pk_opaque_can_do(mbedtls_pk_type_t type) {
     return (type == MBEDTLS_PK_ECKEY || type == MBEDTLS_PK_ECDSA);
 }
 
+} // namespace lbug_mbedtls
 #if defined(MBEDTLS_ECDSA_C)
 
 /*
@@ -803,6 +837,7 @@ static int pk_opaque_can_do(mbedtls_pk_type_t type) {
  * start: start of the output buffer, and also of the mpi to write at the end
  * n_len: length of the mpi to read from start
  */
+namespace lbug_mbedtls {
 static int asn1_write_mpibuf(unsigned char** p, unsigned char* start, size_t n_len) {
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
     size_t len = 0;
@@ -869,8 +904,10 @@ static int pk_ecdsa_sig_asn1_from_psa(unsigned char* sig, size_t* sig_len, size_
     return (0);
 }
 
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_ECDSA_C */
 
+namespace lbug_mbedtls {
 static int pk_opaque_sign_wrap(void* ctx, mbedtls_md_type_t md_alg, const unsigned char* hash,
     size_t hash_len, unsigned char* sig, size_t sig_size, size_t* sig_len,
     int (*f_rng)(void*, unsigned char*, size_t), void* p_rng) {
@@ -923,6 +960,7 @@ const mbedtls_pk_info_t mbedtls_pk_opaque_info = {
     NULL, /* debug - could be done later, or even left NULL */
 };
 
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_USE_PSA_CRYPTO */
 
 #endif /* MBEDTLS_PK_C */

--- a/third_party/mbedtls/library/pk_wrap.h
+++ b/third_party/mbedtls/library/pk_wrap.h
@@ -26,6 +26,7 @@
 #include "mbedtls/build_info.h"
 #include "mbedtls/pk.h"
 
+namespace lbug_mbedtls {
 struct mbedtls_pk_info_t {
     /** Public key type */
     mbedtls_pk_type_t type;
@@ -88,35 +89,48 @@ struct mbedtls_pk_info_t {
     /** Interface with the debug module */
     void (*debug_func)(const void* ctx, mbedtls_pk_debug_item* items);
 };
+} // namespace lbug_mbedtls
 #if defined(MBEDTLS_PK_RSA_ALT_SUPPORT)
 /* Container for RSA-alt */
+namespace lbug_mbedtls {
 typedef struct {
     void* key;
     mbedtls_pk_rsa_alt_decrypt_func decrypt_func;
     mbedtls_pk_rsa_alt_sign_func sign_func;
     mbedtls_pk_rsa_alt_key_len_func key_len_func;
 } mbedtls_rsa_alt_context;
+} // namespace lbug_mbedtls
 #endif
 
 #if defined(MBEDTLS_RSA_C)
+namespace lbug_mbedtls {
 extern const mbedtls_pk_info_t mbedtls_rsa_info;
+} // namespace lbug_mbedtls
 #endif
 
 #if defined(MBEDTLS_ECP_C)
+namespace lbug_mbedtls {
 extern const mbedtls_pk_info_t mbedtls_eckey_info;
 extern const mbedtls_pk_info_t mbedtls_eckeydh_info;
+} // namespace lbug_mbedtls
 #endif
 
 #if defined(MBEDTLS_ECDSA_C)
+namespace lbug_mbedtls {
 extern const mbedtls_pk_info_t mbedtls_ecdsa_info;
+} // namespace lbug_mbedtls
 #endif
 
 #if defined(MBEDTLS_PK_RSA_ALT_SUPPORT)
+namespace lbug_mbedtls {
 extern const mbedtls_pk_info_t mbedtls_rsa_alt_info;
+} // namespace lbug_mbedtls
 #endif
 
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
+namespace lbug_mbedtls {
 extern const mbedtls_pk_info_t mbedtls_pk_opaque_info;
+} // namespace lbug_mbedtls
 #endif
 
 #endif /* MBEDTLS_PK_WRAP_H */

--- a/third_party/mbedtls/library/pkparse.cpp
+++ b/third_party/mbedtls/library/pkparse.cpp
@@ -68,6 +68,7 @@
  * A terminating null byte is always appended. It is included in the announced
  * length only if the data looks like it is PEM encoded.
  */
+namespace lbug_mbedtls {
 int mbedtls_pk_load_file(const char* path, unsigned char** buf, size_t* n) {
     FILE* f;
     long size;
@@ -160,6 +161,7 @@ int mbedtls_pk_parse_public_keyfile(mbedtls_pk_context* ctx, const char* path) {
 
     return (ret);
 }
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_FS_IO */
 
 #if defined(MBEDTLS_ECP_C)
@@ -171,6 +173,7 @@ int mbedtls_pk_parse_public_keyfile(mbedtls_pk_context* ctx, const char* path) {
  *   -- implicitCurve   NULL
  * }
  */
+namespace lbug_mbedtls {
 static int pk_get_ecparams(unsigned char** p, const unsigned char* end, mbedtls_asn1_buf* params) {
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
 
@@ -202,6 +205,7 @@ static int pk_get_ecparams(unsigned char** p, const unsigned char* end, mbedtls_
     return (0);
 }
 
+} // namespace lbug_mbedtls
 #if defined(MBEDTLS_PK_PARSE_EC_EXTENDED)
 /*
  * Parse a SpecifiedECDomain (SEC 1 C.2) and (mostly) fill the group with it.
@@ -222,6 +226,7 @@ static int pk_get_ecparams(unsigned char** p, const unsigned char* end, mbedtls_
  *
  * We only support prime-field as field type, and ignore hash and cofactor.
  */
+namespace lbug_mbedtls {
 static int pk_group_from_specified(const mbedtls_asn1_buf* params, mbedtls_ecp_group* grp) {
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
     unsigned char* p = params->p;
@@ -415,6 +420,7 @@ cleanup:
 
     return (ret);
 }
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_PK_PARSE_EC_EXTENDED */
 
 /*
@@ -425,6 +431,7 @@ cleanup:
  *   specifiedCurve     SpecifiedECDomain -- = SEQUENCE { ... }
  *   -- implicitCurve   NULL
  */
+namespace lbug_mbedtls {
 static int pk_use_ecparams(const mbedtls_asn1_buf* params, mbedtls_ecp_group* grp) {
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
     mbedtls_ecp_group_id grp_id;
@@ -475,6 +482,7 @@ static int pk_get_ecpubkey(unsigned char** p, const unsigned char* end, mbedtls_
 
     return (ret);
 }
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_ECP_C */
 
 #if defined(MBEDTLS_RSA_C)
@@ -484,6 +492,7 @@ static int pk_get_ecpubkey(unsigned char** p, const unsigned char* end, mbedtls_
  *      publicExponent    INTEGER   -- e
  *  }
  */
+namespace lbug_mbedtls {
 static int pk_get_rsapubkey(unsigned char** p, const unsigned char* end, mbedtls_rsa_context* rsa) {
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
     size_t len;
@@ -522,6 +531,7 @@ static int pk_get_rsapubkey(unsigned char** p, const unsigned char* end, mbedtls
 
     return (0);
 }
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_RSA_C */
 
 /* Get a PK algorithm identifier
@@ -530,6 +540,7 @@ static int pk_get_rsapubkey(unsigned char** p, const unsigned char* end, mbedtls
  *       algorithm               OBJECT IDENTIFIER,
  *       parameters              ANY DEFINED BY algorithm OPTIONAL  }
  */
+namespace lbug_mbedtls {
 static int pk_get_pk_alg(unsigned char** p, const unsigned char* end, mbedtls_pk_type_t* pk_alg,
     mbedtls_asn1_buf* params) {
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
@@ -617,6 +628,7 @@ int mbedtls_pk_parse_subpubkey(unsigned char** p, const unsigned char* end,
     return (ret);
 }
 
+} // namespace lbug_mbedtls
 #if defined(MBEDTLS_RSA_C)
 /*
  * Wrapper around mbedtls_asn1_get_mpi() that rejects zero.
@@ -628,6 +640,7 @@ int mbedtls_pk_parse_subpubkey(unsigned char** p, const unsigned char* end,
  * Since values can't be omitted in PKCS#1, passing a zero value to
  * rsa_complete() would be incorrect, so reject zero values early.
  */
+namespace lbug_mbedtls {
 static int asn1_get_nonzero_mpi(unsigned char** p, const unsigned char* end, mbedtls_mpi* X) {
     int ret;
 
@@ -781,12 +794,14 @@ cleanup:
 
     return (ret);
 }
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_RSA_C */
 
 #if defined(MBEDTLS_ECP_C)
 /*
  * Parse a SEC1 encoded private EC key
  */
+namespace lbug_mbedtls {
 static int pk_parse_key_sec1_der(mbedtls_ecp_keypair* eck, const unsigned char* key, size_t keylen,
     int (*f_rng)(void*, unsigned char*, size_t), void* p_rng) {
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
@@ -893,6 +908,7 @@ static int pk_parse_key_sec1_der(mbedtls_ecp_keypair* eck, const unsigned char* 
 
     return (0);
 }
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_ECP_C */
 
 /*
@@ -908,6 +924,7 @@ static int pk_parse_key_sec1_der(mbedtls_ecp_keypair* eck, const unsigned char* 
  *   PK context on failure.
  *
  */
+namespace lbug_mbedtls {
 static int pk_parse_key_pkcs8_unencrypted_der(mbedtls_pk_context* pk, const unsigned char* key,
     size_t keylen, int (*f_rng)(void*, unsigned char*, size_t), void* p_rng) {
     int ret, version;
@@ -999,7 +1016,9 @@ static int pk_parse_key_pkcs8_unencrypted_der(mbedtls_pk_context* pk, const unsi
  * free it after use.
  *
  */
+} // namespace lbug_mbedtls
 #if defined(MBEDTLS_PKCS12_C) || defined(MBEDTLS_PKCS5_C)
+namespace lbug_mbedtls {
 static int pk_parse_key_pkcs8_encrypted_der(mbedtls_pk_context* pk, unsigned char* key,
     size_t keylen, const unsigned char* pwd, size_t pwdlen,
     int (*f_rng)(void*, unsigned char*, size_t), void* p_rng) {
@@ -1087,11 +1106,13 @@ static int pk_parse_key_pkcs8_encrypted_der(mbedtls_pk_context* pk, unsigned cha
 
     return (pk_parse_key_pkcs8_unencrypted_der(pk, buf, len, f_rng, p_rng));
 }
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_PKCS12_C || MBEDTLS_PKCS5_C */
 
 /*
  * Parse a private key
  */
+namespace lbug_mbedtls {
 int mbedtls_pk_parse_key(mbedtls_pk_context* pk, const unsigned char* key, size_t keylen,
     const unsigned char* pwd, size_t pwdlen, int (*f_rng)(void*, unsigned char*, size_t),
     void* p_rng) {
@@ -1372,4 +1393,5 @@ int mbedtls_pk_parse_public_key(mbedtls_pk_context* ctx, const unsigned char* ke
     return (ret);
 }
 
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_PK_PARSE_C */

--- a/third_party/mbedtls/library/platform_util.cpp
+++ b/third_party/mbedtls/library/platform_util.cpp
@@ -63,6 +63,7 @@
  * mbedtls_platform_zeroize() to use a suitable implementation for their
  * platform and needs.
  */
+namespace lbug_mbedtls {
 static void* (*const volatile memset_func)(void*, int, size_t) = memset;
 
 void mbedtls_platform_zeroize(void* buf, size_t len) {
@@ -71,6 +72,7 @@ void mbedtls_platform_zeroize(void* buf, size_t len) {
     if (len > 0)
         memset_func(buf, 0, len);
 }
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_PLATFORM_ZEROIZE_ALT */
 
 #if defined(MBEDTLS_HAVE_TIME_DATE) && !defined(MBEDTLS_PLATFORM_GMTIME_R_ALT)
@@ -98,6 +100,7 @@ void mbedtls_platform_zeroize(void* buf, size_t len) {
              ( defined(_POSIX_THREAD_SAFE_FUNCTIONS ) &&                                           \
                 _POSIX_THREAD_SAFE_FUNCTIONS >= 200112L ) ) */
 
+namespace lbug_mbedtls {
 struct tm* mbedtls_platform_gmtime_r(const mbedtls_time_t* tt, struct tm* tm_buf) {
 #if defined(_WIN32) && !defined(EFIX64) && !defined(EFI32)
     return ((gmtime_s(tm_buf, tt) == 0) ? tm_buf : NULL);
@@ -125,8 +128,11 @@ struct tm* mbedtls_platform_gmtime_r(const mbedtls_time_t* tt, struct tm* tm_buf
     return ((lt == NULL) ? NULL : tm_buf);
 #endif /* _WIN32 && !EFIX64 && !EFI32 */
 }
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_HAVE_TIME_DATE && MBEDTLS_PLATFORM_GMTIME_R_ALT */
 
 #if defined(MBEDTLS_TEST_HOOKS)
+namespace lbug_mbedtls {
 void (*mbedtls_test_hook_test_fail)(const char*, int, const char*);
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_TEST_HOOKS */

--- a/third_party/mbedtls/library/rsa.cpp
+++ b/third_party/mbedtls/library/rsa.cpp
@@ -72,6 +72,7 @@
 #define RSA_VALIDATE_RET(cond) MBEDTLS_INTERNAL_VALIDATE_RET(cond, MBEDTLS_ERR_RSA_BAD_INPUT_DATA)
 #define RSA_VALIDATE(cond) MBEDTLS_INTERNAL_VALIDATE(cond)
 
+namespace lbug_mbedtls {
 int mbedtls_rsa_import(mbedtls_rsa_context* ctx, const mbedtls_mpi* N, const mbedtls_mpi* P,
     const mbedtls_mpi* Q, const mbedtls_mpi* D, const mbedtls_mpi* E) {
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
@@ -455,6 +456,7 @@ size_t mbedtls_rsa_get_len(const mbedtls_rsa_context* ctx) {
     return (ctx->len);
 }
 
+} // namespace lbug_mbedtls
 #if defined(MBEDTLS_GENPRIME)
 
 /*
@@ -463,6 +465,7 @@ size_t mbedtls_rsa_get_len(const mbedtls_rsa_context* ctx) {
  * This generation method follows the RSA key pair generation procedure of
  * FIPS 186-4 if 2^16 < exponent < 2^256 and nbits = 2048 or nbits = 3072.
  */
+namespace lbug_mbedtls {
 int mbedtls_rsa_gen_key(mbedtls_rsa_context* ctx, int (*f_rng)(void*, unsigned char*, size_t),
     void* p_rng, unsigned int nbits, int exponent) {
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
@@ -570,11 +573,13 @@ cleanup:
     return (0);
 }
 
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_GENPRIME */
 
 /*
  * Check a public RSA key
  */
+namespace lbug_mbedtls {
 int mbedtls_rsa_check_pubkey(const mbedtls_rsa_context* ctx) {
     RSA_VALIDATE_RET(ctx != NULL);
 
@@ -974,6 +979,7 @@ cleanup:
     return (ret);
 }
 
+} // namespace lbug_mbedtls
 #if defined(MBEDTLS_PKCS1_V21)
 /**
  * Generate and apply the MGF1 operation (from PKCS#1 v2.1) to a buffer.
@@ -984,6 +990,7 @@ cleanup:
  * \param slen      length of the source buffer
  * \param md_ctx    message digest context to use
  */
+namespace lbug_mbedtls {
 static int mgf_mask(unsigned char* dst, size_t dlen, unsigned char* src, size_t slen,
     mbedtls_md_context_t* md_ctx) {
     unsigned char mask[MBEDTLS_MD_MAX_SIZE];
@@ -1028,12 +1035,14 @@ exit:
 
     return (ret);
 }
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_PKCS1_V21 */
 
 #if defined(MBEDTLS_PKCS1_V21)
 /*
  * Implementation of the PKCS#1 v2.1 RSAES-OAEP-ENCRYPT function
  */
+namespace lbug_mbedtls {
 int mbedtls_rsa_rsaes_oaep_encrypt(mbedtls_rsa_context* ctx,
     int (*f_rng)(void*, unsigned char*, size_t), void* p_rng, const unsigned char* label,
     size_t label_len, size_t ilen, const unsigned char* input, unsigned char* output) {
@@ -1102,12 +1111,14 @@ exit:
 
     return (mbedtls_rsa_public(ctx, output, output));
 }
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_PKCS1_V21 */
 
 #if defined(MBEDTLS_PKCS1_V15)
 /*
  * Implementation of the PKCS#1 v2.1 RSAES-PKCS1-V1_5-ENCRYPT function
  */
+namespace lbug_mbedtls {
 int mbedtls_rsa_rsaes_pkcs1_v15_encrypt(mbedtls_rsa_context* ctx,
     int (*f_rng)(void*, unsigned char*, size_t), void* p_rng, size_t ilen,
     const unsigned char* input, unsigned char* output) {
@@ -1154,11 +1165,13 @@ int mbedtls_rsa_rsaes_pkcs1_v15_encrypt(mbedtls_rsa_context* ctx,
 
     return (mbedtls_rsa_public(ctx, output, output));
 }
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_PKCS1_V15 */
 
 /*
  * Add the message padding, then do an RSA operation
  */
+namespace lbug_mbedtls {
 int mbedtls_rsa_pkcs1_encrypt(mbedtls_rsa_context* ctx, int (*f_rng)(void*, unsigned char*, size_t),
     void* p_rng, size_t ilen, const unsigned char* input, unsigned char* output) {
     RSA_VALIDATE_RET(ctx != NULL);
@@ -1181,10 +1194,12 @@ int mbedtls_rsa_pkcs1_encrypt(mbedtls_rsa_context* ctx, int (*f_rng)(void*, unsi
     }
 }
 
+} // namespace lbug_mbedtls
 #if defined(MBEDTLS_PKCS1_V21)
 /*
  * Implementation of the PKCS#1 v2.1 RSAES-OAEP-DECRYPT function
  */
+namespace lbug_mbedtls {
 int mbedtls_rsa_rsaes_oaep_decrypt(mbedtls_rsa_context* ctx,
     int (*f_rng)(void*, unsigned char*, size_t), void* p_rng, const unsigned char* label,
     size_t label_len, size_t* olen, const unsigned char* input, unsigned char* output,
@@ -1309,12 +1324,14 @@ cleanup:
 
     return (ret);
 }
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_PKCS1_V21 */
 
 #if defined(MBEDTLS_PKCS1_V15)
 /*
  * Implementation of the PKCS#1 v2.1 RSAES-PKCS1-V1_5-DECRYPT function
  */
+namespace lbug_mbedtls {
 int mbedtls_rsa_rsaes_pkcs1_v15_decrypt(mbedtls_rsa_context* ctx,
     int (*f_rng)(void*, unsigned char*, size_t), void* p_rng, size_t* olen,
     const unsigned char* input, unsigned char* output, size_t output_max_len) {
@@ -1347,11 +1364,13 @@ cleanup:
 
     return (ret);
 }
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_PKCS1_V15 */
 
 /*
  * Do an RSA operation, then remove the message padding
  */
+namespace lbug_mbedtls {
 int mbedtls_rsa_pkcs1_decrypt(mbedtls_rsa_context* ctx, int (*f_rng)(void*, unsigned char*, size_t),
     void* p_rng, size_t* olen, const unsigned char* input, unsigned char* output,
     size_t output_max_len) {
@@ -1378,7 +1397,9 @@ int mbedtls_rsa_pkcs1_decrypt(mbedtls_rsa_context* ctx, int (*f_rng)(void*, unsi
     }
 }
 
+} // namespace lbug_mbedtls
 #if defined(MBEDTLS_PKCS1_V21)
+namespace lbug_mbedtls {
 static int rsa_rsassa_pss_sign(mbedtls_rsa_context* ctx,
     int (*f_rng)(void*, unsigned char*, size_t), void* p_rng, mbedtls_md_type_t md_alg,
     unsigned int hashlen, const unsigned char* hash, int saltlen, unsigned char* sig) {
@@ -1511,6 +1532,7 @@ int mbedtls_rsa_rsassa_pss_sign(mbedtls_rsa_context* ctx,
     return rsa_rsassa_pss_sign(ctx, f_rng, p_rng, md_alg, hashlen, hash, MBEDTLS_RSA_SALT_LEN_ANY,
         sig);
 }
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_PKCS1_V21 */
 
 #if defined(MBEDTLS_PKCS1_V15)
@@ -1535,6 +1557,7 @@ int mbedtls_rsa_rsassa_pss_sign(mbedtls_rsa_context* ctx,
  * - dst points to a buffer of size at least dst_len.
  *
  */
+namespace lbug_mbedtls {
 static int rsa_rsassa_pkcs1_v15_encode(mbedtls_md_type_t md_alg, unsigned int hashlen,
     const unsigned char* hash, size_t dst_len, unsigned char* dst) {
     size_t oid_size = 0;
@@ -1697,11 +1720,13 @@ cleanup:
         memset(sig, '!', ctx->len);
     return (ret);
 }
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_PKCS1_V15 */
 
 /*
  * Do an RSA operation to sign the message digest
  */
+namespace lbug_mbedtls {
 int mbedtls_rsa_pkcs1_sign(mbedtls_rsa_context* ctx, int (*f_rng)(void*, unsigned char*, size_t),
     void* p_rng, mbedtls_md_type_t md_alg, unsigned int hashlen, const unsigned char* hash,
     unsigned char* sig) {
@@ -1725,10 +1750,12 @@ int mbedtls_rsa_pkcs1_sign(mbedtls_rsa_context* ctx, int (*f_rng)(void*, unsigne
     }
 }
 
+} // namespace lbug_mbedtls
 #if defined(MBEDTLS_PKCS1_V21)
 /*
  * Implementation of the PKCS#1 v2.1 RSASSA-PSS-VERIFY function
  */
+namespace lbug_mbedtls {
 int mbedtls_rsa_rsassa_pss_verify_ext(mbedtls_rsa_context* ctx, mbedtls_md_type_t md_alg,
     unsigned int hashlen, const unsigned char* hash, mbedtls_md_type_t mgf1_hash_id,
     int expected_salt_len, const unsigned char* sig) {
@@ -1870,12 +1897,14 @@ int mbedtls_rsa_rsassa_pss_verify(mbedtls_rsa_context* ctx, mbedtls_md_type_t md
     return (mbedtls_rsa_rsassa_pss_verify_ext(ctx, md_alg, hashlen, hash, mgf1_hash_id,
         MBEDTLS_RSA_SALT_LEN_ANY, sig));
 }
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_PKCS1_V21 */
 
 #if defined(MBEDTLS_PKCS1_V15)
 /*
  * Implementation of the PKCS#1 v2.1 RSASSA-PKCS1-v1_5-VERIFY function
  */
+namespace lbug_mbedtls {
 int mbedtls_rsa_rsassa_pkcs1_v15_verify(mbedtls_rsa_context* ctx, mbedtls_md_type_t md_alg,
     unsigned int hashlen, const unsigned char* hash, const unsigned char* sig) {
     int ret = 0;
@@ -1932,11 +1961,13 @@ cleanup:
 
     return (ret);
 }
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_PKCS1_V15 */
 
 /*
  * Do an RSA operation and check the message digest
  */
+namespace lbug_mbedtls {
 int mbedtls_rsa_pkcs1_verify(mbedtls_rsa_context* ctx, mbedtls_md_type_t md_alg,
     unsigned int hashlen, const unsigned char* hash, const unsigned char* sig) {
     RSA_VALIDATE_RET(ctx != NULL);
@@ -2032,6 +2063,7 @@ void mbedtls_rsa_free(mbedtls_rsa_context* ctx) {
 #endif
 }
 
+} // namespace lbug_mbedtls
 #endif /* !MBEDTLS_RSA_ALT */
 
 #if defined(MBEDTLS_SELF_TEST)
@@ -2083,6 +2115,7 @@ void mbedtls_rsa_free(mbedtls_rsa_context* ctx) {
     "\x11\x22\x33\x0A\x0B\x0C\xCC\xDD\xDD\xDD\xDD\xDD"
 
 #if defined(MBEDTLS_PKCS1_V15)
+namespace lbug_mbedtls {
 static int myrand(void* rng_state, unsigned char* output, size_t len) {
 #if !defined(__OpenBSD__) && !defined(__NetBSD__)
     size_t i;
@@ -2101,11 +2134,13 @@ static int myrand(void* rng_state, unsigned char* output, size_t len) {
 
     return (0);
 }
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_PKCS1_V15 */
 
 /*
  * Checkup routine
  */
+namespace lbug_mbedtls {
 int mbedtls_rsa_self_test(int verbose) {
     int ret = 0;
 #if defined(MBEDTLS_PKCS1_V15)
@@ -2230,6 +2265,7 @@ cleanup:
     return (ret);
 }
 
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_SELF_TEST */
 
 #endif /* MBEDTLS_RSA_C */

--- a/third_party/mbedtls/library/rsa_alt_helpers.cpp
+++ b/third_party/mbedtls/library/rsa_alt_helpers.cpp
@@ -59,6 +59,7 @@
  * of (a) and (b) above to attempt to factor N.
  *
  */
+namespace lbug_mbedtls {
 int mbedtls_rsa_deduce_primes(mbedtls_mpi const* N, mbedtls_mpi const* E, mbedtls_mpi const* D,
     mbedtls_mpi* P, mbedtls_mpi* Q) {
     int ret = 0;
@@ -423,4 +424,5 @@ cleanup:
     return (ret);
 }
 
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_RSA_C */

--- a/third_party/mbedtls/library/rsa_alt_helpers.h
+++ b/third_party/mbedtls/library/rsa_alt_helpers.h
@@ -58,9 +58,6 @@
 #include "mbedtls/bignum.h"
 #include "mbedtls/build_info.h"
 
-#ifdef __cplusplus
-extern "C" {
-#endif
 
 /**
  * \brief          Compute RSA prime moduli P, Q from public modulus N=PQ
@@ -86,6 +83,7 @@ extern "C" {
  *                 use the helper function \c mbedtls_rsa_validate_params.
  *
  */
+namespace lbug_mbedtls {
 int mbedtls_rsa_deduce_primes(mbedtls_mpi const* N, mbedtls_mpi const* E, mbedtls_mpi const* D,
     mbedtls_mpi* P, mbedtls_mpi* Q);
 
@@ -202,8 +200,6 @@ int mbedtls_rsa_validate_params(const mbedtls_mpi* N, const mbedtls_mpi* P, cons
 int mbedtls_rsa_validate_crt(const mbedtls_mpi* P, const mbedtls_mpi* Q, const mbedtls_mpi* D,
     const mbedtls_mpi* DP, const mbedtls_mpi* DQ, const mbedtls_mpi* QP);
 
-#ifdef __cplusplus
-}
-#endif
 
+} // namespace lbug_mbedtls
 #endif /* rsa_alt_helpers.h */

--- a/third_party/mbedtls/library/sha1.cpp
+++ b/third_party/mbedtls/library/sha1.cpp
@@ -47,6 +47,7 @@
 
 #if !defined(MBEDTLS_SHA1_ALT)
 
+namespace lbug_mbedtls {
 void mbedtls_sha1_init(mbedtls_sha1_context* ctx) {
     SHA1_VALIDATE(ctx != NULL);
 
@@ -85,7 +86,9 @@ int mbedtls_sha1_starts(mbedtls_sha1_context* ctx) {
     return (0);
 }
 
+} // namespace lbug_mbedtls
 #if !defined(MBEDTLS_SHA1_PROCESS_ALT)
+namespace lbug_mbedtls {
 int mbedtls_internal_sha1_process(mbedtls_sha1_context* ctx, const unsigned char data[64]) {
     struct {
         uint32_t temp, W[16], A, B, C, D, E;
@@ -250,11 +253,13 @@ int mbedtls_internal_sha1_process(mbedtls_sha1_context* ctx, const unsigned char
     return (0);
 }
 
+} // namespace lbug_mbedtls
 #endif /* !MBEDTLS_SHA1_PROCESS_ALT */
 
 /*
  * SHA-1 process buffer
  */
+namespace lbug_mbedtls {
 int mbedtls_sha1_update(mbedtls_sha1_context* ctx, const unsigned char* input, size_t ilen) {
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
     size_t fill;
@@ -355,11 +360,13 @@ int mbedtls_sha1_finish(mbedtls_sha1_context* ctx, unsigned char output[20]) {
     return (0);
 }
 
+} // namespace lbug_mbedtls
 #endif /* !MBEDTLS_SHA1_ALT */
 
 /*
  * output = SHA-1( input buffer )
  */
+namespace lbug_mbedtls {
 int mbedtls_sha1(const unsigned char* input, size_t ilen, unsigned char output[20]) {
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
     mbedtls_sha1_context ctx;
@@ -384,10 +391,12 @@ exit:
     return (ret);
 }
 
+} // namespace lbug_mbedtls
 #if defined(MBEDTLS_SELF_TEST)
 /*
  * FIPS-180-1 test vectors
  */
+namespace lbug_mbedtls {
 static const unsigned char sha1_test_buf[3][57] = {{"abc"},
     {"abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq"}, {""}};
 
@@ -463,6 +472,7 @@ exit:
     return (ret);
 }
 
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_SELF_TEST */
 
 #endif /* MBEDTLS_SHA1_C */

--- a/third_party/mbedtls/library/sha256.cpp
+++ b/third_party/mbedtls/library/sha256.cpp
@@ -50,6 +50,7 @@
 
 #if !defined(MBEDTLS_SHA256_ALT)
 
+namespace lbug_mbedtls {
 void mbedtls_sha256_init(mbedtls_sha256_context* ctx) {
     SHA256_VALIDATE(ctx != NULL);
 
@@ -114,7 +115,9 @@ int mbedtls_sha256_starts(mbedtls_sha256_context* ctx, int is224) {
     return (0);
 }
 
+} // namespace lbug_mbedtls
 #if !defined(MBEDTLS_SHA256_PROCESS_ALT)
+namespace lbug_mbedtls {
 static const uint32_t K[] = {
     0x428A2F98,
     0x71374491,
@@ -292,11 +295,13 @@ int mbedtls_internal_sha256_process(mbedtls_sha256_context* ctx, const unsigned 
     return (0);
 }
 
+} // namespace lbug_mbedtls
 #endif /* !MBEDTLS_SHA256_PROCESS_ALT */
 
 /*
  * SHA-256 process buffer
  */
+namespace lbug_mbedtls {
 int mbedtls_sha256_update(mbedtls_sha256_context* ctx, const unsigned char* input, size_t ilen) {
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
     size_t fill;
@@ -404,11 +409,13 @@ int mbedtls_sha256_finish(mbedtls_sha256_context* ctx, unsigned char* output) {
     return (0);
 }
 
+} // namespace lbug_mbedtls
 #endif /* !MBEDTLS_SHA256_ALT */
 
 /*
  * output = SHA-256( input buffer )
  */
+namespace lbug_mbedtls {
 int mbedtls_sha256(const unsigned char* input, size_t ilen, unsigned char* output, int is224) {
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
     mbedtls_sha256_context ctx;
@@ -439,10 +446,12 @@ exit:
     return (ret);
 }
 
+} // namespace lbug_mbedtls
 #if defined(MBEDTLS_SELF_TEST)
 /*
  * FIPS-180-2 test vectors
  */
+namespace lbug_mbedtls {
 static const unsigned char sha256_test_buf[3][57] = {{"abc"},
     {"abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq"}, {""}};
 
@@ -544,6 +553,7 @@ exit:
     return (ret);
 }
 
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_SELF_TEST */
 
 #endif /* MBEDTLS_SHA256_C */

--- a/third_party/mbedtls/library/sha512.cpp
+++ b/third_party/mbedtls/library/sha512.cpp
@@ -57,13 +57,16 @@
 #if !defined(MBEDTLS_SHA512_ALT)
 
 #if defined(MBEDTLS_SHA512_SMALLER)
+namespace lbug_mbedtls {
 static void sha512_put_uint64_be(uint64_t n, unsigned char* b, uint8_t i) {
     MBEDTLS_PUT_UINT64_BE(n, b, i);
 }
+} // namespace lbug_mbedtls
 #else
 #define sha512_put_uint64_be MBEDTLS_PUT_UINT64_BE
 #endif /* MBEDTLS_SHA512_SMALLER */
 
+namespace lbug_mbedtls {
 void mbedtls_sha512_init(mbedtls_sha512_context* ctx) {
     SHA512_VALIDATE(ctx != NULL);
 
@@ -131,11 +134,13 @@ int mbedtls_sha512_starts(mbedtls_sha512_context* ctx, int is384) {
     return (0);
 }
 
+} // namespace lbug_mbedtls
 #if !defined(MBEDTLS_SHA512_PROCESS_ALT)
 
 /*
  * Round constants
  */
+namespace lbug_mbedtls {
 static const uint64_t K[80] = {UL64(0x428A2F98D728AE22), UL64(0x7137449123EF65CD),
     UL64(0xB5C0FBCFEC4D3B2F), UL64(0xE9B5DBA58189DBBC), UL64(0x3956C25BF348B538),
     UL64(0x59F111F1B605D019), UL64(0x923F82A4AF194F9B), UL64(0xAB1C5ED5DA6D8118),
@@ -266,11 +271,13 @@ int mbedtls_internal_sha512_process(mbedtls_sha512_context* ctx, const unsigned 
     return (0);
 }
 
+} // namespace lbug_mbedtls
 #endif /* !MBEDTLS_SHA512_PROCESS_ALT */
 
 /*
  * SHA-512 process buffer
  */
+namespace lbug_mbedtls {
 int mbedtls_sha512_update(mbedtls_sha512_context* ctx, const unsigned char* input, size_t ilen) {
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
     size_t fill;
@@ -379,11 +386,13 @@ int mbedtls_sha512_finish(mbedtls_sha512_context* ctx, unsigned char* output) {
     return (0);
 }
 
+} // namespace lbug_mbedtls
 #endif /* !MBEDTLS_SHA512_ALT */
 
 /*
  * output = SHA-512( input buffer )
  */
+namespace lbug_mbedtls {
 int mbedtls_sha512(const unsigned char* input, size_t ilen, unsigned char* output, int is384) {
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
     mbedtls_sha512_context ctx;
@@ -413,11 +422,13 @@ exit:
     return (ret);
 }
 
+} // namespace lbug_mbedtls
 #if defined(MBEDTLS_SELF_TEST)
 
 /*
  * FIPS-180-2 test vectors
  */
+namespace lbug_mbedtls {
 static const unsigned char sha512_test_buf[3][113] = {{"abc"},
     {"abcdefghbcdefghicdefghijdefghijkefghijklfghijklmghijklmnhijklmnoijklmnopjklmnopqklmnopqrlmnop"
      "qrsmnopqrstnopqrstu"},
@@ -542,6 +553,7 @@ exit:
 
 #undef ARRAY_LENGTH
 
+} // namespace lbug_mbedtls
 #endif /* MBEDTLS_SELF_TEST */
 
 #endif /* MBEDTLS_SHA512_C */

--- a/third_party/ports/mbedtls/Makefile
+++ b/third_party/ports/mbedtls/Makefile
@@ -8,6 +8,6 @@ DISTURL=	https://github.com/Mbed-TLS/mbedtls/archive/refs/tags/v${VERSION}.tar.g
 
 SRCDIR=	mbedtls-${VERSION}
 
-BUILD_COMMANDS=	cp ../../../ports/mbedtls/CMakeLists.txt.custom ../../../mbedtls/CMakeLists.txt && python3 ${SCRIPT_DIR}/scripts/format_c_to_cpp.py ${WRKSRC}
+BUILD_COMMANDS=	cp ../../../ports/mbedtls/CMakeLists.txt.custom ../../../mbedtls/CMakeLists.txt && python3 ../../../ports/mbedtls/do-patch.py .
 
 .include "${.CURDIR}/../bsd.port.mk"

--- a/third_party/ports/mbedtls/do-patch.py
+++ b/third_party/ports/mbedtls/do-patch.py
@@ -1,0 +1,300 @@
+#!/usr/bin/env python3
+"""
+Patch script for mbedtls.
+
+Applies transformations to pristine mbedtls sources for integration into
+the ladybug codebase:
+
+1. Rename library/*.c to *.cpp (the port compiles mbedtls as C++).
+2. Strip extern "C" guards: this port is compiled as C++ everywhere and is
+   never consumed by a C compiler, so C linkage is unnecessary.
+3. Wrap top-level declarations/definitions in `namespace lbug_mbedtls`.
+
+The namespace prevents duplicate-symbol link errors when ladybug is linked
+statically alongside another library that embeds its own mbedtls copy (e.g.
+a statically-linked DuckDB, whose libduckdb_static.a also bundles unprefixed
+`mbedtls_*` symbols).
+
+Because mbedtls sources interleave code with preprocessor conditionals, a
+single namespace pair per file cannot always be balanced (e.g. sibling
+`#if defined(MBEDTLS_AES_ALT)` / `#if defined(MBEDTLS_SELF_TEST)` branches).
+Instead, each *segment* - a maximal run of code sharing the same conditional
+context at brace depth 0 - gets its own `namespace lbug_mbedtls { ... }`
+pair. The namespace is reopened as often as needed, which is legal C++ and
+always balances.
+
+Public headers re-expose the names with `using namespace lbug_mbedtls;` so
+in-tree consumers (src/common/sha256.cpp, extension/httpfs/src/crypto.cpp)
+keep working unchanged with unqualified names.
+"""
+
+import re
+import sys
+from pathlib import Path
+
+NAMESPACE = "lbug_mbedtls"
+
+# Headers containing only preprocessor macros - nothing to wrap.
+SKIP_HEADERS = {
+    "include/mbedtls/build_info.h",
+    "include/mbedtls/check_config.h",
+    "include/mbedtls/mbedtls_config.h",
+    "include/mbedtls/private_access.h",
+}
+
+EXTERN_C_OPEN = 'extern "C" {'
+
+
+def strip_extern_c(text):
+    """Remove extern "C" linkage blocks and their __cplusplus guards."""
+    lines = text.splitlines()
+    changed = True
+    while changed:
+        changed = False
+        for i, line in enumerate(lines):
+            stripped = line.strip()
+            prev = next((lines[j].strip() for j in range(i - 1, -1, -1)
+                         if lines[j].strip()), "")
+            nxt = next((lines[j].strip() for j in range(i + 1, len(lines))
+                        if lines[j].strip()), "")
+
+            def is_cplusplus_guard(s):
+                return s.startswith("#if") and "__cplusplus" in s
+
+            # Opening block: guard + extern "C" { + #endif
+            if stripped == EXTERN_C_OPEN and is_cplusplus_guard(prev) and nxt == "#endif":
+                del lines[i + 1]
+                del lines[i]
+                del lines[i - 1]
+                changed = True
+                break
+            # Closing block: guard + } + #endif
+            if stripped == "}" and is_cplusplus_guard(prev) and nxt == "#endif":
+                del lines[i + 1]
+                del lines[i]
+                del lines[i - 1]
+                changed = True
+                break
+    return "\n".join(lines)
+
+
+def _strip_comments_and_strings(line, in_block_comment):
+    """Replace comment interiors and string/char literal contents with spaces
+    so braces inside them don't confuse brace counting. Tracks multi-line
+    block comment state."""
+    out = []
+    i = 0
+    n = len(line)
+    while i < n:
+        if in_block_comment:
+            j = line.find("*/", i)
+            if j < 0:
+                out.append(" " * (n - i))
+                i = n
+            else:
+                out.append(" " * (j + 2 - i))
+                i = j + 2
+                in_block_comment = False
+            continue
+        c = line[i]
+        if c == "/" and i + 1 < n and line[i + 1] == "/":
+            out.append(" " * (n - i))
+            break
+        if c == "/" and i + 1 < n and line[i + 1] == "*":
+            in_block_comment = True
+            out.append("  ")
+            i += 2
+            continue
+        if c == '"' or c == "'":
+            quote = c
+            out.append(" ")
+            i += 1
+            while i < n:
+                if line[i] == "\\":
+                    out.append("  ")
+                    i += 2
+                    continue
+                if line[i] == quote:
+                    out.append(" ")
+                    i += 1
+                    break
+                out.append(" ")
+                i += 1
+            continue
+        out.append(c)
+        i += 1
+    return "".join(out), in_block_comment
+
+
+def analyze(lines):
+    """Per-line info: conditional-context signature, brace depth at line
+    start, and whether the line carries code (vs blank/comment/directive).
+    Backslash-continued lines are merged into their logical line first, so
+    macro bodies are treated as part of their #define directive."""
+    n = len(lines)
+    infos = [{"sig": None, "depth": None, "content": False} for _ in range(n)]
+    stack = []  # conditional context
+    depth = 0
+    in_comment = False
+    i = 0
+    while i < n:
+        code, in_comment = _strip_comments_and_strings(lines[i], in_comment)
+        logical = code
+        j = i
+        while logical.rstrip().endswith("\\") and j + 1 < n:
+            j += 1
+            nxt, in_comment = _strip_comments_and_strings(lines[j], in_comment)
+            logical = logical.rstrip()[:-1] + " " + nxt
+        sig = tuple(stack)
+        depth_at_start = depth
+        is_directive = logical.lstrip().startswith("#")
+        is_content = (not is_directive) and bool(logical.strip())
+        if is_directive:
+            s = logical.lstrip()
+            if re.match(r"#\s*(if|ifdef|ifndef)\b", s):
+                stack.append(s)
+            elif re.match(r"#\s*endif\b", s):
+                if stack:
+                    stack.pop()
+            # #else / #elif keep the stack shape; boundaries are handled by
+            # the segmentation rules below.
+        else:
+            depth += logical.count("{") - logical.count("}")
+        infos[i] = {"sig": sig, "depth": depth_at_start,
+                    "content": is_content}
+        # Continuation tails belong to this logical line.
+        for k in range(i + 1, j + 1):
+            infos[k] = {"sig": None, "depth": None, "content": False}
+        i = j + 1
+    return infos
+
+
+_INCOMPLETE_ENDING = re.compile(
+    r"([,(+=*&|?:\[{>-]|\b(?:static|inline|extern|const|unsigned|signed|struct|union|enum|"
+    r"return|if|else|while|for|do|switch|case|default|sizeof|typedef))\s*$")
+
+
+def _ends_incomplete(line):
+    """True if a code line syntactically expects continuation, e.g. a lone
+    `static` storage specifier ahead of a conditional attribute block."""
+    code, _ = _strip_comments_and_strings(line, False)
+    return bool(_INCOMPLETE_ENDING.search(code.rstrip()))
+
+
+def plan_segments(lines, infos):
+    """Return [(open_idx, close_idx)] pairs. Each pair brackets one segment:
+    a maximal run of code sharing the same conditional context at brace
+    depth 0. Insertions sit right next to top-level lines, so every pair is
+    balanced."""
+    segments = []
+    cur = None  # [sig, open_idx, last_member_idx, dangling]
+
+    def close(at):
+        nonlocal cur
+        if cur is not None:
+            segments.append((cur[1], at))
+            cur = None
+
+    for i, info in enumerate(infos):
+        line = lines[i]
+        if info["depth"] is None:
+            continue  # continuation tail
+        if info["depth"] == 0:
+            if info["content"]:
+                if cur is None:
+                    cur = [info["sig"], i, i, False]
+                elif info["sig"] != cur[0] and not cur[3]:
+                    close(i)
+                    cur = [info["sig"], i, i, False]
+                else:
+                    cur[2] = i
+                # A complete statement/definition ends a dangling continuation.
+                if cur[3] and re.search(r"[;}]\s*$", _strip_comments_and_strings(line, False)[0]):
+                    cur[3] = False
+            elif line.lstrip().startswith("#"):
+                # A top-level conditional directive is normally a segment
+                # boundary - but not if the segment's last line syntactically
+                # expects continuation (e.g. a lone `static` ahead of a
+                # conditional attribute block), which would split a single
+                # declaration across two namespaces. While dangling, all
+                # nested content joins the same segment.
+                s = line.lstrip()
+                if re.match(r"#\s*(if|ifdef|ifndef|endif|else|elif)\b", s):
+                    if cur is not None and (cur[3] or _ends_incomplete(lines[cur[2]])):
+                        cur[3] = True
+                        continue
+                    close(i)
+        else:
+            if info["content"] and cur is not None:
+                cur[2] = i
+    close(len(lines))
+    return segments
+
+
+def rename_c_to_cpp(srcdir):
+    """Rename library/*.c to *.cpp for C++ compilation."""
+    lib_dir = srcdir / "library"
+    for c_file in lib_dir.glob("*.c"):
+        cpp_file = c_file.with_suffix(".cpp")
+        c_file.rename(cpp_file)
+        print(f"    Renamed: library/{c_file.name} -> {cpp_file.name}")
+
+
+def wrap_file(path, add_using_directive):
+    text = path.read_text(errors="replace")
+    text = strip_extern_c(text)
+    lines = text.splitlines()
+
+    infos = analyze(lines)
+    segments = plan_segments(lines, infos)
+    if not segments:
+        print(f"    Skipped (nothing to wrap): {path}")
+        return False
+
+    # Insert bottom-up so indices stay valid.
+    for open_idx, close_idx in sorted(segments, reverse=True):
+        lines.insert(close_idx, f"}} // namespace {NAMESPACE}")
+        lines.insert(open_idx, f"namespace {NAMESPACE} {{")
+
+    if add_using_directive:
+        lines.append("")
+        lines.append(f"using namespace {NAMESPACE};"
+                     " // keep unqualified names for in-tree consumers")
+
+    path.write_text("\n".join(lines) + "\n")
+    return True
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: do-patch.py <source-directory>")
+        sys.exit(1)
+
+    srcdir = Path(sys.argv[1]).resolve()
+    if not srcdir.exists():
+        print(f"Error: Source directory {srcdir} does not exist")
+        sys.exit(1)
+
+    print("Applying mbedtls patches...")
+
+    rename_c_to_cpp(srcdir)
+
+    patched = 0
+    for pattern in ("include/mbedtls/*.h", "library/*.h", "library/*.cpp"):
+        for path in sorted(srcdir.glob(pattern)):
+            rel = path.relative_to(srcdir).as_posix()
+            if rel in SKIP_HEADERS:
+                continue
+            # Public headers re-expose names unqualified; internal headers and
+            # TUs are used from within the namespace itself.
+            add_using = pattern.startswith("include/")
+            if wrap_file(path, add_using):
+                patched += 1
+                print(f"    Namespaced: {rel}")
+
+    print(f"Patched {patched} files successfully!")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Problem

`GEN=Ninja make shell EXTENSION_STATIC_LINK_LIST='httpfs'` failed at the final link with duplicate symbol errors: both our `third_party/mbedtls` and Homebrew's `libduckdb_static.a` bundle mbedtls with plain, unprefixed `mbedtls_*` symbols, and both copies get pulled into the shell link.

## Fix

Wrap our vendored mbedtls in `namespace lbug_mbedtls` so its symbols can never collide with another statically-linked mbedtls copy:

- **third_party/ports/mbedtls/do-patch.py** (new): port patch script following the zstd port pattern. Renames `.c` -> `.cpp`, strips the dead `extern "C"` guards (the copy is compiled as C++ everywhere, and C linkage is exactly what forces plain symbol names), and wraps top-level code segments in balanced `namespace lbug_mbedtls { }` pairs. Segmentation tracks preprocessor conditional context and brace depth per line, so sibling conditional branches (`MBEDTLS_AES_ALT` vs `MBEDTLS_SELF_TEST`) and mid-declaration conditionals (the lone `static` + conditional-attribute idiom in `bignum.cpp`) stay balanced. Also absorbs the previously-missing `format_c_to_cpp.py` step, making the port runnable again.
- **ports/mbedtls/Makefile**: invoke `do-patch.py` during build.
- **third_party/mbedtls**: vendored sources regenerated via the script (57 files; diff is only namespace pairs and `extern "C"` removals).
- **extension** submodule bump: requires LadybugDB/extensions#63 (linking `libduckdb_generated_extension_loader.a` + bundled extension archives when linking duckdb statically).

Public headers re-expose names via `using namespace lbug_mbedtls`, so in-tree consumers (`src/common/sha256.cpp`, `extension/httpfs/src/crypto.cpp`) are unchanged.

## Verification

`GEN=Ninja make shell EXTENSION_STATIC_LINK_LIST='httpfs'` completes: the link succeeds, `libmbedtls.a` exports zero plain `_mbedtls_*` symbols (222 namespaced ones), and the shell passes a smoke query.