### PR TITLE
Fix degenerate targetSize in ColumnChunkData::split() for string chunks

### DIFF
--- a/src/storage/table/column_chunk_data.cpp
+++ b/src/storage/table/column_chunk_data.cpp
@@ -1063,13 +1063,22 @@ std::vector<std::unique_ptr<ColumnChunkData>> ColumnChunkData::split(bool target
     // times in the inner loop below.
     auto meta = getMetadataToFlush();
     auto dataPages = meta.getNumDataPages(dataType.getPhysicalType());
-    uint64_t nullSize = 0;
-    if (nullData) {
-        nullSize = nullData->getSizeOnDisk();
-    }
-    auto totalSize = dataPages * common::LBUG_PAGE_SIZE + nullSize;
+    // Use the virtual getSizeOnDisk() instead of recomputing the size from base-class metadata
+    // alone: subclasses can own additional storage that must be counted when sizing segments
+    // (StringChunkData adds its index and dictionary chunks). The previously inlined formula
+    // reported a size of 0 for variable-size types (numBytesPerValue == 0), which collapsed
+    // targetSize below to 0 on the checkpoint compaction path and shattered chunks into
+    // single-batch segments: a 131072-value string chunk became 2048 segments instead of ~3,
+    // bloating files ~2x and slowing down COPY FROM (gh-835).
+    auto totalSize = getSizeOnDisk();
 
     auto targetSize = targetMaxSize ? maxSegmentSize : std::min(totalSize / 2, maxSegmentSize);
+    // Defensive fallback: if the size computation still degenerates to 0 for a non-empty chunk
+    // (which would fragment it into one minimal segment per batch), split by the maximum
+    // segment size instead.
+    if (targetSize == 0 && numValues > 0) {
+        targetSize = maxSegmentSize;
+    }
 
     // For fixed-size types, compute a count-based bound directly from the compression metadata.
     // Using pages * valuesPerPage is accurate because it respects page boundaries and avoids the
@@ -1086,6 +1095,10 @@ std::vector<std::unique_ptr<ColumnChunkData>> ColumnChunkData::split(bool target
     std::vector<std::unique_ptr<ColumnChunkData>> newSegments;
     uint64_t pos = 0;
     const uint64_t chunkSize = 64;
+    // A chunk large enough to require splitting must receive a target size of at least one
+    // page; a smaller (especially zero) target fragments it into single-batch segments.
+    DASSERT(numValues <= chunkSize || getSizeOnDisk() <= common::StorageConfig::MAX_SEGMENT_SIZE ||
+            targetSize >= common::LBUG_PAGE_SIZE);
     uint64_t initialCapacity = std::min(chunkSize, numValues);
     while (pos < numValues) {
         std::unique_ptr<ColumnChunkData> newSegment =
@@ -1133,6 +1146,24 @@ std::vector<std::unique_ptr<ColumnChunkData>> ColumnChunkData::split(bool target
         }
         newSegments.push_back(std::move(newSegment));
     }
+    // Guard against excessive segmentation: apart from the trailing remainder, a segment must
+    // not stop after a single batch while still fitting comfortably within the target size.
+    // That is the signature of a degenerate targetSize (gh-835). Single-batch segments holding
+    // genuinely large values (e.g., multi-KB strings exceeding the target size) are legitimate
+    // and excluded by the size condition.
+    DASSERT([&]() {
+        if (newSegments.size() <= 1 || numValues <= 2 * chunkSize) {
+            return true;
+        }
+        for (auto iter = newSegments.begin(); iter != newSegments.end() - 1; ++iter) {
+            const auto& segment = **iter;
+            if (segment.getNumValues() <= chunkSize &&
+                segment.getSizeOnDiskInMemoryStats() <= targetSize / 2) {
+                return false;
+            }
+        }
+        return true;
+    }());
     return newSegments;
 }
 


### PR DESCRIPTION
Fixes #835

## Problem

`e179d72f7` (\"Fix O(N²) ALP metadata recomputation in `ColumnChunkData::split()`\") replaced `split()`'s call to the virtual `getSizeOnDisk()` with an inline recomputation based on the base-class metadata only:

```cpp
auto dataPages = meta.getNumDataPages(dataType.getPhysicalType());
uint64_t nullSize = ...;
auto totalSize = dataPages * LBUG_PAGE_SIZE + nullSize;
```

Two things go wrong for variable-size types:

1. `getDataTypeSizeInChunk(STRING/LIST/ARRAY/STRUCT/JSON) == 0`, so the base metadata contributes 0 pages.
2. `StringChunkData::getSizeOnDisk()` (virtual) additionally counts the index and dictionary chunks; the inlined formula skipped it entirely.

So persistent string chunks were sized at **0 bytes**. Whenever COPY FROM appends into a table whose last node group is partially filled, checkpoint out-of-place compaction calls `split(false)` and computes:

```
targetSize = min(totalSize / 2, MAX_SEGMENT_SIZE) = min(0, 256KB) = 0
```

With `targetSize == 0` the splitter emits one minimal 64-value segment per batch: a 131072-value string chunk becomes **2048 micro-segments instead of ~3**, each flushed with its own dictionary/index pages. This produced both reported symptoms on incremental (day-by-day) loads: ~2x database file bloat and sharply degraded COPY throughput. Single-shot loads into a fresh database never hit this path, which is why it went unnoticed.

## Changes

- Size segments via the virtual `getSizeOnDisk()` (still computed exactly once per `split()` call, so the O(N²) ALP fix is fully preserved).
- Defensive fallback: if the computed target degenerates to 0 for a non-empty chunk, split by `maxSegmentSize` instead.
- Two debug assertions guarding the regression signatures:
  - a chunk large enough to require splitting must get a target size of at least one page;
  - apart from the trailing remainder, no interior segment may stop after a single 64-value batch while fitting comfortably within the target size.

## Measurements

Reproduction of the reporter's workload (LDBC SAM dataset generated from their scripts; 3.35M node rows + 1.95M rel rows appended over 5 days with reopen between days):

| build | node COPY | rel COPY | DB size |
|---|---|---|---|
| before `e179d72f7` | 74.1s | 1.60s | 453 MB |
| `main` (contains `e179d72f7`) | 16.2s | 2.48s | **1074 MB** |
| this PR | **13.0s** | **1.63s** | **453 MB** |

The node-side speedup from `e179d72f7` is kept (the O(N²) recomputation is gone), while file size and rel/checkpoint throughput return to baseline.

## Test evidence

- Release build of the shell; benchmarked above.
- The storage target was rebuilt with `-DRUNTIME_CHECKS` (activates `DASSERT` under `NDEBUG`) and the full 5-day workload was rerun: no assertion failures, identical output size.
- The new assertions were also verified to compile with assertions enabled (`-fsyntax-only` without `-DNDEBUG`).