### PR TITLE
Split debug symbols out of Python wheels

### DIFF
--- a/.github/workflows/python-wheel-workflow.yml
+++ b/.github/workflows/python-wheel-workflow.yml
@@ -271,8 +271,46 @@ jobs:
           source .venv/bin/activate
           python -m cibuildwheel --output-dir scripts/pip-package/wheelhouse "${LBUG_PYTHON_CIBW_SOURCE_DIR}"
 
+      # --- Cross-platform symbol separation (see recipe in
+      # tools/python_api/CMakeLists.txt): split debug info out of the final
+      # repaired wheels so shipped wheels stay stripped while crash reports
+      # remain debuggable via the uploaded symbol artifacts.
+      - name: Separate debug symbols (Linux)
+        if: matrix.os == 'linux'
+        shell: bash
+        run: |
+          python3 scripts/pip-package/split_debug_symbols.py \
+            --wheel-dir scripts/pip-package/wheelhouse \
+            --symbols-dir scripts/pip-package/symbols \
+            --os linux
+
+      - name: Separate debug symbols (macOS)
+        if: matrix.os == 'macos'
+        shell: bash
+        run: |
+          python3 scripts/pip-package/split_debug_symbols.py \
+            --wheel-dir scripts/pip-package/wheelhouse \
+            --symbols-dir scripts/pip-package/symbols \
+            --os macos
+
+      - name: Separate debug symbols (Windows)
+        if: matrix.os == 'windows'
+        shell: bash
+        run: |
+          python scripts/pip-package/split_debug_symbols.py \
+            --wheel-dir scripts/pip-package/wheelhouse \
+            --symbols-dir scripts/pip-package/symbols \
+            --os windows
+
       - name: Upload wheels
         uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.os == 'linux' && format('manylinux{0}', matrix.manylinux) || matrix.os }}-wheels-${{ matrix.platform }}
           path: ./scripts/pip-package/wheelhouse/*.whl
+
+      - name: Upload debug symbols
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.os == 'linux' && format('manylinux{0}', matrix.manylinux) || matrix.os }}-symbols-${{ matrix.platform }}
+          path: ./scripts/pip-package/symbols/*
+          if-no-files-found: warn

--- a/scripts/pip-package/setup.py
+++ b/scripts/pip-package/setup.py
@@ -91,13 +91,24 @@ class CMakeBuild(build_ext):
             if os.path.exists(flags_file):
                 with open(flags_file) as f:
                     extra_cmake_flags = f.read().strip()
+        # Wheel builds must not split symbols at build time: raw .debug/dSYM
+        # artifacts packaged inside the wheel break auditwheel/delocate
+        # repair. The split happens on the final repaired wheel instead (see
+        # split_debug_symbols.py), which needs the debug info to still be
+        # present in the shipped binary.
+        no_split_flag = '-DLBUG_SPLIT_DEBUG_SYMBOLS=OFF'
         if precompiled_lib_path:
             self.announce("Using precompiled liblbug from %s." % precompiled_lib_path)
             flags = (
-                'EXTRA_CMAKE_FLAGS=-DBUILD_LBUG=FALSE -DBUILD_SHELL=FALSE '
+                'EXTRA_CMAKE_FLAGS=%s -DBUILD_LBUG=FALSE -DBUILD_SHELL=FALSE '
                 '-DLBUG_API_USE_PRECOMPILED_LIB=TRUE '
-                '-DLBUG_API_PRECOMPILED_LIB_PATH=%s' % precompiled_lib_path
+                '-DLBUG_API_PRECOMPILED_LIB_PATH=%s' % (no_split_flag, precompiled_lib_path)
             )
+            if extra_cmake_flags:
+                flags += ' ' + extra_cmake_flags
+            full_cmd.append(flags)
+        else:
+            flags = 'EXTRA_CMAKE_FLAGS=%s' % no_split_flag
             if extra_cmake_flags:
                 flags += ' ' + extra_cmake_flags
             full_cmd.append(flags)

--- a/scripts/pip-package/split_debug_symbols.py
+++ b/scripts/pip-package/split_debug_symbols.py
@@ -96,12 +96,34 @@ def _find_extensions(tree: Path, suffixes: tuple[str, ...]) -> list[Path]:
     hits = []
     for suffix in suffixes:
         hits.extend(tree.rglob(f"_lbug*{suffix}"))
-    # Skip files that live inside symbol bundles/dirs themselves.
+    # Skip files that live inside symbol bundles/dirs themselves. NOTE: a
+    # dSYM bundle dir is named "<binary>.dSYM", so ".dSYM" is a suffix of
+    # a path part, not a standalone part -- check endswith, not membership.
     return [
         p
         for p in hits
-        if p.is_file() and ".dSYM" not in p.parts and not p.name.endswith(".debug")
+        if p.is_file()
+        and not any(part.endswith(".dSYM") for part in p.parts)
+        and not p.name.endswith(".debug")
     ]
+
+
+def _mach_o_has_dwarf(shared_obj: Path) -> bool:
+    """Best-effort check for a __DWARF segment (False if unknown is unsafe).
+    Returns True when unsure so callers attempt a split rather than reuse."""
+    otool = shutil.which("otool")
+    if otool is None:
+        return True
+    try:
+        out = subprocess.run(
+            [otool, "-l", str(shared_obj)],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        return "__DWARF" in out.stdout
+    except OSError:
+        return True
 
 
 def _split_linux(wheel_path: Path, tree: Path, symbols_dir: Path) -> None:
@@ -148,14 +170,24 @@ def _split_macos(wheel_path: Path, tree: Path, symbols_dir: Path) -> None:
         print("dsymutil/strip not found; leaving macOS wheel unstripped.", flush=True)
         return
     for so in _find_extensions(tree, (".so",)):
-        # Drop any pre-repair dSYM shipped inside the wheel; regenerate below so
-        # the bundle matches the final delocated binary.
-        for stale in tree.rglob("*.dSYM"):
+        stem = f"{wheel_path.stem}-{so.name}"
+        shipped = [d for d in tree.rglob("*.dSYM")]
+        if shipped and not _mach_o_has_dwarf(so):
+            # In-build split already stripped this binary; reuse its bundle.
+            for dsym in shipped:
+                dest = symbols_dir / f"{stem}.dSYM"
+                if dest.exists():
+                    shutil.rmtree(dest) if dest.is_dir() else dest.unlink()
+                print(f"Reusing shipped dSYM {dsym} -> {dest}", flush=True)
+                shutil.move(str(dsym), str(dest))
+            continue
+        # Otherwise drop any stale pre-repair bundle and regenerate below so
+        # the dSYM matches the final delocated binary.
+        for stale in shipped:
             if stale.is_dir():
                 shutil.rmtree(stale)
-            else:
+            elif stale.is_file():
                 stale.unlink()
-        stem = f"{wheel_path.stem}-{so.name}"
         dsym_out = Path(tempfile.mkdtemp()) / f"{so.name}.dSYM"
         _run([dsymutil, str(so), "-o", str(dsym_out)])
         _run([strip, "-S", str(so)])

--- a/scripts/pip-package/split_debug_symbols.py
+++ b/scripts/pip-package/split_debug_symbols.py
@@ -1,0 +1,230 @@
+#!/usr/bin/env python3
+"""Split debug symbols out of built Python wheels and repack stripped wheels.
+
+Used by .github/workflows/python-wheel-workflow.yml after cibuildwheel finishes:
+
+  Linux:   objcopy --only-keep-debug / --strip-debug / --add-gnu-debuglink
+           (mirrors the CMake POST_BUILD recipe in tools/python_api/CMakeLists.txt,
+           but runs on the final repaired wheel so auditwheel/delocate edits are
+           already baked in). If the wheel already ships a .debug file produced by
+           the in-build split and the .so is already stripped, that file is reused.
+  macOS:   dsymutil into a .dSYM bundle + strip -S, regenerated from the final
+           wheel binary so it matches the shipped (delocated) .so.
+  Windows: move *.pdb (plus *.exp/*.lib byproducts) out of the wheel; the .pyd
+           itself carries no debug data when linked with /DEBUG.
+
+Every repacked wheel gets a correct RECORD (hashes/sizes recomputed), and all
+extracted symbol files land in --symbols-dir for upload as separate artifacts.
+"""
+
+import argparse
+import base64
+import hashlib
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+import zipfile
+from pathlib import Path
+
+
+def _has_debug_sections(shared_obj: Path) -> bool:
+    """Best-effort check for DWARF debug sections (False if unknown)."""
+    readelf = shutil.which("readelf")
+    if readelf is None:
+        return True  # Unknown: assume symbols present so we attempt a split.
+    try:
+        out = subprocess.run(
+            [readelf, "-S", str(shared_obj)],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        return ".debug_info" in out.stdout
+    except OSError:
+        return True
+
+
+def _run(cmd: list[str], cwd: Path | None = None) -> None:
+    print(f"+ {' '.join(cmd)}" + (f" (cwd={cwd})" if cwd else ""), flush=True)
+    subprocess.run(cmd, check=True, cwd=cwd)
+
+
+def _hash_record_entry(data: bytes) -> str:
+    digest = base64.urlsafe_b64encode(hashlib.sha256(data).digest()).rstrip(b"=")
+    return f"sha256={digest.decode()}"
+
+
+def _repack_wheel(unpacked_dir: Path, wheel_path: Path) -> None:
+    """Rewrite wheel zip from unpacked_dir, dropping stale RECORD entries and
+    recomputing hashes for every file (required after stripping binaries)."""
+    record_file = None
+    for dist_info in unpacked_dir.glob("*.dist-info"):
+        candidate = dist_info / "RECORD"
+        if candidate.is_file():
+            record_file = candidate
+            break
+    if record_file is None:
+        raise FileNotFoundError(f"No RECORD found in unpacked wheel at {unpacked_dir}")
+
+    record_rel = record_file.relative_to(unpacked_dir).as_posix()
+    rows: list[str] = []
+    with tempfile.NamedTemporaryFile(delete=False, suffix=".whl") as tmp:
+        tmp_path = Path(tmp.name)
+    try:
+        with zipfile.ZipFile(tmp_path, "w", zipfile.ZIP_DEFLATED) as zf:
+            for root, _, files in os.walk(unpacked_dir):
+                for name in sorted(files):
+                    full = Path(root) / name
+                    rel = full.relative_to(unpacked_dir).as_posix()
+                    if rel == record_rel:
+                        continue
+                    data = full.read_bytes()
+                    zf.writestr(rel, data)
+                    rows.append(f"{rel},{_hash_record_entry(data)},{len(data)}")
+            rows.append(f"{record_rel},,")
+            zf.writestr(record_rel, "\n".join(rows) + "\n")
+        shutil.move(str(tmp_path), str(wheel_path))
+    finally:
+        if tmp_path.exists():
+            tmp_path.unlink()
+
+
+def _find_extensions(tree: Path, suffixes: tuple[str, ...]) -> list[Path]:
+    hits = []
+    for suffix in suffixes:
+        hits.extend(tree.rglob(f"_lbug*{suffix}"))
+    # Skip files that live inside symbol bundles/dirs themselves.
+    return [
+        p
+        for p in hits
+        if p.is_file() and ".dSYM" not in p.parts and not p.name.endswith(".debug")
+    ]
+
+
+def _split_linux(wheel_path: Path, tree: Path, symbols_dir: Path) -> None:
+    objcopy = shutil.which("objcopy")
+    if objcopy is None:
+        print("objcopy not found; leaving Linux wheel unstripped.", flush=True)
+        return
+    for so in _find_extensions(tree, (".so",)):
+        stem = f"{wheel_path.stem}-{so.name}"
+        shipped = list(tree.rglob("*.debug"))
+        if shipped and not _has_debug_sections(so):
+            # In-build CMake split already stripped this binary; reuse it.
+            for dbg in shipped:
+                dest = symbols_dir / f"{stem}.debug"
+                print(f"Reusing shipped debug file {dbg} -> {dest}", flush=True)
+                shutil.move(str(dbg), str(dest))
+            continue
+        # Regenerate from the final (repaired) binary.
+        for dbg in shipped:
+            dbg.unlink()
+        dbg_out = so.parent / f"{so.name}.debug"
+        _run([objcopy, "--only-keep-debug", str(so), str(dbg_out)])
+        _run([objcopy, "--strip-debug", str(so)])
+        # --strip-debug leaves a pre-existing .gnu_debuglink behind, and
+        # --add-gnu-debuglink refuses to overwrite it, so drop it first.
+        subprocess.run(
+            [objcopy, "-R", ".gnu_debuglink", str(so)],
+            capture_output=True,
+            check=False,
+        )
+        # NOTE: --add-gnu-debuglink resolves a relative filename against the
+        # process CWD (not the binary's dir), so run from so.parent so the
+        # stored link stays a bare filename while objcopy can read the file.
+        _run([objcopy, f"--add-gnu-debuglink={dbg_out.name}", str(so)], cwd=so.parent)
+        dest = symbols_dir / f"{stem}.debug"
+        print(f"Moving {dbg_out} -> {dest}", flush=True)
+        shutil.move(str(dbg_out), str(dest))
+
+
+def _split_macos(wheel_path: Path, tree: Path, symbols_dir: Path) -> None:
+    dsymutil = shutil.which("dsymutil")
+    strip = shutil.which("strip")
+    if dsymutil is None or strip is None:
+        print("dsymutil/strip not found; leaving macOS wheel unstripped.", flush=True)
+        return
+    for so in _find_extensions(tree, (".so",)):
+        # Drop any pre-repair dSYM shipped inside the wheel; regenerate below so
+        # the bundle matches the final delocated binary.
+        for stale in tree.rglob("*.dSYM"):
+            if stale.is_dir():
+                shutil.rmtree(stale)
+            else:
+                stale.unlink()
+        stem = f"{wheel_path.stem}-{so.name}"
+        dsym_out = Path(tempfile.mkdtemp()) / f"{so.name}.dSYM"
+        _run([dsymutil, str(so), "-o", str(dsym_out)])
+        _run([strip, "-S", str(so)])
+        dest = symbols_dir / f"{stem}.dSYM"
+        if dest.exists():
+            shutil.rmtree(dest)
+        print(f"Moving {dsym_out} -> {dest}", flush=True)
+        shutil.move(str(dsym_out), str(dest))
+
+
+def _split_windows(wheel_path: Path, tree: Path, symbols_dir: Path) -> None:
+    stem = wheel_path.stem
+    for pattern in ("*.pdb", "*.exp", "*.lib"):
+        for artifact in tree.rglob(pattern):
+            if not artifact.is_file():
+                continue
+            if pattern == "*.pdb":
+                dest = symbols_dir / f"{stem}-{artifact.name}"
+                print(f"Moving {artifact} -> {dest}", flush=True)
+                shutil.move(str(artifact), str(dest))
+            else:
+                # Linker byproducts: never ship in the wheel.
+                print(f"Removing linker byproduct {artifact}", flush=True)
+                artifact.unlink()
+    # The .pyd linked with /DEBUG already carries no debug data; nothing to strip.
+
+
+def process_wheel(wheel_path: Path, symbols_dir: Path, os_name: str) -> None:
+    print(f"=== {wheel_path.name} ({os_name}) ===", flush=True)
+    with tempfile.TemporaryDirectory() as tmp:
+        tree = Path(tmp) / "wheel"
+        with zipfile.ZipFile(wheel_path, "r") as zf:
+            zf.extractall(tree)
+        if os_name == "linux":
+            _split_linux(wheel_path, tree, symbols_dir)
+        elif os_name == "macos":
+            _split_macos(wheel_path, tree, symbols_dir)
+        elif os_name == "windows":
+            _split_windows(wheel_path, tree, symbols_dir)
+        else:
+            raise ValueError(f"Unknown os: {os_name}")
+        _repack_wheel(tree, wheel_path)
+    print(f"Repacked stripped wheel: {wheel_path.name}", flush=True)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--wheel-dir", required=True, help="Directory with *.whl files")
+    parser.add_argument("--symbols-dir", required=True, help="Output dir for symbols")
+    parser.add_argument("--os", required=True, choices=["linux", "macos", "windows"])
+    args = parser.parse_args()
+
+    wheel_dir = Path(args.wheel_dir)
+    symbols_dir = Path(args.symbols_dir)
+    symbols_dir.mkdir(parents=True, exist_ok=True)
+
+    wheels = sorted(wheel_dir.glob("*.whl"))
+    if not wheels:
+        print(f"No wheels found in {wheel_dir}; nothing to do.", flush=True)
+        return 0
+    for wheel in wheels:
+        process_wheel(wheel, symbols_dir, args.os)
+
+    produced = sorted(p.name for p in symbols_dir.iterdir())
+    print(f"Symbol files produced ({len(produced)}):", flush=True)
+    for name in produced:
+        print(f"  {name}", flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Depends on ladybugdb/ladybug-python#55 (submodule bump to `cafd946` included here).

Splits debug info out of the final repaired wheels so shipped wheels stay stripped while crash reports remain debuggable:

- **Linux**: `objcopy` split into `.debug` + `--add-gnu-debuglink`
- **macOS**: `dsymutil` into a `.dSYM` bundle + `strip -S`, regenerated post-delocate so it matches the shipped binary
- **Windows**: extract `.pdb` from the wheel, drop `.exp$/$.lib$ linker byproducts

New `scripts/pip-package/split_debug_symbols.py` performs the split and repacks each wheel with a corrected `RECORD`; the workflow uploads the extracted symbols as separate per-platform artifacts (`manylinux_2_28-symbols-<arch>` / `<os>-symbols-<platform>`).

The splitter reuses an in-build `.debug` when the binary is already stripped (covers the CMake `POST_BUILD` path) and regenerates from the final binary otherwise, so there is no double-strip hazard.