### PR TITLE
fix: make repeated executions of a cached physical plan correct

### DIFF
--- a/src/include/main/prepared_statement.h
+++ b/src/include/main/prepared_statement.h
@@ -44,9 +44,12 @@ struct CachedPreparedStatement {
     // this operator-tree template is cloned and its sink state is refreshed for each call,
     // avoiding the PlanMapper::mapOperator recursion entirely.
     std::unique_ptr<processor::PhysicalPlan> physicalPlanCache;
-    // Cached result-set descriptor. copy() does not propagate the descriptor from an
-    // operator tree, so we store it here separately and re-attach it on the cloned sink.
-    std::unique_ptr<processor::ResultSetDescriptor> resultSetDescriptor;
+    // Cached ResultSetDescriptors of every pipeline-head sink, in preorder position order.
+    // Operator::copy() does not propagate descriptors, and multi-pipeline plans (e.g.
+    // aggregates) clone into several tasks that each need a descriptor to build their
+    // ResultSet, so we snapshot them all from the freshly mapped tree and re-attach them onto
+    // each cloned instance.
+    std::vector<std::unique_ptr<processor::ResultSetDescriptor>> sinkResultSetDescriptors;
 
     CachedPreparedStatement();
     ~CachedPreparedStatement();

--- a/src/include/processor/operator/aggregate/hash_aggregate.h
+++ b/src/include/processor/operator/aggregate/hash_aggregate.h
@@ -73,6 +73,12 @@ public:
 
     std::pair<uint64_t, uint64_t> getNextRangeToRead() override;
 
+    // Re-arm this shared state for another execution of the same cached physical plan: the
+    // object is aliased across clones of that plan (copy() passes the shared_ptr through),
+    // so per-execution state (scan cursor, accumulated partitions) must be reset before each
+    // execution. Mirrors what a freshly mapped plan would start with.
+    void resetForReuse();
+
     void scan(std::span<uint8_t*> entries, std::vector<common::ValueVector*>& keyVectors,
         common::offset_t startOffset, common::offset_t numRowsToScan,
         std::vector<uint32_t>& columnIndices);
@@ -183,6 +189,12 @@ public:
         std::unique_ptr<OPPrintInfo> printInfo)
         : Sink{type_, id, std::move(printInfo)}, sharedState{std::move(sharedState)} {}
 
+    HashAggregateFinalize(std::shared_ptr<HashAggregateSharedState> sharedState,
+        std::unique_ptr<PhysicalOperator> child, physical_op_id id,
+        std::unique_ptr<OPPrintInfo> printInfo)
+        : Sink{type_, std::move(child), id, std::move(printInfo)},
+          sharedState{std::move(sharedState)} {}
+
     bool isSource() const override { return true; }
 
     void executeInternal(ExecutionContext* /*context*/) override {
@@ -193,8 +205,17 @@ public:
         sharedState->assertFinalized();
     }
 
+    void prepareForReuse(storage::MemoryManager* memoryManager) override {
+        sharedState->resetForReuse();
+        PhysicalOperator::prepareForReuse(memoryManager);
+    }
+
+    // Note: The child must be preserved. PlanMapper attaches the aggregate pipeline below this
+    // operator, and physical-plan caching relies on copy() producing a complete tree; dropping
+    // the child here would silently remove whole pipelines from cloned plans.
     std::unique_ptr<PhysicalOperator> copy() override {
-        return make_unique<HashAggregateFinalize>(sharedState, id, printInfo->copy());
+        return make_unique<HashAggregateFinalize>(sharedState, children[0]->copy(), id,
+            printInfo->copy());
     }
 
 private:

--- a/src/include/processor/operator/aggregate/hash_aggregate_scan.h
+++ b/src/include/processor/operator/aggregate/hash_aggregate_scan.h
@@ -15,15 +15,27 @@ public:
           groupByKeyVectorsPos{std::move(groupByKeyVectorsPos)},
           sharedState{std::move(sharedState)} {}
 
+    HashAggregateScan(std::shared_ptr<HashAggregateSharedState> sharedState,
+        std::vector<DataPos> groupByKeyVectorsPos, AggregateScanInfo scanInfo,
+        std::unique_ptr<PhysicalOperator> child, uint32_t id,
+        std::unique_ptr<OPPrintInfo> printInfo)
+        : BaseAggregateScan{std::move(scanInfo), std::move(child), id, std::move(printInfo)},
+          groupByKeyVectorsPos{std::move(groupByKeyVectorsPos)},
+          sharedState{std::move(sharedState)} {}
+
     std::shared_ptr<HashAggregateSharedState> getSharedState() const { return sharedState; }
 
     void initLocalStateInternal(ResultSet* resultSet, ExecutionContext* context) override;
 
     bool getNextTuplesInternal(ExecutionContext* context) override;
 
+    // Note: The child must be preserved. PlanMapper attaches the aggregate's finalize pipeline
+    // below this scan, and physical-plan caching relies on copy() producing a complete tree;
+    // dropping the child here would silently remove whole pipelines from cloned plans.
     std::unique_ptr<PhysicalOperator> copy() override {
-        return std::make_unique<HashAggregateScan>(sharedState, groupByKeyVectorsPos, scanInfo, id,
-            printInfo->copy());
+        return std::make_unique<HashAggregateScan>(sharedState, groupByKeyVectorsPos,
+            AggregateScanInfo{scanInfo.aggregatesPos, scanInfo.moveAggResultToVectorFuncs},
+            children[0]->copy(), id, printInfo->copy());
     }
 
     double getProgress(ExecutionContext* context) const override;

--- a/src/include/processor/operator/aggregate/packed_filtered_count.h
+++ b/src/include/processor/operator/aggregate/packed_filtered_count.h
@@ -40,6 +40,17 @@ struct PackedFilteredCountSharedState {
     void merge(std::unordered_map<int64_t, uint64_t>&& localCounts);
     void finalize();
     std::pair<common::offset_t, common::offset_t> getNextRangeToRead();
+
+    // Re-arm this state for another execution of the same cached physical plan: the object is
+    // aliased across clones of that plan, so accumulated counts must be cleared before each
+    // execution.
+    void resetForReuse() {
+        std::unique_lock lck{mtx};
+        counts.clear();
+        finalizedCounts.clear();
+        nextOffset = 0;
+        finalized = false;
+    }
 };
 
 struct PackedFilteredCountPrintInfo final : OPPrintInfo {
@@ -75,6 +86,11 @@ public:
     void initLocalStateInternal(ResultSet* resultSet, ExecutionContext* context) override;
 
     void executeInternal(ExecutionContext* context) override;
+
+    void prepareForReuse(storage::MemoryManager* memoryManager) override {
+        sharedState->resetForReuse();
+        PhysicalOperator::prepareForReuse(memoryManager);
+    }
 
     std::unique_ptr<PhysicalOperator> copy() override {
         return std::make_unique<PackedFilteredCount>(sharedState, info, children[0]->copy(), id,

--- a/src/include/processor/operator/aggregate/simple_aggregate.h
+++ b/src/include/processor/operator/aggregate/simple_aggregate.h
@@ -9,6 +9,10 @@
 #include "processor/operator/aggregate/base_aggregate.h"
 
 namespace lbug {
+namespace storage {
+class MemoryManager;
+} // namespace storage
+
 namespace processor {
 
 // NOLINTNEXTLINE(cppcoreguidelines-virtual-class-destructor): This is a final class.
@@ -30,6 +34,13 @@ public:
     void finalizeAggregateStates();
 
     std::pair<uint64_t, uint64_t> getNextRangeToRead() override;
+
+    // Re-arm this shared state for another execution of the same cached physical plan: the
+    // object is aliased across clones of that plan (copy() passes the shared_ptr through),
+    // so per-execution state must be reset before each execution. Distinct partitions are
+    // consumed by finalizePartitions during the previous execution and are rebuilt here.
+    void resetForReuse(storage::MemoryManager* memoryManager,
+        const std::vector<AggregateInfo>& aggInfos);
 
     function::AggregateState* getAggregateState(uint64_t idx) {
         return globalAggregateStates[idx].get();
@@ -135,15 +146,29 @@ public:
         : Sink{type_, id, std::move(printInfo)}, sharedState{std::move(sharedState)},
           aggInfos{std::move(aggInfos)} {}
 
+    SimpleAggregateFinalize(std::shared_ptr<SimpleAggregateSharedState> sharedState,
+        std::vector<AggregateInfo> aggInfos, std::unique_ptr<PhysicalOperator> child,
+        physical_op_id id, std::unique_ptr<OPPrintInfo> printInfo)
+        : Sink{type_, std::move(child), id, std::move(printInfo)},
+          sharedState{std::move(sharedState)}, aggInfos{std::move(aggInfos)} {}
+
     bool isSource() const override { return true; }
 
     void executeInternal(ExecutionContext* context) override;
 
     void finalizeInternal(ExecutionContext* context) override;
 
+    void prepareForReuse(storage::MemoryManager* memoryManager) override {
+        sharedState->resetForReuse(memoryManager, aggInfos);
+        PhysicalOperator::prepareForReuse(memoryManager);
+    }
+
+    // Note: The child must be preserved. PlanMapper attaches the aggregate pipeline below this
+    // operator, and physical-plan caching relies on copy() producing a complete tree; dropping
+    // the child here would silently remove whole pipelines from cloned plans.
     std::unique_ptr<PhysicalOperator> copy() override {
-        return std::make_unique<SimpleAggregateFinalize>(sharedState, copyVector(aggInfos), id,
-            printInfo->copy());
+        return std::make_unique<SimpleAggregateFinalize>(sharedState, copyVector(aggInfos),
+            children[0]->copy(), id, printInfo->copy());
     }
 
 private:

--- a/src/include/processor/operator/aggregate/simple_aggregate_scan.h
+++ b/src/include/processor/operator/aggregate/simple_aggregate_scan.h
@@ -13,12 +13,23 @@ public:
         : BaseAggregateScan{std::move(scanInfo), id, std::move(printInfo)},
           sharedState{std::move(sharedState)}, outDataChunk{nullptr} {}
 
+    SimpleAggregateScan(std::shared_ptr<SimpleAggregateSharedState> sharedState,
+        AggregateScanInfo scanInfo, std::unique_ptr<PhysicalOperator> child, uint32_t id,
+        std::unique_ptr<OPPrintInfo> printInfo)
+        : BaseAggregateScan{std::move(scanInfo), std::move(child), id, std::move(printInfo)},
+          sharedState{std::move(sharedState)}, outDataChunk{nullptr} {}
+
     void initLocalStateInternal(ResultSet* resultSet, ExecutionContext* context) override;
 
     bool getNextTuplesInternal(ExecutionContext* context) override;
 
+    // Note: The child must be preserved. PlanMapper attaches the aggregate's finalize pipeline
+    // below this scan, and physical-plan caching relies on copy() producing a complete tree;
+    // dropping the child here would silently remove whole pipelines from cloned plans.
     std::unique_ptr<PhysicalOperator> copy() override {
-        return make_unique<SimpleAggregateScan>(sharedState, scanInfo, id, printInfo->copy());
+        return make_unique<SimpleAggregateScan>(sharedState,
+            AggregateScanInfo{scanInfo.aggregatesPos, scanInfo.moveAggResultToVectorFuncs},
+            children[0]->copy(), id, printInfo->copy());
     }
 
 private:

--- a/src/include/processor/operator/scan/primary_key_scan_node_table.h
+++ b/src/include/processor/operator/scan/primary_key_scan_node_table.h
@@ -37,6 +37,14 @@ struct PrimaryKeyScanSharedState {
 
     explicit PrimaryKeyScanSharedState(common::idx_t numTables) : numTables{numTables}, cursor{0} {}
 
+    // Reset the cursor so a new execution of the operator tree starts scanning from the first
+    // table again. Needed because repeated executions of a cached physical plan share this
+    // object: getTableIdx() hands out each index exactly once until the cursor is reset.
+    void resetForReuse() {
+        std::unique_lock lck{mtx};
+        cursor = 0;
+    }
+
     common::idx_t getTableIdx();
 };
 
@@ -60,6 +68,8 @@ public:
     bool isSource() const override { return true; }
 
     void initLocalStateInternal(ResultSet*, ExecutionContext*) override;
+
+    void initGlobalStateInternal(ExecutionContext* context) override;
 
     bool getNextTuplesInternal(ExecutionContext* context) override;
 

--- a/src/main/client_context.cpp
+++ b/src/main/client_context.cpp
@@ -22,6 +22,7 @@
 #include "parser/visitor/standalone_call_rewriter.h"
 #include "parser/visitor/statement_read_write_analyzer.h"
 #include "planner/planner.h"
+#include "processor/operator/sink.h"
 #include "processor/plan_mapper.h"
 #include "processor/processor.h"
 #include "storage/buffer_manager/buffer_manager.h"
@@ -552,6 +553,40 @@ ClientContext::PrepareResult ClientContext::prepareNoLock(
     return {std::move(preparedStatement), std::move(cachedStatement)};
 }
 
+namespace {
+
+// Walks an operator tree in preorder, snapshotting (slow path) or re-attaching (fast path)
+// the ResultSetDescriptor of every pipeline-head sink. Operator::copy() does not propagate
+// descriptors: only the root of a cloned plan would otherwise get one re-attached, leaving
+// sub-pipeline tasks without a descriptor and unable to build their ResultSet.
+void collectSinkDescriptors(const processor::PhysicalOperator* op,
+    std::vector<std::unique_ptr<processor::ResultSetDescriptor>>& sinks) {
+    if (const auto* sink = dynamic_cast<const processor::Sink*>(op)) {
+        sinks.push_back(sink->getDescriptor() == nullptr ? nullptr : sink->getDescriptor()->copy());
+    } else {
+        sinks.push_back(nullptr);
+    }
+    for (common::idx_t i = 0; i < op->getNumChildren(); ++i) {
+        collectSinkDescriptors(op->getChild(i), sinks);
+    }
+}
+
+void attachSinkDescriptors(processor::PhysicalOperator* op,
+    const std::vector<std::unique_ptr<processor::ResultSetDescriptor>>& sinks, common::idx_t& pos) {
+    if (auto* sink = dynamic_cast<processor::Sink*>(op)) {
+        auto& desc = sinks[pos];
+        if (desc != nullptr) {
+            sink->setDescriptor(desc->copy());
+        }
+    }
+    ++pos;
+    for (common::idx_t i = 0; i < op->getNumChildren(); ++i) {
+        attachSinkDescriptors(op->getChild(i), sinks, pos);
+    }
+}
+
+} // namespace
+
 std::unique_ptr<QueryResult> ClientContext::executeNoLock(PreparedStatement* preparedStatement,
     CachedPreparedStatement* cachedStatement, std::optional<uint64_t> queryID,
     QueryConfig queryConfig, bool cachePhysicalPlan) {
@@ -588,11 +623,11 @@ std::unique_ptr<QueryResult> ClientContext::executeNoLock(PreparedStatement* pre
                     physicalPlan = std::make_unique<PhysicalPlan>(
                         cachedStatement->physicalPlanCache->lastOperator->copy());
                     physicalPlan->lastOperator->prepareForReuse(storage::MemoryManager::Get(*this));
-                    // Re-attach the ResultSetDescriptor (not propagated by copy()).
-                    if (cachedStatement->resultSetDescriptor) {
-                        auto* sink = physicalPlan->lastOperator->ptrCast<Sink>();
-                        sink->setDescriptor(cachedStatement->resultSetDescriptor->copy());
-                    }
+                    // Re-attach the ResultSetDescriptors (not propagated by copy()) of every
+                    // pipeline-head sink, so each sub-task can build its ResultSet.
+                    common::idx_t pos = 0;
+                    attachSinkDescriptors(physicalPlan->lastOperator.get(),
+                        cachedStatement->sinkResultSetDescriptors, pos);
                 } else {
                     auto mapper = PlanMapper(executionContext.get());
                     physicalPlan = mapper.getPhysicalPlan(cachedStatement->logicalPlan.get(),
@@ -601,12 +636,11 @@ std::unique_ptr<QueryResult> ClientContext::executeNoLock(PreparedStatement* pre
                         // Cache the operator tree template for future reuse.
                         cachedStatement->physicalPlanCache =
                             std::make_unique<PhysicalPlan>(physicalPlan->lastOperator->copy());
-                        // Also save the ResultSetDescriptor separately (copy() doesn't
-                        // propagate it, and the cloned sink needs it for getResultSet).
-                        auto* sink = physicalPlan->lastOperator->ptrCast<Sink>();
-                        if (sink->getDescriptor()) {
-                            cachedStatement->resultSetDescriptor = sink->getDescriptor()->copy();
-                        }
+                        // Snapshot the ResultSetDescriptor of every pipeline-head sink
+                        // (copy() doesn't propagate them; each cloned sink needs one for
+                        // getResultSet).
+                        collectSinkDescriptors(physicalPlan->lastOperator.get(),
+                            cachedStatement->sinkResultSetDescriptors);
                     }
                 }
                 if (isTransactionStatement) {

--- a/src/processor/operator/aggregate/hash_aggregate.cpp
+++ b/src/processor/operator/aggregate/hash_aggregate.cpp
@@ -118,6 +118,33 @@ HashAggregateSharedState::HashAggregateSharedState(main::ClientContext* context,
     }
 }
 
+void HashAggregateSharedState::resetForReuse() {
+    // A cached physical plan aliases this state across executions of the operator tree, so the
+    // scan cursor and the accumulated partition tables must be re-armed before each execution.
+    // Mirrors what a freshly mapped plan would start with (see the constructor).
+    std::unique_lock lck{mtx};
+    currentOffset.store(0);
+    readyForFinalization = false;
+    std::unique_ptr<common::InMemOverflowBuffer> buf;
+    while (overflow.pop(buf)) {}
+    auto* mm = memoryManager;
+    for (auto& partition : globalPartitions) {
+        partition.finalized = false;
+        if (partition.queue) {
+            partition.queue = std::make_unique<HashTableQueue>(mm, aggInfo.tableSchema.copy());
+        }
+        for (auto& distinctQueue : partition.distinctTableQueues) {
+            if (distinctQueue) {
+                distinctQueue = distinctQueue->copy();
+            }
+        }
+        if (partition.hashTable) {
+            partition.hashTable =
+                std::make_unique<AggregateHashTable>(partition.hashTable->createEmptyCopy());
+        }
+    }
+}
+
 std::pair<uint64_t, uint64_t> HashAggregateSharedState::getNextRangeToRead() {
     std::unique_lock lck{mtx};
     auto startOffset = currentOffset.load();

--- a/src/processor/operator/aggregate/simple_aggregate.cpp
+++ b/src/processor/operator/aggregate/simple_aggregate.cpp
@@ -110,6 +110,50 @@ void SimpleAggregateSharedState::finalizeAggregateStates() {
     }
 }
 
+void SimpleAggregateSharedState::resetForReuse(storage::MemoryManager* memoryManager,
+    const std::vector<AggregateInfo>& aggInfos) {
+    // A cached physical plan aliases this state across executions of the operator tree, so the
+    // scan cursor and the accumulated aggregate states must be re-armed before each execution.
+    std::unique_lock lck{mtx};
+    currentOffset.store(0);
+    readyForFinalization = false;
+    std::unique_ptr<common::InMemOverflowBuffer> buf;
+    while (overflow.pop(buf)) {}
+    aggregateOverflowBuffer.resetBuffer();
+    for (size_t i = 0; i < aggregateFunctions.size(); ++i) {
+        globalAggregateStates[i] = aggregateFunctions[i].createInitialNullAggregateState();
+    }
+    if (!hasDistinct) {
+        return;
+    }
+    // Distinct partitions are consumed (tables and queues reset) by finalizePartitions during
+    // the previous execution; rebuild them so the next execution starts from an empty slate.
+    // Mirrors the partition construction in the constructor.
+    for (auto& partition : globalPartitions) {
+        for (size_t funcIdx = 0; funcIdx < aggregateFunctions.size(); funcIdx++) {
+            auto& aggregateFunction = aggregateFunctions[funcIdx];
+            if (!aggregateFunction.isDistinct) {
+                continue;
+            }
+            const auto& distinctKeyType = aggInfos[funcIdx].distinctAggKeyType;
+            std::vector<LogicalType> keyTypes(1);
+            keyTypes[0] = distinctKeyType.copy();
+            auto schema = AggregateHashTableUtils::getTableSchemaForKeys(std::vector<LogicalType>{},
+                distinctKeyType);
+            auto hashTable =
+                std::make_unique<AggregateHashTable>(*memoryManager, std::move(keyTypes),
+                    std::vector<LogicalType>{} /*payloadTypes*/, std::vector<AggregateFunction>{},
+                    std::vector<LogicalType>{} /*payloadTypes*/, 0, schema.copy());
+            auto queue = std::make_unique<HashTableQueue>(memoryManager,
+                AggregateHashTableUtils::getTableSchemaForKeys(std::vector<LogicalType>{},
+                    distinctKeyType));
+            partition.distinctTables[funcIdx] = Partition::DistinctData{std::move(hashTable),
+                std::move(queue), aggregateFunction.createInitialNullAggregateState()};
+        }
+        partition.finalized = false;
+    }
+}
+
 std::pair<uint64_t, uint64_t> SimpleAggregateSharedState::getNextRangeToRead() {
     std::unique_lock lck{mtx};
     if (currentOffset >= 1) {

--- a/src/processor/operator/scan/primary_key_scan_node_table.cpp
+++ b/src/processor/operator/scan/primary_key_scan_node_table.cpp
@@ -49,6 +49,13 @@ void PrimaryKeyScanNodeTable::initLocalStateInternal(ResultSet* resultSet,
     }
 }
 
+void PrimaryKeyScanNodeTable::initGlobalStateInternal(ExecutionContext* /*context*/) {
+    // Repeated executions of a cached physical plan clone the operator tree but share this
+    // shared state, so the table cursor must be re-armed for every execution (mirrors
+    // ScanNodeTable::initGlobalStateInternal).
+    sharedState->resetForReuse();
+}
+
 bool PrimaryKeyScanNodeTable::getNextTuplesInternal(ExecutionContext* context) {
     if (isRange) {
         return lookupRange(context);

--- a/test/api/prepare_test.cpp
+++ b/test/api/prepare_test.cpp
@@ -258,3 +258,119 @@ TEST_F(ApiTest, ParameterWith) {
     auto groupTruth = std::vector<std::string>{"abc"};
     ASSERT_EQ(groupTruth, TestHelper::convertResultToString(*result));
 }
+
+// Regression tests for re-executing prepared statements whose physical plan is cached.
+// The cached-plan fast path used to consume per-execution shared state on the first run,
+// so the second and later executions returned empty results for primary-key/index scans
+// and stale/truncated results once aggregates were involved.
+static void createItemTableWithArtIndex(lbug::main::Connection* conn) {
+    ASSERT_TRUE(conn->query("CALL enable_default_hash_index=false")->isSuccess());
+    ASSERT_TRUE(
+        conn->query("CREATE NODE TABLE Item(id INT64, name STRING, price DOUBLE, PRIMARY KEY(id))")
+            ->isSuccess());
+    ASSERT_TRUE(conn->query("CREATE ART INDEX item_id_idx FOR (a:Item) ON (a.id)")->isSuccess());
+}
+
+TEST_F(ApiTest, RepeatedExecutePreparedStatementPrimaryKeyScan) {
+    createItemTableWithArtIndex(conn.get());
+    ASSERT_TRUE(conn->query("CREATE (:Item {id: 50000, name: 'x'})")->isSuccess());
+
+    auto preparedStatement = conn->prepare("MATCH (i:Item) WHERE i.id = 50000 RETURN i.name");
+    ASSERT_TRUE(preparedStatement->isSuccess());
+    auto groundTruth = std::vector<std::string>{"x"};
+    for (auto run = 0u; run < 5; run++) {
+        auto result = conn->execute(preparedStatement.get());
+        ASSERT_TRUE(result->isSuccess()) << "run " << run;
+        ASSERT_EQ(groundTruth,
+            TestHelper::convertResultToString(*result, true /* checkOutputOrder */))
+            << "run " << run;
+    }
+}
+
+TEST_F(ApiTest, RepeatedExecutePreparedStatementPrimaryKeyScanWithParams) {
+    createItemTableWithArtIndex(conn.get());
+    ASSERT_TRUE(conn->query("CREATE (:Item {id: 50000, name: 'x'})")->isSuccess());
+    ASSERT_TRUE(conn->query("CREATE (:Item {id: 1, name: 'y'})")->isSuccess());
+
+    auto preparedStatement = conn->prepare("MATCH (i:Item) WHERE i.id = $id RETURN i.name");
+    ASSERT_TRUE(preparedStatement->isSuccess());
+    struct ParamCase {
+        int64_t id;
+        std::vector<std::string> groundTruth;
+    };
+    const std::vector<ParamCase> cases = {{50000, {"x"}}, {1, {"y"}}, {50000, {"x"}},
+        // A key that is not in the index must return an empty result, also on repeats.
+        {9999, {}}};
+    for (auto run = 0u; run < cases.size(); run++) {
+        const auto& paramCase = cases[run];
+        auto result =
+            conn->execute(preparedStatement.get(), std::make_pair(std::string("id"), paramCase.id));
+        ASSERT_TRUE(result->isSuccess()) << "run " << run;
+        ASSERT_EQ(paramCase.groundTruth, TestHelper::convertResultToString(*result))
+            << "run " << run;
+    }
+}
+
+TEST_F(ApiTest, RepeatedExecutePreparedStatementAggregateOverIndexScan) {
+    createItemTableWithArtIndex(conn.get());
+    ASSERT_TRUE(conn->query("CREATE (:Item {id: 1, name: 'a', price: 1.0})")->isSuccess());
+    ASSERT_TRUE(conn->query("CREATE (:Item {id: 2, name: 'b', price: 2.0})")->isSuccess());
+    ASSERT_TRUE(conn->query("CREATE (:Item {id: 3, name: 'c', price: 3.0})")->isSuccess());
+
+    auto countPS = conn->prepare("MATCH (i:Item) WHERE i.id >= 1 AND i.id <= 3 RETURN COUNT(*)");
+    ASSERT_TRUE(countPS->isSuccess());
+    auto rangePS = conn->prepare("MATCH (i:Item) WHERE i.id >= 2 AND i.id <= 1000 RETURN i.id");
+    ASSERT_TRUE(rangePS->isSuccess());
+    auto countGroundTruth = std::vector<std::string>{"3"};
+    auto rangeGroundTruth = std::vector<std::string>{"2", "3"};
+    for (auto run = 0u; run < 5; run++) {
+        auto result = conn->execute(countPS.get());
+        ASSERT_TRUE(result->isSuccess()) << "run " << run;
+        ASSERT_EQ(countGroundTruth, TestHelper::convertResultToString(*result)) << "run " << run;
+
+        result = conn->execute(rangePS.get());
+        ASSERT_TRUE(result->isSuccess()) << "run " << run;
+        ASSERT_EQ(rangeGroundTruth,
+            TestHelper::convertResultToString(*result, true /* checkOutputOrder */))
+            << "run " << run;
+    }
+}
+
+TEST_F(ApiTest, RepeatedExecutePreparedStatementGroupByDistinctOrderBy) {
+    createItemTableWithArtIndex(conn.get());
+    ASSERT_TRUE(conn->query("CREATE (:Item {id: 1, name: 'a', price: 1.0})")->isSuccess());
+    ASSERT_TRUE(conn->query("CREATE (:Item {id: 2, name: 'b', price: 2.0})")->isSuccess());
+    ASSERT_TRUE(conn->query("CREATE (:Item {id: 3, name: 'a', price: 3.0})")->isSuccess());
+    ASSERT_TRUE(conn->query("CREATE (:Item {id: 4, name: 'b', price: 4.0})")->isSuccess());
+
+    auto groupByPS = conn->prepare("MATCH (i:Item) RETURN i.name, COUNT(*) AS c ORDER BY i.name");
+    ASSERT_TRUE(groupByPS->isSuccess());
+    auto distinctPS = conn->prepare("MATCH (i:Item) RETURN DISTINCT i.name ORDER BY i.name");
+    ASSERT_TRUE(distinctPS->isSuccess());
+    auto orderByLimitPS = conn->prepare("MATCH (i:Item) RETURN i.id ORDER BY i.id DESC LIMIT 3");
+    ASSERT_TRUE(orderByLimitPS->isSuccess());
+
+    auto groupByGroundTruth = std::vector<std::string>{"a|2", "b|2"};
+    auto distinctGroundTruth = std::vector<std::string>{"a", "b"};
+    auto orderByLimitGroundTruth = std::vector<std::string>{"4", "3", "2"};
+    // Interleave different prepared statements to exercise descriptor reuse across plans.
+    for (auto run = 0u; run < 5; run++) {
+        auto result = conn->execute(groupByPS.get());
+        ASSERT_TRUE(result->isSuccess()) << "run " << run;
+        ASSERT_EQ(groupByGroundTruth,
+            TestHelper::convertResultToString(*result, true /* checkOutputOrder */))
+            << "run " << run;
+
+        result = conn->execute(distinctPS.get());
+        ASSERT_TRUE(result->isSuccess()) << "run " << run;
+        ASSERT_EQ(distinctGroundTruth,
+            TestHelper::convertResultToString(*result, true /* checkOutputOrder */))
+            << "run " << run;
+
+        result = conn->execute(orderByLimitPS.get());
+        ASSERT_TRUE(result->isSuccess()) << "run " << run;
+        ASSERT_EQ(orderByLimitGroundTruth,
+            TestHelper::convertResultToString(*result, true /* checkOutputOrder */))
+            << "run " << run;
+    }
+}


### PR DESCRIPTION
## Summary

Re-executing a prepared statement whose physical plan is cached (the fast path from the plan-caching work, e.g. 78e1ccfd4 / 80fa47389) produced wrong results. The reproducer from the issue:

```python
conn.execute('CALL enable_default_hash_index=false')
conn.execute('CREATE NODE TABLE Item(id INT64, name STRING, PRIMARY KEY(id))')
conn.execute('CREATE ART INDEX id_idx FOR (a:Item) ON (a.id)')
conn.execute("CREATE (:Item {id: 50000, name: 'x'})")
ps = pb_conn.prepare("MATCH (i:Item) WHERE i.id = 50000 RETURN i.id", {})
pb_conn.execute(ps, {})   # OK
pb_conn.execute(ps, {})   # empty result  <- bug
```

The same class of failure hit every aggregate over a scan (`RETURN COUNT(*)`, `GROUP BY`, `DISTINCT ... ORDER BY`): first execution correct, later executions empty or stale.

## Root causes

All four come from per-execution state living in objects that are **aliased across clones** of the cached operator tree (`copy()` passes shared_ptrs/pointers through):

1. **`PrimaryKeyScanSharedState::cursor`** — `getTableIdx()` hands out each table index exactly once and nothing ever rewound it; run 2+ immediately saw `cursor >= numTables` → `return false` → empty result. Fixed by adding `PrimaryKeyScanNodeTable::initGlobalStateInternal()` that resets the cursor, mirroring what `ScanNodeTable::initGlobalStateInternal()` already does for its morsel state on every execution.

2. **Aggregate shared states** (`HashAggregateSharedState`, `SimpleAggregateSharedState`, `PackedFilteredCountSharedState`) kept their scan cursor (`currentOffset`), `readyForFinalization`, accumulated aggregate states / partition hash tables / queues across executions. Added `resetForReuse()` to each, invoked from the finalize/count operators' `prepareForReuse()`, re-arming them to what a freshly mapped plan starts with.

3. **Truncated copies**: `SimpleAggregateScan`, `HashAggregateScan`, `SimpleAggregateFinalize`, `HashAggregateFinalize` dropped their child in `copy()`. Latent while plans were freshly mapped each run, but plan caching made it fatal — whole pipelines vanished from the cloned tree (latent-state resets never even ran, sub-tasks didn't exist). Preserved children in `copy()` (+ child-taking constructors).

4. **Missing descriptors**: `PhysicalOperator::copy()` does not propagate `Sink::resultSetDescriptor`; only the plan root was re-attached on the fast path, so sub-pipeline tasks could not build a `ResultSet` (segfault in `ScanTable::initLocalStateInternal`). Now snapshot the descriptor of *every* pipeline-head sink into `CachedPreparedStatement::sinkResultSetDescriptors` (preorder order) when caching the plan, and re-attach them onto each cloned instance.

## Testing

- C++ repro of the exact scenario above now returns 1 tuple on every repeated execution.
- Broadened C++ matrix all green at HEAD+fix: parameterized PK lookups with changing params, ART range scans repeated, PK scan over a second table after cursor exhaustion, non-indexed filter scans, interleaved prepared statements ×50, GROUP BY/DISTINCT/ORDER BY+LIMIT/two-hop joins/UNWIND/OPTIONAL MATCH executed repeatedly, and counts-after-writes via a reused prepared statement.
- Verified the fix is not just masking: removed the reset and the failure returns; TLS-ResultSet cache was confirmed unaffected (it misses per run here because the fast path builds a fresh descriptor per execution).

Full CI suite will validate no regressions.