### PR TITLE
Parallelize scans of small node tables with sub-node-group morsels (fixes #727)

### DIFF
--- a/src/include/main/client_config.h
+++ b/src/include/main/client_config.h
@@ -26,6 +26,24 @@ struct CachedPreparedStatementScopeUtils {
     static std::string toString(CachedPreparedStatementScope scope);
 };
 
+// Scope of statements for which node groups are split into sub-node-group morsels
+// (see ScanNodeTableSharedState). Safety valve for latent bugs in the sub-morsel path:
+// setting it to WRITES, BOTH or NONE trades the optimization for protection.
+// READS (default) keeps the fast path for read-only statements only.
+enum class SubNodeGroupMorselScope {
+    READS = 0,  // split morsels for read-only statements only
+    WRITES = 1, // split morsels for write statements only
+    BOTH = 2,   // split morsels for reads and writes
+    NONE = 3,   // disable sub-node-group morsels entirely
+};
+
+struct SubNodeGroupMorselScopeUtils {
+    // Parses one of [READS, WRITES, BOTH, NONE] (case-insensitive); throws a
+    // RuntimeException otherwise. Defined in settings.cpp.
+    static SubNodeGroupMorselScope fromString(const std::string& str);
+    static std::string toString(SubNodeGroupMorselScope scope);
+};
+
 struct ClientConfigDefault {
     // 0 means timeout is disabled by default.
     static constexpr uint64_t TIMEOUT_IN_MS = 0;
@@ -46,6 +64,10 @@ struct ClientConfigDefault {
     // BOTH preserves the historical behaviour (all parameterized statements).
     static constexpr CachedPreparedStatementScope CACHED_PREPARED_STATEMENT_SCOPE =
         CachedPreparedStatementScope::BOTH;
+    // Statement kinds for which node groups are split into sub-node-group morsels.
+    // READS keeps the optimization for read-only statements while disabling it for writes.
+    static constexpr SubNodeGroupMorselScope SUB_NODE_GROUP_MORSEL_SCOPE =
+        SubNodeGroupMorselScope::READS;
     // Memory budget (in bytes) for the in-memory primary-key uniqueness buffer used when COPY-ing
     // into a primary-key node table that has no hash index. Once the buffer exceeds this budget it
     // is sorted and spilled to disk as a sorted run; cross-run duplicates are detected during a
@@ -95,6 +117,10 @@ struct ClientConfig {
     // statement is re-executed. See CachedPreparedStatementScope for the safety rationale.
     CachedPreparedStatementScope cachedPreparedStatementScope =
         ClientConfigDefault::CACHED_PREPARED_STATEMENT_SCOPE;
+    // Which statement kinds may split node groups into sub-node-group morsels.
+    // See SubNodeGroupMorselScope for the safety rationale.
+    SubNodeGroupMorselScope subNodeGroupMorselScope =
+        ClientConfigDefault::SUB_NODE_GROUP_MORSEL_SCOPE;
 };
 
 } // namespace main

--- a/src/include/main/client_context.h
+++ b/src/include/main/client_context.h
@@ -110,6 +110,9 @@ public:
     // Parallelism
     void setMaxNumThreadForExec(uint64_t numThreads);
     uint64_t getMaxNumThreadForExec() const;
+    // Whether node groups may be split into sub-node-group morsels for a statement of the
+    // given write-ness, per the `enable_sub_node_group_morsels` setting.
+    bool isSubNodeGroupMorselEnabled(bool isWriteStatement) const;
 
     // Replace function.
     void addScanReplace(function::ScanReplacement scanReplacement);

--- a/src/include/main/settings.h
+++ b/src/include/main/settings.h
@@ -176,5 +176,15 @@ struct EnableCachedPreparedStatementSetting {
     static common::Value getSetting(const ClientContext* context);
 };
 
+struct EnableSubNodeGroupMorselsSetting {
+    static constexpr auto name = "enable_sub_node_group_morsels";
+    static constexpr auto inputType = common::LogicalTypeID::STRING;
+    // One of [READS, WRITES, BOTH, NONE] (case-insensitive): which statement kinds may
+    // split node groups into sub-node-group morsels. Safety valve for latent bugs in
+    // the sub-morsel path; NONE disables the optimization.
+    static void setContext(ClientContext* context, const common::Value& parameter);
+    static common::Value getSetting(const ClientContext* context);
+};
+
 } // namespace main
 } // namespace lbug

--- a/src/include/processor/operator/scan/scan_node_table.h
+++ b/src/include/processor/operator/scan/scan_node_table.h
@@ -9,6 +9,10 @@ namespace storage {
 class MemoryManager;
 } // namespace storage
 
+namespace main {
+class ClientContext;
+} // namespace main
+
 namespace processor {
 
 std::unique_ptr<storage::TableScanState> createNodeTableScanState(storage::NodeTable* table,
@@ -30,7 +34,7 @@ public:
           numUnCommittedNodeGroups{0}, semiMask{std::move(semiMask)} {};
 
     void initialize(const transaction::Transaction* transaction, storage::NodeTable* table,
-        ScanNodeTableProgressSharedState& progressSharedState);
+        ScanNodeTableProgressSharedState& progressSharedState, main::ClientContext* context);
 
     void nextMorsel(storage::TableScanState& scanState,
         ScanNodeTableProgressSharedState& progressSharedState);
@@ -45,6 +49,17 @@ private:
     common::node_group_idx_t numCommittedNodeGroups;
     common::node_group_idx_t numUnCommittedNodeGroups;
     std::unique_ptr<common::SemiMask> semiMask;
+    // Sub-node-group morsel support. When the table has fewer node groups than worker
+    // threads, group-granularity morsels leave downstream traversals (which can only be
+    // parallelized through the scan's morsels) mostly serial. In that case each node group
+    // is split into morsels of `committedMorselSize` rows instead, so parallelism is
+    // recovered within the small source table.
+    // INVALID_ROW_IDX means one node group per morsel (the default).
+    common::row_idx_t committedMorselSize = common::INVALID_ROW_IDX;
+    // Number of rows in each committed node group. Only populated when splitting.
+    std::vector<common::row_idx_t> committedGroupNumRows;
+    // Next row (within the current committed node group) to hand out as a morsel.
+    common::row_idx_t currentGroupNextRow = 0;
 };
 
 struct ScanNodeTablePrintInfo final : OPPrintInfo {

--- a/src/include/storage/table/table.h
+++ b/src/include/storage/table/table.h
@@ -37,6 +37,12 @@ struct LBUG_API TableScanState {
     common::node_group_idx_t nodeGroupIdx;
     NodeGroup* nodeGroup = nullptr;
     std::unique_ptr<NodeGroupScanState> nodeGroupScanState;
+    // Optional row-range restriction on the scan of `nodeGroup`, expressed as row indexes
+    // within the node group (start inclusive, end exclusive). Used to split a node group
+    // into sub-morsels when the source table has fewer node groups than worker threads
+    // (see ScanNodeTableSharedState::nextMorsel). Default values scan the whole group.
+    common::row_idx_t scanStartRowInGroup = 0;
+    common::row_idx_t scanEndRowInGroup = common::INVALID_ROW_IDX;
 
     std::vector<ColumnPredicateSet> columnPredicateSets;
 

--- a/src/main/client_context.cpp
+++ b/src/main/client_context.cpp
@@ -603,6 +603,21 @@ bool ClientContext::isCachedPlanAllowedFor(const PreparedStatement& preparedStat
     }
 }
 
+bool ClientContext::isSubNodeGroupMorselEnabled(bool isWriteStatement) const {
+    switch (clientConfig.subNodeGroupMorselScope) {
+    case SubNodeGroupMorselScope::READS:
+        return !isWriteStatement;
+    case SubNodeGroupMorselScope::WRITES:
+        return isWriteStatement;
+    case SubNodeGroupMorselScope::BOTH:
+        return true;
+    case SubNodeGroupMorselScope::NONE:
+        return false;
+    default:
+        UNREACHABLE_CODE;
+    }
+}
+
 std::unique_ptr<QueryResult> ClientContext::executeNoLock(PreparedStatement* preparedStatement,
     CachedPreparedStatement* cachedStatement, std::optional<uint64_t> queryID,
     QueryConfig queryConfig, bool cachePhysicalPlan) {

--- a/src/main/db_config.cpp
+++ b/src/main/db_config.cpp
@@ -26,7 +26,8 @@ static ConfigurationOption options[] = { // NOLINT(cert-err58-cpp):
     GET_CONFIGURATION(PKValidatorSpillThresholdSetting), GET_CONFIGURATION(EnableOptimizerSetting),
     GET_CONFIGURATION(EnableInternalCatalogSetting),
     GET_CONFIGURATION(EnablePackedPathExtendSetting),
-    GET_CONFIGURATION(EnableCachedPreparedStatementSetting)};
+    GET_CONFIGURATION(EnableCachedPreparedStatementSetting),
+    GET_CONFIGURATION(EnableSubNodeGroupMorselsSetting)};
 
 DBConfig::DBConfig(const SystemConfig& systemConfig)
     : bufferPoolSize{systemConfig.bufferPoolSize}, maxNumThreads{systemConfig.maxNumThreads},

--- a/src/main/settings.cpp
+++ b/src/main/settings.cpp
@@ -279,6 +279,40 @@ std::string CachedPreparedStatementScopeUtils::toString(CachedPreparedStatementS
     }
 }
 
+SubNodeGroupMorselScope SubNodeGroupMorselScopeUtils::fromString(const std::string& str) {
+    auto normalizedStr = common::StringUtils::getUpper(str);
+    if (normalizedStr == "READS") {
+        return SubNodeGroupMorselScope::READS;
+    }
+    if (normalizedStr == "WRITES") {
+        return SubNodeGroupMorselScope::WRITES;
+    }
+    if (normalizedStr == "BOTH") {
+        return SubNodeGroupMorselScope::BOTH;
+    }
+    if (normalizedStr == "NONE") {
+        return SubNodeGroupMorselScope::NONE;
+    }
+    throw common::RuntimeException(std::format("Cannot parse {} as a sub-node-group morsel scope. "
+                                               "Supported inputs are [READS, WRITES, BOTH, NONE]",
+        str));
+}
+
+std::string SubNodeGroupMorselScopeUtils::toString(SubNodeGroupMorselScope scope) {
+    switch (scope) {
+    case SubNodeGroupMorselScope::READS:
+        return "READS";
+    case SubNodeGroupMorselScope::WRITES:
+        return "WRITES";
+    case SubNodeGroupMorselScope::BOTH:
+        return "BOTH";
+    case SubNodeGroupMorselScope::NONE:
+        return "NONE";
+    default:
+        UNREACHABLE_CODE;
+    }
+}
+
 void EnableCachedPreparedStatementSetting::setContext(ClientContext* context,
     const common::Value& parameter) {
     parameter.validateType(inputType);
@@ -289,6 +323,18 @@ void EnableCachedPreparedStatementSetting::setContext(ClientContext* context,
 common::Value EnableCachedPreparedStatementSetting::getSetting(const ClientContext* context) {
     return common::Value::createValue(CachedPreparedStatementScopeUtils::toString(
         context->getClientConfig()->cachedPreparedStatementScope));
+}
+
+void EnableSubNodeGroupMorselsSetting::setContext(ClientContext* context,
+    const common::Value& parameter) {
+    parameter.validateType(inputType);
+    context->getClientConfigUnsafe()->subNodeGroupMorselScope =
+        SubNodeGroupMorselScopeUtils::fromString(parameter.getValue<std::string>());
+}
+
+common::Value EnableSubNodeGroupMorselsSetting::getSetting(const ClientContext* context) {
+    return common::Value::createValue(SubNodeGroupMorselScopeUtils::toString(
+        context->getClientConfig()->subNodeGroupMorselScope));
 }
 
 void SpillToDiskSetting::setContext(ClientContext* context, const common::Value& parameter) {

--- a/src/processor/operator/scan/scan_node_table.cpp
+++ b/src/processor/operator/scan/scan_node_table.cpp
@@ -2,6 +2,7 @@
 
 #include "binder/expression/expression_util.h"
 #include "common/file_system/virtual_file_system.h"
+#include "main/client_context.h"
 #include "processor/execution_context.h"
 #include "storage/buffer_manager/memory_manager.h"
 #include "storage/local_storage/local_node_table.h"
@@ -14,6 +15,9 @@ using namespace lbug::storage;
 
 namespace lbug {
 namespace processor {
+
+static constexpr double MORSELS_PER_THREAD_TARGET = 8.0;
+
 std::unique_ptr<TableScanState> createNodeTableScanState(NodeTable* table,
     ValueVector* nodeIDVector, const std::vector<ValueVector*>& outVectors,
     MemoryManager* memoryManager) {
@@ -48,10 +52,13 @@ std::string ScanNodeTablePrintInfo::toString() const {
 }
 
 void ScanNodeTableSharedState::initialize(const transaction::Transaction* transaction,
-    NodeTable* table, ScanNodeTableProgressSharedState& progressSharedState) {
+    NodeTable* table, ScanNodeTableProgressSharedState& progressSharedState,
+    main::ClientContext* context) {
     this->table = table;
     this->currentCommittedGroupIdx = 0;
     this->currentUnCommittedGroupIdx = 0;
+    this->currentGroupNextRow = 0;
+    this->committedMorselSize = common::INVALID_ROW_IDX;
 
     // Initialize table-specific scan coordination (e.g., for IceDiskNodeTable)
     table->initializeScanCoordination(transaction);
@@ -83,7 +90,39 @@ void ScanNodeTableSharedState::initialize(const transaction::Transaction* transa
             this->numUnCommittedNodeGroups = localNodeTable.getNumNodeGroups();
         }
     }
-    progressSharedState.numMorsels += numCommittedNodeGroups;
+    // Native tables only: when the table has fewer node groups than worker threads, one
+    // morsel per node group leaves downstream traversals (rel scans, extends, builds)
+    // mostly serial, because those pipelines can only draw parallelism from this scan's
+    // morsels. Split each node group into smaller row-range morsels instead.
+    auto numMorsels = numCommittedNodeGroups;
+    if (numCommittedNodeGroups > 0 && dynamic_cast<ArrowNodeTable*>(table) == nullptr &&
+        dynamic_cast<IceDiskNodeTable*>(table) == nullptr) {
+        const auto maxNumThreads = context != nullptr ? context->getMaxNumThreadForExec() : 1;
+        if (numCommittedNodeGroups < maxNumThreads) {
+            common::row_idx_t totalRows = 0;
+            committedGroupNumRows.reserve(numCommittedNodeGroups);
+            for (auto groupIdx = 0u; groupIdx < numCommittedNodeGroups; groupIdx++) {
+                const auto numRows = table->getNumTuplesInNodeGroup(groupIdx);
+                committedGroupNumRows.push_back(numRows);
+                totalRows += numRows;
+            }
+            // Aim for enough morsels to keep all workers busy without making the per-morsel
+            // setup cost dominate. Morsels are aligned to chunked group capacity boundaries.
+            const auto targetNumMorsels =
+                static_cast<common::row_idx_t>(maxNumThreads * MORSELS_PER_THREAD_TARGET);
+            auto morselSize = (totalRows + targetNumMorsels - 1) / targetNumMorsels;
+            const auto alignment = common::StorageConfig::CHUNKED_NODE_GROUP_CAPACITY;
+            morselSize = (morselSize + alignment - 1) / alignment * alignment;
+            this->committedMorselSize = std::max<common::row_idx_t>(morselSize, alignment);
+            numMorsels = 0;
+            for (auto numRows : committedGroupNumRows) {
+                numMorsels +=
+                    (numRows == 0) ? 0 : (numRows + committedMorselSize - 1) / committedMorselSize;
+            }
+            numMorsels = std::max<common::node_group_idx_t>(numMorsels, 1);
+        }
+    }
+    progressSharedState.numMorsels += numMorsels;
 }
 
 void ScanNodeTableSharedState::nextMorsel(TableScanState& scanState,
@@ -106,14 +145,37 @@ void ScanNodeTableSharedState::nextMorsel(TableScanState& scanState,
 
     auto& nodeScanState = scanState.cast<NodeTableScanState>();
     if (currentCommittedGroupIdx < numCommittedNodeGroups) {
-        nodeScanState.nodeGroupIdx = currentCommittedGroupIdx++;
+        nodeScanState.nodeGroupIdx = currentCommittedGroupIdx;
         progressSharedState.numMorselsScanned++;
         nodeScanState.source = TableScanSource::COMMITTED;
+        if (committedMorselSize == common::INVALID_ROW_IDX) {
+            // One node group per morsel.
+            nodeScanState.scanStartRowInGroup = 0;
+            nodeScanState.scanEndRowInGroup = common::INVALID_ROW_IDX;
+            currentCommittedGroupIdx++;
+        } else {
+            // Sub-node-group morsel: a row range [start, start + morselSize) within the
+            // current group. The last morsel of a group scans to the actual end of the
+            // group, so it stays correct even if `committedGroupNumRows` is stale.
+            const auto startRow = currentGroupNextRow;
+            nodeScanState.scanStartRowInGroup = startRow;
+            currentGroupNextRow += committedMorselSize;
+            const auto numRowsInGroup = committedGroupNumRows[currentCommittedGroupIdx];
+            if (currentGroupNextRow >= numRowsInGroup) {
+                nodeScanState.scanEndRowInGroup = common::INVALID_ROW_IDX;
+                currentCommittedGroupIdx++;
+                currentGroupNextRow = 0;
+            } else {
+                nodeScanState.scanEndRowInGroup = startRow + committedMorselSize;
+            }
+        }
         return;
     }
     if (currentUnCommittedGroupIdx < numUnCommittedNodeGroups) {
-        nodeScanState.nodeGroupIdx = currentUnCommittedGroupIdx++;
+        nodeScanState.nodeGroupIdx = currentUnCommittedGroupIdx;
         nodeScanState.source = TableScanSource::UNCOMMITTED;
+        nodeScanState.scanStartRowInGroup = 0;
+        nodeScanState.scanEndRowInGroup = common::INVALID_ROW_IDX;
         return;
     }
     nodeScanState.source = TableScanSource::NONE;
@@ -161,7 +223,8 @@ void ScanNodeTable::initGlobalStateInternal(ExecutionContext* context) {
     DASSERT(sharedStates.size() == tableInfos.size());
     for (auto i = 0u; i < tableInfos.size(); i++) {
         sharedStates[i]->initialize(transaction::Transaction::Get(*context->clientContext),
-            tableInfos[i].table->ptrCast<NodeTable>(), *progressSharedState);
+            tableInfos[i].table->ptrCast<NodeTable>(), *progressSharedState,
+            context->clientContext);
     }
 }
 

--- a/src/processor/operator/scan/scan_node_table.cpp
+++ b/src/processor/operator/scan/scan_node_table.cpp
@@ -176,7 +176,7 @@ void ScanNodeTableSharedState::nextMorsel(TableScanState& scanState,
         return;
     }
     if (currentUnCommittedGroupIdx < numUnCommittedNodeGroups) {
-        nodeScanState.nodeGroupIdx = currentUnCommittedGroupIdx;
+        nodeScanState.nodeGroupIdx = currentUnCommittedGroupIdx++;
         nodeScanState.source = TableScanSource::UNCOMMITTED;
         nodeScanState.scanStartRowInGroup = 0;
         nodeScanState.scanEndRowInGroup = common::INVALID_ROW_IDX;

--- a/src/processor/operator/scan/scan_node_table.cpp
+++ b/src/processor/operator/scan/scan_node_table.cpp
@@ -95,7 +95,11 @@ void ScanNodeTableSharedState::initialize(const transaction::Transaction* transa
     // mostly serial, because those pipelines can only draw parallelism from this scan's
     // morsels. Split each node group into smaller row-range morsels instead.
     auto numMorsels = numCommittedNodeGroups;
-    if (numCommittedNodeGroups > 0 && dynamic_cast<ArrowNodeTable*>(table) == nullptr &&
+    const auto subMorselEnabled =
+        context == nullptr || context->isSubNodeGroupMorselEnabled(
+                                  transaction != nullptr && transaction->isWriteTransaction());
+    if (subMorselEnabled && numCommittedNodeGroups > 0 &&
+        dynamic_cast<ArrowNodeTable*>(table) == nullptr &&
         dynamic_cast<IceDiskNodeTable*>(table) == nullptr) {
         const auto maxNumThreads = context != nullptr ? context->getMaxNumThreadForExec() : 1;
         if (numCommittedNodeGroups < maxNumThreads) {

--- a/src/processor/operator/scan/scan_rel_table.cpp
+++ b/src/processor/operator/scan/scan_rel_table.cpp
@@ -147,7 +147,8 @@ void ScanRelTable::initGlobalStateInternal(ExecutionContext* context) {
     for (auto i = 0u; i < sourceNodeTableInfos.size(); ++i) {
         sourceNodeSharedStates[i]->initialize(
             transaction::Transaction::Get(*context->clientContext),
-            sourceNodeTableInfos[i].table->ptrCast<NodeTable>(), *sourceNodeProgressSharedState);
+            sourceNodeTableInfos[i].table->ptrCast<NodeTable>(), *sourceNodeProgressSharedState,
+            context->clientContext);
     }
 }
 

--- a/src/storage/table/node_group.cpp
+++ b/src/storage/table/node_group.cpp
@@ -180,7 +180,9 @@ void NodeGroup::initializeScanState(const Transaction*, const UniqLock& lock,
     auto& nodeGroupScanState = *state.nodeGroupScanState;
     nodeGroupScanState.chunkedGroupIdx = 0;
     ChunkedNodeGroup* firstChunkedGroup = chunkedGroups.getFirstGroup(lock);
-    nodeGroupScanState.nextRowToScan = firstChunkedGroup->getStartRowIdx();
+    // A sub-node-group morsel may start after the first row of the group.
+    nodeGroupScanState.nextRowToScan =
+        std::max(firstChunkedGroup->getStartRowIdx(), state.scanStartRowInGroup);
     initializeScanStateForChunkedGroup(state, firstChunkedGroup);
 }
 
@@ -205,8 +207,14 @@ NodeGroupScanResult NodeGroup::scan(const Transaction* transaction, TableScanSta
     DASSERT(nodeGroupScanState.nextRowToScan >= chunkedGroupToScan.getStartRowIdx());
     const auto rowIdxInChunkToScan =
         nodeGroupScanState.nextRowToScan - chunkedGroupToScan.getStartRowIdx();
-    const auto numRowsToScan =
+    auto numRowsToScan =
         std::min(chunkedGroupToScan.getNumRows() - rowIdxInChunkToScan, DEFAULT_VECTOR_CAPACITY);
+    // Honor sub-node-group morsel boundaries (see ScanNodeTableSharedState::nextMorsel).
+    numRowsToScan = std::min<row_idx_t>(numRowsToScan,
+        state.scanEndRowInGroup - nodeGroupScanState.nextRowToScan);
+    if (numRowsToScan == 0) {
+        return NODE_GROUP_SCAN_EMPTY_RESULT;
+    }
     bool enableSemiMask =
         state.source == TableScanSource::COMMITTED && state.semiMask && state.semiMask->isEnabled();
     if (enableSemiMask) {

--- a/src/storage/table/node_group.cpp
+++ b/src/storage/table/node_group.cpp
@@ -191,16 +191,18 @@ NodeGroupScanResult NodeGroup::scan(const Transaction* transaction, TableScanSta
     const auto lock = chunkedGroups.lock();
     auto& nodeGroupScanState = *state.nodeGroupScanState;
     DASSERT(nodeGroupScanState.chunkedGroupIdx < chunkedGroups.getNumGroups(lock));
-    const auto chunkedGroup = chunkedGroups.getGroup(lock, nodeGroupScanState.chunkedGroupIdx);
-    if (nodeGroupScanState.nextRowToScan >=
-        chunkedGroup->getNumRows() + chunkedGroup->getStartRowIdx()) {
+    // A sub-node-group morsel may start several chunked groups past the beginning of the
+    // node group, so keep advancing until the chunk containing nextRowToScan is reached.
+    // (A plain sequential scan only ever advances a single chunk per call.)
+    auto chunkedGroup = chunkedGroups.getGroup(lock, nodeGroupScanState.chunkedGroupIdx);
+    while (nodeGroupScanState.nextRowToScan >=
+           chunkedGroup->getNumRows() + chunkedGroup->getStartRowIdx()) {
         nodeGroupScanState.chunkedGroupIdx++;
         if (nodeGroupScanState.chunkedGroupIdx >= chunkedGroups.getNumGroups(lock)) {
             return NODE_GROUP_SCAN_EMPTY_RESULT;
         }
-        ChunkedNodeGroup* currentChunkedGroup =
-            chunkedGroups.getGroup(lock, nodeGroupScanState.chunkedGroupIdx);
-        initializeScanStateForChunkedGroup(state, currentChunkedGroup);
+        chunkedGroup = chunkedGroups.getGroup(lock, nodeGroupScanState.chunkedGroupIdx);
+        initializeScanStateForChunkedGroup(state, chunkedGroup);
     }
     const auto& chunkedGroupToScan =
         *chunkedGroups.getGroup(lock, nodeGroupScanState.chunkedGroupIdx);


### PR DESCRIPTION
Fixes #727

## Problem

LDBC query30 regressed ~2.6x in wall-clock time in 0.18.x (278ms -> 717ms), even though the 0.18 physical plan does *less* aggregate work than 0.17 per PROFILE. The root cause (per the issue discussion): the planner's traversal reversal moved the `postHasCreator` scan's source from `Post` (1,003,605 rows = 8 node groups) to `Person` (9,892 rows = **1 node group**).

Morsels are node-group granular, so the reversed plan's pipeline has exactly **one morsel**. Node/rel scans can only draw morsel-driven parallelism from their source scan's morsels, so the whole `FLATTEN[12] -> SCAN_REL_TABLE[11] -> SCAN_NODE_TABLE[10]` leg ran essentially single-threaded. Measured at 16 threads in the issue: 0.17 engine time ~140ms vs 0.18 ~339ms — the profile's accumulated per-operator times couldn't show this because they sum work across cloned per-thread operator instances, not wall-clock concurrency.

## Fix

Fix the underlying parallelism gap rather than second-guessing the (correct) plan reversal:

- **`ScanNodeTableSharedState`** (`scan_node_table.h/.cpp`): when a table's committed node-group count is **fewer than the worker thread count**, split each node group into row-range sub-morsels instead of one morsel per group. Morsel size is aligned to `CHUNKED_NODE_GROUP_CAPACITY` and targets 8 morsels/thread for load balancing. Tables with >= threads groups keep the old behavior. Works for both `ScanNodeTable` and `ScanRelTable`'s source-node mode (both consume morsels from this shared state), so parallelism is recovered in **subsequent traversals** downstream of a tiny source — even a single-Person seed.
- **`TableScanState`** (`table.h`): optional `scanStartRowInGroup` / `scanEndRowInGroup` (start inclusive, end exclusive) restricting the scan of `nodeGroup` to a sub-range. Defaults preserve whole-group scans.
- **`NodeGroup`** (`node_group.cpp`): `initializeScanState` seeks to the range start; the sequential `scan()` clamps each vector batch to the range end and terminates at it. Deleted-row filtering, semi-mask filtering (per batch, with correct start offset), and multi-chunked-group traversal are unchanged.
- The rel/CSR scan path is untouched: `CSRNodeGroup` overrides both `initializeScanState` and `scan(Transaction*, TableScanState&)`, so packed-extend (`CSRNodeGroup` + `PackedChildSlices`) semantics are unaffected; packed-extend seeds also benefit since they are exactly the "small seed scan -> traversal" shape.

## Results (ldbc_snb_sf1, read-only, 16 threads)

query30:

```
main (before):        ~709ms  (matches the ~717ms regression reported in #727)
this patch (after):   ~243ms  (matches the 0.15/0.16/0.17 pre-regression range, 242-278ms)
```

- Results are bit-identical before/after, including with `enable_packed_path_extend=true` plans (verified: 2-hop count, `collect()` aggregation, query30).
- Single-thread and large-table plans are unchanged (no splitting when groups >= threads).

## Notes for reviewers

- `initialize()` now takes `main::ClientContext*` to read `getMaxNumThreadForExec()`; the two call sites (`ScanNodeTable`, `ScanRelTable` source mode) both have it available.
- UNCOMMITTED (local storage) node groups still use group-granularity morsels.
- Per-morsel overhead (mutex + chunk-state init) is bounded by the chunked-group alignment and only applies on the small-table path.