### PR TITLE
Fix wasm httpfs build; silence unused-template warnings

### DIFF
--- a/src/include/common/copy_constructors.h
+++ b/src/include/common/copy_constructors.h
@@ -67,7 +67,7 @@
 // NOLINTEND(bugprone-macro-parentheses):
 
 template<typename T>
-static std::vector<T> copyVector(const std::vector<T>& objects) {
+inline std::vector<T> copyVector(const std::vector<T>& objects) {
     std::vector<T> result;
     result.reserve(objects.size());
     for (auto& object : objects) {
@@ -77,7 +77,7 @@ static std::vector<T> copyVector(const std::vector<T>& objects) {
 }
 
 template<typename T>
-static std::vector<std::shared_ptr<T>> copyVector(const std::vector<std::shared_ptr<T>>& objects) {
+inline std::vector<std::shared_ptr<T>> copyVector(const std::vector<std::shared_ptr<T>>& objects) {
     std::vector<std::shared_ptr<T>> result;
     result.reserve(objects.size());
     for (auto& object : objects) {
@@ -88,7 +88,7 @@ static std::vector<std::shared_ptr<T>> copyVector(const std::vector<std::shared_
 }
 
 template<typename T>
-static std::vector<std::unique_ptr<T>> copyVector(const std::vector<std::unique_ptr<T>>& objects) {
+inline std::vector<std::unique_ptr<T>> copyVector(const std::vector<std::unique_ptr<T>>& objects) {
     std::vector<std::unique_ptr<T>> result;
     result.reserve(objects.size());
     for (auto& object : objects) {
@@ -99,7 +99,7 @@ static std::vector<std::unique_ptr<T>> copyVector(const std::vector<std::unique_
 }
 
 template<typename K, typename V>
-static std::unordered_map<K, V> copyUnorderedMap(const std::unordered_map<K, V>& objects) {
+inline std::unordered_map<K, V> copyUnorderedMap(const std::unordered_map<K, V>& objects) {
     std::unordered_map<K, V> result;
     for (auto& [k, v] : objects) {
         result.insert({k, v.copy()});
@@ -108,7 +108,7 @@ static std::unordered_map<K, V> copyUnorderedMap(const std::unordered_map<K, V>&
 }
 
 template<typename K, typename V>
-static std::map<K, V> copyMap(const std::map<K, V>& objects) {
+inline std::map<K, V> copyMap(const std::map<K, V>& objects) {
     std::map<K, V> result;
     for (auto& [k, v] : objects) {
         result.insert({k, v.copy()});


### PR DESCRIPTION
## Summary

Two build-health fixes surfaced by the wasm CI job:

1. **Wasm build failure in httpfs** — fixed via the extension submodule bump (LadybugDB/extensions#71). `HTTPFS_REMOTE_READ_OPTIMIZATIONS` is `0` on wasm, which compiles out the `PersistentBlockCache`/`PrefetchZone` declarations, but `readFromFile()` still referenced those types unconditionally, failing with:

```
error: unknown type name 'PersistentBlockCache'
error: unknown type name 'PrefetchZone'
error: use of undeclared identifier 'copySpanPortion'
error: use of undeclared identifier 'submitPrefetch'
```

2. **`-Wunused-template` warnings** from `src/include/common/copy_constructors.h` — the five copy helpers (`copyVector` ×3, `copyUnorderedMap`, `copyMap`) were `static` function templates in a header, giving them internal linkage. Any TU that includes the header without instantiating them warns; `static` in a header is also an ODR hazard. They are now `inline`.

⚠️ **Merge dependency:** merge LadybugDB/extensions#71 first; the submodule bump here points at that fix commit.

## Test plan

- `em++ -fsyntax-only -D__WASM__` on `httpfs.cpp`: all 4 errors gone.
- Native release compile of `httpfs.cpp`: clean.
- TU including `copy_constructors.h` compiles clean with `-Wunused-template -Wall -Wextra`.