### PR TITLE
Fix state reuse on the cached-physical-plan fast path (0-row scans, live-result clobbering)

### DIFF
--- a/src/include/function/table/simple_table_function.h
+++ b/src/include/function/table/simple_table_function.h
@@ -39,6 +39,10 @@ public:
 
     virtual TableFuncMorsel getMorsel();
 
+    // Reset the scan position so a reused physical plan (cached-plan fast path)
+    // rescans from the beginning instead of finding an exhausted morsel cursor.
+    void resetState() override { curRowIdx = 0; }
+
     common::row_idx_t curRowIdx = 0;
     common::offset_t maxMorselSize = common::DEFAULT_VECTOR_CAPACITY;
 };

--- a/src/include/processor/operator/result_collector.h
+++ b/src/include/processor/operator/result_collector.h
@@ -22,6 +22,8 @@ public:
 
     std::shared_ptr<FactorizedTable> getTable() { return table; }
 
+    void setTable(std::shared_ptr<FactorizedTable> newTable) { table = std::move(newTable); }
+
 private:
     std::mutex mtx;
     std::shared_ptr<FactorizedTable> table;

--- a/src/processor/operator/result_collector.cpp
+++ b/src/processor/operator/result_collector.cpp
@@ -58,9 +58,21 @@ void ResultCollector::executeInternal(ExecutionContext* context) {
 }
 
 void ResultCollector::prepareForReuse(storage::MemoryManager* memoryManager) {
-    // Clear the existing result table instead of freeing + re-allocating.
-    // This keeps the DataBlocks alive so the next execution reuses them.
-    sharedState->getTable()->clear();
+    auto table = sharedState->getTable();
+    if (table.use_count() <= 1) {
+        // No QueryResult outside this shared state references the table, so we can
+        // keep the DataBlocks alive and reset the bookkeeping (Phase 2 fast path).
+        table->clear();
+    } else {
+        // A previous execution's QueryResult still holds this table (e.g. overlapping
+        // AsyncConnection executions of the same prepared statement on the cached-plan
+        // fast path, which shares one ResultCollectorSharedState with the plan template).
+        // Clearing it would corrupt that live result, so hand this execution a fresh
+        // table with the same schema instead. The old table stays alive until the
+        // QueryResult that references it is destroyed.
+        sharedState->setTable(
+            std::make_shared<FactorizedTable>(memoryManager, info.tableSchema.copy()));
+    }
     PhysicalOperator::prepareForReuse(memoryManager);
 }
 


### PR DESCRIPTION
## Summary
Two bugs in the cached-physical-plan fast path (Phases 1-3) cause wrong results on the *second* execution of the same query string:

### 1. Table-function scans return 0 rows on re-execution
`TableFunctionCall::copy()` shares the `TableFuncSharedState`, and `prepareForReuse()` calls `sharedState->resetState()` to rewind the scan position. `FTableScanSharedState` overrides `resetState()`, but `SimpleTableFuncSharedState` (pandas/polars/arrow scans and most simple table functions) inherited the **no-op** base, so `curRowIdx` stayed at `numRows` and every `getMorsel()` returned an invalid morsel.

User-visible effect: `LOAD FROM df` followed by `LOAD FROM $df RETURN *` returned **0 rows** / "No more tuples in QueryResult" (the Python layer rewrites both to the same string, so the second execution takes the fast path). Reproduced down to `getMorsel()` logging: fresh `initSharedState` was never called on the fast path and the stale cursor served invalid morsels to all worker threads.

**Fix:** override `resetState()` to reset `curRowIdx = 0`, mirroring `FTableScanSharedState`.

### 2. `ResultCollector::prepareForReuse()` clobbered live QueryResults
The plan template shares the `ResultCollectorSharedState` (and its `FactorizedTable`) with every executed clone, and `prepareForReuse()` unconditionally `clear()`ed that table. A `QueryResult` from a previous execution holds a `shared_ptr` to the same table, so overlapping executions (e.g. `AsyncConnection`'s pool running `RETURN $1` concurrently across 4 connections) corrupted live results: queries returned other queries' rows or empty tables — `test_async_prepare_and_execute_concurrent` asserted `[96] == [1]`.

**Fix:** clear-and-reuse the table only when no external `QueryResult` still references it (`use_count() == 1`, which keeps the Phase 2 block-reuse fast path for sequential loops); otherwise hand the execution a **fresh** table with the same schema and let the old table live until its `QueryResult` is destroyed.

## Test plan
- Full Python suite (280 tests) passes, including previously failing `test_scan_pandas::test_scan_pandas` and `test_async_connection::test_async_prepare_and_execute_concurrent`.
- `api_test`, `c_api_test`, and 734 filtered e2e tests pass (the `PartitionRoutingTest.MixedLocalRemoteScanRejected` and `dictionary_bug~orb383` failures pre-exist on clean main and are untouched by this change).
- The `test_fsm.py` failures on the same CI run are a test-side adaptation to #755 (COPY no longer force-checkpoints under `auto_checkpoint=false`) and are fixed in ladybugdb/ladybug-python#53.

Unblocks CI on ladybugdb/ladybug-python#53 (regression test for #866).
