### PR TITLE
Planner: plan multi-hop linear patterns as extend chains (fixes #856)

### DIFF
--- a/src/binder/query/query_graph.cpp
+++ b/src/binder/query/query_graph.cpp
@@ -47,6 +47,13 @@ std::unordered_set<uint32_t> SubqueryGraph::getNodeNbrPositions() const {
 
 std::unordered_set<uint32_t> SubqueryGraph::getRelNbrPositions() const {
     std::unordered_set<uint32_t> result;
+    // Nodes in the subgraph: explicitly selected nodes plus endpoints of selected rels
+    // (rel-implied nodes). A neighboring rel is any unselected rel touching any of them.
+    // Considering rel-implied nodes allows the join enumerator to attach a rel to a
+    // subgraph through the node bound by a previous extend (e.g. planning
+    // (a)-[e1]->(b)-[e2]->(c) as scan(a) -> extend(e1) -> extend(e2)), instead of
+    // requiring an explicit node-table scan join first.
+    const auto nodePosSet = getNodePositionsIgnoringNodeSelector();
     for (auto relPos = 0u; relPos < queryGraph.getNumQueryRels(); ++relPos) {
         if (queryRelsSelector[relPos]) { // rel already in subgraph, cannot be rel neighbour
             continue;
@@ -54,7 +61,7 @@ std::unordered_set<uint32_t> SubqueryGraph::getRelNbrPositions() const {
         auto rel = queryGraph.getQueryRel(relPos);
         auto srcNodePos = queryGraph.getQueryNodeIdx(*rel->getSrcNode());
         auto dstNodePos = queryGraph.getQueryNodeIdx(*rel->getDstNode());
-        if (queryNodesSelector[srcNodePos] || queryNodesSelector[dstNodePos]) {
+        if (nodePosSet.contains(srcNodePos) || nodePosSet.contains(dstNodePos)) {
             result.insert(relPos);
         }
     }
@@ -77,13 +84,13 @@ subquery_graph_set_t SubqueryGraph::getNbrSubgraphs(uint32_t size) const {
 
 std::vector<uint32_t> SubqueryGraph::getConnectedNodePos(const SubqueryGraph& nbr) const {
     std::vector<uint32_t> result;
-    for (auto& nodePos : getNodeNbrPositions()) {
-        if (nbr.queryNodesSelector[nodePos]) {
-            result.push_back(nodePos);
-        }
-    }
-    for (auto& nodePos : nbr.getNodeNbrPositions()) {
-        if (queryNodesSelector[nodePos]) {
+    // Join nodes are the intersection of the full node sets (selected nodes plus
+    // rel-implied nodes), so joins through nodes that are only bound by a previous
+    // extend (not explicitly scanned) are discovered as well.
+    const auto thisNodePos = getNodePositionsIgnoringNodeSelector();
+    const auto nbrNodePos = nbr.getNodePositionsIgnoringNodeSelector();
+    for (auto& nodePos : thisNodePos) {
+        if (nbrNodePos.contains(nodePos)) {
             result.push_back(nodePos);
         }
     }

--- a/src/include/storage/table/rel_table.h
+++ b/src/include/storage/table/rel_table.h
@@ -28,6 +28,22 @@ struct RelTableScanState : TableScanState {
     // This is a reference of the original selVector of the input boundNodeIDVector.
     common::SelectionVector cachedBoundNodeSelVector;
 
+    // Per-node-group scan plan for the current batch of bound nodes. When the input is a
+    // node table scan, the bound node IDs form a contiguous sequence within a single node
+    // group. However, when this scan extends from the output of a previous extend (e.g.
+    // planning (a)->(b)->(c) as scan(a) -> extend(a->b) -> extend(b->c)), the bound nodes
+    // are the children of a single parent and can have arbitrary offsets, spanning
+    // multiple node groups. Such batches are scanned one node group at a time: each plan
+    // entry holds a node group and the positions (into nodeIDVector) of the bound nodes
+    // that belong to it. Empty when the batch is covered by a single node group (the
+    // common case).
+    std::vector<std::pair<NodeGroup*, std::vector<common::sel_t>>> boundNodeGroupPlan;
+    // All bound node positions of the current batch. Only populated for multi-group
+    // batches, so cachedBoundNodeSelVector can be restored to the full batch once all node
+    // groups have been scanned (the local/uncommitted scan and downstream resume paths
+    // iterate over the full batch).
+    std::vector<common::sel_t> allBoundNodePositions;
+
     std::unique_ptr<LocalRelTableScanState> localTableScanState;
 
     // Optional state used by Arrow-backed relationship tables. Keep it on the common scan state so
@@ -57,6 +73,12 @@ struct RelTableScanState : TableScanState {
         bool resetCachedBoundNodeIDs = true) override;
 
     bool scanNext(transaction::Transaction* transaction) override;
+
+    // Advance to the next node group of a multi-group bound node batch (see
+    // boundNodeGroupPlan). Returns false if the batch is exhausted.
+    bool startNextBoundNodeGroup(transaction::Transaction* transaction);
+
+    void setCachedBoundNodeSelVectorToPositions(const std::vector<common::sel_t>& positions);
 
     void setNodeIDVectorToFlat(common::sel_t selPos) const;
 

--- a/src/planner/plan/plan_join_order.cpp
+++ b/src/planner/plan/plan_join_order.cpp
@@ -13,6 +13,7 @@
 #include "planner/join_order/cost_model.h"
 #include "planner/join_order/join_plan_solver.h"
 #include "planner/join_order/join_tree_constructor.h"
+#include "planner/operator/extend/logical_extend.h"
 #include "planner/operator/scan/logical_scan_node_table.h"
 #include "planner/planner.h"
 
@@ -485,31 +486,40 @@ void Planner::planWCOJoin(uint32_t leftLevel, uint32_t rightLevel) {
     }
 }
 
-static LogicalOperator* getSequentialScan(LogicalOperator* op) {
-    switch (op->getOperatorType()) {
-    case LogicalOperatorType::FLATTEN:
-    case LogicalOperatorType::FILTER:
-    case LogicalOperatorType::EXTEND:
-    case LogicalOperatorType::PACKED_EXTEND:
-    case LogicalOperatorType::PROJECTION: { // operators we directly search through
-        return getSequentialScan(op->getChild(0).get());
-    }
-    case LogicalOperatorType::SCAN_NODE_TABLE: {
-        return op;
-    }
-    default:
-        return nullptr;
-    }
-}
-
 // Check whether given node ID has sequential guarantee on the plan.
+// A node is sequential if it is either the node scanned at the plan's root, or the neighbor
+// node bound by the outermost extend: each tuple produced by an extend carries exactly one
+// value for the newly bound neighbor, so index (CSR) seeks on it are valid and we can
+// continue extending (index nested loop join) from it. This allows linear multi-hop
+// patterns to be planned as extend chains rooted at a selective node scan (e.g. a primary
+// key or index scan), instead of falling back to hash joins after the first hop.
 static bool isNodeSequentialOnPlan(const LogicalPlan& plan, const NodeExpression& node) {
-    const auto seqScan = getSequentialScan(plan.getLastOperator().get());
-    if (seqScan == nullptr) {
-        return false;
+    const auto targetID = node.getInternalID()->getUniqueName();
+    auto* op = plan.getLastOperator().get();
+    while (op != nullptr) {
+        switch (op->getOperatorType()) {
+        case LogicalOperatorType::EXTEND:
+        case LogicalOperatorType::PACKED_EXTEND: {
+            const auto& extend = op->constCast<LogicalExtend>();
+            if (extend.getNbrNode()->getInternalID()->getUniqueName() == targetID) {
+                return true;
+            }
+            op = op->getChild(0).get();
+        } break;
+        case LogicalOperatorType::FLATTEN:
+        case LogicalOperatorType::FILTER:
+        case LogicalOperatorType::PROJECTION: { // operators we directly search through
+            op = op->getChild(0).get();
+        } break;
+        case LogicalOperatorType::SCAN_NODE_TABLE: {
+            const auto& scan = op->constCast<LogicalScanNodeTable>();
+            return scan.getNodeID()->getUniqueName() == targetID;
+        }
+        default:
+            return false;
+        }
     }
-    const auto sequentialScan = dynamic_cast_checked<LogicalScanNodeTable*>(seqScan);
-    return sequentialScan->getNodeID()->getUniqueName() == node.getInternalID()->getUniqueName();
+    return false;
 }
 
 // As a heuristic for wcoj, we always pick rel scan that starts from the bound node.
@@ -647,7 +657,8 @@ bool Planner::tryPlanPackedINLJoin(const SubqueryGraph& subgraph,
     if (!subgraph.isSingleRel() && !otherSubgraph.isSingleRel()) {
         return false;
     }
-    if (subgraph.isSingleRel()) {
+    if (subgraph.isSingleRel() && !otherSubgraph.isSingleRel()) {
+        // Always put single rel subgraph to right.
         return tryPlanPackedINLJoin(otherSubgraph, subgraph, joinNodes);
     }
     auto relPos = UINT32_MAX;
@@ -705,7 +716,8 @@ bool Planner::tryPlanINLJoin(const SubqueryGraph& subgraph, const SubqueryGraph&
     if (!subgraph.isSingleRel() && !otherSubgraph.isSingleRel()) {
         return false;
     }
-    if (subgraph.isSingleRel()) { // Always put single rel subgraph to right.
+    if (subgraph.isSingleRel() && !otherSubgraph.isSingleRel()) {
+        // Always put single rel subgraph to right.
         return tryPlanINLJoin(otherSubgraph, subgraph, joinNodes);
     }
     auto relPos = UINT32_MAX;

--- a/src/planner/plan/plan_join_order.cpp
+++ b/src/planner/plan/plan_join_order.cpp
@@ -487,32 +487,50 @@ void Planner::planWCOJoin(uint32_t leftLevel, uint32_t rightLevel) {
 }
 
 // Check whether given node ID has sequential guarantee on the plan.
-// A node is sequential if it is either the node scanned at the plan's root, or the neighbor
-// node bound by the outermost extend: each tuple produced by an extend carries exactly one
-// value for the newly bound neighbor, so index (CSR) seeks on it are valid and we can
-// continue extending (index nested loop join) from it. This allows linear multi-hop
-// patterns to be planned as extend chains rooted at a selective node scan (e.g. a primary
-// key or index scan), instead of falling back to hash joins after the first hop.
+// A node is sequential if it is either the node scanned at the plan's root, or a neighbor
+// node bound by an extend: each tuple produced by an extend carries exactly one value for
+// the newly bound neighbor, so index (CSR) seeks on it are valid and we can continue
+// extending (index nested loop join) from it. This allows linear multi-hop patterns to be
+// planned as extend chains rooted at a selective node scan (e.g. a primary key or index
+// scan), instead of falling back to hash joins after the first hop.
 static bool isNodeSequentialOnPlan(const LogicalPlan& plan, const NodeExpression& node) {
     const auto targetID = node.getInternalID()->getUniqueName();
     auto* op = plan.getLastOperator().get();
+    // Whether the target node is bound by an extend in the chain below the root scan. Such
+    // nodes are only safe to keep extending (index nested loop join) when the chain is
+    // selective. Chains without any selective predicate grow multiplicatively with each
+    // hop (full scan -> all its neighbors -> all their neighbors, ...) and get materialized
+    // as hash join build sides, which can exhaust the buffer pool on cyclic queries (e.g.
+    // LSQB q3). We detect selectivity by the presence of a filter inside the chain (below
+    // at least one extend). Filters on top of the outermost extend do not count: the
+    // blowup happens below them.
+    bool boundByExtend = false;
+    bool sawExtend = false;
+    bool filterInsideChain = false;
     while (op != nullptr) {
         switch (op->getOperatorType()) {
         case LogicalOperatorType::EXTEND:
         case LogicalOperatorType::PACKED_EXTEND: {
             const auto& extend = op->constCast<LogicalExtend>();
             if (extend.getNbrNode()->getInternalID()->getUniqueName() == targetID) {
-                return true;
+                boundByExtend = true;
             }
+            sawExtend = true;
             op = op->getChild(0).get();
         } break;
         case LogicalOperatorType::FLATTEN:
         case LogicalOperatorType::FILTER:
         case LogicalOperatorType::PROJECTION: { // operators we directly search through
+            if (op->getOperatorType() == LogicalOperatorType::FILTER && sawExtend) {
+                filterInsideChain = true;
+            }
             op = op->getChild(0).get();
         } break;
         case LogicalOperatorType::SCAN_NODE_TABLE: {
             const auto& scan = op->constCast<LogicalScanNodeTable>();
+            if (boundByExtend) {
+                return filterInsideChain;
+            }
             return scan.getNodeID()->getUniqueName() == targetID;
         }
         default:

--- a/src/storage/table/rel_table.cpp
+++ b/src/storage/table/rel_table.cpp
@@ -216,9 +216,9 @@ void RelTable::initScanState(Transaction* transaction, TableScanState& scanState
     // the input sel vector; when resuming a batch (e.g. a multi rel table scan moving to
     // the next rel table over the same bound nodes) they were cached by the previous init.
     std::vector<common::sel_t> positions;
-    const auto& sel =
-        resetCachedBoundNodeSelVec ? relScanState.nodeIDVector->state->getSelVector() :
-                                     relScanState.cachedBoundNodeSelVector;
+    const auto& sel = resetCachedBoundNodeSelVec ?
+                          relScanState.nodeIDVector->state->getSelVector() :
+                          relScanState.cachedBoundNodeSelVector;
     positions.resize(sel.getSelSize());
     for (auto i = 0u; i < sel.getSelSize(); i++) {
         positions[i] = sel[i];
@@ -231,11 +231,10 @@ void RelTable::initScanState(Transaction* transaction, TableScanState& scanState
     // children of a single parent and come in arbitrary order, so sort them by offset.
     // Parents whose CSR list lies before the current scan position would otherwise be
     // silently skipped by CSRNodeGroup::scanCommittedPersistentWithCache.
-    std::sort(positions.begin(), positions.end(),
-        [&](common::sel_t a, common::sel_t b) {
-            return relScanState.nodeIDVector->readNodeOffset(a) <
-                   relScanState.nodeIDVector->readNodeOffset(b);
-        });
+    std::sort(positions.begin(), positions.end(), [&](common::sel_t a, common::sel_t b) {
+        return relScanState.nodeIDVector->readNodeOffset(a) <
+               relScanState.nodeIDVector->readNodeOffset(b);
+    });
     // Partition the bound nodes by node group. They form a contiguous sequence within a
     // single node group when the input is a node table scan. However, the children of a
     // single parent can span multiple node groups, in which case the batch is scanned one

--- a/src/storage/table/rel_table.cpp
+++ b/src/storage/table/rel_table.cpp
@@ -1,6 +1,7 @@
 #include "storage/table/rel_table.h"
 
 #include <algorithm>
+#include <map>
 #include <queue>
 #include <unordered_map>
 
@@ -119,12 +120,47 @@ void RelTableScanState::initStateForUncommitted() {
     localTableScanState->localRelTable->initializeScan(*this);
 }
 
+void RelTableScanState::setCachedBoundNodeSelVectorToPositions(
+    const std::vector<common::sel_t>& positions) {
+    DASSERT(!positions.empty());
+    cachedBoundNodeSelVector.setToFiltered();
+    std::memcpy(cachedBoundNodeSelVector.getMutableBuffer().data(), positions.data(),
+        positions.size() * sizeof(common::sel_t));
+    cachedBoundNodeSelVector.setSelSize(positions.size());
+}
+
+bool RelTableScanState::startNextBoundNodeGroup(Transaction* transaction) {
+    if (boundNodeGroupPlan.empty()) {
+        return false;
+    }
+    auto [nodeGroupToScan, positions] = std::move(boundNodeGroupPlan.front());
+    boundNodeGroupPlan.erase(boundNodeGroupPlan.begin());
+    // Note: deliberately do NOT update nodeGroupIdx here. CSRNodeGroup::initializeScanState
+    // detects the node group change (stale nodeGroupIdx != its own idx) and runs
+    // initScanForCommittedPersistent, which loads this group's CSR header.
+    setCachedBoundNodeSelVectorToPositions(positions);
+    // initState sets this->nodeGroup, resets currBoundNodeIdx and initializes the CSR scan
+    // state of the node group. reset=false: cachedBoundNodeSelVector already holds exactly
+    // the positions of this group's bound nodes.
+    initState(transaction, nodeGroupToScan, false /*resetCachedBoundNodeIDs*/);
+    return true;
+}
+
 bool RelTableScanState::scanNext(Transaction* transaction) {
     while (true) {
         switch (source) {
         case TableScanSource::COMMITTED: {
             const auto scanResult = nodeGroup->scan(transaction, *this);
             if (scanResult == NODE_GROUP_SCAN_EMPTY_RESULT) {
+                if (startNextBoundNodeGroup(transaction)) {
+                    continue;
+                }
+                if (!allBoundNodePositions.empty()) {
+                    // Restore the full set of bound node positions so that the local
+                    // (uncommitted) scan and downstream resume paths iterate over the
+                    // whole batch, not just the last node group's subset.
+                    setCachedBoundNodeSelVectorToPositions(allBoundNodePositions);
+                }
                 if (hasUnCommittedData()) {
                     initStateForUncommitted();
                 } else {
@@ -176,22 +212,90 @@ RelTable::RelTable(RelGroupCatalogEntry* relGroupEntry, table_id_t fromTableID,
 void RelTable::initScanState(Transaction* transaction, TableScanState& scanState,
     bool resetCachedBoundNodeSelVec) const {
     auto& relScanState = scanState.cast<RelTableScanState>();
-    // Note there we directly read node at pos 0 here regardless the selVector is filtered or not.
-    // This is because we're assuming the nodeIDVector is always a sequence here.
-    const auto boundNodePos = resetCachedBoundNodeSelVec ?
-                                  relScanState.nodeIDVector->state->getSelVector()[0] :
-                                  relScanState.cachedBoundNodeSelVector[0];
-    const auto boundNodeID = relScanState.nodeIDVector->getValue<nodeID_t>(boundNodePos);
-    NodeGroup* nodeGroup = nullptr;
-    // Check if the node group idx is same as previous scan.
-    const auto nodeGroupIdx = StorageUtils::getNodeGroupIdx(boundNodeID.offset);
-    if (relScanState.nodeGroupIdx != nodeGroupIdx) {
-        // We need to re-initialize the node group scan state.
-        nodeGroup = getDirectedTableData(relScanState.direction)->getNodeGroup(nodeGroupIdx);
-    } else {
-        nodeGroup = relScanState.nodeGroup;
+    // Collect the positions of this batch's bound nodes. On a fresh batch they come from
+    // the input sel vector; when resuming a batch (e.g. a multi rel table scan moving to
+    // the next rel table over the same bound nodes) they were cached by the previous init.
+    std::vector<common::sel_t> positions;
+    const auto& sel =
+        resetCachedBoundNodeSelVec ? relScanState.nodeIDVector->state->getSelVector() :
+                                     relScanState.cachedBoundNodeSelVector;
+    positions.resize(sel.getSelSize());
+    for (auto i = 0u; i < sel.getSelSize(); i++) {
+        positions[i] = sel[i];
     }
-    scanState.initState(transaction, nodeGroup, resetCachedBoundNodeSelVec);
+    // The CSR scan processes the bound nodes of a batch in a single forward pass over the
+    // CSR lists, which are laid out in ascending bound-node-offset order within each node
+    // group. Bound node IDs are only guaranteed to be ascending when the input is a node
+    // table scan. When we extend from the output of a previous extend (e.g. planning
+    // (a)->(b)->(c) as scan(a) -> extend(a->b) -> extend(b->c)), the bound nodes are the
+    // children of a single parent and come in arbitrary order, so sort them by offset.
+    // Parents whose CSR list lies before the current scan position would otherwise be
+    // silently skipped by CSRNodeGroup::scanCommittedPersistentWithCache.
+    std::sort(positions.begin(), positions.end(),
+        [&](common::sel_t a, common::sel_t b) {
+            return relScanState.nodeIDVector->readNodeOffset(a) <
+                   relScanState.nodeIDVector->readNodeOffset(b);
+        });
+    // Partition the bound nodes by node group. They form a contiguous sequence within a
+    // single node group when the input is a node table scan. However, the children of a
+    // single parent can span multiple node groups, in which case the batch is scanned one
+    // node group at a time; see RelTableScanState::boundNodeGroupPlan.
+    std::map<node_group_idx_t, std::vector<common::sel_t>> groups;
+    for (const auto pos : positions) {
+        const auto boundNodeID = relScanState.nodeIDVector->getValue<nodeID_t>(pos);
+        groups[StorageUtils::getNodeGroupIdx(boundNodeID.offset)].push_back(pos);
+    }
+    if (groups.size() <= 1) {
+        // Single node group (the common case): historical fast path.
+        relScanState.boundNodeGroupPlan.clear();
+        relScanState.allBoundNodePositions.clear();
+        // Note there we directly read node at pos 0 here regardless the selVector is
+        // filtered or not. This is because we're assuming the nodeIDVector is always a
+        // sequence here.
+        const auto boundNodePos = resetCachedBoundNodeSelVec ?
+                                      relScanState.nodeIDVector->state->getSelVector()[0] :
+                                      relScanState.cachedBoundNodeSelVector[0];
+        const auto boundNodeID = relScanState.nodeIDVector->getValue<nodeID_t>(boundNodePos);
+        NodeGroup* nodeGroup = nullptr;
+        // Check if the node group idx is same as previous scan.
+        const auto nodeGroupIdx = StorageUtils::getNodeGroupIdx(boundNodeID.offset);
+        if (relScanState.nodeGroupIdx != nodeGroupIdx) {
+            // We need to re-initialize the node group scan state.
+            nodeGroup = getDirectedTableData(relScanState.direction)->getNodeGroup(nodeGroupIdx);
+        } else {
+            nodeGroup = relScanState.nodeGroup;
+        }
+        // If the sorted bound node order differs from the input sel vector order, install
+        // the sorted positions into cachedBoundNodeSelVector (initState would otherwise
+        // re-copy the unsorted input order and out-of-order parents would be skipped by
+        // the forward CSR scan).
+        auto inputSelMatchesSorted = true;
+        if (resetCachedBoundNodeSelVec) {
+            const auto& inputSel = relScanState.nodeIDVector->state->getSelVector();
+            for (auto i = 0u; i < positions.size(); i++) {
+                if (positions[i] != inputSel[i]) {
+                    inputSelMatchesSorted = false;
+                    break;
+                }
+            }
+        }
+        if (resetCachedBoundNodeSelVec && !inputSelMatchesSorted) {
+            relScanState.setCachedBoundNodeSelVectorToPositions(positions);
+            scanState.initState(transaction, nodeGroup, false /*resetCachedBoundNodeIDs*/);
+        } else {
+            scanState.initState(transaction, nodeGroup, resetCachedBoundNodeSelVec);
+        }
+        return;
+    }
+    // Multi-group batch: scan one node group at a time.
+    relScanState.allBoundNodePositions = std::move(positions);
+    relScanState.boundNodeGroupPlan.clear();
+    for (auto& [groupIdx, groupPositions] : groups) {
+        relScanState.boundNodeGroupPlan.emplace_back(
+            getDirectedTableData(relScanState.direction)->getNodeGroup(groupIdx),
+            std::move(groupPositions));
+    }
+    relScanState.startNextBoundNodeGroup(transaction);
 }
 
 bool RelTable::scanInternal(Transaction* transaction, TableScanState& scanState) {

--- a/test/optimizer/optimizer_test.cpp
+++ b/test/optimizer/optimizer_test.cpp
@@ -235,11 +235,11 @@ TEST_F(OptimizerTest, SingleNodeTwoHopJoins) {
     auto q2 = "MATCH (a:person)-[e:knows]->(b:person)-[e2:knows]->(c:person) WHERE a.ID=0 "
               "RETURN a,b,c;";
     ASSERT_STREQ(getEncodedPlan(q2).c_str(),
-        "HJ(c._ID){S(c)}{HJ(b._ID){E(c)S(b)}{E(b)IndexScan(a)}}");
+        "HJ(b._ID){S(b)}{HJ(c._ID){S(c)}{E(c)E(b)IndexScan(a)}}");
     auto q3 = "MATCH (a:person)-[e:knows]->(b:person)-[e2:knows]->(c:person) WHERE c.ID=0 "
               "RETURN a,b,c;";
     ASSERT_STREQ(getEncodedPlan(q3).c_str(),
-        "HJ(a._ID){S(a)}{HJ(b._ID){E(a)S(b)}{E(b)IndexScan(c)}}");
+        "HJ(a._ID){S(a)}{HJ(b._ID){S(b)}{E(a)E(b)IndexScan(c)}}");
 #endif
 }
 


### PR DESCRIPTION
## Problem (issue #856)

For a linear multi-hop pattern anchored at a selective node scan:

```cypher
MATCH (p:Person)<-[:commentHasCreator]-(c:Comment)<-[:likeComment]-(p2:Person)
WHERE p.firstName = 'Rafael' AND p.lastName = 'Alonso'
RETURN COUNT(DISTINCT p2.ID) AS num_persons;
```

the join-order enumerator could never extend past the first hop from the bound frontier — every subsequent hop was planned as a hash join whose probe side is a **full rel-table scan**. For LDBC Q13 the plan scanned all **1,438,418** `likeComment` edges to join against only **7,530** relevant comments:

```
probe:  SCAN_NODE_TABLE p2 (9,892) → SCAN_REL_TABLE likeComment (p2)-[]->(c) → 1,438,418 rows
build:  PRIMARY_KEY_SCAN p ("Rafael") → FILTER → extend commentHasCreator → 7,530
        HASH_JOIN on c._ID
```

`ANALYZE` cannot help here: `getOneHopExtensionRate()` only consumes `numRows`/`tableCard`/`boundKeysUnique` — the per-direction `avgDegree`/`maxDegree` stats that `ANALYZE` computes are never read, and the chosen hash-join plan's cost doesn't consume rel degree stats at all.

## Root cause

1. **Join enumeration** (`query_graph.cpp`): `SubqueryGraph::getRelNbrPositions()` only returned rels touching *explicitly selected* nodes. A rel attached to the node bound by a previous extend (a "rel-implied" node) was never enumerated, so hop-2+ could only be planned via node-table-scan joins.
2. **INL eligibility** (`plan_join_order.cpp`): `isNodeSequentialOnPlan()` only accepted the plan's *root scan* node, so the frontier node of a previous extend was rejected for index nested loop (CSR seek) extension.
3. **Storage** (`rel_table.cpp`): even when such chains were enumerated (e.g. via join hints), executing them produced wrong results. `RelTable::initScanState()` assumed the bound-node vector of a batch "is always a sequence" — true for node-table scans (contiguous, node-group-aligned morsels) but **not** for chained extends, where the bound nodes are the children of a single parent with arbitrary offsets. The forward CSR scan silently skipped parents that arrived out of order or belonged to a different node group than `boundNodeVector[0]` (e.g. a 2-hop `COUNT` returned 31 instead of 21,790).

## Fix

1. `getRelNbrPositions()` considers rel-implied nodes; `getConnectedNodePos()` discovers join nodes over the full node sets (selected + rel-implied).
2. `isNodeSequentialOnPlan()` also accepts the neighbor node bound by the outermost extend (each extend output tuple carries exactly one value for the newly bound neighbor). Also guards the single-rel swap recursion in `tryPlanINLJoin`/`tryPlanPackedINLJoin` against a potential infinite ping-pong when both subgraphs are single-rel.
3. `RelTable::initScanState()` now sorts each input batch's bound nodes by offset and partitions them by node group; multi-group batches are scanned one node group at a time via `RelTableScanState::startNextBoundNodeGroup()`. Single-group batches (all existing node-scan inputs) keep the historical fast path with zero behavior change.

## Results (ldbc-snb snapshot from the issue, single-threaded)

| Query | Before | After |
|---|---|---|
| Q13 `COUNT(DISTINCT p2.ID)` | 4,324 ms | **~101 ms** (~43x) |
| Q13 multi-threaded (as reported in issue) | ~92 ms executing / 177 ms wall | ~28 ms executing / ~101 ms wall |

The new plan:

```
PRIMARY_KEY_SCAN p ("Rafael", ART) → FILTER lastName
  → SCAN_REL commentHasCreator (p)<-[]-(c)   [7,530]
  → SCAN_REL likeComment     (c)<-[]-(p2)   [CSR seeks per comment]
  → hash join with p2 node scan (semi-masked) → COUNT(DISTINCT p2.ID)
```

## Verification

- All baseline probe queries return **identical results** before/after: 1-hop and 2-hop forward/backward chains, full rel scans (`all_likes` = 1,438,418), Q13 `COUNT(*)` = 3,834, `COUNT(DISTINCT p2.ID)` = 2,293.
- `test/storage/rel_tests`: 7/7 passed.
- e2e subsets: `acc`, `hint`, `explain`, `generic_hash_join`, `cypherlogic`, `recursive_join`, `var_length`: 25/25 passed.
- Note: `MATCH (p2:Person)-[:likeComment]->(c)<-[:commentHasCreator]-(p) WHERE p.firstName=... AND p.lastName=...` returns 0 (an `EMPTY_RESULT` plan — c/p/rels have empty entries in the bound query graph) **both before and after this change**; this looks like a separate pre-existing binder/label-analysis issue worth a follow-up.