### PR TITLE
dumpLogical: handle recent operators; make logical operator type-to-string switch exhaustive

### DIFF
--- a/src/optimizer/optimizer.cpp
+++ b/src/optimizer/optimizer.cpp
@@ -4,6 +4,8 @@
 #include <cstdlib>
 #include <unordered_set>
 
+#include "binder/expression/expression_util.h"
+
 #include "common/enums/extend_direction_util.h"
 #include "main/client_context.h"
 #include "optimizer/acc_hash_join_optimizer.h"
@@ -32,6 +34,14 @@
 #include "planner/operator/logical_filter.h"
 #include "planner/operator/logical_hash_join.h"
 #include "planner/operator/logical_operator.h"
+#include "planner/operator/logical_partitioner.h"
+#include "planner/operator/logical_unwind_deduplicate.h"
+#include "planner/operator/scan/logical_count_anti_edge_chain.h"
+#include "planner/operator/scan/logical_count_extend_chain.h"
+#include "planner/operator/scan/logical_count_rel_table.h"
+#include "planner/operator/scan/logical_query_primary_key_lookup.h"
+#include "planner/operator/scan/logical_reachable_count.h"
+#include "planner/operator/scan/logical_rel_degree_table.h"
 #include "planner/operator/scan/logical_scan_node_table.h"
 #include "transaction/transaction.h"
 
@@ -88,6 +98,62 @@ void dumpLogicalTree(const planner::LogicalOperator* op, int depth,
     } else if (op->getOperatorType() == planner::LogicalOperatorType::SCAN_NODE_TABLE) {
         fprintf(stderr, " [%s]",
             op->constCast<planner::LogicalScanNodeTable>().getNodeID()->toString().c_str());
+    } else if (op->getOperatorType() == planner::LogicalOperatorType::COUNT_REL_TABLE) {
+        auto& count = op->constCast<planner::LogicalCountRelTable>();
+        fprintf(stderr, " [%s dir=%s bound=%s]", count.getRelGroupEntry()->getName().c_str(),
+            common::ExtendDirectionUtil::toString(count.getDirection()).c_str(),
+            count.getBoundNode()->getUniqueName().c_str());
+    } else if (op->getOperatorType() == planner::LogicalOperatorType::COUNT_EXTEND_CHAIN) {
+        auto& count = op->constCast<planner::LogicalCountExtendChain>();
+        fprintf(stderr, " [hops=%llu tables=", (unsigned long long)count.getHops().size());
+        bool first = true;
+        for (auto& hop : count.getHops()) {
+            for (auto& spec : hop.relScans) {
+                fprintf(stderr, "%s%s", first ? "" : ",", spec.relTableName.c_str());
+                first = false;
+            }
+        }
+        fprintf(stderr, "]");
+    } else if (op->getOperatorType() == planner::LogicalOperatorType::COUNT_ANTI_EDGE_CHAIN) {
+        auto& count = op->constCast<planner::LogicalCountAntiEdgeChain>();
+        fprintf(stderr, " [%s antiDir=%s hops=%llu id<>=",
+            count.getAntiRelEntry()->getName().c_str(),
+            common::ExtendDirectionUtil::toString(count.getAntiEdgeDir()).c_str(),
+            (unsigned long long)count.getSuffixHops().size());
+        fprintf(stderr, "%s]", count.getHasNotEquals() ? "true" : "false");
+    } else if (op->getOperatorType() == planner::LogicalOperatorType::REACHABLE_COUNT) {
+        auto& count = op->constCast<planner::LogicalReachableCount>();
+        fprintf(stderr, " [%s dir=%s bound=%s nbr=%s range=%u..%u]",
+            count.getRelGroupEntry()->getName().c_str(),
+            common::ExtendDirectionUtil::toString(count.getDirection()).c_str(),
+            count.getBoundNode()->getUniqueName().c_str(),
+            count.getNbrNode()->getUniqueName().c_str(), count.getLowerBound(),
+            count.getUpperBound());
+    } else if (op->getOperatorType() == planner::LogicalOperatorType::REL_DEGREE_TABLE) {
+        auto& degree = op->constCast<planner::LogicalRelDegreeTable>();
+        fprintf(stderr, " [%s dir=%s mode=%s]", degree.getRelGroupEntry()->getName().c_str(),
+            common::ExtendDirectionUtil::toString(degree.getDirection()).c_str(),
+            degree.getMode() == planner::RelDegreeTableMode::ACTIVE_BOUND_COUNT ?
+                "ACTIVE_BOUND_COUNT" :
+                degree.getMode() == planner::RelDegreeTableMode::TOP_K_DEGREES ? "TOP_K_DEGREES" :
+                                                                                 "OFFSET_COUNT");
+    } else if (op->getOperatorType() ==
+               planner::LogicalOperatorType::QUERY_PRIMARY_KEY_LOOKUP) {
+        auto& lookup = op->constCast<planner::LogicalQueryPrimaryKeyLookup>();
+        fprintf(stderr, " [table=%llu key=%s]", (unsigned long long)lookup.getTableID(),
+            lookup.getKey()->toString().c_str());
+    } else if (op->getOperatorType() == planner::LogicalOperatorType::UNWIND_DEDUPLICATE) {
+        auto& dedup = op->constCast<planner::LogicalUnwindDeduplicate>();
+        fprintf(stderr, " [keys=%s]", binder::ExpressionUtil::toString(dedup.getKeyExpressions()).c_str());
+    } else if (op->getOperatorType() == planner::LogicalOperatorType::PARTITIONER) {
+        fprintf(stderr, " [keys=%llu]",
+            (unsigned long long)op->constCast<planner::LogicalPartitioner>().getInfo().getNumInfos());
+    } else {
+        // Generic fallback for operators without a dedicated handler above.
+        auto exprs = op->getExpressionsForPrinting();
+        if (!exprs.empty()) {
+            fprintf(stderr, " [%s]", exprs.c_str());
+        }
     }
     fprintf(stderr, "\n");
     for (auto i = 0u; i < op->getNumChildren(); ++i) {

--- a/src/optimizer/optimizer.cpp
+++ b/src/optimizer/optimizer.cpp
@@ -5,7 +5,6 @@
 #include <unordered_set>
 
 #include "binder/expression/expression_util.h"
-
 #include "common/enums/extend_direction_util.h"
 #include "main/client_context.h"
 #include "optimizer/acc_hash_join_optimizer.h"
@@ -116,8 +115,8 @@ void dumpLogicalTree(const planner::LogicalOperator* op, int depth,
         fprintf(stderr, "]");
     } else if (op->getOperatorType() == planner::LogicalOperatorType::COUNT_ANTI_EDGE_CHAIN) {
         auto& count = op->constCast<planner::LogicalCountAntiEdgeChain>();
-        fprintf(stderr, " [%s antiDir=%s hops=%llu id<>=",
-            count.getAntiRelEntry()->getName().c_str(),
+        fprintf(stderr,
+            " [%s antiDir=%s hops=%llu id<>=", count.getAntiRelEntry()->getName().c_str(),
             common::ExtendDirectionUtil::toString(count.getAntiEdgeDir()).c_str(),
             (unsigned long long)count.getSuffixHops().size());
         fprintf(stderr, "%s]", count.getHasNotEquals() ? "true" : "false");
@@ -135,19 +134,21 @@ void dumpLogicalTree(const planner::LogicalOperator* op, int depth,
             common::ExtendDirectionUtil::toString(degree.getDirection()).c_str(),
             degree.getMode() == planner::RelDegreeTableMode::ACTIVE_BOUND_COUNT ?
                 "ACTIVE_BOUND_COUNT" :
-                degree.getMode() == planner::RelDegreeTableMode::TOP_K_DEGREES ? "TOP_K_DEGREES" :
-                                                                                 "OFFSET_COUNT");
-    } else if (op->getOperatorType() ==
-               planner::LogicalOperatorType::QUERY_PRIMARY_KEY_LOOKUP) {
+            degree.getMode() == planner::RelDegreeTableMode::TOP_K_DEGREES ? "TOP_K_DEGREES" :
+                                                                             "OFFSET_COUNT");
+    } else if (op->getOperatorType() == planner::LogicalOperatorType::QUERY_PRIMARY_KEY_LOOKUP) {
         auto& lookup = op->constCast<planner::LogicalQueryPrimaryKeyLookup>();
         fprintf(stderr, " [table=%llu key=%s]", (unsigned long long)lookup.getTableID(),
             lookup.getKey()->toString().c_str());
     } else if (op->getOperatorType() == planner::LogicalOperatorType::UNWIND_DEDUPLICATE) {
         auto& dedup = op->constCast<planner::LogicalUnwindDeduplicate>();
-        fprintf(stderr, " [keys=%s]", binder::ExpressionUtil::toString(dedup.getKeyExpressions()).c_str());
+        fprintf(stderr, " [keys=%s]",
+            binder::ExpressionUtil::toString(dedup.getKeyExpressions()).c_str());
     } else if (op->getOperatorType() == planner::LogicalOperatorType::PARTITIONER) {
         fprintf(stderr, " [keys=%llu]",
-            (unsigned long long)op->constCast<planner::LogicalPartitioner>().getInfo().getNumInfos());
+            (unsigned long long)op->constCast<planner::LogicalPartitioner>()
+                .getInfo()
+                .getNumInfos());
     } else {
         // Generic fallback for operators without a dedicated handler above.
         auto exprs = op->getExpressionsForPrinting();

--- a/src/planner/operator/logical_operator.cpp
+++ b/src/planner/operator/logical_operator.cpp
@@ -24,6 +24,8 @@ std::string LogicalOperatorUtils::logicalOperatorTypeToString(LogicalOperatorTyp
         return "COPY_FROM";
     case LogicalOperatorType::COPY_TO:
         return "COPY_TO";
+    case LogicalOperatorType::COUNT_ANTI_EDGE_CHAIN:
+        return "COUNT_ANTI_EDGE_CHAIN";
     case LogicalOperatorType::COUNT_EXTEND_CHAIN:
         return "COUNT_EXTEND_CHAIN";
     case LogicalOperatorType::COUNT_REL_TABLE:
@@ -132,9 +134,11 @@ std::string LogicalOperatorUtils::logicalOperatorTypeToString(LogicalOperatorTyp
         return "EXTENSION_CLAUSE";
     case LogicalOperatorType::UNWIND_DEDUPLICATE:
         return "UNWIND_DEDUPLICATE";
-    default:
-        throw RuntimeException("Unknown logical operator type.");
     }
+    // No default label: -Wswitch then enforces that every LogicalOperatorType enumerator is
+    // handled above, so adding a new operator fails the build here instead of failing at
+    // runtime. The throw only guards against out-of-range values (e.g. deserialized data).
+    throw RuntimeException("Unknown logical operator type.");
 }
 // LCOV_EXCL_STOP
 


### PR DESCRIPTION
## Summary

Two related fixes found while debugging LSQB q9 with `LBUG_DUMP_LOGICAL=1`:

### 1. `dumpLogical` handles the recent operators

`dumpLogicalTree()` in `src/optimizer/optimizer.cpp` only had detail handlers for `EXTEND`/`PACKED_EXTEND`, `FILTER`, `HASH_JOIN`, `AGGREGATE` and `SCAN_NODE_TABLE` — everything else printed as a bare operator name. Adds handlers for the recently added operators:

- `COUNT_REL_TABLE` — rel group, direction, bound node
- `COUNT_EXTEND_CHAIN` — hop count and rel table names
- `COUNT_ANTI_EDGE_CHAIN` — anti-edge rel table, anti-edge direction, suffix hops, `id<>` flag
- `REACHABLE_COUNT` — rel table, direction, bound/nbr nodes, `[lower..upper]` bounds
- `REL_DEGREE_TABLE` — rel table, direction, mode
- `QUERY_PRIMARY_KEY_LOOKUP` — table ID, key expression
- `UNWIND_DEDUPLICATE` — key expressions
- `PARTITIONER` — number of partitioning keys

Plus a generic fallback that prints `getExpressionsForPrinting()` when non-empty, so any operator without a dedicated handler (including future ones) still prints its key expressions instead of nothing.

### 2. Missing `COUNT_ANTI_EDGE_CHAIN` in type-to-string; switch made exhaustive

`LogicalOperatorUtils::logicalOperatorTypeToString()` had no case for `COUNT_ANTI_EDGE_CHAIN`, so the "after optimization" dump of q9 crashed with `Unknown logical operator type.` — the switch's `default: throw` label silently disabled `-Wswitch` exhaustiveness checking.

The `default:` label is removed and the throw moved after the switch, so `-Wswitch` (in `-Wall`) now fails the build under `-Werror` when a new `LogicalOperatorType` enumerator is added without a case here. The runtime throw is kept as a guard for out-of-range values.

The same treatment for the sibling enum→string switches across the codebase is tracked in #935.

## Testing

- Clean release build, clang-format clean
- `LBUG_DUMP_LOGICAL=1` on LSQB q9 now dumps and executes end to end:
  ```
  === LOGICAL PLAN (after optimization) ===
  PROJECTION [count]
    COUNT_ANTI_EDGE_CHAIN [Person_knows_Person antiDir=fwd hops=1 id<>=true]
  === END LOGICAL PLAN ===
  ```
- Verified enforcement: temporarily commenting out any single `case` produces `warning: enumeration value 'X' not handled in switch [-Wswitch]`