### PR TITLE
lsqb benchmark: run nightly wheel from TestPyPI after build-and-deploy

### DIFF
--- a/.github/workflows/lsqb-benchmark-workflow.yml
+++ b/.github/workflows/lsqb-benchmark-workflow.yml
@@ -1,7 +1,10 @@
 name: LSQB Benchmark
 on:
   schedule:
-    - cron: "0 5 * * *"
+    # Run after the nightly Build and Deploy (scheduled 11:00 UTC,
+    # typically takes ~3h) with at least an hour of buffer so the fresh
+    # nightly wheels are published to TestPyPI before we install them.
+    - cron: "0 15 * * *"
 
   workflow_dispatch:
     inputs:
@@ -52,11 +55,11 @@ jobs:
       - name: Install uv
         run: pip install uv
 
-      - name: Install ladybug wheel from PyPI
+      - name: Install ladybug nightly wheel from TestPyPI
         run: |
           uv venv
           source .venv/bin/activate
-          uv pip install --prerelease=allow ladybug psutil
+          uv pip install --prerelease=allow --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ --index-strategy unsafe-first-match ladybug psutil
 
       - name: Benchmark
         run: uv run benchmark/lsqb/benchmark_runner.py


### PR DESCRIPTION
LSQB benchmark currently installs the latest release from PyPI on a 05:00 UTC schedule, before the nightly Build and Deploy (11:00 UTC) publishes.

- Install ladybug nightly from TestPyPI (test.pypi.org) with PyPI as fallback for deps, using unsafe-first-match so the nightly dev version wins over the PyPI release.
- Reschedule to 15:00 UTC, safely over an hour after the nightly build-and-deploy (which typically takes ~3h) finishes publishing.