### PR TITLE
Fix race between FWD/BWD rel batch inserts sharing one partition cursor

### DIFF
--- a/src/include/processor/operator/base_partitioner_shared_state.h
+++ b/src/include/processor/operator/base_partitioner_shared_state.h
@@ -25,11 +25,18 @@ struct LBUG_API PartitionerSharedState {
     std::array<common::offset_t, DIRECTIONS> numNodes;
     std::array<common::partition_idx_t, DIRECTIONS>
         numPartitions; // num of partitions in each direction.
-    std::atomic<common::partition_idx_t> nextPartitionIdx;
+    // One partition cursor per direction. The FWD and BWD RelBatchInsert pipelines share this
+    // state and run concurrently, so a single shared cursor lets workers steal each other's
+    // partition indices, and lets one direction's resetState() re-issue partitions the other
+    // direction is still processing (two workers mutating the same partition buffer in place).
+    std::array<std::atomic<common::partition_idx_t>, DIRECTIONS> nextPartitionIdx;
 
     PartitionerSharedState()
         : srcNodeTable{nullptr}, dstNodeTable{nullptr}, relTable(nullptr), numNodes{0, 0},
-          numPartitions{0, 0}, nextPartitionIdx{0} {}
+          numPartitions{0, 0} {
+        nextPartitionIdx[0] = 0;
+        nextPartitionIdx[1] = 0;
+    }
     virtual ~PartitionerSharedState() = default;
 
     template<class TARGET>

--- a/src/processor/operator/base_partitioner_shared_state.cpp
+++ b/src/processor/operator/base_partitioner_shared_state.cpp
@@ -19,7 +19,8 @@ void PartitionerSharedState::initialize(const common::logical_type_vec_t&,
 }
 
 common::partition_idx_t PartitionerSharedState::getNextPartition(common::idx_t partitioningIdx) {
-    auto nextPartitionIdxToReturn = nextPartitionIdx++;
+    DASSERT(partitioningIdx < DIRECTIONS);
+    auto nextPartitionIdxToReturn = nextPartitionIdx[partitioningIdx]++;
     if (nextPartitionIdxToReturn >= numPartitions[partitioningIdx]) {
         return common::INVALID_PARTITION_IDX;
     }
@@ -31,7 +32,8 @@ common::partition_idx_t PartitionerSharedState::getNumPartitionsFromRows(common:
            common::StorageConfig::NODE_GROUP_SIZE;
 }
 
-void PartitionerSharedState::resetState(common::idx_t) {
-    nextPartitionIdx = 0;
+void PartitionerSharedState::resetState(common::idx_t partitioningIdx) {
+    DASSERT(partitioningIdx < DIRECTIONS);
+    nextPartitionIdx[partitioningIdx] = 0;
 }
 } // namespace lbug::processor


### PR DESCRIPTION
## Summary

Fixes a crash seen as `free(): unaligned chunk detected in tcache` during parallel rel insert workloads. That abort is a delayed symptom of heap corruption, not the root cause.

## Root cause

COPY of a rel table builds two `RelBatchInsert` pipelines (FWD with `partitioningIdx=0`, BWD with `partitioningIdx=1`) that share one `CopyPartitionerSharedState` and run concurrently. But `PartitionerSharedState::nextPartitionIdx` was a single atomic cursor used for both directions:

- Workers steal each other's partition indices (the shared counter is compared against a per-direction limit), so partitions get skipped.
- Worse, when one direction finishes, `RelBatchInsert::finalizeInternal` -> `resetState()` zeroes the shared cursor while the other direction is still consuming partitions, so an already-handed-out partition is issued again. Two workers then mutate the same partition buffer in place (`setOffsetToWithinNodeGroup` subtracts the start offset twice, underflowing to a huge offset; `lengthData[nodeOffset]++` and row-idx computation then write out of bounds), corrupting heap metadata. This violates the `getPartitionBuffer` contract of being called exactly once per partition.

## Fix

Give each partitioning direction its own cursor: `nextPartitionIdx` becomes `std::array<std::atomic<partition_idx_t>, DIRECTIONS>`, with `getNextPartition()`/`resetState()` operating on the caller's direction only.

## Verification

- Incremental release build compiles clean; edited files are clang-format clean.
- All 229 copy-related e2e tests pass (`e2e_test --gtest_filter="*copy*"`).