### PR TITLE
Apply node table update before updating indexes (fixes HNSW SET-on-NULL segfault, #896)

### DIFF
--- a/src/storage/table/node_table.cpp
+++ b/src/storage/table/node_table.cpp
@@ -26,6 +26,17 @@ using namespace lbug::evaluator;
 
 namespace lbug {
 namespace storage {
+namespace {
+// Whether index maintenance for an update must run AFTER the new value has been written to
+// the node table. The HNSW index re-scans the updated node's embedding from the node table
+// during re-insertion (see OnDiskHNSWIndex), so it must observe the NEW value. All other
+// index kinds (e.g. FTS, which re-tokenizes the OLD document from the node table while
+// deleting its entries) must run before the write. We key on the serialized index type
+// name to avoid extending the extension-facing Index API.
+bool updatesAfterTableWrite(const Index& index) {
+    return index.getIndexInfo().indexType == "HNSW";
+}
+} // namespace
 
 NodeTableVersionRecordHandler::NodeTableVersionRecordHandler(NodeTable* table) : table(table) {}
 
@@ -527,18 +538,22 @@ void NodeTable::update(Transaction* transaction, TableUpdateState& updateState) 
         throw RuntimeException("Cannot update pk.");
     }
     const auto nodeOffset = nodeUpdateState.nodeIDVector.readNodeOffset(pos);
+    // Indexes that need to read the OLD value from the node table (e.g. FTS re-tokenizing the
+    // document being deleted) must be updated before the row is written.
     for (auto i = 0u; i < indexes.size(); i++) {
         // Skip unloaded (orphaned) index holders; see initUpdateState().
         if (!indexes[i].isLoaded()) {
             continue;
         }
         auto index = indexes[i].getIndex();
-        if (!nodeUpdateState.needToUpdateIndex(i)) {
+        if (!nodeUpdateState.needToUpdateIndex(i) || updatesAfterTableWrite(*index)) {
             continue;
         }
         index->update(transaction, nodeUpdateState.nodeIDVector, nodeUpdateState.propertyVector,
             *nodeUpdateState.indexUpdateState[i]);
     }
+    // Indexes that re-scan the node table to observe the NEW value during update (e.g. HNSW)
+    // must be updated after the row is written.
     if (transaction->isUnCommitted(tableID, nodeOffset)) {
         const auto localTable = transaction->getLocalStorage()->getLocalTable(tableID);
         DASSERT(localTable);
@@ -550,6 +565,18 @@ void NodeTable::update(Transaction* transaction, TableUpdateState& updateState) 
         nodeGroups->getNodeGroup(nodeGroupIdx)
             ->update(transaction, rowIdxInGroup, nodeUpdateState.columnID,
                 nodeUpdateState.propertyVector);
+    }
+    for (auto i = 0u; i < indexes.size(); i++) {
+        // Skip unloaded (orphaned) index holders; see initUpdateState().
+        if (!indexes[i].isLoaded()) {
+            continue;
+        }
+        auto index = indexes[i].getIndex();
+        if (!nodeUpdateState.needToUpdateIndex(i) || !updatesAfterTableWrite(*index)) {
+            continue;
+        }
+        index->update(transaction, nodeUpdateState.nodeIDVector, nodeUpdateState.propertyVector,
+            *nodeUpdateState.indexUpdateState[i]);
     }
     if (updateState.logToWAL && transaction->shouldLogToWAL()) {
         DASSERT(transaction->isWriteTransaction());


### PR DESCRIPTION
Fixes #896.

## Problem
`SET n.embedding = $vec` on a node whose `embedding` is NULL, while an HNSW vector index exists on the column, segfaults (SIGSEGV) nondeterministically and can leave the WAL unreplayable (`Corrupted wal file. Read out invalid WAL record type.` on next open). Reported with a self-contained repro and stacks in #896 (0.20.1, macOS arm64).

## Root cause
`NodeTable::update()` called `index->update()` **before** writing the new value into the node table. HNSW index maintenance (`OnDiskHNSWIndex::update` -> `commitInsert` -> `insertToLayer` -> `createRels` -> `shrinkForNode`) scans the node table to read the updated node's embedding. With the old ordering it read the **stale** value — NULL when the row had no embedding at index build — producing a null `EmbeddingHandle` whose `getPtr()` was passed to the distance function (`simsimd_cos_f32_neon`), i.e. an out-of-bounds read that segfaults depending on memory layout. This also explains the issue's observed shape-dependence: re-SET of a row that already had a vector and CREATE of a row carrying its vector never hit the NULL path.

## Changes
Index kinds have conflicting needs when their column is updated:
- FTS `delete_` re-tokenizes the **old** document from the node table → must run *before* the row write,
- HNSW re-scans the updated node's **new** embedding during re-insertion → must run *after*.

`NodeTable::update()` is now two-phase: run "before" indexes, apply the row update to the node table (local storage or node group), then run "after" indexes. The ordering is keyed on the serialized index type name (`"HNSW"`) to avoid extending the extension-facing `Index` API, so this PR needs no coordinated extension change. The existing `isLoaded()` orphaned-holder guard is preserved in both loops.

Paired extension change (already merged, submodule bumped here): ladybugdb/extensions#78 — guards `shrinkForNode()` against a NULL scanned embedding and adds regression tests.

## Testing
- All FTS + vector extension e2e tests pass (including the 3 regression cases from extensions#78: SET on a row that was NULL at index build, SET to NULL and back, and NULL-row SET surviving checkpoint + reopen). The only local failure is `show_loaded_extensions`, which requires duckdb/httpfs extensions not built in this environment.
- 140 core update/set-related e2e tests pass.
- Issue-scale C++ repro (2000x768-dim vectors + 1000 NULL rows, `mu 30 / ml 60 / cosine / efc 200`): 50 SETs on NULL rows + `CHECKPOINT` + reopen, 5/5 runs clean, WAL replays without corruption.
