### PR TITLE
c_api: include cstdlib for malloc

### DIFF
--- a/src/c_api/helpers.cpp
+++ b/src/c_api/helpers.cpp
@@ -1,5 +1,6 @@
 #include "c_api/helpers.h"
 
+#include <cstdlib>
 #include <cstring>
 
 #include "c_api/lbug.h"
@@ -70,7 +71,7 @@ char* takeLastCAPIErrorMessage() {
 
 char* convertToOwnedCString(const std::string& str) {
     size_t src_len = str.size();
-    auto* c_str = (char*)malloc(sizeof(char) * (src_len + 1));
+    auto* c_str = static_cast<char*>(std::malloc(sizeof(char) * (src_len + 1)));
     if (c_str == nullptr) {
         return nullptr;
     }


### PR DESCRIPTION
`src/c_api/helpers.cpp` calls `malloc` without including its declaring header.
This relied on transitive standard-library includes and fails with the macOS 14 SDK, this was spotted in https://github.com/Homebrew/homebrew-core/pull/301351.

Include `<cstdlib>` and use `std::malloc` explicitly.