### PR TITLE
storage: fail fast on foreign rel traversal; exclude scan-backed rels from CountRelTable

### DIFF
--- a/src/include/function/table/bind_data.h
+++ b/src/include/function/table/bind_data.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <optional>
+#include <utility>
+
 #include "common/types/types.h"
 #include "optional_params.h"
 #include "storage/predicate/column_predicate.h"
@@ -54,6 +57,16 @@ struct LBUG_API TableFuncBindData {
     std::string getOrderBy() const { return orderBy; }
 
     virtual bool getIgnoreErrorsOption() const;
+
+    // For foreign-backed rel tables whose src/dst columns carry node offsets
+    // directly (the csr_rel_* contract: foreign keys are usable as table
+    // offsets by design), the positions of the src and dst columns in the
+    // scan output. nullopt means the scan output cannot be interpreted as
+    // internal node IDs, so MATCH traversal over the table is unsupported.
+    virtual std::optional<std::pair<common::column_id_t, common::column_id_t>>
+    getSrcDstColumnPositions() const {
+        return std::nullopt;
+    }
 
     virtual std::unique_ptr<TableFuncBindData> copy() const;
 

--- a/src/include/storage/table/foreign_rel_table.h
+++ b/src/include/storage/table/foreign_rel_table.h
@@ -67,6 +67,7 @@ public:
     common::row_idx_t getNumTotalRows(const transaction::Transaction* transaction) override;
 
 private:
+    catalog::RelGroupCatalogEntry* relGroupEntry;
     function::TableFunction scanFunction;
     std::shared_ptr<function::TableFuncBindData> scanBindData;
 };

--- a/src/main/database_manager.cpp
+++ b/src/main/database_manager.cpp
@@ -422,9 +422,12 @@ std::pair<catalog::Catalog*, storage::StorageManager*> DatabaseManager::resolveT
             if (attachedLbug->getStorageManager()->containsTable(tableID)) {
                 return {attachedDB->getCatalog(), attachedLbug->getStorageManager()};
             }
+            throw common::RuntimeException(
+                std::format("Table with ID {} not found in database {}.", tableID, dbName));
         }
-        throw common::RuntimeException(
-            std::format("Table with ID {} not found in database {}.", tableID, dbName));
+        // Foreign attached databases (duckdb, sqlite, postgres) register their
+        // tables in the main catalog/storage manager (shadow entries guarantee
+        // table ID uniqueness); fall through to the main-path resolution.
     }
     auto* mainSM = storage::StorageManager::Get(context);
     if (mainSM->containsTable(tableID)) {

--- a/src/optimizer/count_rel_table_optimizer.cpp
+++ b/src/optimizer/count_rel_table_optimizer.cpp
@@ -161,6 +161,11 @@ static bool relTablesForExtend(const LogicalExtend& extend, std::vector<table_id
     }
     DASSERT(rel->getNumEntries() == 1);
     relGroupEntry = rel->getEntry(0)->ptrCast<RelGroupCatalogEntry>();
+    // Foreign-backed rel tables are scan-driven and own no CSR metadata to count
+    // from; let the regular aggregate pipeline scan them instead.
+    if (relGroupEntry->getScanFunction().has_value()) {
+        return false;
+    }
     auto boundNodeTableIDs = extend.getBoundNode()->getTableIDsSet();
     auto nbrNodeTableIDs = extend.getNbrNode()->getTableIDsSet();
     for (auto& info : relGroupEntry->getRelEntryInfos()) {
@@ -211,6 +216,16 @@ bool CountRelTableOptimizer::canOptimize(LogicalOperator* aggregate) const {
     auto rel = extend.getRel();
     if (rel->isMultiLabeled()) {
         return false;
+    }
+
+    // Foreign-backed rel tables are scan-driven and own no CSR metadata to
+    // count from (ForeignRelTable::getNumTotalRows is not a CSR count); let
+    // the regular aggregate pipeline scan them instead.
+    for (auto entryIdx = 0u; entryIdx < rel->getNumEntries(); ++entryIdx) {
+        auto* relGroupEntry = rel->getEntry(entryIdx)->ptrCast<RelGroupCatalogEntry>();
+        if (relGroupEntry != nullptr && relGroupEntry->getScanFunction().has_value()) {
+            return false;
+        }
     }
 
     if (!isCountStar(aggregate) && !isCountRelID(aggregate, *rel)) {

--- a/src/optimizer/foreign_join_push_down_optimizer.cpp
+++ b/src/optimizer/foreign_join_push_down_optimizer.cpp
@@ -106,14 +106,27 @@ static std::string getRelForeignDatabaseName(const RelExpression* rel,
     if (!relEntry) {
         return "";
     }
-    // First try the stored foreignDatabaseName
+    // First try the stored foreignDatabaseName. Stored names come in two
+    // shapes: "db(TYPE)" from DDL-created rel tables (bind_ddl.cpp) and the
+    // raw attached-db name from extension-registered groups. Normalize both
+    // to the "db(TYPE)" format used by getNodeForeignDatabaseName so the
+    // three-way equality check below works.
     auto storedName = relEntry->getForeignDatabaseName();
     if (!storedName.empty()) {
+        auto rawName = storedName;
+        auto parenPos = storedName.find('(');
+        if (parenPos != std::string::npos) {
+            rawName = storedName.substr(0, parenPos);
+        }
         auto dbManager = main::DatabaseManager::Get(*context);
         if (!dbManager) {
             return storedName;
         }
-        return storedName;
+        auto* attachedDB = dbManager->getAttachedDatabase(rawName);
+        if (!attachedDB) {
+            return storedName;
+        }
+        return std::format("{}({})", rawName, attachedDB->getDBType());
     }
     // For foreign rel tables, extract from storage
     auto storage = relEntry->getStorage();

--- a/src/processor/operator/scan/count_rel_table.cpp
+++ b/src/processor/operator/scan/count_rel_table.cpp
@@ -12,6 +12,7 @@
 #include "storage/table/columnar_rel_table_base.h"
 #include "storage/table/csr_chunked_node_group.h"
 #include "storage/table/csr_node_group.h"
+#include "storage/table/foreign_rel_table.h"
 #include "storage/table/rel_table_data.h"
 #include "transaction/transaction.h"
 
@@ -40,6 +41,13 @@ bool CountRelTable::getNextTuplesInternal(ExecutionContext* context) {
 
     for (auto* relTable : relTables) {
         if (dynamic_cast<ColumnarRelTableBase*>(relTable) != nullptr) {
+            totalCount += relTable->getNumTotalRows(transaction);
+            continue;
+        }
+
+        // Foreign-backed rel tables are scan-driven and own no CSR metadata.
+        // Count via the scan function (ForeignRelTable::getNumTotalRows).
+        if (dynamic_cast<ForeignRelTable*>(relTable) != nullptr) {
             totalCount += relTable->getNumTotalRows(transaction);
             continue;
         }

--- a/src/storage/table/foreign_rel_table.cpp
+++ b/src/storage/table/foreign_rel_table.cpp
@@ -1,5 +1,7 @@
 #include "storage/table/foreign_rel_table.h"
 
+#include <unordered_set>
+
 #include "function/table/table_function.h"
 #include "processor/operator/scan/scan_rel_table.h"
 #include "storage/storage_manager.h"
@@ -26,7 +28,8 @@ ForeignRelTable::ForeignRelTable(catalog::RelGroupCatalogEntry* relGroupEntry,
     const StorageManager* storageManager, MemoryManager* memoryManager,
     function::TableFunction scanFunction, std::shared_ptr<function::TableFuncBindData> scanBindData)
     : RelTable{relGroupEntry, fromTableID, toTableID, storageManager, memoryManager},
-      scanFunction{std::move(scanFunction)}, scanBindData{std::move(scanBindData)} {}
+      relGroupEntry{relGroupEntry}, scanFunction{std::move(scanFunction)},
+      scanBindData{std::move(scanBindData)} {}
 
 void ForeignRelTable::initScanState([[maybe_unused]] transaction::Transaction* transaction,
     TableScanState& scanState, [[maybe_unused]] bool resetCachedBoundNodeSelVec) const {
@@ -47,19 +50,137 @@ void ForeignRelTable::initScanState([[maybe_unused]] transaction::Transaction* t
     foreignRelScanState.localState = scanFunction.initLocalStateFunc(localInput);
 }
 
+// Raw foreign key values must be integers to be usable as node offsets.
+static int64_t readOffsetValue(const common::ValueVector& vector, common::sel_t pos) {
+    switch (vector.dataType.getLogicalTypeID()) {
+    case common::LogicalTypeID::INT64:
+        return vector.getValue<int64_t>(pos);
+    case common::LogicalTypeID::INT32:
+        return vector.getValue<int32_t>(pos);
+    default:
+        throw common::RuntimeException(
+            std::format("Foreign key columns of foreign-backed rel tables must be INT32 or INT64 "
+                        "to be usable as node offsets, got {}",
+                vector.dataType.toString()));
+    }
+}
+
 bool ForeignRelTable::scanInternal([[maybe_unused]] transaction::Transaction* transaction,
-    [[maybe_unused]] TableScanState& scanState) {
-    // Extending over a foreign-backed rel table requires translating the raw
-    // foreign-key values returned by the scan function into lbug internal node
-    // IDs. That mapping layer is not implemented yet, so a physical scan
-    // cannot produce valid extend output (vectors are wired for node IDs, not
-    // raw columns). Queries that can be rewritten by the foreign join
-    // push-down optimizer never reach this path; everything else fails fast
-    // instead of producing garbage or crashing.
-    throw common::RuntimeException(
-        std::format("MATCH traversal over foreign-backed rel table \"{}\" is not supported "
-                    "yet: the foreign key to internal ID mapping layer is not implemented",
+    TableScanState& scanState) {
+    auto& foreignRelScanState = static_cast<ForeignRelTableScanState&>(scanState);
+    if (!scanBindData || scanFunction.tableFunc == nullptr) {
+        throw common::RuntimeException(
+            std::format("Cannot scan foreign-backed rel table \"{}\" without a bound scan function",
+                tableName));
+    }
+    // The csr_rel_* contract: the src/dst scan columns contain node offsets
+    // directly (foreign keys usable as table offsets by design), so the raw
+    // values can be wrapped into internal node IDs without a mapping layer.
+    const auto srcDstPos = scanBindData->getSrcDstColumnPositions();
+    if (!srcDstPos) {
+        throw common::RuntimeException(
+            std::format("MATCH traversal over foreign-backed rel table \"{}\" is not supported: "
+                        "the foreign keys cannot be interpreted as node offsets. Register the "
+                        "table with the csr_rel_ prefix to promise offset-compatible foreign keys",
+                tableName));
+    }
+    if (foreignRelScanState.sharedState == nullptr) {
+        throw common::RuntimeException(std::format(
+            "Cannot scan foreign-backed rel table \"{}\": scan state was not initialized",
             tableName));
+    }
+
+    // Scan the foreign table into an internal chunk (one vector per scan
+    // output column), then distribute rows into the operator's vectors.
+    const auto numScanColumns = scanBindData->getNumColumns();
+    auto chunkState = std::make_shared<common::DataChunkState>();
+    common::DataChunk chunk(numScanColumns, chunkState);
+    for (auto i = 0u; i < numScanColumns; i++) {
+        chunk.valueVectors[i] = std::make_shared<common::ValueVector>(
+            scanBindData->columns[i]->dataType.copy(), memoryManager, chunkState);
+    }
+
+    const bool fwd = foreignRelScanState.direction == common::RelDataDirection::FWD;
+    const auto nbrTableID = fwd ? getToNodeTableID() : getFromNodeTableID();
+
+    // Bound node offsets for the current input batch. The operator fills
+    // nodeIDVector before each initScanState; extend output must be limited
+    // to edges whose bound-side endpoint is in this batch.
+    std::unordered_set<common::offset_t> boundOffsets;
+    if (scanState.nodeIDVector != nullptr) {
+        auto& boundVec = *scanState.nodeIDVector;
+        const auto& boundSel = boundVec.state->getSelVector();
+        for (auto i = 0u; i < boundSel.getSelSize(); i++) {
+            boundOffsets.insert(boundVec.getValue<common::nodeID_t>(boundSel[i]).offset);
+        }
+    }
+
+    // Map operator output columns (columnIDs[i] >= 1) to scan column positions.
+    std::vector<common::column_id_t> outToScanCol(scanState.outputVectors.size(),
+        common::INVALID_COLUMN_ID);
+    for (auto i = 1u; i < scanState.outputVectors.size(); i++) {
+        const auto columnID = scanState.columnIDs[i];
+        if (columnID == common::INVALID_COLUMN_ID) {
+            continue;
+        }
+        auto scanPos = 0u;
+        for (auto& property : relGroupEntry->getProperties()) {
+            if (relGroupEntry->getColumnID(property.getName()) == columnID) {
+                outToScanCol[i] = scanPos;
+                break;
+            }
+            scanPos++;
+        }
+    }
+
+    auto numEmitted = 0u;
+    for (;;) {
+        common::DataChunk dc;
+        dc.valueVectors = chunk.valueVectors;
+        dc.state = chunkState;
+        function::TableFuncOutput output{std::move(dc)};
+        function::TableFuncInput input{scanBindData.get(), foreignRelScanState.localState.get(),
+            foreignRelScanState.sharedState.get(), nullptr /* clientContext */};
+        const auto numTuples = scanFunction.tableFunc(input, output);
+        if (numTuples == 0) {
+            break;
+        }
+        // FWD scan: bound side is the src column, nbr side the dst column.
+        // BWD scan: reversed.
+        const auto boundPos = fwd ? srcDstPos->first : srcDstPos->second;
+        const auto nbrPos = fwd ? srcDstPos->second : srcDstPos->first;
+        auto& boundVec = *chunk.valueVectors[boundPos];
+        auto& nbrVec = *chunk.valueVectors[nbrPos];
+        for (common::sel_t r = 0; r < numTuples; r++) {
+            if (boundVec.isNull(r) || nbrVec.isNull(r)) {
+                continue;
+            }
+            const auto boundOffset = readOffsetValue(boundVec, r);
+            if (!boundOffsets.empty() && !boundOffsets.contains(boundOffset)) {
+                continue;
+            }
+            const auto nbrOffset = readOffsetValue(nbrVec, r);
+            // Wrap the raw foreign key value as the node offset (by design).
+            scanState.outputVectors[0]->setValue<common::nodeID_t>(numEmitted,
+                common::nodeID_t{static_cast<common::offset_t>(nbrOffset), nbrTableID});
+            for (auto i = 1u; i < scanState.outputVectors.size(); i++) {
+                if (outToScanCol[i] == common::INVALID_COLUMN_ID) {
+                    continue;
+                }
+                scanState.outputVectors[i]->copyFromVectorData(numEmitted,
+                    chunk.valueVectors[outToScanCol[i]].get(), r);
+            }
+            numEmitted++;
+        }
+        if (numEmitted > 0) {
+            break;
+        }
+    }
+    if (numEmitted == 0) {
+        return false;
+    }
+    foreignRelScanState.outState->getSelVectorUnsafe().setToUnfiltered(numEmitted);
+    return true;
 }
 
 common::row_idx_t ForeignRelTable::getNumTotalRows(

--- a/src/storage/table/foreign_rel_table.cpp
+++ b/src/storage/table/foreign_rel_table.cpp
@@ -4,6 +4,7 @@
 #include "processor/operator/scan/scan_rel_table.h"
 #include "storage/storage_manager.h"
 #include "transaction/transaction.h"
+#include <format>
 
 namespace lbug {
 namespace storage {
@@ -47,19 +48,18 @@ void ForeignRelTable::initScanState([[maybe_unused]] transaction::Transaction* t
 }
 
 bool ForeignRelTable::scanInternal([[maybe_unused]] transaction::Transaction* transaction,
-    TableScanState& scanState) {
-    auto& foreignRelScanState = static_cast<ForeignRelTableScanState&>(scanState);
-    if (!scanBindData || scanFunction.tableFunc == nullptr) {
-        return false;
-    }
-    function::TableFuncInput input{scanBindData.get(), foreignRelScanState.localState.get(),
-        foreignRelScanState.sharedState.get(), nullptr /* clientContext */};
-    common::DataChunk dc;
-    dc.valueVectors = foreignRelScanState.dataChunk.valueVectors;
-    dc.state = foreignRelScanState.dataChunk.state;
-    function::TableFuncOutput output{std::move(dc)};
-    auto numTuples = scanFunction.tableFunc(input, output);
-    return numTuples > 0;
+    [[maybe_unused]] TableScanState& scanState) {
+    // Extending over a foreign-backed rel table requires translating the raw
+    // foreign-key values returned by the scan function into lbug internal node
+    // IDs. That mapping layer is not implemented yet, so a physical scan
+    // cannot produce valid extend output (vectors are wired for node IDs, not
+    // raw columns). Queries that can be rewritten by the foreign join
+    // push-down optimizer never reach this path; everything else fails fast
+    // instead of producing garbage or crashing.
+    throw common::RuntimeException(
+        std::format("MATCH traversal over foreign-backed rel table \"{}\" is not supported "
+                    "yet: the foreign key to internal ID mapping layer is not implemented",
+            tableName));
 }
 
 common::row_idx_t ForeignRelTable::getNumTotalRows(


### PR DESCRIPTION
Fixes a segfault and a silent wrong-count found by the duckdb extension rel auto-detection tests (LadybugDB/extensions#65, duckdb_rel branch).

`MATCH` traversal over a foreign-backed rel table (`RelGroupCatalogEntry` with a scan function — the auto-detected `rel_*` / `csr_rel_*` tables) cannot work yet: the extend pipeline expects lbug internal node IDs while the foreign scan produces raw foreign-key values, and the FK→internal-ID mapping layer is not implemented (tracked as deferred work for pg_client too). Scanning through the mis-wired vectors segfaulted.

- `ForeignRelTable::scanInternal` now throws a clear `RuntimeException` instead. Queries rewritten by the foreign join push-down optimizer never reach this path.
- `CountRelTableOptimizer` no longer rewrites count plans over scan-backed rel groups: `ForeignRelTable::getNumTotalRows` is a stub returning 0, which silently produced wrong counts.
- `CountRelTable` guards `ForeignRelTable` at execution time as defense-in-depth.

Verified: duckdb_rel e2e cases pass; 249 tinysnb/multihop main tests pass.