### PR TITLE
fix: bad downcast of ArrowResultCollector in plan mapper re-enables skipped arrow/CSR tests (#881)

### DIFF
--- a/src/processor/map/plan_mapper.cpp
+++ b/src/processor/map/plan_mapper.cpp
@@ -45,11 +45,14 @@ std::unique_ptr<PhysicalPlan> PlanMapper::getPhysicalPlan(const LogicalPlan* log
         } else {
             root = createResultCollector(AccumulateType::REGULAR, expressions,
                 logicalPlan->getSchema(), std::move(root));
-        }
-        // The plan root collector is the only one whose table is handed to the client via
-        // getQueryResult(); every other ResultCollector feeds other operators of the same
-        // plan and must be cleared in place (not replaced) on reuse.
-        if (root->getOperatorType() == PhysicalOperatorType::RESULT_COLLECTOR) {
+            // The plan root collector is the only one whose table is handed to the client via
+            // getQueryResult(); every other ResultCollector feeds other operators of the same
+            // plan and must be cleared in place (not replaced) on reuse.
+            // NOTE: This must only run on the regular (factorized-table) ResultCollector.
+            // ArrowResultCollector shares PhysicalOperatorType::RESULT_COLLECTOR but is NOT a
+            // ResultCollector — downcasting it here is undefined behaviour (and trips the
+            // checked dynamic_cast under RUNTIME_CHECKS), so the flag is set inside the
+            // non-arrow branch instead of after the if/else via an operator-type check.
             root->ptrCast<ResultCollector>()->setResultExposedToClient();
         }
     }

--- a/test/api/arrow_test.cpp
+++ b/test/api/arrow_test.cpp
@@ -495,9 +495,6 @@ TEST_F(ArrowTest, resultToArrow) {
 }
 
 TEST_F(ArrowTest, queryAsArrow) {
-    // TODO(#881): intermittent SIGSEGV race in the arrow collector task path (worker threads
-    // execute a corrupted task clone). Skip until the race is fixed.
-    GTEST_SKIP() << "Flaky SIGSEGV in the arrow collector task path; see issue #881.";
     auto query = "MATCH (a:person) WHERE a.fName = 'Bob' RETURN a.fName";
     auto result = conn->queryAsArrow(query, 1);
     auto arrowArray = result->getNextArrowChunk(1);
@@ -511,8 +508,6 @@ TEST_F(ArrowTest, queryAsArrow) {
 }
 
 TEST_F(ArrowTest, getArrowResult) {
-    // TODO(#881): intermittent SIGSEGV race in the arrow collector task path. Skip until fixed.
-    GTEST_SKIP() << "Flaky SIGSEGV in the arrow collector task path; see issue #881.";
     auto query = "MATCH (a:person) WHERE a.fName = 'Bob' RETURN a.fName";
     auto result = conn->queryAsArrow(query, 1);
     try {
@@ -599,8 +594,6 @@ TEST_F(ArrowTest, mapColumnArrowSchemaHasNonNullableEntriesAndKey) {
 }
 
 TEST_F(ArrowTest, queryAsArrowDirectCSRRowIDProjection) {
-    // TODO(#881): intermittent SIGSEGV / CSR-loss race in the arrow collector task path.
-    GTEST_SKIP() << "Flaky SIGSEGV in the arrow collector task path; see issue #881.";
     ASSERT_TRUE(
         conn->query("CREATE NODE TABLE DirectPerson(id INT64, PRIMARY KEY(id));")->isSuccess());
     ASSERT_TRUE(conn->query("CREATE REL TABLE DirectKnows(FROM DirectPerson TO DirectPerson);")
@@ -653,8 +646,6 @@ TEST_F(ArrowTest, queryAsArrowDirectCSRRowIDProjection) {
 }
 
 TEST_F(ArrowTest, queryAsArrowDirectCSRRowIDProjectionKeepsCSRMetadataWithFourThreads) {
-    // TODO(#881): intermittent SIGSEGV / CSR-loss race in the arrow collector task path.
-    GTEST_SKIP() << "Flaky SIGSEGV in the arrow collector task path; see issue #881.";
     auto query = "MATCH (a:person)-[b:knows]->(c:person) RETURN a.rowid, b.rowid, c.rowid "
                  "ORDER BY a.rowid, b.rowid, c.rowid";
     conn->setMaxNumThreadForExec(4);
@@ -665,8 +656,6 @@ TEST_F(ArrowTest, queryAsArrowDirectCSRRowIDProjectionKeepsCSRMetadataWithFourTh
 }
 
 TEST_F(ArrowTest, queryAsArrowTracksCSRMetadataWithoutRelIDs) {
-    // TODO(#881): intermittent SIGSEGV / CSR-loss race in the arrow collector task path.
-    GTEST_SKIP() << "Flaky SIGSEGV in the arrow collector task path; see issue #881.";
     auto query =
         "MATCH (a:person)-[:knows]->(b:person) RETURN a.rowid, b.rowid ORDER BY a.rowid, b.rowid";
     auto rowResult = conn->query(query);
@@ -712,8 +701,6 @@ TEST_F(ArrowTest, queryAsArrowTracksCSRMetadataWithoutRelIDs) {
 }
 
 TEST_F(ArrowTest, queryAsArrowTracksCSRMetadataWithRelIDsAndExtraColumns) {
-    // TODO(#881): intermittent SIGSEGV / CSR-loss race in the arrow collector task path.
-    GTEST_SKIP() << "Flaky SIGSEGV in the arrow collector task path; see issue #881.";
     auto query = "MATCH (a:person)-[e:knows]->(b:person) "
                  "RETURN a.rowid, e.rowid, b.rowid, e.date, b.fName "
                  "ORDER BY a.rowid, e.rowid, b.rowid";
@@ -756,8 +743,6 @@ TEST_F(ArrowTest, queryAsArrowTracksCSRMetadataWithRelIDsAndExtraColumns) {
 }
 
 TEST_F(ArrowTest, queryAsArrowDoesNotTrackCSRMetadataForNonCSRShape) {
-    // TODO(#881): intermittent SIGSEGV / CSR-loss race in the arrow collector task path.
-    GTEST_SKIP() << "Flaky SIGSEGV in the arrow collector task path; see issue #881.";
     auto query = "MATCH (a:person)-[e:knows]->(b:person) RETURN a.rowid, e.date ORDER BY a.rowid";
     auto result = conn->queryAsArrow(query, 8);
     auto* arrowResult = dynamic_cast<ArrowQueryResult*>(result.get());

--- a/test/api/project_graph_csr_test.cpp
+++ b/test/api/project_graph_csr_test.cpp
@@ -35,8 +35,6 @@ public:
 };
 
 TEST_F(ProjectGraphCsrTest, materializesArrowCsr) {
-    // TODO(#881): intermittent SIGSEGV / CSR-loss race in the arrow collector task path.
-    GTEST_SKIP() << "Flaky SIGSEGV in the arrow collector task path; see issue #881.";
     ASSERT_TRUE(conn->query("CALL PROJECT_GRAPH('CsrG', ['CsrNode'], ['CsrEdge'])")->isSuccess());
     const auto& entry = getNativeEntry("CsrG");
     ASSERT_EQ(entry.relCsrResults.size(), 1u);
@@ -51,8 +49,6 @@ TEST_F(ProjectGraphCsrTest, materializesArrowCsr) {
 }
 
 TEST_F(ProjectGraphCsrTest, materializedCsrSurvivesConsumingQueries) {
-    // TODO(#881): intermittent SIGSEGV / CSR-loss race in the arrow collector task path.
-    GTEST_SKIP() << "Flaky SIGSEGV in the arrow collector task path; see issue #881.";
     ASSERT_TRUE(conn->query("CALL PROJECT_GRAPH('CsrG', ['CsrNode'], ['CsrEdge'])")->isSuccess());
     // The pinned result must stay valid across later statements on the same connection.
     ASSERT_TRUE(conn->query("MATCH (a:CsrNode) RETURN COUNT(*)")->isSuccess());

--- a/test/api/read_only_test.cpp
+++ b/test/api/read_only_test.cpp
@@ -23,8 +23,6 @@ TEST_F(ReadOnlyTest, Test) {
 }
 
 TEST_F(ReadOnlyTest, ProjectGraphOnReadOnlyDatabase) {
-    // TODO(#881): intermittent SIGSEGV / CSR-loss race in the arrow collector task path.
-    GTEST_SKIP() << "Flaky SIGSEGV in the arrow collector task path; see issue #881.";
     if (databasePath == "" || databasePath == ":memory:") {
         return;
     }


### PR DESCRIPTION
Fixes #881.

## Root cause

`ArrowResultCollector` and the regular `ResultCollector` both declare
`static constexpr PhysicalOperatorType type_ = PhysicalOperatorType::RESULT_COLLECTOR`.
In `PlanMapper::getPhysicalPlan()` the plan-root marker introduced by #870/#877 work was applied via an operator-type check:

```cpp
if (root->getOperatorType() == PhysicalOperatorType::RESULT_COLLECTOR) {
    root->ptrCast<ResultCollector>()->setResultExposedToClient();
}
```

For **every** arrow query (`resultType=ARROW`), the newly created `ArrowResultCollector` matched that check and was then downcast to `ResultCollector`, which it is not:

- **With `RUNTIME_CHECKS` (or any `!NDEBUG` build)**, `dynamic_cast_checked` asserts and throws. Every `queryAsArrow()` execution failed and returned an error `MaterializedQueryResult` whose iterator is null. Tests calling `getNextArrowChunk()` without checking `isSuccess()` then SIGSEGV in `FactorizedTableIterator::hasNext` — the `Fatal signal 11` in the linux minimal-test job. The remaining tests fail on `dynamic_cast<ArrowQueryResult*>(result.get()) == nullptr` and `entry.relCsrResults[0] == nullptr` (`PROJECT_GRAPH` materialization also runs through `queryAsArrow`).
- **With `NDEBUG`** (plain release), the checked cast is a `reinterpret_cast` and `setResultExposedToClient()` writes a byte at `ResultCollector::internalResultTable`'s offset (192), which in an `ArrowResultCollector` object is `localState.batchIndex` — UB on every arrow query.

The minimal-test job builds with `-DENABLE_RUNTIME_CHECKS=1`, which made the failure deterministic across all 10 arrow/CSR tests — while local (non-RUNTIME_CHECKS) runs looked healthy, which is why the issue looked like a timing-dependent race.

## Fix

Mark the client-facing result table on the freshly created regular `ResultCollector` inside the non-arrow branch of the `if/else`, instead of matching on the shared operator-type enum afterwards.

Also re-enables the ten tests skipped in 520abda2c.

## Note on the earlier investigation

The "corrupted task clone" evidence in the issue (`this` == sharedState, garbage batch indices, CSR metadata present for CSR-free queries) was an artefact of the temporary `LBUG_ARROW_DEBUG` tracing: its `fprintf` macro appended the thread-id string **after** the caller's varargs while the format consumed `%s` first, shifting every printed value by one slot. The deterministic "reproduction with instrumentation" was the tracing itself crashing in `strlen()` on an integer consumed as `%s`. With corrected tracing, all collector state is healthy up to the crash.

## Validation

- Full `api_test` (304 tests) passes with `-DCMAKE_BUILD_TYPE=RelWithDebInfo -DENABLE_RUNTIME_CHECKS=1` (the minimal-test configuration), plain `RelWithDebInfo`, and `Debug` builds.
- `TSAN` run of the arrow/CSR suite is clean.