### PR TITLE
fix(storage): guard unloaded index holders in write/commit paths and allow DROP/rebuild of orphan holders

### DIFF
--- a/src/processor/operator/ddl/drop.cpp
+++ b/src/processor/operator/ddl/drop.cpp
@@ -223,7 +223,10 @@ void Drop::dropIndex(const main::ClientContext* context) {
     // An index may live in the catalog (user-created indexes), in storage only (the default
     // built-in PK hash index), or in both. Drop whichever are present.
     const auto inCatalog = catalog->containsIndex(transaction, tableID, dropInfo.indexName);
-    const auto inStorage = nodeTable->getIndex(dropInfo.indexName).has_value();
+    // Use getIndexHolder (not getIndex) so an unloaded/orphan holder — whose catalog entry
+    // is already gone — is still recognized as present and can be dropped, instead of
+    // throwing "Index ... not loaded yet".
+    const auto inStorage = nodeTable->getIndexHolder(dropInfo.indexName).has_value();
     if (!inCatalog && !inStorage) {
         auto message =
             std::format("Index {} does not exist in table {}.", dropInfo.indexName, dropInfo.name);

--- a/src/storage/table/node_table.cpp
+++ b/src/storage/table/node_table.cpp
@@ -439,6 +439,13 @@ void NodeTable::initInsertState(main::ClientContext* context, TableInsertState& 
     nodeInsertState.indexInsertStates.resize(indexes.size());
     for (auto i = 0u; i < indexes.size(); i++) {
         auto& indexHolder = indexes[i];
+        // Skip unloaded (orphaned) index holders — e.g. after a WAL-replayed DROP INDEX that
+        // could not reach the storage layer, the holder survives without its index object.
+        // Dereferencing it here would segfault on the next insert; see insert().
+        if (!indexHolder.isLoaded()) {
+            nodeInsertState.indexInsertStates[i] = nullptr;
+            continue;
+        }
         const auto index = indexHolder.getIndex();
         nodeInsertState.indexInsertStates[i] =
             index->initInsertState(context, [&](offset_t offset) {
@@ -459,6 +466,12 @@ void NodeTable::insert(Transaction* transaction, TableInsertState& insertState) 
     validatePkNotExists(transaction, const_cast<ValueVector*>(&nodeInsertState.pkVector));
     localTable->insert(transaction, insertState);
     for (auto i = 0u; i < indexes.size(); i++) {
+        // Skip unloaded (orphaned) index holders; getIndex() would return a null pointer
+        // and index->insert() would segfault. Such a holder has no catalog entry, so no
+        // index maintenance is expected.
+        if (!indexes[i].isLoaded()) {
+            continue;
+        }
         auto index = indexes[i].getIndex();
         std::vector<ValueVector*> indexedPropertyVectors;
         for (const auto columnID : index->getIndexInfo().columnIDs) {
@@ -482,6 +495,12 @@ void NodeTable::initUpdateState(main::ClientContext* context, TableUpdateState& 
     nodeUpdateState.indexUpdateState.resize(indexes.size());
     for (auto i = 0u; i < indexes.size(); i++) {
         auto& indexHolder = indexes[i];
+        // Skip unloaded (orphaned) index holders; getIndex() would return a null pointer
+        // and index->isPrimary() would segfault.
+        if (!indexHolder.isLoaded()) {
+            nodeUpdateState.indexUpdateState[i] = nullptr;
+            continue;
+        }
         auto index = indexHolder.getIndex();
         if (index->isPrimary() || !index->isBuiltOnColumn(nodeUpdateState.columnID)) {
             nodeUpdateState.indexUpdateState[i] = nullptr;
@@ -509,6 +528,10 @@ void NodeTable::update(Transaction* transaction, TableUpdateState& updateState) 
     }
     const auto nodeOffset = nodeUpdateState.nodeIDVector.readNodeOffset(pos);
     for (auto i = 0u; i < indexes.size(); i++) {
+        // Skip unloaded (orphaned) index holders; see initUpdateState().
+        if (!indexes[i].isLoaded()) {
+            continue;
+        }
         auto index = indexes[i].getIndex();
         if (!nodeUpdateState.needToUpdateIndex(i)) {
             continue;
@@ -547,6 +570,11 @@ bool NodeTable::delete_(Transaction* transaction, TableDeleteState& deleteState)
     bool isDeleted = false;
     const auto nodeOffset = nodeDeleteState.nodeIDVector.readNodeOffset(pos);
     for (auto& index : indexes) {
+        // Skip unloaded (orphaned) index holders; getIndex() would return a null pointer
+        // and delete_() would segfault. See insert().
+        if (!index.isLoaded()) {
+            continue;
+        }
         auto indexDeleteState = index.getIndex()->initDeleteState(transaction, memoryManager,
             getVisibleFunc(transaction));
         index.getIndex()->delete_(transaction, nodeDeleteState.nodeIDVector, *indexDeleteState);
@@ -654,13 +682,14 @@ void NodeTable::commit(main::ClientContext* context, TableCatalogEntry* tableEnt
 
     // 3. Scan index columns for newly inserted tuples.
     for (auto& index : indexes) {
-        if (!index.needCommitInsert()) {
+        // Check isLoaded BEFORE needCommitInsert(): the latter dereferences the index object,
+        // which is null for an unloaded (orphan) holder — e.g. after a WAL-replayed DROP INDEX
+        // that removed only the catalog entry — and would segfault during commit/recovery.
+        if (!index.isLoaded()) {
             continue;
         }
-        if (!index.isLoaded()) {
-            throw RuntimeException(
-                "Cannot commit index insertions for index " + index.getName() +
-                ", because it is not loaded. Please load the extension for the index first.");
+        if (!index.needCommitInsert()) {
+            continue;
         }
         UncommittedIndexInserter indexInserter{startNodeOffset, this, index.getIndex(),
             getVisibleFunc(transaction)};
@@ -985,8 +1014,20 @@ void NodeTable::scanIndexColumns(main::ClientContext* context, IndexScanHelper& 
 }
 
 void NodeTable::addIndex(std::unique_ptr<Index> index) {
-    if (getIndex(index->getName()).has_value()) {
-        throw RuntimeException("Index with name " + index->getName() + " already exists.");
+    // If a holder with the same name already exists (including an unloaded orphan left by a
+    // torn DROP INDEX whose catalog entry is gone), remove it before adding the new one so a
+    // rebuild in place succeeds. Previously this called getIndex(), which throws
+    // "Index ... not loaded yet" for an unloaded holder and made CREATE_FTS_INDEX fail on
+    // the cross-set residue state.
+    for (auto it = indexes.begin(); it != indexes.end(); ++it) {
+        if (StringUtils::caseInsensitiveEquals(it->getName(), index->getName())) {
+            if (it->isLoaded()) {
+                throw RuntimeException("Index with name " + index->getName() + " already exists.");
+            }
+            droppedIndexes.push_back(std::move(*it));
+            indexes.erase(it);
+            break;
+        }
     }
     indexes.push_back(IndexHolder{std::move(index)});
     setHasChanges();
@@ -1005,10 +1046,12 @@ void NodeTable::buildIndexAndAdd(main::ClientContext* context, std::unique_ptr<I
 }
 
 void NodeTable::dropIndex(const std::string& name) {
-    DASSERT(getIndex(name) != nullptr);
     for (auto it = indexes.begin(); it != indexes.end(); ++it) {
         if (StringUtils::caseInsensitiveEquals(it->getName(), name)) {
-            DASSERT(it->isLoaded());
+            // Also allow dropping an unloaded (orphan) holder — e.g. after a WAL-replayed
+            // DROP INDEX that removed only the catalog entry. Previously the DASSERTs here
+            // (and getIndex() above) failed on such a holder, blocking DROP INDEX with
+            // "Index ... not loaded yet" and trapping the cross-set residue state.
             // Retain the holder so its page range is known; the pages are reclaimed at the
             // next checkpoint (reclaimDroppedIndexes), not here, since freeing them within the
             // dropping transaction would be unsafe on rollback.


### PR DESCRIPTION
## Summary

When a node-table index's **storage holder survives without its catalog entry and without a loaded `Index` object** (an orphan state the engine itself can produce — the FTS extension builds indexes through a non-atomic multi-statement rewrite, and a WAL replay of a torn DROP removes the catalog entry but never the storage holder), the engine currently:

- **segfaults** on the next `INSERT` / `UPDATE` / `DELETE` and during `commit()` (null `Index*` dereference), because the write paths call `holder.getIndex()` without an `isLoaded()` guard, and `commit()` calls `needCommitInsert()` *before* its `isLoaded()` check (making that check dead code);
- **dead-locks recovery**: `DROP INDEX` throws `Index ... is not loaded yet` instead of removing the orphan, and re-`CREATE`-ing the same name throws the same — the table can only be restored from a backup.

## Changes

- **`src/storage/table/node_table.cpp`** — skip unloaded (orphan) holders in `initInsertState` / `insert` / `initUpdateState` / `update` / `delete_`; check `isLoaded()` **before** `needCommitInsert()` in `commit()`; allow `addIndex` to replace a same-named unloaded holder; allow `dropIndex` to remove an unloaded holder (drop the `DASSERT`s that made this impossible in debug and were vacuous in release).
- **`src/processor/operator/ddl/drop.cpp`** — in `Drop::dropIndex`, probe storage presence via `getIndexHolder()` (which does not require the index to be loaded) instead of `getIndex()`, so an orphan is recognized as present and actually dropped.

No behavior change for well-formed databases: for a normally loaded index the guards are all no-ops.

## How to reproduce (deterministic)

1. Build the FTS extension (or any extension that registers an index on a node table).
2. Create an index and **force a checkpoint** so the storage holder is on disk.
3. `DROP INDEX` the index, then **kill the process (SIGKILL) before checkpoint** so the DROP is only recorded in the WAL.
4. Reopen the database. WAL replay drops the catalog entry but leaves the storage holder unloaded.
5. Now:
   - `INSERT` into the node table → segfault (`node_table.cpp` write path).
   - `DROP INDEX idx` → `Index idx is not loaded yet` (cannot clean up).
   - `CREATE INDEX ... idx` (same name) → `Index idx is not loaded yet` (cannot rebuild in place).

Verified: the write-path segfault was reproduced on the unpatched engine, and the commit-path segfault by replaying an insert-bearing WAL. Post-patch, writes are safe (holder skipped) and DROP/rebuild of the same name succeeds in place. The touched functions are byte-identical across v0.19.0 → v0.20.2 / `main`, so the change applies cleanly to the current tree.

## Files changed

| File | Change |
|---|---|
| `src/storage/table/node_table.cpp` | isLoaded guards in 5 write paths + commit; addIndex replaces orphan; dropIndex removes unloaded holder |
| `src/processor/operator/ddl/drop.cpp` | dropIndex probes via getIndexHolder() |

Happy to adjust scope or add a formal test under `test/` if the maintainers prefer.