### PR TITLE
test: tolerate catalog iteration order when FSM leak checker drops tables

### DIFF
--- a/test/test_runner/fsm_leak_checker.cpp
+++ b/test/test_runner/fsm_leak_checker.cpp
@@ -30,6 +30,12 @@ std::uint64_t getNumFreePagesImpl(main::Connection* conn) {
     return std::accumulate(entries.begin(), entries.end(), 0ULL,
         [](std::uint64_t a, const auto& b) { return a + b.numPages; });
 }
+
+std::unique_ptr<main::QueryResult> dropTableIfExists(main::Connection* conn,
+    const std::string& name) {
+    return conn->query(
+        std::format("drop table if exists {}", common::StringUtils::quoteIdentifier(name)));
+}
 } // namespace
 
 void FSMLeakChecker::checkForLeakedPages(main::Connection* conn) {
@@ -90,22 +96,37 @@ void FSMLeakChecker::checkForLeakedPages(main::Connection* conn) {
         tableNames.emplace_back(next->getValue(0)->toString(), next->getValue(1)->toString());
     }
 
-    // Drop rel tables first. Use IF EXISTS because dropping a partitioned parent already cascades
-    // to (and removes) its partition subgraphs, which may still appear in the collected listing.
+    // Drop rel tables first, then non-rel: a node table referenced by a rel table refuses to
+    // drop. Use IF EXISTS because dropping a partitioned parent already cascades to (and
+    // removes) its partition subgraphs, which may still appear in the collected listing.
+    // Dropping such a subgraph directly is refused even with IF EXISTS while its parent exists,
+    // and the listing comes from unordered catalog storage whose iteration order differs across
+    // platforms (e.g. native vs WASM), so a subgraph can be listed before its parent. Defer any
+    // failed drop and retry it after everything else is dropped: by then the parent has cascaded
+    // its subgraphs away and IF EXISTS turns the retry into a no-op.
+    std::vector<std::pair<std::string, std::string>> deferredDrops; // (name, first error)
+    const auto tryDropTable = [&](const auto& name) {
+        if (auto result = dropTableIfExists(conn, name); !result->isSuccess()) {
+            deferredDrops.emplace_back(name, result->getErrorMessage());
+        }
+    };
     for (const auto& [name, type] : tableNames) {
         if (type == common::TableTypeUtils::toString(common::TableType::REL)) {
-            ASSERT_TRUE(conn->query(std::format("drop table if exists {}",
-                                        common::StringUtils::quoteIdentifier(name)))
-                            ->isSuccess());
+            tryDropTable(name);
         }
     }
     // Then non-rel
     for (const auto& [name, type] : tableNames) {
         if (type != common::TableTypeUtils::toString(common::TableType::REL)) {
-            ASSERT_TRUE(conn->query(std::format("drop table if exists {}",
-                                        common::StringUtils::quoteIdentifier(name)))
-                            ->isSuccess());
+            tryDropTable(name);
         }
+    }
+
+    for (const auto& [name, firstError] : deferredDrops) {
+        auto result = dropTableIfExists(conn, name);
+        ASSERT_TRUE(result->isSuccess())
+            << "Failed to drop table " << name << ": " << result->getErrorMessage()
+            << " (first attempt failed with: " << firstError << ")" << std::endl;
     }
 
     ASSERT_TRUE(conn->query("call enable_internal_catalog=false")->isSuccess());


### PR DESCRIPTION
## Problem

`ddl~partitioned.PartitionedAlterRestrictions` failed only in WASM mode:

```
../../test/test_runner/fsm_leak_checker.cpp:107: Failure
Value of: conn->query(std::format("drop table if exists {}", ...)) ->isSuccess()
  Actual: false
Expected: true
```

## Root cause

The FSM leak checker collects table names via `show_tables()`, which iterates the
catalog's `case_insensitive_map_t` (`std::unordered_map`). Iteration order is not
stable across standard libraries: native builds (libstdc++) happen to list the
partitioned parent before its partition subgraphs, while the WASM build (libc++)
lists a subgraph first.

Dropping a partition subgraph directly is refused by `Drop::dropTable` even with
`IF EXISTS` (`Cannot drop table Q_p0 because it is a partition of partitioned table Q.`)
as long as its parent exists, so when a subgraph was listed before its parent, the
teardown assertion failed. Native runs passed purely by luck of hash ordering.

## Fix

Defer any failed `DROP TABLE IF EXISTS` and retry it after all other tables have been
dropped. By then the parent is gone and its partition subgraphs were cascaded away,
so `IF EXISTS` turns the retry into a no-op. This makes teardown independent of catalog
iteration order. Also include the failing table name and both error messages in the
assertion output.

## Verification

WASM-only nightly CI run (build-and-deploy, all other jobs skipped): kernel ctest
on-disk + in-memory, both green.
https://github.com/LadybugDB/ladybug/actions/runs/32811296247