### PR TITLE
Fix parameter collection inside subquery WHERE clauses

### DIFF
--- a/src/include/parser/expression/parsed_subquery_expression.h
+++ b/src/include/parser/expression/parsed_subquery_expression.h
@@ -31,6 +31,7 @@ public:
     }
     bool hasWhereClause() const { return whereClause != nullptr; }
     const ParsedExpression* getWhereClause() const { return whereClause.get(); }
+    ParsedExpression* getWhereClauseUnsafe() { return whereClause.get(); }
 
     void setHint(std::shared_ptr<JoinHintNode> root) { hintRoot = std::move(root); }
     bool hasHint() const { return hintRoot != nullptr; }

--- a/src/parser/expression/parsed_expression_visitor.cpp
+++ b/src/parser/expression/parsed_expression_visitor.cpp
@@ -6,6 +6,7 @@
 #include "parser/expression/parsed_case_expression.h"
 #include "parser/expression/parsed_function_expression.h"
 #include "parser/expression/parsed_lambda_expression.h"
+#include "parser/expression/parsed_subquery_expression.h"
 #include "transaction/transaction.h"
 
 using namespace lbug::common;
@@ -93,6 +94,19 @@ void ParsedExpressionVisitor::visitChildren(const ParsedExpression& expr) {
         auto& lambda = expr.constCast<ParsedLambdaExpression>();
         visit(lambda.getFunctionExpr());
     } break;
+    case ExpressionType::SUBQUERY: {
+        // The where clause of a parsed subquery is not stored as a child expression, so it must
+        // be visited explicitly. Otherwise parameter expressions (or any other nested parsed
+        // expressions) inside e.g. "WHERE p.id IN $posts" of a COUNT subquery are invisible to
+        // visitors like ParsedParamExprCollector.
+        auto& subquery = expr.constCast<ParsedSubqueryExpression>();
+        if (subquery.hasWhereClause()) {
+            visit(subquery.getWhereClause());
+        }
+        for (auto i = 0u; i < expr.getNumChildren(); ++i) {
+            visit(expr.getChild(i));
+        }
+    } break;
     default: {
         for (auto i = 0u; i < expr.getNumChildren(); ++i) {
             visit(expr.getChild(i));
@@ -105,6 +119,15 @@ void ParsedExpressionVisitor::visitChildrenUnsafe(ParsedExpression& expr) {
     switch (expr.getExpressionType()) {
     case ExpressionType::CASE_ELSE: {
         visitCaseChildrenUnsafe(expr);
+    } break;
+    case ExpressionType::SUBQUERY: {
+        auto& subquery = expr.cast<ParsedSubqueryExpression>();
+        if (subquery.hasWhereClause()) {
+            visitUnsafe(subquery.getWhereClauseUnsafe());
+        }
+        for (auto i = 0u; i < expr.getNumChildren(); ++i) {
+            visitUnsafe(expr.getChild(i));
+        }
     } break;
     default: {
         for (auto i = 0u; i < expr.getNumChildren(); ++i) {

--- a/test/api/prepare_test.cpp
+++ b/test/api/prepare_test.cpp
@@ -1,3 +1,7 @@
+#include <algorithm>
+#include <memory>
+#include <vector>
+
 #include "api_test/api_test.h"
 
 using namespace lbug::common;
@@ -806,4 +810,70 @@ TEST_F(ApiTest, ParameterOnlyPredicateAfterConstantWith) {
         conn->execute(statement.get(), std::make_pair(std::string("depth"), (int64_t)5));
     ASSERT_TRUE(included->isSuccess()) << included->getErrorMessage();
     ASSERT_EQ(included->getNumTuples(), 8u);
+}
+
+// Regression test for LadybugDB/ladybug-rust#32: a parameter used inside a COUNT subquery's
+// WHERE clause was invisible to the binder's parameter collection, because the parsed subquery
+// expression's where clause is not stored as a child expression and visitors did not descend
+// into it. When the statement was prepared without parameters, the subquery's parameters were
+// never registered, so at execute time the subquery's predicate was replaced by a placeholder
+// and changing the parameter values had no effect (stale results).
+TEST_F(ApiTest, ParameterizedCountSubqueryWithParameterizedComparison) {
+    ASSERT_TRUE(
+        conn->query("CREATE NODE TABLE IssueUser(id INT64, PRIMARY KEY(id));")->isSuccess());
+    ASSERT_TRUE(
+        conn->query("CREATE NODE TABLE IssuePost(id INT64, PRIMARY KEY(id));")->isSuccess());
+    ASSERT_TRUE(
+        conn->query("CREATE REL TABLE IssueLikes(FROM IssueUser TO IssuePost);")->isSuccess());
+    for (auto id = 0; id < 3; id++) {
+        ASSERT_TRUE(
+            conn->query("CREATE (:IssueUser {id: " + std::to_string(id) + "});")->isSuccess());
+        ASSERT_TRUE(
+            conn->query("CREATE (:IssuePost {id: " + std::to_string(id) + "});")->isSuccess());
+    }
+    // u0 likes posts 0,1,2; u1 likes posts 0,1; u2 likes posts 1,2 (mirrors the issue dataset)
+    const std::vector<std::pair<int64_t, int64_t>> likes = {{0, 0}, {0, 1}, {0, 2}, {1, 0}, {1, 1},
+        {2, 1}, {2, 2}};
+    for (auto& [u, p] : likes) {
+        ASSERT_TRUE(conn->query("MATCH (u:IssueUser {id: " + std::to_string(u) +
+                                "}), (p:IssuePost {id: " + std::to_string(p) +
+                                "}) CREATE (u)-[:IssueLikes]->(p);")
+                        ->isSuccess());
+    }
+
+    // Users that like exactly the posts in $posts, i.e. COUNT{...} = $count.
+    const auto query = "MATCH (u:IssueUser) WHERE COUNT { "
+                       "MATCH (u)-[:IssueLikes]->(p:IssuePost) WHERE p.id IN $posts "
+                       "} = $count RETURN u.id;";
+    auto preparedStatement = conn->prepare(query);
+    ASSERT_TRUE(preparedStatement->isSuccess()) << preparedStatement->getErrorMessage();
+
+    auto makePostsParam = [](std::vector<int64_t> ids) {
+        std::vector<std::unique_ptr<Value>> children;
+        children.reserve(ids.size());
+        for (auto id : ids) {
+            children.push_back(std::make_unique<Value>(id));
+        }
+        return Value(LogicalType::LIST(LogicalType::INT64()), std::move(children));
+    };
+
+    // First execution: users liking exactly posts [1, 2] are u0 and u2.
+    auto result = conn->execute(preparedStatement.get(),
+        std::make_pair(std::string("posts"), makePostsParam({1, 2})),
+        std::make_pair(std::string("count"), (int64_t)2));
+    ASSERT_TRUE(result->isSuccess()) << result->getErrorMessage();
+    auto rows = TestHelper::convertResultToString(*result);
+    std::sort(rows.begin(), rows.end());
+    ASSERT_EQ((std::vector<std::string>{"0", "2"}), rows);
+
+    // Re-executing the SAME prepared statement with changed parameter values must pick up the
+    // new values: users liking exactly posts [0, 1] are u0 and u1. Before the fix the $posts
+    // parameter was never registered and its values were ignored (stale results).
+    result = conn->execute(preparedStatement.get(),
+        std::make_pair(std::string("posts"), makePostsParam({0, 1})),
+        std::make_pair(std::string("count"), (int64_t)2));
+    ASSERT_TRUE(result->isSuccess()) << result->getErrorMessage();
+    rows = TestHelper::convertResultToString(*result);
+    std::sort(rows.begin(), rows.end());
+    ASSERT_EQ((std::vector<std::string>{"0", "1"}), rows);
 }


### PR DESCRIPTION
Fixes the core bug reported in https://github.com/LadybugDB/ladybug-rust/issues/32

## Problem

`ParsedSubqueryExpression` stores its WHERE clause in a dedicated field (`whereClause`), **not** as a child expression. `ParsedExpressionVisitor::visitChildren` only walks `getChild(i)`, so no generic visitor — including `ParsedParamExprCollector` — ever sees expressions inside a subquery's WHERE clause.

For the issue's query:

```cypher
MATCH (u:USER)
WHERE COUNT { MATCH (u)-[:LIKES]->(p:POST) WHERE p.id IN $posts } = $count
RETURN u.id;
```

when prepared **without** parameters:

1. Binding the comparison `COUNT{...} = $count` collected only `$count` (outer, visible) into `unknownParameters`; `$posts` inside the subquery WHERE was never seen, and the whole comparison was replaced by a placeholder parameter expression, so the subquery was never bound during prepare.
2. At execute time only `count` was registered. The re-bind bound the subquery now, but `$posts` was still unknown, so `p.id IN $posts` was silently replaced by a placeholder (type ANY, NULL value) — always false.
3. Every execution returned wrong/empty results, and **changing `$posts` values had no effect** — the "stale values" reported in the issue.

(The single-parameter variants worked because their one parameter happened to be registered via either the subquery WHERE bind or the outer comparison — masking the visitor gap.)

## Fix

`visitChildren` (and `visitChildrenUnsafe`) now explicitly visit a parsed subquery's WHERE clause. Parameter collection therefore registers subquery WHERE parameters as unknown parameters during prepare, and the existing unknown-parameter re-bind flow binds them correctly on first execute; later executions pick up new values normally.

This also fixes the same blind spot for `ReadWriteExprAnalyzer` (side-effecting functions hidden in subquery WHERE clauses) and `MacroParameterReplacer`.

## Test

Regression test `ApiTest.ParameterizedCountSubqueryWithParameterizedComparison` in `test/api/prepare_test.cpp`: prepares the issue's query shape, executes it twice on the same prepared statement with different `$posts` values, and asserts correct results both times. Verified it fails without the visitor change (returns `{}` instead of `{0, 2}`) and passes with it.