### PR TITLE
Fix missing algorithm include in null mask

### DIFF
--- a/src/include/common/null_mask.h
+++ b/src/include/common/null_mask.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <algorithm>
 #include <cstdint>
 #include <memory>
 


### PR DESCRIPTION
I spotted in https://github.com/Homebrew/homebrew-core/pull/301351 that ladybug fails to build in some situations. Homebrew CI shows

```
2026-08-29T20:28:25.4356720Z ##[error]In file included from /private/tmp/ladybug-20260829-4391-uknlsk/ladybug-0.20.0/src/include/binder/bound_scan_source.h:5:
In file included from /private/tmp/ladybug-20260829-4391-uknlsk/ladybug-0.20.0/src/include/binder/bound_table_scan_info.h:4:
In file included from /private/tmp/ladybug-20260829-4391-uknlsk/ladybug-0.20.0/src/include/function/table/table_function.h:5:
In file included from /private/tmp/ladybug-20260829-4391-uknlsk/ladybug-0.20.0/src/include/common/data_chunk/data_chunk.h:8:
In file included from /private/tmp/ladybug-20260829-4391-uknlsk/ladybug-0.20.0/src/include/common/vector/value_vector.h:10:
/private/tmp/ladybug-20260829-4391-uknlsk/ladybug-0.20.0/src/include/common/null_mask.h:85:14: error: no member named 'fill' in namespace 'std'
   85 |         std::fill(data.begin(), data.end(), NO_NULL_ENTRY);
      |              ^~~~
/private/tmp/ladybug-20260829-4391-uknlsk/ladybug-0.20.0/src/include/common/null_mask.h:96:14: error: no member named 'fill' in namespace 'std'
   96 |         std::fill(data.begin(), data.end(), NO_NULL_ENTRY);
      |              ^~~~
/private/tmp/ladybug-20260829-4391-uknlsk/ladybug-0.20.0/src/include/common/null_mask.h:100:14: error: no member named 'fill' in namespace 'std'
  100 |         std::fill(data.begin(), data.end(), ALL_NULL_ENTRY);
      |              ^~~~
```

`null_mask.h` uses `std::fill` in inline methods but did not include `<algorithm>`, which declares it.

I believe the project previously built only because another included standard header happened to expose `std::fill` transitively with some compiler/standard-library versions.

This PR adds the direct `<algorithm>` include so the header is self-contained and portable.