### PR TITLE
Fix SIGSEGV re-executing a parameterized write query string (#862)

### DIFF
--- a/src/processor/result/factorized_table.cpp
+++ b/src/processor/result/factorized_table.cpp
@@ -333,6 +333,13 @@ void FactorizedTable::setNonOverflowColNull(uint8_t* nullBuffer, ft_col_idx_t co
 }
 
 void FactorizedTable::clear() {
+    if (tableSchema.isEmpty()) {
+        // Tables with an empty schema (e.g. the root ResultCollector of a CREATE / DDL
+        // statement) never allocate block collections or an overflow buffer; there is
+        // nothing to reset. Mirrors the constructor, which skips allocation entirely for
+        // an empty schema.
+        return;
+    }
     numTuples = 0;
     // Reuse the first DataBlock (zeroed) and drop the rest. This skips the
     // 256KB malloc on the next append while preserving the dense-packing

--- a/test/api/prepare_test.cpp
+++ b/test/api/prepare_test.cpp
@@ -470,3 +470,74 @@ TEST_F(ApiTest, RepeatedExecutePreparedStatementVariableLengthResults) {
             << "run " << run;
     }
 }
+
+// Regression test for https://github.com/LadybugDB/ladybug/issues/862: re-executing the
+// prepared statement of the same parameterized write query string (which takes the cached
+// physical-plan fast path once the statement was prepared WITH its parameters) crashed with
+// SIGSEGV. The root ResultCollector of a write statement has an empty result schema, so its
+// FactorizedTable never allocates block collections or an overflow buffer; clear() in
+// prepareForReuse() dereferenced the null collection.
+static std::unordered_map<std::string, std::unique_ptr<Value>> makeIdValueParams(int64_t id,
+    std::string val) {
+    std::unordered_map<std::string, std::unique_ptr<Value>> params;
+    params["id"] = std::make_unique<Value>(id);
+    params["val"] = std::make_unique<Value>(std::move(val));
+    return params;
+}
+
+TEST_F(ApiTest, RepeatedExecuteCachedPlanParameterizedWrite) {
+    ASSERT_TRUE(
+        conn->query("CREATE NODE TABLE Log(id INT64, value STRING, PRIMARY KEY(id))")->isSuccess());
+
+    // Parameterized CREATE, same statement executed repeatedly (fast path on every run but
+    // the first).
+    const std::string createQuery = "CREATE (:Log {id: $id, value: $val})";
+    auto createStmt = conn->prepareWithParams(createQuery, makeIdValueParams(1, "a"));
+    ASSERT_TRUE(createStmt->isSuccess());
+    for (auto run = 0u; run < 3; run++) {
+        auto result = conn->executeWithParams(createStmt.get(),
+            makeIdValueParams(run + 1, "v" + std::to_string(run)));
+        ASSERT_TRUE(result->isSuccess()) << "run " << run;
+    }
+
+    // Parameterized MATCH ... SET, same statement executed repeatedly.
+    const std::string setQuery = "MATCH (l:Log) WHERE l.id = $id SET l.value = $val";
+    auto setStmt = conn->prepareWithParams(setQuery, makeIdValueParams(1, "x"));
+    ASSERT_TRUE(setStmt->isSuccess());
+    for (auto run = 0u; run < 2; run++) {
+        auto result = conn->executeWithParams(setStmt.get(),
+            makeIdValueParams(run + 1, "x" + std::to_string(run)));
+        ASSERT_TRUE(result->isSuccess()) << "run " << run;
+    }
+
+    // Same string writes inside an explicit transaction.
+    ASSERT_TRUE(conn->query("BEGIN TRANSACTION")->isSuccess());
+    auto txStmt = conn->prepareWithParams(createQuery, makeIdValueParams(10, "t1"));
+    ASSERT_TRUE(txStmt->isSuccess());
+    for (auto run = 0u; run < 2; run++) {
+        auto result = conn->executeWithParams(txStmt.get(),
+            makeIdValueParams(10 + run, "t" + std::to_string(run)));
+        ASSERT_TRUE(result->isSuccess()) << "run " << run;
+    }
+    ASSERT_TRUE(conn->query("COMMIT")->isSuccess());
+
+    ASSERT_EQ(std::vector<std::string>{"5"},
+        TestHelper::convertResultToString(*conn->query("MATCH (l:Log) RETURN COUNT(l)")));
+}
+
+TEST_F(ApiTest, RepeatedExecuteCachedPlanParameterizedRead) {
+    createItemTableWithArtIndex(conn.get());
+    ASSERT_TRUE(conn->query("CREATE (:Item {id: 1, name: 'a', price: 1.0})")->isSuccess());
+
+    // Reads through the fast path must keep working too (they were unaffected by #862, but
+    // guard the empty-schema fix against regressing the non-empty-schema case).
+    auto readStmt = conn->prepareWithParams("MATCH (i:Item) WHERE i.id = $id RETURN i.name",
+        makeIdValueParams(1, "a"));
+    ASSERT_TRUE(readStmt->isSuccess());
+    for (auto run = 0u; run < 3; run++) {
+        auto result = conn->executeWithParams(readStmt.get(), makeIdValueParams(1, "a"));
+        ASSERT_TRUE(result->isSuccess()) << "run " << run;
+        ASSERT_EQ(std::vector<std::string>{"a"}, TestHelper::convertResultToString(*result))
+            << "run " << run;
+    }
+}


### PR DESCRIPTION
## Summary

Calling `Connection.execute(<query string>, <params>)` twice with the same string for a parameterized **write** query segfaulted on the second call (0.20.0 regression, #862). Reads and the explicit `prepare()`-without-params path were unaffected.

```python
conn.execute("CREATE (:Log {id: $id, value: $val})", {"id": 1, "val": "a"})  # ok
conn.execute("CREATE (:Log {id: $id, value: $val})", {"id": 2, "val": "b"})  # SIGSEGV
```

## Root cause

The Python string+params path implicitly prepares *with* its parameters bound, so the second execution takes the cached-physical-plan fast path in `ClientContext::executeNoLock()`, which calls `prepareForReuse()` on the cloned plan. That reaches `ResultCollector::prepareForReuse()` → `FactorizedTable::clear()`.

For a write statement, the plan's root `ResultCollector` has an **empty result schema** (writes return no columns). `FactorizedTable`'s constructor skips allocating `flatTupleBlockCollection` / `unFlatTupleBlockCollection` / `inMemOverflowBuffer` entirely when the schema is empty, but `clear()` unconditionally dereferenced the null `flatTupleBlockCollection` — null-pointer SIGSEGV.

This explains every variant in the issue:
- reads are unaffected (non-empty result schema → allocations exist)
- `prepare()` once + `execute()` twice is unaffected (`unknownParameters` non-empty → `canReuseCachedPlanWith()` returns false → rebind path, no `prepareForReuse()`)
- transactions change nothing (the fast path is used inside them too)

## Fix

`FactorizedTable::clear()` now early-returns for empty-schema tables, mirroring the constructor's guard. No behavior change for tables that do allocate.

## Testing

- New regression tests in `test/api/prepare_test.cpp`:
  - `RepeatedExecuteCachedPlanParameterizedWrite`: parameterized `CREATE` ×3, parameterized `MATCH ... SET` ×2, writes inside `BEGIN TRANSACTION`/`COMMIT`, final row-count verification
  - `RepeatedExecuteCachedPlanParameterizedRead`: guards the non-empty-schema path through the fast path
- Verified the issue's reproducer (ASAN) crashes before the fix and passes after, along with all variants from the issue (extra-space, DDL via string path, 3rd+ executions)
- Full ASAN `api_test` suite: 283/283 passed; clang-format clean

Fixes #862