### PR TITLE
Fix canRead to accept storage version 46

### DIFF
--- a/src/include/storage/storage_version_info.h
+++ b/src/include/storage/storage_version_info.h
@@ -53,7 +53,7 @@ struct StorageVersionInfo {
         return storageVersion == STORAGE_VERSION_40 || storageVersion == STORAGE_VERSION_41 ||
                storageVersion == STORAGE_VERSION_42 || storageVersion == STORAGE_VERSION_43 ||
                storageVersion == STORAGE_VERSION_44 || storageVersion == STORAGE_VERSION_45 ||
-               storageVersion == getStorageVersion();
+               storageVersion == STORAGE_VERSION_46 || storageVersion == getStorageVersion();
     }
 
     static constexpr const char* MAGIC_BYTES = "LBUG";


### PR DESCRIPTION
## Summary
- `5eac1dd70` bumped the storage version to 47 (LIST partitioning) but did not add `STORAGE_VERSION_46` to `canReadStorageVersion()`, so databases written by the v46 build (`f41eab013`) fail to open:
  ```
  Trying to read a database file with a different version. Database file version: 46, Current build storage version: 47
  ```
- Add v46 to the read whitelist. Deserializer version guards for the partitioning / LIST-key fields are already in place, so v46 DBs deserialize correctly and are re-written in v47 format on next checkpoint.

Fixes #914