### PR TITLE
fix(storage): harden unloaded index holder reclamation and commit-path index maintenance

### DIFF
--- a/src/include/storage/index/index.h
+++ b/src/include/storage/index/index.h
@@ -251,7 +251,17 @@ public:
         if (loaded) {
             DASSERT(index);
             index->reclaimStorage(pageAllocator);
+            return;
         }
+        // An unloaded holder has no Index object to reclaim from. This is safe because:
+        // * Built-in indexes (PK hash / ART) are always force-loaded in NodeTable::deserialize(),
+        //   so an unloaded holder can never be a built-in index that owns raw page ranges.
+        // * Extension indexes own no raw pages at the holder level: their data lives in
+        //   catalog-managed internal tables and is reclaimed through the catalog when those
+        //   tables are dropped (their Index::reclaimStorage is a no-op even when loaded).
+        // If a future built-in index is not force-loaded, or an extension starts owning raw
+        // pages, holders dropped while unloaded would silently leak their pages.
+        DASSERT(!indexInfo.isBuiltin);
     }
     std::vector<IndexStorageEntry> getStorageEntries() const {
         if (!loaded) {

--- a/src/storage/table/node_table.cpp
+++ b/src/storage/table/node_table.cpp
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 
+#include "catalog/catalog.h"
 #include "catalog/catalog_entry/node_table_catalog_entry.h"
 #include "common/cast.h"
 #include "common/exception/message.h"
@@ -686,6 +687,23 @@ void NodeTable::commit(main::ClientContext* context, TableCatalogEntry* tableEnt
         // which is null for an unloaded (orphan) holder — e.g. after a WAL-replayed DROP INDEX
         // that removed only the catalog entry — and would segfault during commit/recovery.
         if (!index.isLoaded()) {
+            // An unloaded holder is either an orphan (its catalog entry is already gone, so
+            // there is nothing to maintain), or a cataloged index whose extension is not
+            // loaded. For the latter, the binder refuses INSERT/DELETE/COPY and SET of indexed
+            // columns on tables with cataloged-but-unloaded indexes, so user transactions can
+            // only reach commit() with the orphan case, which we skip silently. WAL replay
+            // bypasses the binder, but throwing during recovery would prevent the database
+            // from opening at all, so the index is left stale (rebuildable) there. The check
+            // below is a tripwire for future paths that bypass the binder: rows were appended
+            // in step 1 and would never be indexed — fail loudly instead of silently
+            // committing them.
+            if (!transaction->isRecovery() && numLocalRows > 0 &&
+                Catalog::Get(*context)->containsIndex(transaction, tableEntry->getTableID(),
+                    index.getName())) {
+                throw RuntimeException(
+                    "Cannot commit index insertions for index " + index.getName() +
+                    ", because it is not loaded. Please load the extension for the index first.");
+            }
             continue;
         }
         if (!index.needCommitInsert()) {
@@ -1054,7 +1072,8 @@ void NodeTable::dropIndex(const std::string& name) {
             // "Index ... not loaded yet" and trapping the cross-set residue state.
             // Retain the holder so its page range is known; the pages are reclaimed at the
             // next checkpoint (reclaimDroppedIndexes), not here, since freeing them within the
-            // dropping transaction would be unsafe on rollback.
+            // dropping transaction would be unsafe on rollback. (An unloaded holder owns no
+            // holder-level pages — see IndexHolder::reclaimStorage.)
             droppedIndexes.push_back(std::move(*it));
             indexes.erase(it);
             setHasChanges();


### PR DESCRIPTION
Follow-up to #897 (merged as d2db8acb4). Rebased on `main`; contains only the refinements discussed in the [review thread on #897](https://github.com/LadybugDB/ladybug/pull/897#issuecomment-5512581358).

## 1. Unloaded-holder reclamation invariant made explicit (`IndexHolder::reclaimStorage`)

`src/include/storage/index/index.h`

The PR-merged code lets `reclaimStorage()` silently no-op for unloaded holders. That is safe, but only because of an *implicit* invariant, which is now documented and asserted:

- **Built-in indexes** (PK hash / ART) are always force-loaded in `NodeTable::deserialize()`, so an unloaded holder can never be a built-in index that owns raw page ranges.
- **Extension indexes** own no raw pages at the holder level: their data lives in catalog-managed internal tables, reclaimed through the catalog when those tables are dropped (their `Index::reclaimStorage` is a no-op even when loaded). This mirrors the FTS lifecycle analyzed in LadybugDB/extensions#77 — a torn `DROP FTS INDEX` can orphan the storage holder, but the holder itself owns no pages.

If a future built-in index is not force-loaded, or an extension starts owning raw pages, holders dropped while unloaded would silently leak their pages. `DASSERT(!indexInfo.isBuiltin)` trips in debug builds if that happens. `NodeTable::dropIndex()`'s comment now cross-references the invariant.

## 2. Commit-path tripwire for cataloged-but-unloaded indexes (`NodeTable::commit`)

`src/storage/table/node_table.cpp`

The merged code silently skips index maintenance for any unloaded holder during commit. For the *reachable* states that's correct:

- **Orphan holders** (catalog entry gone, e.g. after a WAL-replayed `DROP INDEX` that never reached storage) have nothing to maintain.
- **Cataloged-but-unloaded indexes**: the binder already refuses `INSERT` / `DELETE` / `COPY FROM` and `SET` of indexed columns on tables with cataloged-but-unloaded indexes (`bindInsert`, `bindDeleteClause`, `bindSetItem`, `bind_copy_from.cpp`), so user transactions cannot produce indexed inserts for them.
- **WAL replay** bypasses the binder, but throwing during recovery would prevent the database from opening at all — skipping leaves the index stale-but-rebuildable (`isRecovery()` check preserves this).

However, if a *future* code path bypasses the binder and appends rows while an unloaded holder still has a catalog entry, the index would permanently miss those rows with no signal. Commit now fails loudly in that case (restoring the original intent of the "Please load the extension for the index first." error):

```cpp
if (!transaction->isRecovery() && numLocalRows > 0 &&
    Catalog::Get(*context)->containsIndex(transaction, tableEntry->getTableID(),
        index.getName())) {
    throw RuntimeException(...);
}
```

`numLocalRows > 0` excludes update/delete-only commits (which the binder permits for non-indexed columns and which require no index maintenance), so there are no false positives.

## Validation
- Release build clean; clang-format-18 clean.
- e2e smoke: `*index*` (6/6), `*create_index*`/`*drop_index*`/`*fts*` (5/5) passed.