### PR TITLE
Generalize COUNT_REL_TABLE metadata counting to packed extend chains

### DIFF
--- a/src/include/optimizer/count_rel_table_optimizer.h
+++ b/src/include/optimizer/count_rel_table_optimizer.h
@@ -44,6 +44,11 @@ private:
     std::shared_ptr<planner::LogicalOperator> visitOrderByReplace(
         std::shared_ptr<planner::LogicalOperator> op) override;
 
+    // Rewrite COUNT(*) over a chain of >= 2 extends (a pure path, possibly connected by
+    // node-ID hash joins) into a count-only chain operator.
+    std::shared_ptr<planner::LogicalOperator> tryRewriteExtendChainCount(
+        std::shared_ptr<planner::LogicalOperator> op);
+
     // Check if the aggregate is a simple (non-distinct) COUNT with no keys.
     bool isSimpleCount(planner::LogicalOperator* op) const;
 

--- a/src/include/planner/operator/logical_operator.h
+++ b/src/include/planner/operator/logical_operator.h
@@ -23,6 +23,7 @@ enum class LogicalOperatorType : uint8_t {
     ATTACH_DATABASE,
     COPY_FROM,
     COPY_TO,
+    COUNT_EXTEND_CHAIN,
     COUNT_REL_TABLE,
     CREATE_GRAPH,
     CREATE_INDEX,

--- a/src/include/planner/operator/scan/logical_count_extend_chain.h
+++ b/src/include/planner/operator/scan/logical_count_extend_chain.h
@@ -1,0 +1,108 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include "binder/expression/expression.h"
+#include "common/enums/rel_direction.h"
+#include "common/types/types.h"
+#include "planner/operator/logical_operator.h"
+
+namespace lbug {
+namespace planner {
+
+// A single rel-table scan participating in one hop of a count chain. The CSR of the rel table
+// is scanned in `scanDirection`, which is the direction keyed by the hop's "from" node table:
+// FWD when the from-node is the rel's src side, BWD when it is the dst side. Iterating the
+// from-side node offsets and reading the nbr column then yields exactly the (from, to) edges
+// crossing this hop.
+struct CountChainRelScanSpec {
+    common::table_id_t relTableID = common::INVALID_TABLE_ID;
+    common::RelDataDirection scanDirection = common::RelDataDirection::FWD;
+    common::table_id_t fromNodeTableID = common::INVALID_TABLE_ID;
+    common::table_id_t toNodeTableID = common::INVALID_TABLE_ID;
+    std::string relTableName; // for printing
+};
+
+// One hop of the extend chain. A hop may cover several rel tables (e.g. multi-entry rel groups
+// matched against the same node table pair).
+struct CountChainHop {
+    std::vector<CountChainRelScanSpec> relScans;
+};
+
+struct LogicalCountExtendChainPrintInfo final : OPPrintInfo {
+    std::vector<std::string> relTableNames;
+    uint64_t numHops;
+
+    LogicalCountExtendChainPrintInfo(std::vector<std::string> relTableNames, uint64_t numHops)
+        : relTableNames{std::move(relTableNames)}, numHops{numHops} {}
+
+    std::string toString() const override {
+        auto result = std::string("Tables: ");
+        for (auto i = 0u; i < relTableNames.size(); ++i) {
+            result += relTableNames[i];
+            if (i + 1 < relTableNames.size()) {
+                result += ", ";
+            }
+        }
+        result += ", Hops: " + std::to_string(numHops);
+        return result;
+    }
+
+    std::unique_ptr<OPPrintInfo> copy() const override {
+        return std::make_unique<LogicalCountExtendChainPrintInfo>(relTableNames, numHops);
+    }
+};
+
+/**
+ * LogicalCountExtendChain computes COUNT(*) over a pure chain of extends (a path in the query
+ * graph) using count-only arithmetic instead of materializing tuples. Created by
+ * CountRelTableOptimizer::tryRewriteExtendChainCount when the plan under a COUNT(*) aggregate is
+ * an unfiltered chain of extends (possibly connected by hash joins on node IDs).
+ *
+ * The count is the number of paths through the chain, which can be computed hop by hop: each
+ * hop accumulates, per destination node, the sum of the partial path counts of its source
+ * nodes. Only per-node count vectors (one int64 per node offset) are propagated; neighbor IDs
+ * are read from the CSR neighbor column but never materialized as tuples, and no hash joins are
+ * required.
+ */
+class LogicalCountExtendChain final : public LogicalOperator {
+    static constexpr LogicalOperatorType type_ = LogicalOperatorType::COUNT_EXTEND_CHAIN;
+
+public:
+    LogicalCountExtendChain(std::vector<CountChainHop> hops,
+        std::shared_ptr<binder::Expression> countExpr)
+        : LogicalOperator{type_}, hops{std::move(hops)}, countExpr{std::move(countExpr)} {
+        cardinality = 1; // Always returns exactly one row.
+    }
+
+    void computeFactorizedSchema() override;
+    void computeFlatSchema() override;
+
+    std::string getExpressionsForPrinting() const override { return countExpr->toString(); }
+
+    const std::vector<CountChainHop>& getHops() const { return hops; }
+    std::shared_ptr<binder::Expression> getCountExpr() const { return countExpr; }
+
+    std::unique_ptr<OPPrintInfo> getPrintInfo() const override {
+        std::vector<std::string> relTableNames;
+        for (auto& hop : hops) {
+            for (auto& spec : hop.relScans) {
+                relTableNames.push_back(spec.relTableName);
+            }
+        }
+        return std::make_unique<LogicalCountExtendChainPrintInfo>(std::move(relTableNames),
+            hops.size());
+    }
+
+    std::unique_ptr<LogicalOperator> copy() override {
+        return std::make_unique<LogicalCountExtendChain>(hops, countExpr);
+    }
+
+private:
+    std::vector<CountChainHop> hops;
+    std::shared_ptr<binder::Expression> countExpr;
+};
+
+} // namespace planner
+} // namespace lbug

--- a/src/include/processor/operator/physical_operator.h
+++ b/src/include/processor/operator/physical_operator.h
@@ -48,6 +48,7 @@ enum class PhysicalOperatorType : uint8_t {
     ATTACH_DATABASE,
     BATCH_INSERT,
     COPY_TO,
+    COUNT_EXTEND_CHAIN,
     COUNT_REL_TABLE,
     CREATE_GRAPH,
     CREATE_INDEX,

--- a/src/include/processor/operator/scan/count_extend_chain.h
+++ b/src/include/processor/operator/scan/count_extend_chain.h
@@ -1,0 +1,109 @@
+#pragma once
+
+#include <unordered_map>
+
+#include "common/enums/rel_direction.h"
+#include "common/types/types.h"
+#include "processor/data_pos.h"
+#include "processor/operator/physical_operator.h"
+#include "storage/table/node_table.h"
+#include "storage/table/rel_table.h"
+
+namespace lbug {
+namespace storage {
+class MemoryManager;
+}
+
+namespace processor {
+
+struct CountExtendChainPrintInfo final : OPPrintInfo {
+    std::vector<std::string> relTableNames;
+    uint64_t numHops;
+
+    CountExtendChainPrintInfo(std::vector<std::string> relTableNames, uint64_t numHops)
+        : relTableNames{std::move(relTableNames)}, numHops{numHops} {}
+
+    std::string toString() const override {
+        auto result = std::string("Tables: ");
+        for (auto i = 0u; i < relTableNames.size(); ++i) {
+            result += relTableNames[i];
+            if (i + 1 < relTableNames.size()) {
+                result += ", ";
+            }
+        }
+        result += ", Hops: " + std::to_string(numHops);
+        return result;
+    }
+
+    std::unique_ptr<OPPrintInfo> copy() const override {
+        return std::make_unique<CountExtendChainPrintInfo>(relTableNames, numHops);
+    }
+};
+
+/**
+ * CountExtendChain computes COUNT(*) over a chain of rel-table extends using count-only
+ * arithmetic. Instead of materializing the (multi-million-row) intermediate extend outputs and
+ * hash joining them, each hop propagates a per-node int64 count vector:
+ *
+ *   c_0[v] = 1 for every node of the chain's source node table
+ *   c_{j+1}[w] = sum over visible edges (v -> w) of rel table j of c_j[v]
+ *   result     = sum over visible edges of the last hop of c_{N-1}[v]
+ *
+ * The per-hop edge scans reuse the standard rel table scan machinery (persistent CSR, in-memory
+ * CSR, local storage and version/deletion filtering all come for free); the neighbor IDs read
+ * from the neighbor column are consumed immediately by the accumulation and never materialized
+ * as tuples. The operator is a single-threaded source emitting one row with the final count.
+ */
+class CountExtendChain final : public PhysicalOperator {
+    static constexpr PhysicalOperatorType type_ = PhysicalOperatorType::COUNT_EXTEND_CHAIN;
+
+public:
+    struct Hop {
+        std::vector<storage::RelTable*> relTables;
+        std::vector<common::RelDataDirection> scanDirections;
+        std::vector<common::table_id_t> fromNodeTableIDs;
+        std::vector<common::table_id_t> toNodeTableIDs;
+    };
+
+    CountExtendChain(std::vector<Hop> hops,
+        std::unordered_map<common::table_id_t, storage::NodeTable*> nodeTables,
+        DataPos countOutputPos, physical_op_id id, std::unique_ptr<OPPrintInfo> printInfo)
+        : PhysicalOperator{type_, id, std::move(printInfo)}, hops{std::move(hops)},
+          nodeTables{std::move(nodeTables)}, countOutputPos{countOutputPos} {}
+
+    bool isSource() const override { return true; }
+    bool isParallel() const override { return false; }
+
+    void initLocalStateInternal(ResultSet* resultSet, ExecutionContext* context) override;
+
+    bool getNextTuplesInternal(ExecutionContext* context) override;
+
+    std::unique_ptr<PhysicalOperator> copy() override {
+        return std::make_unique<CountExtendChain>(hops, nodeTables, countOutputPos, id,
+            printInfo->copy());
+    }
+
+private:
+    // Compute the upper bound (exclusive) of the node offsets that need to be iterated for the
+    // given node table. This covers the full committed offset space (including in-memory node
+    // groups), while c vectors are sized to numGroups * NODE_GROUP_SIZE so that offsets
+    // referencing nodes of a partially-deleted tail group remain in bounds.
+    common::offset_t getOffsetUpperBound(storage::NodeTable* nodeTable) const;
+
+    void processBatch(uint64_t hopIdx, common::table_id_t fromTableID, common::table_id_t toTableID,
+        bool isLastHop, const storage::RelTableScanState& scanState,
+        const common::ValueVector& nodeIDVector, const common::ValueVector& nbrVector);
+
+private:
+    std::vector<Hop> hops;
+    std::unordered_map<common::table_id_t, storage::NodeTable*> nodeTables;
+    DataPos countOutputPos;
+    common::ValueVector* countVector = nullptr;
+    bool hasExecuted = false;
+    int64_t totalCount = 0;
+    // counts[j] maps a node table ID to the per-node partial path counts at chain position j.
+    std::vector<std::unordered_map<common::table_id_t, std::vector<int64_t>>> counts;
+};
+
+} // namespace processor
+} // namespace lbug

--- a/src/include/processor/plan_mapper.h
+++ b/src/include/processor/plan_mapper.h
@@ -93,6 +93,8 @@ public:
     std::unique_ptr<PhysicalOperator> mapCopyTo(const planner::LogicalOperator* logicalOperator);
     std::unique_ptr<PhysicalOperator> mapCountRelTable(
         const planner::LogicalOperator* logicalOperator);
+    std::unique_ptr<PhysicalOperator> mapCountExtendChain(
+        const planner::LogicalOperator* logicalOperator);
     std::unique_ptr<PhysicalOperator> mapCreateMacro(
         const planner::LogicalOperator* logicalOperator);
     std::unique_ptr<PhysicalOperator> mapCreateSequence(

--- a/src/optimizer/count_rel_table_optimizer.cpp
+++ b/src/optimizer/count_rel_table_optimizer.cpp
@@ -11,6 +11,7 @@
 #include "catalog/catalog_entry/node_table_catalog_entry.h"
 #include "catalog/catalog_entry/node_table_id_pair.h"
 #include "common/enums/path_semantic.h"
+#include "common/enums/storage_format.h"
 #include "function/aggregate/count.h"
 #include "function/aggregate/count_star.h"
 #include "function/aggregate_function.h"
@@ -25,12 +26,14 @@
 #include "planner/operator/logical_order_by.h"
 #include "planner/operator/logical_path_property_probe.h"
 #include "planner/operator/logical_projection.h"
+#include "planner/operator/scan/logical_count_extend_chain.h"
 #include "planner/operator/scan/logical_count_rel_table.h"
 #include "planner/operator/scan/logical_reachable_count.h"
 #include "planner/operator/scan/logical_rel_degree_table.h"
 #include "planner/operator/scan/logical_scan_node_table.h"
 #include "storage/storage_manager.h"
 #include "storage/table/table.h"
+#include "transaction/transaction.h"
 
 using namespace lbug::common;
 using namespace lbug::planner;
@@ -51,6 +54,240 @@ std::shared_ptr<LogicalOperator> CountRelTableOptimizer::visitOperator(
         op->setChild(i, visitOperator(op->getChild(i)));
     }
     auto result = visitOperatorReplaceSwitch(op);
+    result->computeFlatSchema();
+    return result;
+}
+
+std::shared_ptr<LogicalOperator> CountRelTableOptimizer::tryRewriteExtendChainCount(
+    std::shared_ptr<LogicalOperator> op) {
+    // Must be a keyless COUNT_STAR aggregate. Single-hop chains are handled by the (cheaper,
+    // metadata-based) COUNT_REL_TABLE rewrite below, so require >= 2 hops.
+    if (op->getOperatorType() != LogicalOperatorType::AGGREGATE) {
+        return op;
+    }
+    auto& aggregate = op->constCast<LogicalAggregate>();
+    if (aggregate.hasKeys() || aggregate.getDependentKeys().size() != 0 ||
+        aggregate.getAggregates().size() != 1) {
+        return op;
+    }
+    auto aggExpr = aggregate.getAggregates()[0];
+    if (aggExpr->expressionType != ExpressionType::AGGREGATE_FUNCTION) {
+        return op;
+    }
+    auto& aggFuncExpr = aggExpr->constCast<AggregateFunctionExpression>();
+    if (aggFuncExpr.getFunction().name != function::CountStarFunction::name ||
+        aggFuncExpr.isDistinct() || aggFuncExpr.getNumChildren() != 0) {
+        return op;
+    }
+
+    // The fast path enumerates the committed offset space of the node tables; it must not run
+    // for transactions that can carry uncommitted node inserts beyond that space.
+    auto transaction = transaction::Transaction::Get(*_context);
+    if (transaction != nullptr && transaction->isWriteTransaction()) {
+        return op;
+    }
+
+    // Collect the extends in the subtree. Only row-count-invariant operators may appear:
+    // projections and node-ID-only inner hash joins; scans are ignored. Anything else
+    // (filters, multiplicity reducers, ...) can change row counts and disqualifies.
+    std::vector<const LogicalExtend*> extends;
+    std::function<bool(const LogicalOperator*)> collect =
+        [&](const LogicalOperator* current) -> bool {
+        switch (current->getOperatorType()) {
+        case LogicalOperatorType::PROJECTION: {
+            return collect(current->getChild(0).get());
+        }
+        case LogicalOperatorType::SCAN_NODE_TABLE: {
+            // The planner can fold node predicates (e.g. a name lookup) into the scan as
+            // property predicates or a primary-key scan. Such a scan yields a restricted node
+            // set, but the count chain iterates ALL node offsets, so a restricted scan
+            // disqualifies the rewrite.
+            auto& scan = current->constCast<LogicalScanNodeTable>();
+            if (scan.getScanType() == LogicalScanNodeTableType::PRIMARY_KEY_SCAN) {
+                return false;
+            }
+            for (auto& predicateSet : scan.getPropertyPredicates()) {
+                if (!predicateSet.isEmpty()) {
+                    return false;
+                }
+            }
+            return true;
+        }
+        case LogicalOperatorType::EXTEND:
+        case LogicalOperatorType::PACKED_EXTEND: {
+            extends.push_back(&current->constCast<LogicalExtend>());
+            return collect(current->getChild(0).get());
+        }
+        case LogicalOperatorType::HASH_JOIN: {
+            auto& join = current->constCast<LogicalHashJoin>();
+            const auto joinConditions = join.getJoinConditions();
+            if (join.getJoinType() != JoinType::INNER || joinConditions.size() != 1) {
+                return false;
+            }
+            const auto& probeKey = joinConditions[0].first;
+            const auto& buildKey = joinConditions[0].second;
+            auto isNodeInternalID = [](const std::shared_ptr<Expression>& expression) {
+                return expression->expressionType == ExpressionType::PROPERTY &&
+                       expression->constCast<PropertyExpression>().isInternalID();
+            };
+            if (!isNodeInternalID(probeKey) || !isNodeInternalID(buildKey) ||
+                probeKey->constCast<PropertyExpression>().getVariableName() !=
+                    buildKey->constCast<PropertyExpression>().getVariableName()) {
+                return false;
+            }
+            return collect(current->getChild(0).get()) && collect(current->getChild(1).get());
+        }
+        default:
+            return false;
+        }
+    };
+    if (!collect(op->getChild(0).get())) {
+        return op;
+    }
+    if (extends.size() < 2) {
+        return op;
+    }
+
+    // Validate the extends form a simple path over single-table nodes with single-entry,
+    // storage-backed rel groups.
+    // The fast path below iterates the committed node-group grid of native node tables and
+    // reads the CSR of native rel tables. Arrow-backed and icebug-disk tables have neither,
+    // so they must be left to the regular plan.
+    auto isNativeRelGroupEntry = [](const RelGroupCatalogEntry* entry) {
+        return entry->getStorage().empty() && entry->getStorageFormat() == StorageFormat::NONE;
+    };
+    auto isNativeNodeEntry = [](const NodeTableCatalogEntry* entry) {
+        return entry->getStorage().empty() && entry->getStorageFormat() == StorageFormat::NONE;
+    };
+    struct ChainEdge {
+        std::string u;
+        std::string v;
+        const LogicalExtend* extend;
+        bool used = false;
+    };
+    std::vector<ChainEdge> edges;
+    edges.reserve(extends.size());
+    std::unordered_map<std::string, std::shared_ptr<NodeExpression>> chainNodes;
+    for (auto extend : extends) {
+        auto rel = extend->getRel();
+        if (rel->getRelType() != QueryRelType::NON_RECURSIVE ||
+            extend->getDirection() == ExtendDirection::BOTH || rel->getNumEntries() != 1) {
+            return op;
+        }
+        auto* relGroupEntry = rel->getEntry(0)->ptrCast<RelGroupCatalogEntry>();
+        if (relGroupEntry->getScanFunction().has_value() || !isNativeRelGroupEntry(relGroupEntry)) {
+            return op;
+        }
+        auto boundNode = extend->getBoundNode();
+        auto nbrNode = extend->getNbrNode();
+        if (boundNode->isMultiLabeled() || nbrNode->isMultiLabeled() ||
+            boundNode->getNumEntries() != 1 || nbrNode->getNumEntries() != 1) {
+            return op;
+        }
+        if (!isNativeNodeEntry(boundNode->getEntry(0)->ptrCast<NodeTableCatalogEntry>()) ||
+            !isNativeNodeEntry(nbrNode->getEntry(0)->ptrCast<NodeTableCatalogEntry>())) {
+            return op;
+        }
+        chainNodes.emplace(boundNode->getUniqueName(), boundNode);
+        chainNodes.emplace(nbrNode->getUniqueName(), nbrNode);
+        edges.push_back({boundNode->getUniqueName(), nbrNode->getUniqueName(), extend});
+    }
+    std::unordered_map<std::string, uint32_t> degrees;
+    for (auto& edge : edges) {
+        degrees[edge.u]++;
+        degrees[edge.v]++;
+        if (degrees[edge.u] > 2 || degrees[edge.v] > 2) {
+            return op;
+        }
+    }
+    if (edges.size() != chainNodes.size() - 1) {
+        return op;
+    }
+
+    // Order the path starting at a degree-1 endpoint. At each interior node exactly one
+    // incident edge is already used, so the next unused incident edge continues the path.
+    std::string start;
+    for (auto& [name, degree] : degrees) {
+        if (degree == 1) {
+            start = name;
+            break;
+        }
+    }
+    if (start.empty()) {
+        return op;
+    }
+    std::vector<std::string> ordered;
+    ordered.push_back(start);
+    auto current = start;
+    for (auto step = 0u; step < edges.size(); ++step) {
+        auto found = false;
+        for (auto& edge : edges) {
+            if (edge.used) {
+                continue;
+            }
+            if (edge.u == current) {
+                edge.used = true;
+                current = edge.v;
+                found = true;
+                break;
+            }
+            if (edge.v == current) {
+                edge.used = true;
+                current = edge.u;
+                found = true;
+                break;
+            }
+        }
+        if (!found) {
+            return op;
+        }
+        ordered.push_back(current);
+    }
+
+    // Build the hop specs. For each hop the scan direction is the rel direction keyed by the
+    // hop's from-node: FWD when the from-node is the rel's src side, BWD when it is the dst.
+    std::vector<CountChainHop> hops;
+    hops.reserve(ordered.size() - 1);
+    for (auto j = 0u; j + 1 < ordered.size(); ++j) {
+        const auto& xName = ordered[j];
+        const auto& yName = ordered[j + 1];
+        auto x = chainNodes.at(xName);
+        auto y = chainNodes.at(yName);
+        const LogicalExtend* extend = nullptr;
+        for (auto& edge : edges) {
+            if ((edge.u == xName && edge.v == yName) || (edge.u == yName && edge.v == xName)) {
+                extend = edge.extend;
+                break;
+            }
+        }
+        DASSERT(extend != nullptr);
+        auto rel = extend->getRel();
+        auto* relGroupEntry = rel->getEntry(0)->ptrCast<RelGroupCatalogEntry>();
+        const auto extendFromSource = extend->extendFromSourceNode();
+        const auto xIsBound = xName == extend->getBoundNode()->getUniqueName();
+        const auto fromIsSrc = xIsBound ? extendFromSource : !extendFromSource;
+        const auto scanDirection = fromIsSrc ? RelDataDirection::FWD : RelDataDirection::BWD;
+        const auto xTableID = x->getTableIDs()[0];
+        const auto yTableID = y->getTableIDs()[0];
+        CountChainHop hop;
+        auto matched = false;
+        for (auto& info : relGroupEntry->getRelEntryInfos()) {
+            const auto fromTableID =
+                fromIsSrc ? info.nodePair.srcTableID : info.nodePair.dstTableID;
+            const auto toTableID = fromIsSrc ? info.nodePair.dstTableID : info.nodePair.srcTableID;
+            if (fromTableID == xTableID && toTableID == yTableID) {
+                hop.relScans.push_back(
+                    {info.oid, scanDirection, fromTableID, toTableID, relGroupEntry->getName()});
+                matched = true;
+            }
+        }
+        if (!matched) {
+            return op;
+        }
+        hops.push_back(std::move(hop));
+    }
+
+    auto result = std::make_shared<LogicalCountExtendChain>(std::move(hops), aggExpr);
     result->computeFlatSchema();
     return result;
 }
@@ -342,6 +579,9 @@ bool CountRelTableOptimizer::canOptimize(LogicalOperator* aggregate) const {
 
 std::shared_ptr<LogicalOperator> CountRelTableOptimizer::visitAggregateReplace(
     std::shared_ptr<LogicalOperator> op) {
+    if (auto rewritten = tryRewriteExtendChainCount(op); rewritten != op) {
+        return rewritten;
+    }
     if (auto rewritten = tryRewriteReachableCount(op); rewritten != op) {
         return rewritten;
     }

--- a/src/planner/operator/logical_operator.cpp
+++ b/src/planner/operator/logical_operator.cpp
@@ -24,6 +24,8 @@ std::string LogicalOperatorUtils::logicalOperatorTypeToString(LogicalOperatorTyp
         return "COPY_FROM";
     case LogicalOperatorType::COPY_TO:
         return "COPY_TO";
+    case LogicalOperatorType::COUNT_EXTEND_CHAIN:
+        return "COUNT_EXTEND_CHAIN";
     case LogicalOperatorType::COUNT_REL_TABLE:
         return "COUNT_REL_TABLE";
     case LogicalOperatorType::CREATE_MACRO:

--- a/src/planner/operator/scan/CMakeLists.txt
+++ b/src/planner/operator/scan/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_library(lbug_planner_scan
         OBJECT
+        logical_count_extend_chain.cpp
         logical_count_rel_table.cpp
         logical_expressions_scan.cpp
         logical_index_look_up.cpp

--- a/src/planner/operator/scan/logical_count_extend_chain.cpp
+++ b/src/planner/operator/scan/logical_count_extend_chain.cpp
@@ -1,0 +1,21 @@
+#include "planner/operator/scan/logical_count_extend_chain.h"
+
+namespace lbug {
+namespace planner {
+
+void LogicalCountExtendChain::computeFactorizedSchema() {
+    createEmptySchema();
+    // This operator is a source - it has no child in the logical plan.
+    auto groupPos = schema->createGroup();
+    schema->insertToGroupAndScope(countExpr, groupPos);
+    schema->setGroupAsSingleState(groupPos);
+}
+
+void LogicalCountExtendChain::computeFlatSchema() {
+    createEmptySchema();
+    auto groupPos = schema->createGroup();
+    schema->insertToGroupAndScope(countExpr, groupPos);
+}
+
+} // namespace planner
+} // namespace lbug

--- a/src/processor/map/CMakeLists.txt
+++ b/src/processor/map/CMakeLists.txt
@@ -9,6 +9,7 @@ add_library(lbug_processor_mapper
         map_aggregate.cpp
         map_analyze.cpp
         map_count_rel_table.cpp
+        map_count_extend_chain.cpp
         map_standalone_call.cpp
         map_table_function_call.cpp
         map_copy_to.cpp

--- a/src/processor/map/map_count_extend_chain.cpp
+++ b/src/processor/map/map_count_extend_chain.cpp
@@ -1,0 +1,52 @@
+#include "main/client_context.h"
+#include "planner/operator/scan/logical_count_extend_chain.h"
+#include "processor/operator/scan/count_extend_chain.h"
+#include "processor/plan_mapper.h"
+#include "storage/storage_manager.h"
+
+using namespace lbug::common;
+using namespace lbug::planner;
+using namespace lbug::storage;
+
+namespace lbug {
+namespace processor {
+
+std::unique_ptr<PhysicalOperator> PlanMapper::mapCountExtendChain(
+    const LogicalOperator* logicalOperator) {
+    auto& logicalCountExtendChain = logicalOperator->constCast<LogicalCountExtendChain>();
+    auto outSchema = logicalCountExtendChain.getSchema();
+    auto countOutputPos = getDataPos(*logicalCountExtendChain.getCountExpr(), *outSchema);
+
+    auto* storageManager = StorageManager::Get(*clientContext);
+    std::unordered_map<table_id_t, NodeTable*> nodeTables;
+    std::vector<CountExtendChain::Hop> hops;
+    hops.reserve(logicalCountExtendChain.getHops().size());
+    for (auto& logicalHop : logicalCountExtendChain.getHops()) {
+        CountExtendChain::Hop hop;
+        hop.relTables.reserve(logicalHop.relScans.size());
+        hop.scanDirections.reserve(logicalHop.relScans.size());
+        hop.fromNodeTableIDs.reserve(logicalHop.relScans.size());
+        hop.toNodeTableIDs.reserve(logicalHop.relScans.size());
+        for (auto& spec : logicalHop.relScans) {
+            hop.relTables.push_back(storageManager->getTable(spec.relTableID)->ptrCast<RelTable>());
+            hop.scanDirections.push_back(spec.scanDirection);
+            hop.fromNodeTableIDs.push_back(spec.fromNodeTableID);
+            hop.toNodeTableIDs.push_back(spec.toNodeTableID);
+            if (!nodeTables.contains(spec.fromNodeTableID)) {
+                nodeTables.emplace(spec.fromNodeTableID,
+                    storageManager->getTable(spec.fromNodeTableID)->ptrCast<NodeTable>());
+            }
+            if (!nodeTables.contains(spec.toNodeTableID)) {
+                nodeTables.emplace(spec.toNodeTableID,
+                    storageManager->getTable(spec.toNodeTableID)->ptrCast<NodeTable>());
+            }
+        }
+        hops.push_back(std::move(hop));
+    }
+
+    return std::make_unique<CountExtendChain>(std::move(hops), std::move(nodeTables),
+        countOutputPos, getOperatorID(), logicalCountExtendChain.getPrintInfo());
+}
+
+} // namespace processor
+} // namespace lbug

--- a/src/processor/map/plan_mapper.cpp
+++ b/src/processor/map/plan_mapper.cpp
@@ -90,6 +90,9 @@ std::unique_ptr<PhysicalOperator> PlanMapper::mapOperator(const LogicalOperator*
     case LogicalOperatorType::COUNT_REL_TABLE: {
         physicalOperator = mapCountRelTable(logicalOperator);
     } break;
+    case LogicalOperatorType::COUNT_EXTEND_CHAIN: {
+        physicalOperator = mapCountExtendChain(logicalOperator);
+    } break;
     case LogicalOperatorType::CREATE_MACRO: {
         physicalOperator = mapCreateMacro(logicalOperator);
     } break;

--- a/src/processor/operator/physical_operator.cpp
+++ b/src/processor/operator/physical_operator.cpp
@@ -29,6 +29,8 @@ std::string PhysicalOperatorUtils::operatorTypeToString(PhysicalOperatorType ope
         return "BATCH_INSERT";
     case PhysicalOperatorType::COPY_TO:
         return "COPY_TO";
+    case PhysicalOperatorType::COUNT_EXTEND_CHAIN:
+        return "COUNT_EXTEND_CHAIN";
     case PhysicalOperatorType::COUNT_REL_TABLE:
         return "COUNT_REL_TABLE";
     case PhysicalOperatorType::CREATE_MACRO:

--- a/src/processor/operator/scan/CMakeLists.txt
+++ b/src/processor/operator/scan/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_library(lbug_processor_operator_scan
         OBJECT
+        count_extend_chain.cpp
         count_rel_table.cpp
         primary_key_scan_node_table.cpp
         reachable_count.cpp

--- a/src/processor/operator/scan/count_extend_chain.cpp
+++ b/src/processor/operator/scan/count_extend_chain.cpp
@@ -1,0 +1,193 @@
+#include "processor/operator/scan/count_extend_chain.h"
+
+#include "common/system_config.h"
+#include "common/types/int128_t.h"
+#include "main/client_context.h"
+#include "processor/execution_context.h"
+#include "storage/buffer_manager/memory_manager.h"
+#include "transaction/transaction.h"
+
+using namespace lbug::common;
+using namespace lbug::storage;
+using namespace lbug::transaction;
+
+namespace lbug {
+namespace processor {
+
+offset_t CountExtendChain::getOffsetUpperBound(NodeTable* nodeTable) const {
+    const auto numGroups = nodeTable->getNumNodeGroups();
+    if (numGroups == 0) {
+        return 0;
+    }
+    return (numGroups - 1) * StorageConfig::NODE_GROUP_SIZE +
+           nodeTable->getNumTuplesInNodeGroup(numGroups - 1);
+}
+
+void CountExtendChain::initLocalStateInternal(ResultSet* resultSet, ExecutionContext* /*context*/) {
+    countVector = resultSet->getValueVector(countOutputPos).get();
+    hasExecuted = false;
+    totalCount = 0;
+    counts.clear();
+}
+
+void CountExtendChain::processBatch(uint64_t hopIdx, table_id_t fromTableID, table_id_t toTableID,
+    bool isLastHop, const RelTableScanState& scanState, const ValueVector& nodeIDVector,
+    const ValueVector& nbrVector) {
+    const auto outputSize = scanState.outState->getSelVector().getSelSize();
+    if (outputSize == 0) {
+        return;
+    }
+    auto& cCur = counts[hopIdx][fromTableID];
+    const auto& boundSel = nodeIDVector.state->getSelVector();
+    const auto boundSelSize = boundSel.getSelSize();
+    const auto& outSel = scanState.outState->getSelVector();
+    if (isLastHop) {
+        // The final count is the number of paths of the full chain length, i.e. the sum of
+        // c_{N-1}[src] over all visible edges of the last hop.
+        if (boundSelSize > 1) {
+            // Multi-parent packed batch: served parents are in the (unflat) bound selection
+            // vector; rows [packedChildOffsets[p], packedChildOffsets[p+1]) belong to parent p.
+            const auto& packedChildOffsets = scanState.packedChildOffsets;
+            DASSERT(packedChildOffsets.size() == size_t(boundSelSize) + 1);
+            DASSERT(packedChildOffsets.back() == outputSize);
+            for (auto p = 0u; p < boundSelSize; ++p) {
+                const auto u = nodeIDVector.readNodeOffset(boundSel[p]);
+                totalCount += cCur[u] * (packedChildOffsets[p + 1] - packedChildOffsets[p]);
+            }
+        } else {
+            DASSERT(boundSelSize == 1);
+            const auto u = nodeIDVector.readNodeOffset(boundSel[0]);
+            totalCount += cCur[u] * outputSize;
+        }
+        return;
+    }
+    auto& cNext = counts[hopIdx + 1][toTableID];
+    if (boundSelSize > 1) {
+        const auto& packedChildOffsets = scanState.packedChildOffsets;
+        DASSERT(packedChildOffsets.size() == size_t(boundSelSize) + 1);
+        DASSERT(packedChildOffsets.back() == outputSize);
+        for (auto p = 0u; p < boundSelSize; ++p) {
+            const auto u = nodeIDVector.readNodeOffset(boundSel[p]);
+            const auto cu = cCur[u];
+            if (cu == 0) {
+                continue;
+            }
+            for (auto r = packedChildOffsets[p]; r < packedChildOffsets[p + 1]; ++r) {
+                cNext[nbrVector.readNodeOffset(outSel[r])] += cu;
+            }
+        }
+    } else {
+        // Single-parent batch (also the contract of the in-memory/local scan paths): all rows
+        // of the batch belong to the bound node pointed at by the flat bound selection vector.
+        DASSERT(boundSelSize == 1);
+        const auto u = nodeIDVector.readNodeOffset(boundSel[0]);
+        const auto cu = cCur[u];
+        if (cu == 0) {
+            return;
+        }
+        for (auto r = 0u; r < outputSize; ++r) {
+            cNext[nbrVector.readNodeOffset(outSel[r])] += cu;
+        }
+    }
+}
+
+bool CountExtendChain::getNextTuplesInternal(ExecutionContext* context) {
+    if (hasExecuted) {
+        return false;
+    }
+    auto transaction = Transaction::Get(*context->clientContext);
+    auto* memoryManager = MemoryManager::Get(*context->clientContext);
+
+    const auto numHops = hops.size();
+    // counts[j]: per-node partial path counts for chain position j (0..numHops). Position 0 is
+    // ones over the chain's source node table; position numHops is never materialized (the last
+    // hop accumulates directly into the total).
+    counts.resize(numHops);
+    totalCount = 0;
+
+    // Allocate zero count vectors for chain positions 1..numHops-1, sized to the full node
+    // group grid so that offsets referencing any allocated node remain in bounds even when the
+    // tail node group is partially deleted (deleted tail offsets never carry visible edges).
+    for (auto j = 0u; j + 1 < numHops; ++j) {
+        auto& nextMap = counts[j + 1];
+        for (auto i = 0u; i < hops[j].relTables.size(); ++i) {
+            const auto toTableID = hops[j].toNodeTableIDs[i];
+            if (!nextMap.contains(toTableID)) {
+                const auto* nodeTable = nodeTables.at(toTableID);
+                nextMap.emplace(toTableID,
+                    std::vector<int64_t>(
+                        nodeTable->getNumNodeGroups() * StorageConfig::NODE_GROUP_SIZE, 0));
+            }
+        }
+    }
+    // Position 0: ones over the first hop's from-side node tables.
+    for (auto i = 0u; i < hops[0].relTables.size(); ++i) {
+        const auto fromTableID = hops[0].fromNodeTableIDs[i];
+        if (!counts[0].contains(fromTableID)) {
+            const auto* nodeTable = nodeTables.at(fromTableID);
+            counts[0].emplace(fromTableID,
+                std::vector<int64_t>(nodeTable->getNumNodeGroups() * StorageConfig::NODE_GROUP_SIZE,
+                    1));
+        }
+    }
+
+    for (auto j = 0u; j < numHops; ++j) {
+        const auto isLastHop = j + 1 == numHops;
+        auto& hop = hops[j];
+        for (auto i = 0u; i < hop.relTables.size(); ++i) {
+            auto* relTable = hop.relTables[i];
+            const auto fromTableID = hop.fromNodeTableIDs[i];
+            const auto toTableID = hop.toNodeTableIDs[i];
+            auto* fromNodeTable = nodeTables.at(fromTableID);
+
+            auto nodeIDVector = std::make_shared<ValueVector>(LogicalType::INTERNAL_ID(),
+                memoryManager, std::make_shared<DataChunkState>());
+            auto nbrVector = std::make_shared<ValueVector>(LogicalType::INTERNAL_ID(),
+                memoryManager, std::make_shared<DataChunkState>());
+            std::vector<ValueVector*> outVectors{nbrVector.get()};
+            RelTableScanState scanState(*memoryManager, nodeIDVector.get(), outVectors,
+                nbrVector->state);
+            scanState.setToTable(transaction, relTable, {NBR_ID_COLUMN_ID}, {},
+                hop.scanDirections[i]);
+            scanState.packedMultiParentScan = true;
+
+            // Iterate the from-side node offsets sequentially. Batches of one vector capacity
+            // aligned to the table origin never span more than one node group.
+            const auto offsetUpper = getOffsetUpperBound(fromNodeTable);
+            for (auto start = offset_t{0}; start < offsetUpper; start += DEFAULT_VECTOR_CAPACITY) {
+                const auto n = static_cast<sel_t>(
+                    std::min<offset_t>(DEFAULT_VECTOR_CAPACITY, offsetUpper - start));
+                nodeIDVector->state->setToUnflat();
+                nodeIDVector->state->getSelVectorUnsafe().setToUnfiltered(n);
+                for (auto k = 0u; k < n; ++k) {
+                    nodeIDVector->setValue<nodeID_t>(k, nodeID_t{start + k, fromTableID});
+                }
+                relTable->initScanState(transaction, scanState);
+                while (relTable->scan(transaction, scanState)) {
+                    processBatch(j, fromTableID, toTableID, isLastHop, scanState, *nodeIDVector,
+                        *nbrVector);
+                }
+            }
+        }
+    }
+
+    hasExecuted = true;
+
+    // Write the count to the output vector (single value).
+    countVector->state->getSelVectorUnsafe().setToUnfiltered(1);
+    countVector->setNull(0, false);
+    switch (countVector->dataType.getPhysicalType()) {
+    case PhysicalTypeID::INT64:
+        countVector->setValue<int64_t>(0, totalCount);
+        break;
+    case PhysicalTypeID::INT128:
+        countVector->setValue<int128_t>(0, int128_t{totalCount});
+        break;
+    default:
+        UNREACHABLE_CODE;
+    }
+    return true;
+}
+
+} // namespace processor
+} // namespace lbug

--- a/test/optimizer/optimizer_test.cpp
+++ b/test/optimizer/optimizer_test.cpp
@@ -111,7 +111,7 @@ TEST_F(OptimizerTest, JoinHint) {
     ASSERT_STREQ(getEncodedPlan(q3).c_str(), "HJ(c._ID){HJ(a._ID){E(c)E(a)S(b)}{S(a)}}{S(c)}");
     auto q4 = "MATCH (a:person)-[e1:knows]->(b:person)-[e2:knows]->(c:person) "
               "HINT (((a JOIN e1) JOIN b) JOIN e2) JOIN c "
-              "RETURN COUNT(*)";
+              "RETURN COUNT(e1.date)";
     ASSERT_STREQ(getEncodedPlan(q4).c_str(), "HJ(b._ID){E(b)S(a)}{E(c)S(b)}");
     // Cycle
     auto q5 = "MATCH (a:person)-[e1:knows]->(b:person)-[e2:knows]->(a) "


### PR DESCRIPTION
## Problem

\`COUNT(*)\` over a long chain of extends (LSQB q1: 7 hops, packed path extend enabled) materializes 100M+ intermediate tuples and hash joins each hop:

```
Time: 14.50ms (compiling), 5645.25ms (executing)
```

The existing `COUNT_REL_TABLE` rewrite handles only a single hop (metadata count). Multi-hop chains get no benefit: every intermediate hop materializes neighbor IDs into data chunks and feeds hash joins, only for the result to be aggregated away.

## Change

Add a `CountRelTableOptimizer` rewrite (`tryRewriteExtendChainCount`) that detects a **pure path of >= 2 extends** under a keyless `COUNT(*)` aggregate — hops may be connected by node-ID-only inner hash joins (packed INL join plans) — and replaces the whole subtree with a new count-only operator: `LogicalCountExtendChain` → `CountExtendChain` (physical).

Execution propagates **per-node int64 count vectors** hop by hop instead of materializing tuples:

```
c_0[v]      = 1 for every source node
c_{j+1}[w]  = sum over visible edges (v -> w) of rel table j of c_j[v]
result      = sum over last-hop edges of c_{N-1}[v]
```

- Each hop scans the rel table CSR with the direction keyed by the hop's **from-node** (FWD if from-node is the rel's src side, BWD if dst side), so the per-destination accumulation is a pure gather+add over the neighbor column.
- Only one `int64` per node offset is carried between hops; neighbor IDs are read from the nbr column and consumed immediately — never materialized, no hash joins.
- Versioned deletions, in-memory CSR groups and local (uncommitted) rel data are handled by reusing the standard rel-table scan machinery (`RelTableScanState`), including multi-parent packed batches via `packedChildOffsets`.

### Correctness gates (rewrite skipped otherwise)

- read-only transaction (uncommitted node inserts are not enumerated)
- no filters; scans carrying property predicates or primary-key scans restrict the node set and disqualify the rewrite
- extends not `BOTH` direction, single-entry storage-backed rel groups, single-table nodes
- the hop graph is a simple path (all degrees <= 2, connected, edges == nodes - 1)
- the subtree contains only row-count-invariant operators (projections, node-ID-only inner hash joins, scans); single-hop chains keep the cheaper existing `COUNT_REL_TABLE` rewrite

## Results (ldbc_snb_sf1, 7-hop chain, count = 179,510,748 — identical before/after)

| config | before | after |
|---|---|---|
| `enable_packed_path_extend=true` | 5.65–5.84s | 0.11–0.17s |
| `enable_packed_path_extend=false` | 5.60–5.69s | 0.11–0.11s |

**~35–50x faster.** Chain-prefix cross-checks (2–7 hops, reversed chain) all produce identical counts vs the pre-change engine; filtered queries correctly fall back to the regular plan and match.

## Testing

- Manual cross-validation against the pre-change binary on LDBC SNB sf1 (see above)
- Plan shows `COUNT_EXTEND_CHAIN` as a single-threaded source; filtered / GROUP BY queries unchanged
- LSQB test suite (`test/test_files/lsqb/lsqb_queries.test`) to be exercised in CI