### PR TITLE
fix iceberg extension REST catalog file binder exception

### DIFF
--- a/src/binder/bind/bind_file_scan.cpp
+++ b/src/binder/bind/bind_file_scan.cpp
@@ -1,3 +1,5 @@
+#include <cctype>
+
 #include "binder/binder.h"
 #include "binder/bound_scan_source.h"
 #include "binder/expression/literal_expression.h"
@@ -120,12 +122,48 @@ bool handleFileViaFunction(main::ClientContext* context, std::vector<std::string
     return handleFileViaFunction;
 }
 
+// Qualified Iceberg REST table names are not filesystem paths and must bypass
+// local globbing before the Iceberg extension resolves them.
+bool isIcebergCatalogName(const main::ClientContext* context, const std::string& source,
+    const case_insensitive_map_t<Value>& options) {
+    // Keep this workaround scoped to a loaded Iceberg REST configuration.
+    auto warehouseOption = context->getExtensionOption("iceberg_warehouse");
+    if (warehouseOption == nullptr ||
+        context->getCurrentSetting("iceberg_warehouse").toString().empty()) {
+        return false;
+    }
+    auto format = options.find(FileScanInfo::FILE_FORMAT_OPTION_NAME);
+    if (format == options.end() || StringUtils::getLower(format->second.toString()) != "iceberg") {
+        return false;
+    }
+    if (source.find('/') != std::string::npos || source.find('\\') != std::string::npos) {
+        return false;
+    }
+    idx_t dot_count = 0;
+    for (idx_t i = 0; i < source.size(); i++) {
+        auto c = static_cast<unsigned char>(source[i]);
+        if (source[i] == '.') {
+            dot_count++;
+            continue;
+        }
+        if ((i == 0 || source[i - 1] == '.') && !std::isalpha(c) && source[i] != '_') {
+            return false;
+        }
+        if (!std::isalnum(c) && source[i] != '_' && source[i] != '$') {
+            return false;
+        }
+    }
+    return dot_count == 1 || dot_count == 2;
+}
+
 std::unique_ptr<BoundBaseScanSource> Binder::bindFileScanSource(const BaseScanSource& scanSource,
     const options_t& options, const std::vector<std::string>& columnNames,
     const std::vector<LogicalType>& columnTypes) {
     auto fileSource = scanSource.constPtrCast<FileScanSource>();
-    auto filePaths = bindFilePaths(fileSource->filePaths);
     auto boundOptions = bindParsingOptions(options);
+    bool catalogName = fileSource->filePaths.size() == 1 &&
+                       isIcebergCatalogName(clientContext, fileSource->filePaths[0], boundOptions);
+    auto filePaths = catalogName ? fileSource->filePaths : bindFilePaths(fileSource->filePaths);
     FileTypeInfo fileTypeInfo;
 
     if (boundOptions.contains(FileScanInfo::FILE_FORMAT_OPTION_NAME)) {
@@ -136,7 +174,7 @@ std::unique_ptr<BoundBaseScanSource> Binder::bindFileScanSource(const BaseScanSo
     }
     // If we defined a certain FileType, we have to ensure the path is a file, not something else
     // (e.g. an existed directory)
-    if (fileTypeInfo.fileType != FileType::UNKNOWN) {
+    if (fileTypeInfo.fileType != FileType::UNKNOWN && !catalogName) {
         for (const auto& filePath : filePaths) {
             if (!LocalFileSystem::fileExists(filePath) && LocalFileSystem::isLocalPath(filePath)) {
                 throw BinderException{std::format("Provided path is not a file: {}.", filePath)};

--- a/src/binder/bind/bind_file_scan.cpp
+++ b/src/binder/bind/bind_file_scan.cpp
@@ -1,5 +1,3 @@
-#include <cctype>
-
 #include "binder/binder.h"
 #include "binder/bound_scan_source.h"
 #include "binder/expression/literal_expression.h"
@@ -47,7 +45,8 @@ FileTypeInfo Binder::bindFileTypeInfo(const std::vector<std::string>& filePaths)
     return expectedFileType;
 }
 
-std::vector<std::string> Binder::bindFilePaths(const std::vector<std::string>& filePaths) const {
+std::vector<std::string> Binder::bindFilePaths(const std::vector<std::string>& filePaths,
+    bool passThroughOnNoMatch) const {
     std::vector<std::string> boundFilePaths;
     for (auto& filePath : filePaths) {
         // This is a temporary workaround because we use duckdb to read from iceberg/delta/azure.
@@ -66,6 +65,13 @@ std::vector<std::string> Binder::bindFilePaths(const std::vector<std::string>& f
         auto globbedFilePaths =
             VirtualFileSystem::GetUnsafe(*clientContext)->glob(clientContext, filePath);
         if (globbedFilePaths.empty()) {
+            if (passThroughOnNoMatch) {
+                // The format's scan function owns the interpretation of the scan source, so
+                // leave the source unmodified for the extension to resolve (e.g. as a
+                // REST catalog table identifier) and to produce its own error if invalid.
+                boundFilePaths.push_back(filePath);
+                continue;
+            }
             throw BinderException{
                 std::format("No file found that matches the pattern: {}.", filePath)};
         }
@@ -122,59 +128,35 @@ bool handleFileViaFunction(main::ClientContext* context, std::vector<std::string
     return handleFileViaFunction;
 }
 
-// Qualified Iceberg REST table names are not filesystem paths and must bypass
-// local globbing before the Iceberg extension resolves them.
-bool isIcebergCatalogName(const main::ClientContext* context, const std::string& source,
-    const case_insensitive_map_t<Value>& options) {
-    // Keep this workaround scoped to a loaded Iceberg REST configuration.
-    auto warehouseOption = context->getExtensionOption("iceberg_warehouse");
-    if (warehouseOption == nullptr ||
-        context->getCurrentSetting("iceberg_warehouse").toString().empty()) {
-        return false;
-    }
-    auto format = options.find(FileScanInfo::FILE_FORMAT_OPTION_NAME);
-    if (format == options.end() || StringUtils::getLower(format->second.toString()) != "iceberg") {
-        return false;
-    }
-    if (source.find('/') != std::string::npos || source.find('\\') != std::string::npos) {
-        return false;
-    }
-    idx_t dot_count = 0;
-    for (idx_t i = 0; i < source.size(); i++) {
-        auto c = static_cast<unsigned char>(source[i]);
-        if (source[i] == '.') {
-            dot_count++;
-            continue;
-        }
-        if ((i == 0 || source[i - 1] == '.') && !std::isalpha(c) && source[i] != '_') {
-            return false;
-        }
-        if (!std::isalnum(c) && source[i] != '_' && source[i] != '$') {
-            return false;
-        }
-    }
-    return dot_count == 1 || dot_count == 2;
-}
-
 std::unique_ptr<BoundBaseScanSource> Binder::bindFileScanSource(const BaseScanSource& scanSource,
     const options_t& options, const std::vector<std::string>& columnNames,
     const std::vector<LogicalType>& columnTypes) {
     auto fileSource = scanSource.constPtrCast<FileScanSource>();
     auto boundOptions = bindParsingOptions(options);
-    bool catalogName = fileSource->filePaths.size() == 1 &&
-                       isIcebergCatalogName(clientContext, fileSource->filePaths[0], boundOptions);
-    auto filePaths = catalogName ? fileSource->filePaths : bindFilePaths(fileSource->filePaths);
+    auto formatOption = boundOptions.find(FileScanInfo::FILE_FORMAT_OPTION_NAME);
+    // An explicitly declared format that is not one of the built-in file types is provided by
+    // an extension (e.g. 'iceberg', 'delta'). The <FORMAT>_SCAN table function registered by
+    // that extension owns the interpretation of the scan source: it may be a filesystem path,
+    // but it can also be a logical identifier (e.g. an Iceberg REST catalog table name) that
+    // must not be validated against the filesystem. When globbing finds no match, the source
+    // is therefore passed through verbatim so the extension can resolve it and produce its
+    // own error if invalid.
+    const bool extensionFormat =
+        formatOption != boundOptions.end() &&
+        FileTypeUtils::fromString(formatOption->second.toString()) == FileType::UNKNOWN;
+    auto filePaths =
+        bindFilePaths(fileSource->filePaths, extensionFormat /* passThroughOnNoMatch */);
     FileTypeInfo fileTypeInfo;
 
-    if (boundOptions.contains(FileScanInfo::FILE_FORMAT_OPTION_NAME)) {
-        auto fileFormat = boundOptions.at(FileScanInfo::FILE_FORMAT_OPTION_NAME).toString();
+    if (formatOption != boundOptions.end()) {
+        auto fileFormat = formatOption->second.toString();
         fileTypeInfo = FileTypeInfo{FileTypeUtils::fromString(fileFormat), fileFormat};
     } else {
         fileTypeInfo = bindFileTypeInfo(filePaths);
     }
     // If we defined a certain FileType, we have to ensure the path is a file, not something else
-    // (e.g. an existed directory)
-    if (fileTypeInfo.fileType != FileType::UNKNOWN && !catalogName) {
+    // (e.g. an existed directory). Extension-provided formats interpret the source themselves.
+    if (fileTypeInfo.fileType != FileType::UNKNOWN) {
         for (const auto& filePath : filePaths) {
             if (!LocalFileSystem::fileExists(filePath) && LocalFileSystem::isLocalPath(filePath)) {
                 throw BinderException{std::format("Provided path is not a file: {}.", filePath)};

--- a/src/include/binder/binder.h
+++ b/src/include/binder/binder.h
@@ -188,7 +188,8 @@ public:
     common::case_insensitive_map_t<common::Value> bindParsingOptions(
         const parser::options_t& parsingOptions);
     common::FileTypeInfo bindFileTypeInfo(const std::vector<std::string>& filePaths) const;
-    std::vector<std::string> bindFilePaths(const std::vector<std::string>& filePaths) const;
+    std::vector<std::string> bindFilePaths(const std::vector<std::string>& filePaths,
+        bool passThroughOnNoMatch = false) const;
 
     /*** bind query ***/
     std::unique_ptr<BoundRegularQuery> bindQuery(const parser::Statement& statement);


### PR DESCRIPTION
fix https://github.com/LadybugDB/ladybug/issues/871  



### Root Cause

The REST Catalog implementation was added in the Iceberg extension, but the core `LOAD FROM` binder still assumes that the source must be a filesystem path.

The failure occurs before the extension table function is bound:

```text
LOAD FROM
  -> bindFileScanSource()
  -> bindFilePaths()
  -> filesystem glob
  -> binder error
```

### Solution

Update `bindFileScanSource()` to recognize qualified Iceberg REST Catalog table names before filesystem globbing.

When the following conditions are met:

- the Iceberg extension is loaded;
- `iceberg_warehouse` is configured;
- `file_format='iceberg'`;
- the source matches `namespace.table` or `iceberg_catalog.namespace.table`;

the binder bypasses filesystem globbing and passes the source directly to the Iceberg extension.

Filesystem path validation is also skipped for these Catalog names because they are logical table identifiers, not local files.

### Scope and Compatibility

The change is intentionally limited to Iceberg REST Catalog identifiers.

Existing behavior remains unchanged for:

- Parquet, CSV, JSON, and other file formats;
- regular Iceberg filesystem paths;
- metadata file paths;
- wildcard file patterns;
- REST-like strings when the Iceberg REST configuration is not enabled.

No changes are made to the Iceberg extension implementation itself.

### Result

After rebuilding Ladybug, the following queries can be resolved through the REST Catalog:

```cypher
CALL iceberg_warehouse='warehouse';
CALL iceberg_endpoint='http://127.0.0.1:8181';
CALL iceberg_authorization_type='none';

LOAD FROM 'perf_demo.User'
(file_format='iceberg')
RETURN count(*);
```

```cypher
LOAD FROM 'perf_demo.Session'
(file_format='iceberg')
RETURN count(*);
```

```cypher
LOAD FROM 'perf_demo.User_owns_Session'
(file_format='iceberg')
RETURN count(*);
```

The fully qualified form is also supported:

```cypher
LOAD FROM 'iceberg_catalog.perf_demo.User'
(file_format='iceberg')
RETURN count(*);
```