### PR TITLE
fix: crash re-executing DISTINCT aggregate on cached-plan fast path (#906)

### DIFF
--- a/src/include/processor/operator/aggregate/base_aggregate.h
+++ b/src/include/processor/operator/aggregate/base_aggregate.h
@@ -59,6 +59,8 @@ protected:
         HashTableQueue(storage::MemoryManager* memoryManager, FactorizedTableSchema tableSchema);
 
         std::unique_ptr<HashTableQueue> copy() const {
+            // Only valid on a live queue: mergeInto() consumes the queue (nulling headBlock).
+            DASSERT(headBlock.load() != nullptr);
             return std::make_unique<HashTableQueue>(headBlock.load()->table.getMemoryManager(),
                 headBlock.load()->table.getTableSchema()->copy());
         }

--- a/src/include/processor/operator/aggregate/hash_aggregate.h
+++ b/src/include/processor/operator/aggregate/hash_aggregate.h
@@ -4,6 +4,7 @@
 
 #include <cstdint>
 #include <memory>
+#include <optional>
 #include <vector>
 
 #include "aggregate_hash_table.h"
@@ -117,6 +118,11 @@ public:
     uint64_t limitNumber;
     storage::MemoryManager* memoryManager;
     std::vector<Partition> globalPartitions;
+    // Table schemas for the per-function distinct queues, indexed by aggregate function
+    // (std::nullopt for non-distinct functions). Saved at construction so resetForReuse()
+    // can rebuild the queues from scratch: mergeInto() consumes a queue (nulling its
+    // headBlock), so the old queue cannot be used as a copy source on the next execution.
+    std::vector<std::optional<FactorizedTableSchema>> distinctTableSchemas;
 };
 
 struct HashAggregateLocalState {

--- a/src/processor/operator/aggregate/hash_aggregate.cpp
+++ b/src/processor/operator/aggregate/hash_aggregate.cpp
@@ -68,6 +68,7 @@ HashAggregateSharedState::HashAggregateSharedState(main::ClientContext* context,
     auto& partition = globalPartitions[0];
     partition.queue = std::make_unique<HashTableQueue>(MemoryManager::Get(*context),
         this->aggInfo.tableSchema.copy());
+    distinctTableSchemas.resize(aggregateFunctions.size());
 
     // Always create a hash table for the first partition. Any other partitions which are non-empty
     // when finalizing will create an empty copy of this table
@@ -94,6 +95,7 @@ HashAggregateSharedState::HashAggregateSharedState(main::ClientContext* context,
             distinctTableSchema.appendColumn(
                 ColumnSchema(false /* isUnFlat */, 0 /* groupID */, sizeof(hash_t)));
 
+            distinctTableSchemas[functionIdx] = distinctTableSchema.copy();
             partition.distinctTableQueues.emplace_back(std::make_unique<HashTableQueue>(
                 MemoryManager::Get(*context), std::move(distinctTableSchema)));
         } else {
@@ -133,9 +135,14 @@ void HashAggregateSharedState::resetForReuse() {
         if (partition.queue) {
             partition.queue = std::make_unique<HashTableQueue>(mm, aggInfo.tableSchema.copy());
         }
-        for (auto& distinctQueue : partition.distinctTableQueues) {
-            if (distinctQueue) {
-                distinctQueue = distinctQueue->copy();
+        for (size_t i = 0; i < partition.distinctTableQueues.size(); i++) {
+            if (partition.distinctTableQueues[i]) {
+                // Rebuild from the saved schema: mergeInto() consumes the queue (nulling
+                // its headBlock), so the old queue cannot serve as a copy source. A fresh
+                // queue also drops the previous execution's tuples, mirroring a new plan.
+                DASSERT(distinctTableSchemas[i].has_value());
+                partition.distinctTableQueues[i] = std::make_unique<HashTableQueue>(mm,
+                    distinctTableSchemas[i]->copy());
             }
         }
         if (partition.hashTable) {

--- a/src/processor/operator/aggregate/hash_aggregate.cpp
+++ b/src/processor/operator/aggregate/hash_aggregate.cpp
@@ -141,8 +141,8 @@ void HashAggregateSharedState::resetForReuse() {
                 // its headBlock), so the old queue cannot serve as a copy source. A fresh
                 // queue also drops the previous execution's tuples, mirroring a new plan.
                 DASSERT(distinctTableSchemas[i].has_value());
-                partition.distinctTableQueues[i] = std::make_unique<HashTableQueue>(mm,
-                    distinctTableSchemas[i]->copy());
+                partition.distinctTableQueues[i] =
+                    std::make_unique<HashTableQueue>(mm, distinctTableSchemas[i]->copy());
             }
         }
         if (partition.hashTable) {

--- a/test/api/prepare_test.cpp
+++ b/test/api/prepare_test.cpp
@@ -615,6 +615,40 @@ TEST_F(ApiTest, RepeatedParameterizedCachedPlanExecution877) {
 
 // Returns true iff the cached physical plan of the prepared statement named `ps.getName()`
 // has been populated (i.e. the statement is allowed to take the cached-plan fast path).
+static bool cachedPlanExists(Connection* conn, const PreparedStatement& ps);
+
+// Regression test for issue #906 (LDBC query 11 shape): re-executing a DISTINCT aggregate
+// through the cached-physical-plan fast path segfaulted in FactorizedTableSchema::copy.
+// Root cause: HashTableQueue::mergeInto() consumes a queue (nulling its headBlock), and
+// HashAggregateSharedState::resetForReuse() rebuilt the per-function distinct queues via
+// distinctQueue->copy(), dereferencing the nulled headBlock. The queues are now rebuilt
+// from schemas saved at construction time.
+TEST_F(ApiTest, RepeatedDistinctAggregateCachedPlanExecution906) {
+    // LDBC query 11 shape against the tinysnb graph loaded by the fixture: traversal join,
+    // DISTINCT hash aggregate grouped by key, ORDER BY plus LIMIT.
+    const std::string query = "MATCH (p:person)-[:workAt]->(o:organisation) WHERE o.ID > 0 "
+                              "RETURN COUNT(DISTINCT p.ID) AS num_e, o.name "
+                              "ORDER BY num_e DESC LIMIT 1;";
+    std::unordered_map<std::string, std::unique_ptr<Value>> noParams;
+    auto prepared = conn->prepareWithParams(query, std::move(noParams));
+    ASSERT_TRUE(prepared->isSuccess()) << prepared->getErrorMessage();
+    // First execution populates the plan cache; the second takes the fast path that crashed.
+    std::vector<std::string> first;
+    for (auto run = 0; run < 3; run++) {
+        std::unordered_map<std::string, std::unique_ptr<Value>> params;
+        auto result = conn->executeWithParams(prepared.get(), std::move(params));
+        ASSERT_TRUE(result->isSuccess()) << "run " << run;
+        auto rows = TestHelper::convertResultToString(*result);
+        ASSERT_FALSE(rows.empty()) << "run " << run;
+        if (run == 0) {
+            first = rows;
+        } else {
+            ASSERT_EQ(first, rows) << "run " << run;
+        }
+    }
+    ASSERT_TRUE(cachedPlanExists(conn.get(), *prepared));
+}
+
 static bool cachedPlanExists(Connection* conn, const PreparedStatement& ps) {
     const auto& manager = conn->getClientContext()->getCachedPreparedStatementManager();
     if (!manager.containsStatement(ps.getName())) {


### PR DESCRIPTION
Fixes #906.

## Problem
LDBC query 11 segfaults on its second execution with the prepared-statement plan cache enabled (default `both`). First execution populates the cache; the rerun takes the cached-plan fast path and crashes in `FactorizedTableSchema::FactorizedTableSchema(copy)`.

## Root cause
The query's `COUNT(DISTINCT p.ID)` hash aggregate stores per-function distinct-value queues (`HashAggregateSharedState::Partition::distinctTableQueues`). `HashTableQueue::mergeInto()` **consumes** a queue during finalization (ends with `headBlock = nullptr`), but `HashAggregateSharedState::resetForReuse()` rebuilt those queues via `distinctQueue->copy()`, and `HashTableQueue::copy()` unconditionally dereferences `headBlock` — null-pointer dereference on the second execution. (The adjacent main queue was already rebuilt fresh from `aggInfo.tableSchema`; only the distinct queues used the dead queue as a copy source, and even without the crash that would have carried stale tuples forward.)

## Changes
- `HashAggregateSharedState` saves each distinct queue's `FactorizedTableSchema` at construction (`distinctTableSchemas`, indexed by aggregate function); `resetForReuse()` rebuilds distinct queues fresh from the saved schemas.
- `HashTableQueue::copy()` gains a `DASSERT(headBlock != nullptr)` so future use-after-consume fails loudly.
- New regression test `ApiTest.RepeatedDistinctAggregateCachedPlanExecution906` (traversal join + `COUNT(DISTINCT …)` + `ORDER BY` + `LIMIT`, 3× through `executeWithParams`, asserting identical rows and that the cached plan was used). Verified it passes with the fix (local `api_test` run).