### PR TITLE
Fix memory leak on prepare() close; activate thread-local ResultSet cache

### DIFF
--- a/src/include/main/client_context.h
+++ b/src/include/main/client_context.h
@@ -129,7 +129,7 @@ public:
     AttachedLbugDatabase* getAttachedDatabase() const;
 
     const CachedPreparedStatementManager& getCachedPreparedStatementManager() const {
-        return cachedPreparedStatementManager;
+        return *cachedPreparedStatementManager;
     }
 
     bool isInMemory() const;
@@ -239,8 +239,11 @@ private:
     ClientConfig clientConfig;
     // Current query.
     ActiveQuery activeQuery;
-    // Cache prepare statement.
-    CachedPreparedStatementManager cachedPreparedStatementManager;
+    // Cache prepare statement. Shared (rather than held inline) so prepared statements can
+    // hold a weak back-reference and unregister themselves from their destructor without
+    // dangling when they outlive the client context.
+    std::shared_ptr<CachedPreparedStatementManager> cachedPreparedStatementManager =
+        std::make_shared<CachedPreparedStatementManager>();
     // Transaction context.
     std::unique_ptr<transaction::TransactionContext> transactionContext;
     // Replace external object as pointer Value;

--- a/src/include/main/prepared_statement.h
+++ b/src/include/main/prepared_statement.h
@@ -32,6 +32,8 @@ class LogicalPlan;
 
 namespace main {
 
+class CachedPreparedStatementManager;
+
 // Prepared statement cached in client context and NEVER serialized to client side.
 struct CachedPreparedStatement {
     bool useInternalCatalogEntry = false;
@@ -104,6 +106,11 @@ private:
     std::string errMsg;
     PreparedSummary preparedSummary;
     std::string cachedPreparedStatementName;
+    // Weak back-reference to the manager this statement was registered with (via
+    // ClientContext::prepareWithParams). The destructor uses it to unregister itself so the
+    // cached plan is freed promptly. Weak so that a statement destroyed after its connection
+    // (possible through the C API) does not access a freed manager.
+    std::weak_ptr<CachedPreparedStatementManager> ownerManager;
     std::unordered_set<std::string> unknownParameters;
     std::unordered_map<std::string, std::shared_ptr<common::Value>> parameterMap;
 };

--- a/src/include/main/prepared_statement_manager.h
+++ b/src/include/main/prepared_statement_manager.h
@@ -16,6 +16,11 @@ public:
 
     std::string addStatement(std::unique_ptr<CachedPreparedStatement> statement);
 
+    // Removes the cached statement registered under `name` (if any). Called when the owning
+    // PreparedStatement is destroyed, so the parsed statement, logical plan, and cached
+    // physical plan are freed instead of living until the connection is closed.
+    void removeStatement(const std::string& name);
+
     bool containsStatement(const std::string& name) const { return statementMap.contains(name); }
 
     CachedPreparedStatement* getCachedStatement(const std::string& name) const;

--- a/src/include/processor/result/result_set_descriptor.h
+++ b/src/include/processor/result/result_set_descriptor.h
@@ -30,6 +30,11 @@ struct LBUG_API ResultSetDescriptor {
     // prevention).  Thread-local ResultSet caching in ProcessorTask::run()
     // compares this ID instead of the raw pointer so that a descriptor
     // allocated at the same address as a freed one is never confused with it.
+    // copy() preserves the id: a copy semantically represents the same descriptor
+    // slot (same plan position, same content). In particular the per-execution
+    // re-attach of cached-plan sink descriptors (ClientContext::attachSinkDescriptors)
+    // must carry the same id across executions, otherwise the thread-local cache
+    // would miss on every execution of the same prepared statement.
     static inline std::atomic<uint64_t> nextID{0};
     uint64_t id;
 

--- a/src/main/client_context.cpp
+++ b/src/main/client_context.cpp
@@ -346,7 +346,8 @@ std::unique_ptr<PreparedStatement> ClientContext::prepareWithParams(std::string_
     auto [preparedStatement, cachedStatement] = prepareNoLock(parsedStatements[0],
         true /*shouldCommitNewTransaction*/, std::move(inputParamsTmp));
     preparedStatement->cachedPreparedStatementName =
-        cachedPreparedStatementManager.addStatement(std::move(cachedStatement));
+        cachedPreparedStatementManager->addStatement(std::move(cachedStatement));
+    preparedStatement->ownerManager = cachedPreparedStatementManager;
     useInternalCatalogEntry_ = false;
     return std::move(preparedStatement);
 }
@@ -384,12 +385,12 @@ std::unique_ptr<QueryResult> ClientContext::executeWithParams(PreparedStatement*
     auto name = preparedStatement->getName();
     // LCOV_EXCL_START
     // The following should never happen. But we still throw just in case.
-    if (!cachedPreparedStatementManager.containsStatement(name)) {
+    if (!cachedPreparedStatementManager->containsStatement(name)) {
         return QueryResult::getQueryResultWithError(
             std::format("Cannot find prepared statement with name {}.", name));
     }
     // LCOV_EXCL_STOP
-    auto cachedStatement = cachedPreparedStatementManager.getCachedStatement(name);
+    auto cachedStatement = cachedPreparedStatementManager->getCachedStatement(name);
     if (useCachedPlan) {
         return executeNoLock(preparedStatement, cachedStatement, queryID, {}, true);
     }

--- a/src/main/prepared_statement.cpp
+++ b/src/main/prepared_statement.cpp
@@ -3,6 +3,7 @@
 #include "binder/expression/expression.h" // IWYU pragma: keep
 #include "common/exception/binder.h"
 #include "common/types/value/value.h"
+#include "main/prepared_statement_manager.h"
 #include "planner/operator/logical_plan.h" // IWYU pragma: keep
 #include "processor/physical_plan.h"       // IWYU pragma: keep
 #include <format>
@@ -109,7 +110,18 @@ void PreparedStatement::setParameter(const std::string& name, Value value) {
     *oldValue = std::move(value);
 }
 
-PreparedStatement::~PreparedStatement() = default;
+PreparedStatement::~PreparedStatement() {
+    // Unregister from the CachedPreparedStatementManager so the cached parsed statement,
+    // logical plan, and physical plan are freed with the statement instead of living until
+    // the connection is closed (see https://github.com/LadybugDB/ladybug/issues/849).
+    // Statements that failed to prepare were never registered (empty name), and if the
+    // owning ClientContext is already gone the weak_ptr is expired - both no-ops.
+    if (!cachedPreparedStatementName.empty()) {
+        if (auto manager = ownerManager.lock()) {
+            manager->removeStatement(cachedPreparedStatementName);
+        }
+    }
+}
 
 std::unique_ptr<PreparedStatement> PreparedStatement::getPreparedStatementWithError(
     const std::string& errorMessage) {

--- a/src/main/prepared_statement_manager.cpp
+++ b/src/main/prepared_statement_manager.cpp
@@ -25,5 +25,10 @@ CachedPreparedStatement* CachedPreparedStatementManager::getCachedStatement(
     return statementMap.at(name).get();
 }
 
+void CachedPreparedStatementManager::removeStatement(const std::string& name) {
+    std::unique_lock lck{mtx};
+    statementMap.erase(name);
+}
+
 } // namespace main
 } // namespace lbug

--- a/src/processor/result/result_set.cpp
+++ b/src/processor/result/result_set.cpp
@@ -46,6 +46,14 @@ void ResultSet::resetForReuse() {
         if (dataChunk == nullptr) {
             continue;
         }
+        // Restore the DataChunkState to its freshly-constructed condition: identity
+        // (unfiltered) selection with size 1 for flat / 0 for unflat states, and no packed
+        // child slices. Producers set the real selection for each run; without this, stale
+        // filtered positions or packed slices from a prior execution would be observed by
+        // operators that assume a fresh state.
+        auto& state = dataChunk->state;
+        state->clearPackedChildSlices();
+        state->getSelVectorUnsafe().setToUnfiltered(state->isFlat() ? 1 : 0);
         for (auto& valueVector : dataChunk->valueVectors) {
             // setAllNonNull() clears any null bits the previous run may have
             // set (operators that only call setValue<T>() don't touch the null

--- a/src/processor/result/result_set_descriptor.cpp
+++ b/src/processor/result/result_set_descriptor.cpp
@@ -24,7 +24,15 @@ std::unique_ptr<ResultSetDescriptor> ResultSetDescriptor::copy() const {
         dataChunkDescriptorsCopy.push_back(
             std::make_unique<DataChunkDescriptor>(*dataChunkDescriptor));
     }
-    return std::make_unique<ResultSetDescriptor>(std::move(dataChunkDescriptorsCopy));
+    auto descriptorCopy =
+        std::make_unique<ResultSetDescriptor>(std::move(dataChunkDescriptorsCopy));
+    // A copy is the same descriptor slot with identical content (copies are never mutated
+    // afterwards), so it inherits the source's identity. This keeps the id stable across
+    // executions of a prepared statement's cached plan, letting the thread-local ResultSet
+    // cache in ProcessorTask::run() actually hit. Two live descriptors with the same id are
+    // by construction content-identical, so cache reuse remains safe.
+    descriptorCopy->id = id;
+    return descriptorCopy;
 }
 
 } // namespace processor


### PR DESCRIPTION
Fixes #849

## Problem

Every successful `prepare()` leaked memory for the lifetime of the connection:

1. **Leaked cached plan (issue #849).** `ClientContext::prepareWithParams()` registers each statement in `CachedPreparedStatementManager::statementMap`, but there was no removal method and `~PreparedStatement` never unregistered. Every `prepare()`/`close()` cycle leaked the parsed statement, logical plan and cached physical plan. `CHECKPOINT` can't help — it's a plain in-memory map. The reporter's repro (10k `MERGE` prepare+execute+destroy cycles) grew ~24 MB → ~141 MB.

2. **Thread-local ResultSet cache never hit.** The thread-local pool in `ProcessorTask::run()` (80fa473895ff) keys on `ResultSetDescriptor::id`, but `attachSinkDescriptors()` re-attaches `desc->copy()` on every execution and `copy()` minted a fresh monotonic id each call — so the cache missed on every execution of the same prepared statement and reallocated an identical `ResultSet`. Memory was released (not a leak), but the optimization was inert.

## Changes

**Commit 1 — leak fix**
- `CachedPreparedStatementManager::removeStatement()` (mutex-protected erase).
- The manager is held via `std::shared_ptr` in `ClientContext`; `PreparedStatement` holds a `weak_ptr` back-reference set at registration and unregisters from its destructor.
- `weak_ptr` (not raw) so a statement destroyed *after* its connection (possible through the C API) cannot touch a freed manager — the `weak_ptr` is expired and removal is a no-op. Failed prepares were never registered (empty name) and remain no-ops. No public API changes.

**Commit 2 — activate the thread-local cache**
- `ResultSetDescriptor::copy()` preserves the source's id: a copy is the same descriptor slot with identical content, and descriptor content is never mutated after construction. ABA protection is unaffected — ids still uniquely identify a slot; two live descriptors sharing an id are by construction content-identical.
- `ResultSet::resetForReuse()` now also restores each chunk's `DataChunkState` to its freshly-constructed condition (identity unfiltered selection, size 1 flat / 0 unflat, cleared `packedChildSlices`). With the cache now actually hitting across executions, stale selection state from a prior execution must not be observable.

## Verification

- Regression tests in #851: prepare + execute + destroy × 100 must unregister the cached entry; failed prepares released; repeated executions with overflow-buffer strings and NULLs return exact results.
- Full build green; formatted with clang-format-18.