### PR TITLE
Fix heap corruption in FTS query path when scans race committing writers

### DIFF
--- a/src/function/gds/gds_frontier.cpp
+++ b/src/function/gds/gds_frontier.cpp
@@ -1,5 +1,7 @@
 #include "function/gds/gds_frontier.h"
 
+#include <algorithm>
+
 #include "function/gds/gds_utils.h"
 #include "processor/execution_context.h"
 #include "transaction/transaction.h"
@@ -22,11 +24,12 @@ void SparseFrontier::addNode(nodeID_t nodeID, iteration_t iter) {
 
 void SparseFrontier::addNode(offset_t offset, iteration_t iter) {
     DASSERT(curData);
-    if (!curData->contains(offset)) {
-        curData->insert({offset, iter});
-    } else {
-        curData->at(offset) = iter;
-    }
+    // The underlying map can be mutated from multiple worker threads (e.g. parallel
+    // frontier tasks adding to a sparse next frontier), so map operations must be
+    // serialized. Concurrent unsynchronized mutations can rehash the map while other
+    // threads iterate/insert into it, corrupting the heap.
+    std::lock_guard lck{sparseObjects.getMtx()};
+    (*curData)[offset] = iter;
 }
 
 void SparseFrontier::addNodes(const std::vector<nodeID_t>& nodeIDs, iteration_t iter) {
@@ -38,6 +41,9 @@ void SparseFrontier::addNodes(const std::vector<nodeID_t>& nodeIDs, iteration_t 
 
 iteration_t SparseFrontier::getIteration(offset_t offset) const {
     DASSERT(curData);
+    // See SparseFrontier::addNode. Readers must be synchronized against concurrent
+    // rehashes of the underlying map.
+    std::lock_guard lck{sparseObjects.getMtx()};
     if (!curData->contains(offset)) {
         return FRONTIER_UNVISITED;
     }
@@ -50,11 +56,9 @@ void SparseFrontierReference::pinTableID(table_id_t tableID) {
 
 void SparseFrontierReference::addNode(offset_t offset, iteration_t iter) {
     DASSERT(curData);
-    if (!curData->contains(offset)) {
-        curData->insert({offset, iter});
-    } else {
-        curData->at(offset) = iter;
-    }
+    // See SparseFrontier::addNode.
+    std::lock_guard lck{sparseObjects.getMtx()};
+    (*curData)[offset] = iter;
 }
 
 void SparseFrontierReference::addNode(nodeID_t nodeID, iteration_t iter) {
@@ -71,6 +75,8 @@ void SparseFrontierReference::addNodes(const std::vector<nodeID_t>& nodeIDs, ite
 
 iteration_t SparseFrontierReference::getIteration(offset_t offset) const {
     DASSERT(curData);
+    // See SparseFrontier::getIteration.
+    std::lock_guard lck{sparseObjects.getMtx()};
     if (!curData->contains(offset)) {
         return FRONTIER_UNVISITED;
     }
@@ -87,7 +93,13 @@ public:
         return true;
     }
 
-    void vertexCompute(offset_t startOffset, offset_t endOffset, table_id_t) override {
+    void vertexCompute(offset_t startOffset, offset_t endOffset, table_id_t tableID) override {
+        // The morsel range is derived from a re-read of the table's total row count,
+        // which is not snapshot-isolated: a concurrent committing transaction can grow
+        // the table after the frontier buffer was allocated. Clamp the range to the
+        // allocated size so we never write past the end of the frontier buffer.
+        const auto allocatedSize = frontier.nodeMaxOffsetMap.at(tableID);
+        endOffset = std::min(endOffset, allocatedSize);
         for (auto i = startOffset; i < endOffset; ++i) {
             frontier.addNode(i, val);
         }
@@ -172,6 +184,13 @@ std::unique_ptr<DenseFrontier> DenseFrontier::getVisitedFrontier(ExecutionContex
     auto frontier = std::make_unique<DenseFrontier>(graph->getMaxOffsetMap(transaction));
     frontier->init(context, graph, FRONTIER_INITIAL_VISITED);
     for (auto [tableID, numNodes] : graph->getMaxOffsetMap(transaction)) {
+        // numNodes comes from a re-read of the (non-snapshot-isolated) total row count and
+        // can exceed the allocated frontier size if the table grew in between. Clamp to the
+        // allocated size to avoid writing past the end of the frontier buffer.
+        if (!frontier->nodeMaxOffsetMap.contains(tableID)) {
+            continue;
+        }
+        numNodes = std::min(numNodes, frontier->nodeMaxOffsetMap.at(tableID));
         frontier->pinTableID(tableID);
         if (maskMap->containsTableID(tableID)) {
             auto mask = maskMap->getOffsetMask(tableID);

--- a/src/include/function/gds/gds_frontier.h
+++ b/src/include/function/gds/gds_frontier.h
@@ -97,6 +97,7 @@ private:
 // Dense frontier implementation assuming the number of nodes is large.
 // Use an array of iteration number. The array is allocated to max offset
 class LBUG_API DenseFrontier : public Frontier {
+    friend class DenseFrontierInitVertexCompute;
     friend class SparseFrontier;
     friend class DenseFrontierReference;
     friend class SPFrontierPair;

--- a/src/include/function/gds/gds_object_manager.h
+++ b/src/include/function/gds/gds_object_manager.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <atomic>
+#include <mutex>
 #include <vector>
 
 #include "storage/buffer_manager/memory_manager.h"
@@ -242,8 +243,15 @@ public:
         return result;
     }
 
+    // Mutex guarding the per-table maps. The maps can be mutated (and thus rehashed)
+    // concurrently by multiple worker threads through the sparse frontier interfaces, so
+    // all accesses to the maps must hold this mutex. The mutex is shared between a
+    // sparse frontier object and all its references (which alias the same manager).
+    std::mutex& getMtx() const { return mtx; }
+
 private:
     common::table_id_map_t<std::unordered_map<common::offset_t, T>> mapPerTable;
+    mutable std::mutex mtx;
 };
 
 } // namespace function

--- a/src/transaction/transaction_manager.cpp
+++ b/src/transaction/transaction_manager.cpp
@@ -325,17 +325,10 @@ void TransactionManager::checkpointNoLock(main::ClientContext& clientContext) {
         checkpointer->rollback();
         throw CheckpointException{e};
     }
-    // Release the write gate early when WAL was rotated. New writers create a fresh active WAL
-    // isolated from the frozen checkpoint WAL, so node-data reads during checkpointStoragePhase
-    // remain bounded to snapshotTS.
-    // NOTE: HashIndexLocalStorage has no per-entry timestamps, so post-snapshotTS inserts that
-    // arrive after the gate is released may appear in the on-disk hash index while the
-    // corresponding node data was not included in this checkpoint.  This is a pre-existing
-    // limitation of the Vela design; fixing it requires adding timestamp-aware snapshotting
-    // to HashIndexLocalStorage (tracked as a follow-up).
-    if (checkpointer->wasWalRotated()) {
-        writeGate = {};
-    }
+    // NOTE: The write gate must be held until the checkpoint completes. Releasing it early
+    // (e.g. after WAL rotation) allows new write transactions to update persistent chunks'
+    // version/update info while checkpointStoragePhase is concurrently scanning and resetting
+    // those structures, which corrupts the version chains and crashes committing writers.
     try {
         checkpointer->checkpointStoragePhase();
         progress.update(0.75);

--- a/third_party/zstd/include/zstd/common/compiler.h
+++ b/third_party/zstd/include/zstd/common/compiler.h
@@ -429,6 +429,13 @@ void __msan_print_shadow(const volatile void *x, size_t size);
  * include the header file... */
 #include <stddef.h>  /* size_t */
 
+/* When the zstd sources are compiled as C++ (as done in this repository), these
+ * declarations must have C linkage to match the symbols exported by the ASan
+ * runtime; otherwise they resolve to C++-mangled names that do not exist. */
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * Marks a memory region (<c>[addr, addr+size)</c>) as unaddressable.
  *
@@ -459,6 +466,10 @@ void __asan_poison_memory_region(void const volatile *addr, size_t size);
  * \param addr Start of memory region.
  * \param size Size of memory region. */
 void __asan_unpoison_memory_region(void const volatile *addr, size_t size);
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
 #endif
 
 #endif /* ZSTD_COMPILER_H */


### PR DESCRIPTION
## Summary

Fixes three memory-safety bugs hit when concurrent `QUERY_FTS_INDEX` scans race committing writers and periodic `CHECKPOINT`s (investigated via the repro from #840 — heap corruption manifesting as `malloc(): invalid next size (unsorted)` at arbitrary allocation sites, e.g. `SparseFrontier::addNode` under the FTS `tableFunc`).

All three were confirmed with an ASAN build (`BM_MALLOC` buffer manager) running the repro workload (3 scanner threads + writer + checkpointer on an on-disk DB with an FTS index):

### 1. `DenseFrontier` out-of-bounds write

ASAN: `heap-buffer-overflow WRITE of size 2` in `DenseFrontier::addNode` from `DenseFrontierInitVertexCompute`.

`DenseFrontier` buffers are sized from `getMaxOffsetMap()` → `NodeTable::getNumTotalRows()`, which returns the *current committed* row count (`NodeGroupCollection::numTotalRows`) and is not snapshot-isolated. The parallel init vertex compute re-fetches a fresh max offset; a concurrent commit (the FTS index appends to the docs/terms tables on every `CREATE`) grows the table between the two reads, so the morsel range exceeds the allocation and the init writes past the end of the `atomic<iteration_t>` array.

**Fix:** clamp the init/visited ranges to the frontier's allocated size.

### 2. Checkpoint write gate released before the storage phase

ASAN: `InternalException` from `UpdateInfo::getUpdateNode` during writer commit, and a null-`UpdateNode` deref in `UpdateInfo::rollback` (`updates[vectorIdx]` wiped) — heap corruption in release builds.

`TransactionManager::checkpointNoLock` released the write gate after WAL rotation but *before* `checkpointStoragePhase()`. New write transactions could then mutate persistent chunks' `UpdateInfo` (the FTS insert path updates the terms-table `df` column) while the checkpointer was concurrently scanning and `resetVersionAndUpdateInfo()`-ing those same chunks.

**Fix:** hold the write gate for the entire checkpoint. (This also removes the acknowledged hash-index snapshot limitation noted in the old comment, since writers can no longer start mid-checkpoint.)

### 3. Unsynchronized `unordered_map` mutations in the GDS frontier

`SparseFrontier`/`SparseFrontierReference::addNode` mutate the per-table map with no lock while parallel frontier tasks can reach the sparse write path; concurrent rehash corrupts the heap. **Fix:** serialize via a mutex in `GDSSpareObjectManager` (shared between a sparse frontier and its references). Dense frontiers keep lock-free atomic stores.

### Build fix

The vendored zstd declares the ASan poison functions without `extern "C"`; compiled as C++ it emits an unresolvable mangled `__asan_unpoison_memory_region` symbol, so ASan builds of `liblbug.so` fail to `dlopen`. Add proper C-linkage guards.

## Extensions submodule

Bumped to include https://github.com/ladybugdb/extensions/pull/69 — `QFTSEdgeCompute` copies (one per worker thread) share the `scores` map by reference and mutated it without synchronization; now guarded by a shared mutex mirroring the existing `MatchTermsVertexCompute::resDfsMutex` pattern.

## Testing

- ASAN repro run: the frontier overflow and `UpdateInfo` corruption no longer reproduce; the original release-build crash signature (`malloc(): invalid next size (unsorted)` inside `SparseFrontier::addNode`) is resolved.
- Known remaining issue (needs a design follow-up, tracked as the core of #840): concurrent read-transaction scans can still race the checkpointer's storage phase when it rewrites/reclaims node-group chunk structures that in-flight scans reference (the original `NodeTableScanState::scanNext` SIGSEGV family). Repro crash rate on release builds dropped from ~always to ~1/3 with these fixes; the residual crashes are this remaining race.

TODO before merge: run `make test` and `make extension-test`.
