### PR TITLE
docs: fix broken threat model link in SECURITY.md and a typo

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -14,4 +14,4 @@ To report a security issue, please email [security@ladybugdb.com](mailto:securit
 
 ## Threat Model
 
-Ladybug's current threat model is documented in [security/threat-model.md](security/threat-model.md).
+Ladybug's current threat model is documented in [security/threat_model.md](security/threat_model.md).

--- a/tools/shell/shell_development_guide.md
+++ b/tools/shell/shell_development_guide.md
@@ -135,7 +135,7 @@ The first difference is how the queries get displayed. In the `refreshLine()` fu
 
 Once truncation is done, continue markers are added. These are visual symbols added to the front of the line to indicate what line you are currently adding and make the terminal look nicer. Once the continuation markers are added, the highlight callback from before is called. Again, a buffer is used to clear the screen and write all changes at once.
 
-For multiline, better highlighting is implemented due to the whole query being avaiable. Multiline comments and errors are able to be highlighted in this mode. After the query is tokenized, the highlight errors function is called. This function iterates over every character and checks for comments, unclosed strings, and unclosed brackets. If any errors are found, the highlighting is changed to indicate an error. Highlighting then continues as normal.
+For multiline, better highlighting is implemented due to the whole query being available. Multiline comments and errors are able to be highlighted in this mode. After the query is tokenized, the highlight errors function is called. This function iterates over every character and checks for comments, unclosed strings, and unclosed brackets. If any errors are found, the highlighting is changed to indicate an error. Highlighting then continues as normal.
 
 For history, the newlines and comments do not need to be ignored as the shell is able to display those characters. Currently, history search is still only `:singleline` mode so when `ctrl_r` is pressed, newlines and returns are converted into spaces. However, when the search is selected, these spaces return back into newlines and are properly displayed by `refreshLine()`.
 


### PR DESCRIPTION
Two small docs fixes, verified against the current tree on `main`.

**Broken link.** `SECURITY.md:17` points at `security/threat-model.md`, but the file in the repository is `security/threat_model.md` — hyphen vs. underscore, so the link 404s.

**Typo.** `tools/shell/shell_development_guide.md:138` — "due to the whole query being avaiable" → "available".

---

One thing I did **not** change, since the fix isn't obvious: `docs/testing.md:42` links to `../tools/nodejs_api/docs/nodejs_testing.md` as the "Node.js API — Testing Guide". `tools/nodejs_api/` exists, but it has no `docs/` directory and no markdown files at all, so there's no obvious intended target. Let me know if the guide moved or is still to be written and I'll follow up.
