### PR TITLE
Replace __builtin_cpu_supports("avx2") with direct CPUID/XGETBV detection

### DIFF
--- a/src/function/simd_filter.cpp
+++ b/src/function/simd_filter.cpp
@@ -7,6 +7,7 @@
 #include "common/data_chunk/sel_vector.h"
 #include "common/exception/runtime.h"
 #include "common/null_mask.h"
+#include "common/simd/cpu_features.h"
 #include "common/vector/value_vector.h"
 
 #if defined(_MSC_VER) && defined(LBUG_SIMD_COMPILED_AVX2)
@@ -169,27 +170,7 @@ bool isSupportedType(common::PhysicalTypeID type) {
 
 #if defined(LBUG_SIMD_COMPILED_AVX2)
 bool cpuSupportsAVX2() {
-#if defined(_MSC_VER)
-    int registers[4] = {};
-    __cpuid(registers, 0);
-    if (registers[0] < 7) {
-        return false;
-    }
-    __cpuidex(registers, 1, 0);
-    constexpr int OSXSAVE = 1 << 27;
-    constexpr int AVX = 1 << 28;
-    if ((registers[2] & (OSXSAVE | AVX)) != (OSXSAVE | AVX) || (_xgetbv(0) & 0x6) != 0x6) {
-        return false;
-    }
-    __cpuidex(registers, 7, 0);
-    constexpr int AVX2 = 1 << 5;
-    return (registers[1] & AVX2) != 0;
-#elif defined(__GNUC__) || defined(__clang__)
-    __builtin_cpu_init();
-    return __builtin_cpu_supports("avx2");
-#else
-    return false;
-#endif
+    return common::simd::cpuSupportsAVX2();
 }
 
 bool useAVX2() {

--- a/src/include/common/simd/cpu_features.h
+++ b/src/include/common/simd/cpu_features.h
@@ -1,0 +1,72 @@
+#pragma once
+
+#include <cstdint>
+
+#if defined(_MSC_VER) && (defined(__x86_64__) || defined(_M_X64))
+#include <intrin.h>
+#endif
+
+namespace lbug {
+namespace common {
+namespace simd {
+
+// Runtime detection of AVX2 support (CPU + OS/XSAVE enablement), callable from code that is not
+// itself compiled with AVX2 enabled. This is implemented with direct CPUID/XGETBV instead of
+// __builtin_cpu_supports() because Apple Clang lowers that builtin to a reference to the
+// __cpu_model symbol, which Apple's toolchain does not provide for x86_64 static linking
+// (https://github.com/LadybugDB/ladybug/issues/848).
+inline bool cpuSupportsAVX2() {
+#if defined(__x86_64__) || defined(_M_X64)
+#if defined(_MSC_VER)
+    int registers[4] = {};
+    __cpuid(registers, 0);
+    if (registers[0] < 7) {
+        return false;
+    }
+    __cpuidex(registers, 1, 0);
+    constexpr int OSXSAVE = 1 << 27;
+    constexpr int AVX = 1 << 28;
+    if ((registers[2] & (OSXSAVE | AVX)) != (OSXSAVE | AVX) || (_xgetbv(0) & 0x6) != 0x6) {
+        return false;
+    }
+    __cpuidex(registers, 7, 0);
+    constexpr int AVX2 = 1 << 5;
+    return (registers[1] & AVX2) != 0;
+#elif defined(__GNUC__) || defined(__clang__)
+    uint32_t maxLeaf = 0, ebx = 0, ecx = 0, edx = 0;
+    __asm__ __volatile__("cpuid" : "=a"(maxLeaf), "=b"(ebx), "=c"(ecx), "=d"(edx) : "a"(0), "c"(0));
+    if (maxLeaf < 7) {
+        return false;
+    }
+    // CPUID leaf 1: check OSXSAVE and AVX.
+    uint32_t eax = 0;
+    __asm__ __volatile__("cpuid" : "=a"(eax), "=b"(ebx), "=c"(ecx), "=d"(edx) : "a"(1), "c"(0));
+    constexpr uint32_t OSXSAVE = 1u << 27;
+    constexpr uint32_t AVX = 1u << 28;
+    if ((ecx & (OSXSAVE | AVX)) != (OSXSAVE | AVX)) {
+        return false;
+    }
+    // XGETBV(0): the OS must have enabled XMM (SSE) and YMM (AVX) state.
+    uint32_t xcr0Lo = 0, xcr0Hi = 0;
+    __asm__ __volatile__("xgetbv" : "=a"(xcr0Lo), "=d"(xcr0Hi) : "c"(0));
+    constexpr uint32_t XSTATE_SSE = 1u << 1;
+    constexpr uint32_t XSTATE_AVX = 1u << 2;
+    const uint64_t xcr0 = (static_cast<uint64_t>(xcr0Hi) << 32) | xcr0Lo;
+    if ((xcr0 & (XSTATE_SSE | XSTATE_AVX)) != (XSTATE_SSE | XSTATE_AVX)) {
+        return false;
+    }
+    // CPUID leaf 7, subleaf 0: check AVX2.
+    __asm__ __volatile__("cpuid" : "=a"(eax), "=b"(ebx), "=c"(ecx), "=d"(edx) : "a"(7), "c"(0));
+    constexpr uint32_t AVX2 = 1u << 5;
+    return (ebx & AVX2) != 0;
+#else
+    return false;
+#endif
+#else
+    return false;
+#endif
+}
+
+} // namespace simd
+} // namespace common
+} // namespace lbug

--- a/src/include/common/simd/cpu_features.h
+++ b/src/include/common/simd/cpu_features.h
@@ -15,7 +15,7 @@ namespace simd {
 // __builtin_cpu_supports() because Apple Clang lowers that builtin to a reference to the
 // __cpu_model symbol, which Apple's toolchain does not provide for x86_64 static linking
 // (https://github.com/LadybugDB/ladybug/issues/848).
-inline bool cpuSupportsAVX2() {
+inline bool detectAVX2Support() {
 #if defined(__x86_64__) || defined(_M_X64)
 #if defined(_MSC_VER)
     int registers[4] = {};
@@ -65,6 +65,12 @@ inline bool cpuSupportsAVX2() {
 #else
     return false;
 #endif
+}
+
+// Public entry point. CPUID results never change at runtime, so detect once and cache.
+inline bool cpuSupportsAVX2() {
+    static const bool supported = detectAVX2Support();
+    return supported;
 }
 
 } // namespace simd

--- a/src/processor/operator/persistent/reader/csv/base_csv_reader.cpp
+++ b/src/processor/operator/persistent/reader/csv/base_csv_reader.cpp
@@ -3,6 +3,7 @@
 #include <vector>
 
 #include "common/file_system/virtual_file_system.h"
+#include "common/simd/cpu_features.h"
 #include "common/string_utils.h"
 #include "common/system_message.h"
 #include "common/utils.h"
@@ -609,11 +610,7 @@ findNextCSVStructuralByteAVX2(const char* buffer, uint64_t position, uint64_t bu
 }
 
 static bool hasAVX2() {
-#if defined(__GNUC__) || defined(__clang__)
-    return __builtin_cpu_supports("avx2");
-#else
-    return false;
-#endif
+    return common::simd::cpuSupportsAVX2();
 }
 #endif
 


### PR DESCRIPTION
## Description

Fixes #848.

`__builtin_cpu_supports("avx2")` (used in `base_csv_reader.cpp` and `simd_filter.cpp`) is lowered by Apple Clang to a reference to the `__cpu_model` symbol from the compiler runtime. Apple's toolchain does not provide that symbol for `x86_64-apple-darwin` static linking, so source builds fail at the final link:

```text
Undefined symbols for architecture x86_64:
  "___cpu_model", referenced from:
      ... in liblbug.a(base_csv_reader.cpp.o)
```

This PR moves runtime AVX2 detection into a shared helper, `src/include/common/simd/cpu_features.h` (`common::simd::cpuSupportsAVX2()`), implemented with direct CPUID/XGETBV for all x86_64 GCC/Clang builds (mirroring the existing MSVC `__cpuid`/`_xgetbv` path). It checks:

- CPUID leaf 0: maximum standard leaf >= 7
- CPUID leaf 1: `OSXSAVE` + `AVX` feature bits
- XGETBV(0): OS has enabled XMM (SSE) and YMM (AVX) state
- CPUID leaf 7/subleaf 0: `AVX2` feature bit

This keeps identical semantics to the builtin (CPU + OS/XSAVE enablement) while removing the `__cpu_model` compiler-runtime dependency entirely, so it works uniformly on Apple Clang, upstream Clang, and GCC.

## Testing

- Rebuilt `simd_filter.cpp.o` and `base_csv_reader.cpp.o`: `nm -u` no longer shows any `__cpu_model` reference.
- e2e tests pass with the AVX2 path active: `copy~copy_snap_*`, `csv~*`, `LoadFromCSVTest` (34 tests), and filter-heavy suites under both `LBUG_SIMD=avx2` (forced AVX2, exercising the new detection) and `LBUG_SIMD=scalar` (forced scalar) — 13 tests each.
- clang-format clean on all touched files.