### PR TITLE
Fix silent row loss when LOAD FROM/UNWIND feeds a MATCH primary key predicate

### DIFF
--- a/src/include/optimizer/logical_operator_visitor.h
+++ b/src/include/optimizer/logical_operator_visitor.h
@@ -93,6 +93,12 @@ protected:
         return op;
     }
 
+    virtual void visitIndexLookUp(planner::LogicalOperator* /*op*/) {}
+    virtual std::shared_ptr<planner::LogicalOperator> visitIndexLookUpReplace(
+        std::shared_ptr<planner::LogicalOperator> op) {
+        return op;
+    }
+
     virtual void visitIntersect(planner::LogicalOperator* /*op*/) {}
     virtual std::shared_ptr<planner::LogicalOperator> visitIntersectReplace(
         std::shared_ptr<planner::LogicalOperator> op) {
@@ -191,6 +197,12 @@ protected:
 
     virtual void visitUnwind(planner::LogicalOperator* /*op*/) {}
     virtual std::shared_ptr<planner::LogicalOperator> visitUnwindReplace(
+        std::shared_ptr<planner::LogicalOperator> op) {
+        return op;
+    }
+
+    virtual void visitUnwindDeduplicate(planner::LogicalOperator* /*op*/) {}
+    virtual std::shared_ptr<planner::LogicalOperator> visitUnwindDeduplicateReplace(
         std::shared_ptr<planner::LogicalOperator> op) {
         return op;
     }

--- a/src/include/optimizer/projection_push_down_optimizer.h
+++ b/src/include/optimizer/projection_push_down_optimizer.h
@@ -36,10 +36,12 @@ private:
     void visitFilter(planner::LogicalOperator* op) override;
     void visitNodeLabelFilter(planner::LogicalOperator* op) override;
     void visitHashJoin(planner::LogicalOperator* op) override;
+    void visitIndexLookUp(planner::LogicalOperator* op) override;
     void visitIntersect(planner::LogicalOperator* op) override;
     void visitProjection(planner::LogicalOperator* op) override;
     void visitOrderBy(planner::LogicalOperator* op) override;
     void visitUnwind(planner::LogicalOperator* op) override;
+    void visitUnwindDeduplicate(planner::LogicalOperator* op) override;
     void visitQueryPrimaryKeyLookup(planner::LogicalOperator* op) override;
     void visitSetProperty(planner::LogicalOperator* op) override;
     void visitInsert(planner::LogicalOperator* op) override;

--- a/src/include/optimizer/projection_push_down_optimizer.h
+++ b/src/include/optimizer/projection_push_down_optimizer.h
@@ -40,6 +40,7 @@ private:
     void visitProjection(planner::LogicalOperator* op) override;
     void visitOrderBy(planner::LogicalOperator* op) override;
     void visitUnwind(planner::LogicalOperator* op) override;
+    void visitQueryPrimaryKeyLookup(planner::LogicalOperator* op) override;
     void visitSetProperty(planner::LogicalOperator* op) override;
     void visitInsert(planner::LogicalOperator* op) override;
     void visitDelete(planner::LogicalOperator* op) override;

--- a/src/optimizer/logical_operator_visitor.cpp
+++ b/src/optimizer/logical_operator_visitor.cpp
@@ -46,6 +46,9 @@ void LogicalOperatorVisitor::visitOperatorSwitch(LogicalOperator* op) {
     case LogicalOperatorType::HASH_JOIN: {
         visitHashJoin(op);
     } break;
+    case LogicalOperatorType::INDEX_LOOK_UP: {
+        visitIndexLookUp(op);
+    } break;
     case LogicalOperatorType::INTERSECT: {
         visitIntersect(op);
     } break;
@@ -96,6 +99,9 @@ void LogicalOperatorVisitor::visitOperatorSwitch(LogicalOperator* op) {
     } break;
     case LogicalOperatorType::UNWIND: {
         visitUnwind(op);
+    } break;
+    case LogicalOperatorType::UNWIND_DEDUPLICATE: {
+        visitUnwindDeduplicate(op);
     } break;
     case LogicalOperatorType::CROSS_PRODUCT: {
         visitCrossProduct(op);

--- a/src/optimizer/projection_push_down_optimizer.cpp
+++ b/src/optimizer/projection_push_down_optimizer.cpp
@@ -23,6 +23,7 @@
 #include "planner/operator/persistent/logical_insert.h"
 #include "planner/operator/persistent/logical_merge.h"
 #include "planner/operator/persistent/logical_set.h"
+#include "planner/operator/scan/logical_query_primary_key_lookup.h"
 
 using namespace lbug::common;
 using namespace lbug::planner;
@@ -185,6 +186,15 @@ void ProjectionPushDownOptimizer::visitOrderBy(LogicalOperator* op) {
 void ProjectionPushDownOptimizer::visitUnwind(LogicalOperator* op) {
     auto& unwind = op->constCast<LogicalUnwind>();
     collectExpressionsInUse(unwind.getInExpr());
+}
+
+void ProjectionPushDownOptimizer::visitQueryPrimaryKeyLookup(LogicalOperator* op) {
+    auto& lookup = op->constCast<LogicalQueryPrimaryKeyLookup>();
+    // The key expression is evaluated on top of the child pipeline (e.g. a table function
+    // scan). If it is not collected here, the scan column it references may be pruned,
+    // causing the key to silently evaluate to NULL and the lookup to return no rows.
+    collectExpressionsInUse(lookup.getKey());
+    collectExpressionsInUse(lookup.getNodeID());
 }
 
 void ProjectionPushDownOptimizer::visitInsert(LogicalOperator* op) {

--- a/src/optimizer/projection_push_down_optimizer.cpp
+++ b/src/optimizer/projection_push_down_optimizer.cpp
@@ -18,11 +18,13 @@
 #include "planner/operator/logical_projection.h"
 #include "planner/operator/logical_table_function_call.h"
 #include "planner/operator/logical_unwind.h"
+#include "planner/operator/logical_unwind_deduplicate.h"
 #include "planner/operator/persistent/logical_copy_from.h"
 #include "planner/operator/persistent/logical_delete.h"
 #include "planner/operator/persistent/logical_insert.h"
 #include "planner/operator/persistent/logical_merge.h"
 #include "planner/operator/persistent/logical_set.h"
+#include "planner/operator/scan/logical_index_look_up.h"
 #include "planner/operator/scan/logical_query_primary_key_lookup.h"
 
 using namespace lbug::common;
@@ -122,6 +124,20 @@ void ProjectionPushDownOptimizer::visitHashJoin(LogicalOperator* op) {
     preAppendProjection(op, 1, expressionsAfterPruning);
 }
 
+void ProjectionPushDownOptimizer::visitIndexLookUp(LogicalOperator* op) {
+    auto& indexLookup = op->constCast<LogicalPrimaryKeyLookup>();
+    // The lookup key is evaluated on top of the child pipeline (the copy-from source scan). If
+    // it is not collected here, the source column it references may be pruned, causing the key
+    // to silently evaluate to NULL and the lookup to produce no offsets.
+    for (auto i = 0u; i < indexLookup.getNumInfos(); ++i) {
+        const auto& info = indexLookup.getInfo(i);
+        collectExpressionsInUse(info.key);
+        for (auto& warningExpr : info.warningExprs) {
+            collectExpressionsInUse(warningExpr);
+        }
+    }
+}
+
 void ProjectionPushDownOptimizer::visitIntersect(LogicalOperator* op) {
     auto& intersect = op->constCast<LogicalIntersect>();
     collectExpressionsInUse(intersect.getIntersectNodeID());
@@ -195,6 +211,14 @@ void ProjectionPushDownOptimizer::visitQueryPrimaryKeyLookup(LogicalOperator* op
     // causing the key to silently evaluate to NULL and the lookup to return no rows.
     collectExpressionsInUse(lookup.getKey());
     collectExpressionsInUse(lookup.getNodeID());
+}
+
+void ProjectionPushDownOptimizer::visitUnwindDeduplicate(LogicalOperator* op) {
+    auto& dedup = op->constCast<LogicalUnwindDeduplicate>();
+    // Deduplication keys are consumed by this operator but are not part of its output schema.
+    for (auto& key : dedup.getKeyExpressions()) {
+        collectExpressionsInUse(key);
+    }
 }
 
 void ProjectionPushDownOptimizer::visitInsert(LogicalOperator* op) {

--- a/test/test_files/load_from/load_from.test
+++ b/test/test_files/load_from/load_from.test
@@ -200,3 +200,18 @@ Binder exception: Number of columns mismatch. Expected .+
 ---- 2
 Adam|30|2020-06-22
 Karissa|40|2019-05-12
+
+-LOG LoadFromMatchOnPrimaryKey
+-STATEMENT LOAD FROM "${LBUG_ROOT_DIRECTORY}/dataset/tinysnb/vPerson.csv" (header=true) MATCH (p:person {ID: id}) RETURN COUNT(*);
+---- 1
+5
+-STATEMENT LOAD FROM "${LBUG_ROOT_DIRECTORY}/dataset/tinysnb/vPerson.csv" (header=true) MATCH (p:person) WHERE p.ID = id RETURN COUNT(*);
+---- 1
+5
+-STATEMENT LOAD FROM "${LBUG_ROOT_DIRECTORY}/dataset/tinysnb/vPerson.csv" (header=true) MATCH (p:person {ID: id}) SET p.fName = fName RETURN p.fName ORDER BY id;
+---- 5
+Alice
+Bob
+Carol
+Dan
+Elizabeth


### PR DESCRIPTION
## Summary

Fixes #861

`LOAD FROM <source>` followed directly by `MATCH (n:Label {pk: col})` — where `col` is a scan column — matched **zero rows** silently on 0.19.0–0.20.0. No error was raised, the query reported success, and any `SET`/`MERGE` hanging off the `MATCH` never executed:

```cypher
LOAD FROM 'updates.csv' (header=true)
MATCH (p:Products {handle: handle})
SET p.description = description
RETURN p.handle   -- 0 rows; p.description unchanged
```

## Root cause

The planner legitimately rewrites a single-node `MATCH` with a primary-key equality predicate into a `QUERY_PRIMARY_KEY_LOOKUP` whose key is evaluated on top of the outer (scan) pipeline. However, `ProjectionPushDownOptimizer` never visited `LogicalQueryPrimaryKeyLookup`, so its **key expression was never collected as in-use**. `visitTableFunctionCall` then marked the referenced scan column as skippable (`columnSkips`) and the physical scan stopped writing that vector. The key evaluator subsequently read an unwritten vector, the key evaluated to NULL for every row, `lookupPK` failed, and the lookup returned an empty result — silently.

This also explains the report's observations:

- `LOAD FROM df MATCH (p:Products {handle: handle}) SET ...` failed silently (the key column was pruned from the scan).
- An explicit `WITH handle AS h` between the scan and the `MATCH` worked: the intermediate `PROJECTION` starts a fresh push-down pass that keeps the column alive.
- Matching on a **non-primary-key** property (`{description: description}`) worked: it becomes a regular filter, which collects its predicate.
- `MATCH (p:Products {handle: 'a'})` (literal key) worked: no outer dependency, no pruning.

## Fix

Override `visitQueryPrimaryKeyLookup` in `ProjectionPushDownOptimizer` to collect the lookup's key and node-ID expressions as in-use, so the scan column they reference is kept alive. This works for both the raw-variable case (the issue's `{pk: col}`) and arbitrary key expressions (e.g. the implicit CAST inserted for a `SERIAL` primary key), since `collectExpressionsInUse` recurses into children.

## Testing

- Added regression cases to `test/test_files/load_from/load_from.test`:
  - `LOAD FROM ... MATCH (p:person {ID: id}) RETURN COUNT(*)` → 5 (property-map form)
  - `LOAD FROM ... MATCH (p:person) WHERE p.ID = id RETURN COUNT(*)` → 5 (equivalent `WHERE` form)
  - `LOAD FROM ... MATCH (p:person {ID: id}) SET p.fName = fName RETURN p.fName ORDER BY id` → 5 rows (verifies `SET` executes through the lookup)
- `e2e_test` full run: 1960 passed; the only 2 failures (`copy_to_csv.CopyToInvalidCase`, `dictionary_bug~...AnonymousParquetDeleteReload`) are pre-existing environment issues (missing `dataset/empty` fixtures; JSON export extension not built) and fail identically without this change.
- `optimizer_test`, `planner_tests`, `binder_test`, `api_test` all pass.