### PR TITLE
fix(storage): prevent corrupted HASH PK entries from crashing MERGE

### DIFF
--- a/src/storage/local_storage/local_node_table.cpp
+++ b/src/storage/local_storage/local_node_table.cpp
@@ -3,6 +3,7 @@
 #include "catalog/catalog_entry/node_table_catalog_entry.h"
 #include "common/cast.h"
 #include "common/exception/message.h"
+#include "common/exception/runtime.h"
 #include "common/types/types.h"
 #include "common/types/value/value.h"
 #include "storage/index/hash_index.h"
@@ -42,9 +43,19 @@ void LocalNodeTable::initLocalHashIndex(MemoryManager& mm) {
 }
 
 bool LocalNodeTable::isVisible(const Transaction* transaction, offset_t offset) const {
+    if (offset < startOffset) {
+        throw RuntimeException(
+            "Primary-key index contains an invalid local node offset. Please drop and rebuild "
+            "the _PK index.");
+    }
     auto [nodeGroupIdx, offsetInGroup] =
         StorageUtils::getNodeGroupIdxAndOffsetInChunk(offset - startOffset);
-    auto* nodeGroup = nodeGroups.getNodeGroup(nodeGroupIdx);
+    auto* nodeGroup = nodeGroups.getNodeGroup(nodeGroupIdx, true /*mayOutOfBound*/);
+    if (nodeGroup == nullptr || offsetInGroup >= nodeGroup->getNumRows()) {
+        throw RuntimeException(
+            "Primary-key index contains an invalid local node offset. Please drop and rebuild "
+            "the _PK index.");
+    }
     if (nodeGroup->isDeleted(transaction, offsetInGroup)) {
         return false;
     }

--- a/src/storage/table/node_table.cpp
+++ b/src/storage/table/node_table.cpp
@@ -877,6 +877,9 @@ bool NodeTable::isVisibleNoLock(const Transaction* transaction, offset_t offset)
         return false;
     }
     const auto* nodeGroup = getNodeGroupNoLock(nodeGroupIdx);
+    if (nodeGroup == nullptr) {
+        return false;
+    }
     return nodeGroup->isVisibleNoLock(transaction, offsetInGroup);
 }
 
@@ -928,7 +931,32 @@ bool NodeTable::lookupPK(const Transaction* transaction, ValueVector* keyVector,
     }
     if (auto* pkIndex = tryGetPrimaryKeyIndex()) {
         return pkIndex->lookupPrimaryKey(transaction, keyVector, vectorPos, result,
-            [&](offset_t offset) { return isVisibleNoLock(transaction, offset); });
+            [&](offset_t offset) {
+                // A stale/corrupt PK index entry must not reach isVisibleNoLock(), where an
+                // invalid node offset could otherwise be dereferenced in a release build. Keep
+                // this validation O(1) on the normal lookup path and fail the transaction instead
+                // of treating a corrupt entry as a missing key.
+                if (offset == INVALID_OFFSET) {
+                    throw RuntimeException(
+                        "Primary-key index contains an invalid node offset. Please drop and "
+                        "rebuild the _PK index.");
+                }
+                const auto nodeGroupIdx = StorageUtils::getNodeGroupIdx(offset);
+                if (nodeGroupIdx >= nodeGroups->getNumNodeGroupsNoLock()) {
+                    throw RuntimeException(
+                        "Primary-key index points to a missing node group. Please drop and "
+                        "rebuild the _PK index.");
+                }
+                const auto* nodeGroup = getNodeGroupNoLock(nodeGroupIdx);
+                const auto offsetInGroup =
+                    offset - StorageUtils::getStartOffsetOfNodeGroup(nodeGroupIdx);
+                if (nodeGroup == nullptr || offsetInGroup >= nodeGroup->getNumRows()) {
+                    throw RuntimeException(
+                        "Primary-key index contains an out-of-range node offset. Please drop "
+                        "and rebuild the _PK index.");
+                }
+                return isVisibleNoLock(transaction, offset);
+            });
     }
     auto keyToLookup = keyVector->getAsValue(vectorPos);
     ColumnPredicateSet predicateSet;

--- a/test/issues/issues_merge_on_match_set.cpp
+++ b/test/issues/issues_merge_on_match_set.cpp
@@ -1,6 +1,7 @@
 #include "graph_test/private_graph_test.h"
 #include "main/connection.h"
 #include "main/database.h"
+#include <format>
 
 namespace lbug {
 namespace testing {
@@ -148,6 +149,46 @@ TEST_F(MergeOnMatchSetTest, PersistentDelete) {
     ASSERT_TRUE(relResult->isSuccess()) << relResult->getErrorMessage();
     ASSERT_EQ(relResult->getNext()->getValue(0)->getValue<int64_t>(), 0);
     ASSERT_FALSE(relResult->hasNext());
+}
+
+// A duplicate-PK-only COPY must not leave a stale HASH PK entry that makes a later UNWIND +
+// MERGE dereference an invalid node offset during PK validation. The CSV contains one duplicate
+// row (id=10); the subsequent MERGE matches ids 10 and 24 and inserts id 99.
+TEST_F(MergeOnMatchSetTest, CopySkipDuplicatePKThenUnwindMerge) {
+    runQuery("CREATE NODE TABLE copy_merge_person (id STRING, name STRING, PRIMARY KEY(id));");
+    runQuery(std::format(
+        "COPY copy_merge_person FROM \"{}/dataset/copy-fault-tests/duplicate-ids/vPerson.csv\" "
+        "(IGNORE_ERRORS=true (DUPLICATE_PK_ONLY), PARALLEL=false);",
+        LBUG_ROOT_DIRECTORY));
+
+    auto result = conn->query("UNWIND ["
+                              "{id: '10', name: 'updated'},"
+                              "{id: '24', name: 'matched'},"
+                              "{id: '99', name: 'inserted'}"
+                              "] AS row "
+                              "MERGE (p:copy_merge_person {id: row.id}) "
+                              "SET p.name = row.name "
+                              "RETURN count(*);");
+    ASSERT_TRUE(result->isSuccess()) << result->getErrorMessage();
+    ASSERT_EQ(result->getNext()->getValue(0)->getValue<int64_t>(), 3);
+    ASSERT_FALSE(result->hasNext());
+
+    result = conn->query("MATCH (p:copy_merge_person) RETURN p.id, p.name ORDER BY p.id;");
+    ASSERT_TRUE(result->isSuccess()) << result->getErrorMessage();
+    ASSERT_EQ(result->getNumTuples(), 4);
+    auto tuple = result->getNext();
+    ASSERT_EQ(tuple->getValue(0)->getValue<std::string>(), "10");
+    ASSERT_EQ(tuple->getValue(1)->getValue<std::string>(), "updated");
+    tuple = result->getNext();
+    ASSERT_EQ(tuple->getValue(0)->getValue<std::string>(), "24");
+    ASSERT_EQ(tuple->getValue(1)->getValue<std::string>(), "matched");
+    tuple = result->getNext();
+    ASSERT_EQ(tuple->getValue(0)->getValue<std::string>(), "31");
+    ASSERT_EQ(tuple->getValue(1)->getValue<std::string>(), "Xiyang");
+    tuple = result->getNext();
+    ASSERT_EQ(tuple->getValue(0)->getValue<std::string>(), "99");
+    ASSERT_EQ(tuple->getValue(1)->getValue<std::string>(), "inserted");
+    ASSERT_FALSE(result->hasNext());
 }
 
 } // namespace testing


### PR DESCRIPTION
fix: https://github.com/LadybugDB/ladybug/issues/931 


## Root Cause

The immediate root cause is an invalid offset stored in, or returned by, the persistent HASH PK index.

The lookup path previously assumed that every index offset was valid:

```text
HASH PK lookup
  -> offset
  -> node group lookup
  -> node group visibility check
```

No runtime validation existed between the index result and node-group access. Therefore an invalid index entry became a native invalid-memory access instead of a database error.

The supplied database reproduces this failure even after copying it and executing a single-threaded, one-batch `UNWIND + MERGE`, without running `COPY` in that execution. This proves that the persisted database state already contains the problematic index state.

The exact producer of that invalid index entry cannot be proven from the available database and core dump alone. The historical workflow included:

```cypher
COPY ... (IGNORE_ERRORS=true (DUPLICATE_PK_ONLY))
```

followed by `UNWIND + MERGE`, so COPY-local PK-index/row lifecycle inconsistency is a credible source, but it is not conclusively established.

## Example Impact

Given an index entry such as:

```text
id = "new-id" -> offset = invalid node group / invalid in-group row
```

a statement such as:

```cypher
UNWIND [{id: 'new-id'}] AS row
MERGE (n:Table {id: row.id})
```

must validate whether `new-id` already exists before inserting it. Instead of returning a database error for the invalid index entry, the previous code dereferenced the invalid offset and terminated the process with SIGSEGV.

This affects both writes and reads that perform HASH PK lookup. The most severe effect is process termination and possible interruption of the active transaction.

## Fix

Validate HASH PK lookup results before accessing node-group storage:

- reject `INVALID_OFFSET`;
- reject offsets whose node group does not exist;
- reject offsets beyond the number of rows in the target node group;
- throw `RuntimeException` instructing the user to drop and rebuild `_PK`.

The same protection is applied to local node-table PK lookup.

The normal path only adds constant-time integer bounds checks and a node-group pointer read. It adds no scans, no extra disk reads, no locks, and no change to normal COPY or query execution semantics.

A corrupted entry is deliberately not treated as “PK does not exist”: doing so could permit a duplicate primary key to be inserted.

## Regression Test

Added coverage for the normal historical workflow:

```cypher
COPY ... (IGNORE_ERRORS=true (DUPLICATE_PK_ONLY), PARALLEL=false);
UNWIND [...]
MERGE (...)
SET ...
```

The test verifies that duplicate-PK-only COPY followed by MERGE correctly matches existing rows, inserts a new row, and preserves PK uniqueness.

## Relation to `e98835d3f`

`e98835d3f` is the only previously identified change directly related to the historical workflow: it fixes HASH PK rollback after a failed COPY by discarding the inserted local PK entry.

The supplied core dump proves that a HASH PK lookup later returned an invalid/stale node offset, which was dereferenced during `validatePkNotExists()` and caused SIGSEGV. The available evidence does not prove that this invalid entry was created specifically by the failed-COPY path fixed in `e98835d3f`; it only makes that path a credible source.

This PR closes the remaining safety gap: regardless of how an invalid HASH PK offset entered the index, PK lookup reports a recoverable index-corruption error instead of dereferencing it and crashing the process.

## Limitations

- This patch prevents the crash and preserves PK correctness, but it does not repair an already corrupted `_PK` index.
- Affected databases require dropping and recreating `_PK` (or an equivalent index rebuild operation).
- The original SQL sequence can be tested for correct behavior on a fresh database, but no normal SQL-only reproducer has been found that creates the corrupted index state from scratch.
- Therefore, the test covers the intended COPY + MERGE workflow, not construction of a malformed persisted index file.
- The patch intentionally does not change `DUPLICATE_PK_ONLY` transaction semantics beyond existing fixes, because broadening that behavior would increase scope and may affect COPY performance and error-handling semantics.



