### PR TITLE
Checkout dataset submodule in nightly sanitizer workflow

### DIFF
--- a/.github/workflows/nightly-sanitizers.yml
+++ b/.github/workflows/nightly-sanitizers.yml
@@ -16,6 +16,9 @@ jobs:
     timeout-minutes: 300
     steps:
       - uses: actions/checkout@v4
+      - name: Checkout dataset and benchmarks
+        run: |
+          git submodule update --init dataset benchmark # needed for demo db
       - name: Install build dependencies
         run: |
           sudo apt-get update
@@ -35,6 +38,9 @@ jobs:
     continue-on-error: true
     steps:
       - uses: actions/checkout@v4
+      - name: Checkout dataset and benchmarks
+        run: |
+          git submodule update --init dataset benchmark # needed for demo db
       - name: Install build dependencies
         run: |
           sudo apt-get update


### PR DESCRIPTION
## Summary
- Adds a `Checkout dataset and benchmarks` step to both jobs (asan-ubsan, tsan) in `.github/workflows/nightly-sanitizers.yml`
- Runs `git submodule update --init dataset benchmark` after checkout, matching the pattern in `ci-workflow.yml` — the test suite needs the dataset submodule for the demo db