### PR TITLE
fix: align QueryPrimaryKeyLookup rows with the input chunk selection

### DIFF
--- a/src/processor/operator/query_primary_key_lookup.cpp
+++ b/src/processor/operator/query_primary_key_lookup.cpp
@@ -1,5 +1,7 @@
 #include "processor/operator/query_primary_key_lookup.h"
 
+#include <algorithm>
+
 #include "binder/expression/expression_util.h"
 #include "processor/execution_context.h"
 #include "storage/buffer_manager/memory_manager.h"
@@ -51,21 +53,39 @@ bool QueryPrimaryKeyLookup::getNextTuplesInternal(ExecutionContext* context) {
         saveSelVector(*nodeIDVector->state);
         keyEvaluator->evaluate();
         auto* keyVector = keyEvaluator->resultVector.get();
-        const auto& inputSelVector = keyVector->state->getSelVector();
+        // The key evaluator's result vector may own a DataChunkState that is independent of the
+        // input chunk. When the key is not a direct reference to an in-scope expression (e.g. an
+        // implicit CAST wrapped around a correlated variable, such as comparing a SERIAL primary
+        // key with an INT64 UNWIND element), ExpressionMapper hands back an evaluator whose
+        // already-flat children give it a fresh state pinned at position 0, so its selection does
+        // not track the rows exposed by the child operator. The evaluator contract aligns the i-th
+        // selected entry of a result with the i-th selected entry of each operand, so zip the two
+        // selections by index and drive everything from the input chunk's selection: indexing the
+        // node-id vector with the key result's positions resolved node IDs into slot 0 and
+        // collapsed the shared output selection to [0], freezing every downstream read of
+        // pre-lookup variables (and any later lookup's key) at the first input row.
+        // If the key result shares this state, both selections are the same object; writing
+        // outputSelVector[outputSize] with outputSize <= i only rewrites slots at or before the
+        // one being read, so no snapshot is needed.
+        const auto& inputSelVector = nodeIDVector->state->getSelVector();
+        const auto& keySelVector = keyVector->state->getSelVector();
+        const auto numRows =
+            std::min<sel_t>(inputSelVector.getSelSize(), keySelVector.getSelSize());
         auto& outputSelVector = nodeIDVector->state->getSelVectorUnsafe();
         outputSelVector.setToFiltered();
         outputSize = 0;
-        for (sel_t i = 0; i < inputSelVector.getSelSize(); ++i) {
-            const auto pos = inputSelVector[i];
-            if (keyVector->isNull(pos)) {
+        for (sel_t i = 0; i < numRows; ++i) {
+            const auto inputPos = inputSelVector[i];
+            const auto keyPos = keySelVector[i];
+            if (keyVector->isNull(keyPos)) {
                 continue;
             }
             offset_t offset;
-            if (!table->lookupPK(transaction, keyVector, pos, offset)) {
+            if (!table->lookupPK(transaction, keyVector, keyPos, offset)) {
                 continue;
             }
-            nodeIDVector->setValue<nodeID_t>(pos, {offset, table->getTableID()});
-            outputSelVector[outputSize++] = pos;
+            nodeIDVector->setValue<nodeID_t>(inputPos, {offset, table->getTableID()});
+            outputSelVector[outputSize++] = inputPos;
         }
         outputSelVector.setSelSize(outputSize);
     } while (outputSize == 0);

--- a/test/api/api_test.cpp
+++ b/test/api/api_test.cpp
@@ -240,6 +240,82 @@ TEST_F(ApiTest, UnwindQueryPrimaryKeyLookupLeadingMissThenHits) {
     ASSERT_EQ(TestHelper::convertResultToString(*result), (std::vector<std::string>{"20", "30"}));
 }
 
+// Regression for issue #822: when the lookup key needs an implicit cast (SERIAL primary key vs
+// INT64 UNWIND element), the key evaluator's result vector owns a DataChunkState pinned at
+// position 0 instead of sharing the input chunk's state. The operator used to index the node-id
+// vector and the output selection with that state, so with two sequential MATCH ... WHERE clauses
+// every created relationship pointed at the first UNWIND row's node (row count was correct, the
+// content was not). Each row must resolve to its own endpoints.
+TEST_F(ApiTest, UnwindQueryPrimaryKeyLookupTwoMatchesWithCastKey) {
+    ASSERT_TRUE(conn->query("CREATE NODE TABLE Item(id SERIAL, kind STRING, PRIMARY KEY(id));"
+                            "CREATE REL TABLE Contains(FROM Item TO Item, label STRING);")
+                    ->isSuccess());
+    ASSERT_TRUE(conn->query("CREATE (:Item {kind: 'container'});"
+                            "CREATE (:Item {kind: 'leaf1'});"
+                            "CREATE (:Item {kind: 'leaf2'});"
+                            "CREATE (:Item {kind: 'leaf3'});")
+                    ->isSuccess());
+
+    auto explain = conn->query("EXPLAIN UNWIND [{src: 0, tgt: 1}, {src: 0, tgt: 2}, "
+                               "{src: 0, tgt: 3}] AS item "
+                               "MATCH (s:Item) WHERE s.id = item.src "
+                               "MATCH (t:Item) WHERE t.id = item.tgt "
+                               "RETURN s.id, t.id");
+    ASSERT_TRUE(explain->isSuccess());
+    EXPECT_NE(explain->toString().find("QUERY_PRIMARY_KEY_LOOKUP"), std::string::npos);
+
+    auto create =
+        conn->query("UNWIND [{src: 0, tgt: 1}, {src: 0, tgt: 2}, {src: 0, tgt: 3}] AS item "
+                    "MATCH (s:Item) WHERE s.id = item.src "
+                    "MATCH (t:Item) WHERE t.id = item.tgt "
+                    "CREATE (s)-[:Contains {label: 'contains'}]->(t)");
+    ASSERT_TRUE(create->isSuccess());
+
+    auto edges =
+        conn->query("MATCH (a:Item)-[:Contains]->(b:Item) RETURN a.id, b.id ORDER BY b.id");
+    ASSERT_TRUE(edges->isSuccess());
+    ASSERT_EQ(TestHelper::convertResultToString(*edges),
+        (std::vector<std::string>{"0|1", "0|2", "0|3"}));
+}
+
+// Regression for issue #822 (single lookup variant): reading an UNWIND variable after a MATCH
+// whose primary-key equality needed an implicit cast used to return the first row's value on
+// every row. The unwind variable must stay aligned with the looked-up node per row.
+TEST_F(ApiTest, UnwindQueryPrimaryKeyLookupKeepsUnwindValuesAligned) {
+    ASSERT_TRUE(conn->query("CREATE NODE TABLE AlignedItem(id SERIAL, v STRING, PRIMARY KEY(id));")
+                    ->isSuccess());
+    ASSERT_TRUE(conn->query("CREATE (:AlignedItem {v: 'v0'});"
+                            "CREATE (:AlignedItem {v: 'v1'});"
+                            "CREATE (:AlignedItem {v: 'v2'});")
+                    ->isSuccess());
+
+    auto result = conn->query("UNWIND [2, 0, 1] AS i "
+                              "MATCH (t:AlignedItem) WHERE t.id = i "
+                              "RETURN i, t.v ORDER BY i");
+    ASSERT_TRUE(result->isSuccess());
+    ASSERT_EQ(TestHelper::convertResultToString(*result),
+        (std::vector<std::string>{"0|v0", "1|v1", "2|v2"}));
+
+    // Misses and NULL keys must still be skipped without disturbing later rows.
+    auto sparse = conn->query("UNWIND [9, 2, NULL, 0] AS i "
+                              "MATCH (t:AlignedItem) WHERE t.id = i "
+                              "RETURN i, t.v ORDER BY i");
+    ASSERT_TRUE(sparse->isSuccess());
+    ASSERT_EQ(TestHelper::convertResultToString(*sparse),
+        (std::vector<std::string>{"0|v0", "2|v2"}));
+
+    // A batch larger than the vector capacity forces the upstream Flatten to refill mid-run;
+    // alignment must survive the refill as well.
+    ASSERT_TRUE(
+        conn->query("CREATE NODE TABLE AlignedBatch(id SERIAL, PRIMARY KEY(id));")->isSuccess());
+    ASSERT_TRUE(conn->query("CREATE (:AlignedBatch);CREATE (:AlignedBatch);CREATE (:AlignedBatch);")
+                    ->isSuccess());
+    auto capped = conn->query("UNWIND range(0, 2500) AS x MATCH (t:AlignedBatch) WHERE t.id = x "
+                              "RETURN count(t)");
+    ASSERT_TRUE(capped->isSuccess());
+    ASSERT_EQ(TestHelper::convertResultToString(*capped), (std::vector<std::string>{"3"}));
+}
+
 TEST_F(ApiTest, Profile) {
     auto result =
         conn->query("EXPLAIN MATCH (a:person) WHERE EXISTS { MATCH (a)-[:knows]->(b:person) WHERE "

--- a/test/test_files/issue/issue822.test
+++ b/test/test_files/issue/issue822.test
@@ -1,0 +1,51 @@
+-DATASET CSV empty
+
+--
+
+-CASE Issue822UnwindTwoMatchesPrimaryKeyLookup
+# Reproduction for github issue #822:
+# UNWIND + two sequential MATCH ... WHERE clauses on primary keys bound every created
+# relationship to the first UNWIND row's node when the key comparison needed an implicit
+# cast (SERIAL primary key vs INT64 unwind element). Row count was correct; content was not.
+
+-STATEMENT CREATE NODE TABLE Item(id SERIAL, kind STRING, PRIMARY KEY(id));
+---- ok
+
+-STATEMENT CREATE REL TABLE Contains(FROM Item TO Item, label STRING);
+---- ok
+
+-STATEMENT CREATE (:Item {kind: 'container'});
+---- ok
+
+-STATEMENT CREATE (:Item {kind: 'leaf1'});
+---- ok
+
+-STATEMENT CREATE (:Item {kind: 'leaf2'});
+---- ok
+
+-STATEMENT CREATE (:Item {kind: 'leaf3'});
+---- ok
+
+# Read-only variant: every row must pair its own unwind values with its own matched nodes.
+-STATEMENT UNWIND [{src: 0, tgt: 1},{src: 0, tgt: 2},{src: 0, tgt: 3}] AS item MATCH (s:Item) WHERE s.id = item.src MATCH (t:Item) WHERE t.id = item.tgt RETURN item.tgt, s.id, t.id ORDER BY item.tgt;
+---- 3
+1|0|1
+2|0|2
+3|0|3
+
+# The bug: all created edges collapsed onto the first unwound target.
+-STATEMENT UNWIND [{src: 0, tgt: 1},{src: 0, tgt: 2},{src: 0, tgt: 3}] AS item MATCH (s:Item) WHERE s.id = item.src MATCH (t:Item) WHERE t.id = item.tgt CREATE (s)-[:Contains {label: 'contains'}]->(t);
+---- ok
+
+-STATEMENT MATCH (a:Item)-[r:Contains]->(b:Item) RETURN a.id, b.id ORDER BY b.id;
+---- 3
+0|1
+0|2
+0|3
+
+# Single-MATCH variant: reading the unwind variable after the lookup must stay aligned per row.
+-STATEMENT UNWIND [3, 0, 2] AS i MATCH (t:Item) WHERE t.id = i RETURN i, t.kind ORDER BY i;
+---- 3
+0|container
+2|leaf2
+3|leaf3


### PR DESCRIPTION
Fixes #822

## Summary

`UNWIND [...] AS item MATCH (s) WHERE s.id = item.src MATCH (t) WHERE t.id = item.tgt CREATE (s)-[:Contains]->(t)` created the correct *number* of edges, but every edge pointed at the **first** unwound row's node. The equivalent single-MATCH form (`MATCH (s), (t) WHERE ... AND ...`) behaved correctly.

## Root cause

`QueryPrimaryKeyLookup` indexed the node-id vector and built its output selection from the **key evaluator's result-vector state**, assuming it shared the input chunk's `DataChunkState`. That assumption only holds when the key is a direct reference to an in-scope expression.

When the comparison needs an implicit cast — e.g. a `SERIAL` primary key matched against an `INT64` UNWIND element, which is what the issue's repro does — the mapped `CAST` evaluator sees already-flat children after `appendFlattens` and allocates its own fresh flat state pinned at position 0. Its selection then never tracks the rows exposed by the child operator:

1. The resolved node id was always written into slot 0 of the node-id vector while the output selection collapsed to `[0]`, so downstream operators read pre-lookup variables at row 0 on every row (visible even with a single MATCH: `RETURN item.tgt` repeats row 0's value).
2. With two stacked lookups, the second lookup's key was evaluated through that clobbered selection, resolving every row to row 0's endpoint — all created edges collapse onto one target with the correct row count.

The existing regression tests passed because their schemas used `INT64 = INT64`, which needs no cast and keeps the evaluator sharing the chunk state.

## Fix

Zip the input chunk's selection and the key result's selection **by index** — the expression-evaluator contract aligns the i-th selected entry of a result with the i-th selected entry of each operand — and drive writes and output exposure from the input positions. When the result does share the chunk state both selections are the same object; the `outputSize <= i` write invariant keeps in-place rewriting safe without snapshots.

## Testing

- New API regression tests (fail without the fix, pass with it):
  - `UnwindQueryPrimaryKeyLookupTwoMatchesWithCastKey` — the issue's two-MATCH + `CREATE` scenario with `SERIAL` keys
  - `UnwindQueryPrimaryKeyLookupKeepsUnwindValuesAligned` — per-row alignment of unwind variables after a single casted lookup, including misses, NULL keys, and batches larger than vector capacity
- New e2e reproduction: `test/test_files/issue/issue822.test`
- Full `api_test` suite passes; e2e groups `issue`, `unwind`, `dml_rel`, `dml_node`, `subquery`, `filter`, `projection`, `optional_match`, `cypherlogic` all pass
