### PR TITLE
Add missing standard library includes for libc++ 23

### DIFF
--- a/src/c_api/helpers.cpp
+++ b/src/c_api/helpers.cpp
@@ -1,5 +1,6 @@
 #include "c_api/helpers.h"
 
+#include <cstdlib>
 #include <cstring>
 
 #include "c_api/lbug.h"

--- a/src/include/common/task_system/task.h
+++ b/src/include/common/task_system/task.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <condition_variable>
+#include <exception>
 #include <mutex>
 #include <vector>
 

--- a/src/include/function/array/functions/array_distance.h
+++ b/src/include/function/array/functions/array_distance.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "math.h"
+#include <cmath>
 
 #include "common/vector/value_vector.h"
 #include "function/array/functions/array_squared_distance.h"

--- a/src/include/function/list/functions/base_list_sort_function.h
+++ b/src/include/function/list/functions/base_list_sort_function.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <algorithm>
+
 #include "common/exception/runtime.h"
 #include "common/string_utils.h"
 #include "common/vector/value_vector.h"

--- a/src/include/main/prepared_statement_manager.h
+++ b/src/include/main/prepared_statement_manager.h
@@ -2,6 +2,7 @@
 
 #include <memory>
 #include <mutex>
+#include <string>
 #include <unordered_map>
 
 namespace lbug {

--- a/src/processor/operator/aggregate/base_aggregate.cpp
+++ b/src/processor/operator/aggregate/base_aggregate.cpp
@@ -2,6 +2,7 @@
 
 #include "main/client_context.h"
 #include "processor/operator/aggregate/aggregate_hash_table.h"
+#include <bit>
 
 using namespace lbug::function;
 

--- a/src/processor/result/base_hash_table.cpp
+++ b/src/processor/result/base_hash_table.cpp
@@ -1,6 +1,6 @@
 #include "processor/result/base_hash_table.h"
 
-#include "math.h"
+#include <cmath>
 
 #include "common/constants.h"
 #include "common/null_buffer.h"


### PR DESCRIPTION
libc++ 23 dropped several transitive includes, so building with LLVM 23 fails on missing `malloc`, `std::exception_ptr`, `std::bit_width`, and similar. This adds the headers each file actually uses, and switches two files from `"math.h"` to `<cmath>` since they call `std::sqrt`/`std::log2`.

Follow-up to b8b2436. Verified with LLVM 23.1.0 and Apple clang 21.