### PR TITLE
fix: string hash portability across platforms with different char signedness (issue #882)

### DIFF
--- a/src/include/function/hash/hash_functions.h
+++ b/src/include/function/hash/hash_functions.h
@@ -146,7 +146,12 @@ inline void Hash::operation(const std::string_view& key, common::hash_t& result)
     }
     uint64_t last = 0;
     for (size_t i = 0u; i < key.size() % 8; i++) {
-        last |= static_cast<uint64_t>(key[key.size() / 8 * 8 + i]) << i * 8;
+        // Zero-extend the byte explicitly so the hash is identical on platforms where plain
+        // `char` is signed (x86-64, macOS arm64, wasm32) and unsigned (aarch64/riscv64 linux).
+        // This matches the convention of PostgreSQL, BerkeleyDB, SQLite and MySQL, and keeps
+        // behavior identical on unsigned-char platforms (aarch64/riscv64 linux).
+        last |= static_cast<uint64_t>(static_cast<unsigned char>(key[key.size() / 8 * 8 + i]))
+                << i * 8;
     }
     hashValue = lbug::function::combineHashScalar(hashValue, lbug::function::murmurhash64(last));
     result = hashValue;


### PR DESCRIPTION
## Description

Fixes #882.

`Hash::operation(const std::string_view&)` (`src/include/function/hash/hash_functions.h`) hashed the tail bytes (`len % 8`) by indexing the `string_view` directly, which yields plain `char`. The behavior of `char` differs by platform:

- **signed** on x86-64-linux, macOS arm64, wasm32
- **unsigned** on aarch64-linux, riscv64-linux

A byte >= 0x80 in the tail was sign-extended before the shift on signed-char platforms but not on unsigned-char ones, so the same string produced different hashes. A database written on one platform then read on another silently returned no rows for `=` on non-ASCII primary keys (`José`, `Müller`, Cyrillic, CJK, emoji) whenever the key's byte length was not a multiple of 8. Keys of length ≡ 0 (mod 8) skip the tail loop entirely and were always portable — consistent with the report.

## The fix

Standardizes on the **unsigned** behavior (as suggested in the issue, and per review on this PR — PostgreSQL, BerkeleyDB, SQLite and MySQL all use unsigned char semantics by default):

```cpp
last |= static_cast<uint64_t>(static_cast<unsigned char>(key[key.size() / 8 * 8 + i]))
        << i * 8;
```

- On unsigned-char platforms (aarch64/riscv64 linux) this is behaviorally identical to the previous code — **existing databases and index hashes on those platforms remain valid**.
- On signed-char platforms (x86-64, macOS arm64, wasm32) the hash now matches aarch64/riscv64, fixing cross-platform portability.

## Verification

- Compiled a standalone program using this header with `-fsigned-char` and `-funsigned-char`: hashes for `José`, `Müller`, Cyrillic, emoji, and ASCII keys are now identical under both flags.
- Compared against the pre-fix header under `-funsigned-char`: values are byte-identical, confirming no change for existing unsigned-char-platform databases.

## Caveat

Databases *written on signed-char platforms* (x86-64, macOS arm64, wasm32) before this fix have hashes baked in with the sign-extended tail semantics. After this change, reading them on the same platform with an affected non-ASCII key (`len % 8 != 0`) would miss. Affected string-PK indexes need a rebuild/re-import. Worth a note in the release notes.