### PR TITLE
fix(storage): pin Arrow registry entries with shared_ptr to prevent use-after-free

### DIFF
--- a/src/include/storage/table/arrow_node_table.h
+++ b/src/include/storage/table/arrow_node_table.h
@@ -13,6 +13,7 @@
 #include "storage/table/columnar_node_table_base.h"
 
 namespace lbug {
+struct ArrowTableData;
 namespace storage {
 
 struct ArrowNodeTableScanState final : ColumnarNodeTableScanState {
@@ -75,7 +76,7 @@ class ArrowNodeTable final : public ColumnarNodeTableBase {
 public:
     ArrowNodeTable(const StorageManager* storageManager,
         const catalog::NodeTableCatalogEntry* nodeTableEntry, MemoryManager* memoryManager,
-        ArrowSchemaWrapper schema, std::vector<ArrowArrayWrapper> arrays, std::string arrowId);
+        std::shared_ptr<ArrowTableData> arrowData, std::string arrowId);
 
     ~ArrowNodeTable();
 
@@ -121,6 +122,10 @@ private:
         const std::vector<int64_t>& outputToArrowColumnIdx) const;
 
 private:
+    // Pin on the registry entry: keeps the Arrow buffers alive even after
+    // unregisterArrowData() erases the registry map entry (issue #933).
+    // `schema`/`arrays` below are shallow non-owning views into `arrowData`.
+    std::shared_ptr<ArrowTableData> arrowData;
     ArrowSchemaWrapper schema;
     std::vector<ArrowArrayWrapper> arrays;
     std::vector<std::optional<common::ArrowLogicalTypeInfo>> columnLogicalTypeInfos;

--- a/src/include/storage/table/arrow_rel_table.h
+++ b/src/include/storage/table/arrow_rel_table.h
@@ -32,10 +32,7 @@ public:
     ArrowRelTable(catalog::RelGroupCatalogEntry* relGroupEntry, common::table_id_t fromTableID,
         common::table_id_t toTableID, const StorageManager* storageManager,
         MemoryManager* memoryManager, const NodeTable* fromNodeTable, const NodeTable* toNodeTable,
-        ArrowRelTableLayout layout, ArrowSchemaWrapper schema,
-        std::vector<ArrowArrayWrapper> arrays, ArrowSchemaWrapper indptrSchema,
-        std::vector<ArrowArrayWrapper> indptrArrays, std::string arrowId,
-        std::string dstColumnName = "to");
+        std::shared_ptr<ArrowRelTableData> arrowData, std::string arrowId);
     ~ArrowRelTable();
 
     void initScanState(transaction::Transaction* transaction, TableScanState& scanState,
@@ -78,6 +75,9 @@ private:
 
     const NodeTable* fromNodeTable;
     const NodeTable* toNodeTable;
+    // Pin on the registry entry (issue #933); `schema`/`arrays`/`indptrSchema`/
+    // `indptrArrays` below are shallow non-owning views into `arrowData`.
+    std::shared_ptr<ArrowRelTableData> arrowData;
     ArrowRelTableLayout layout;
     ArrowSchemaWrapper schema;
     std::vector<ArrowArrayWrapper> arrays;

--- a/src/include/storage/table/arrow_table_support.h
+++ b/src/include/storage/table/arrow_table_support.h
@@ -22,6 +22,16 @@ struct ArrowRelTableData {
     std::string dstColumnName = "to";
 };
 
+// Registry-owned Arrow node-table payload. Stored as a shared_ptr in the
+// process-wide registry so that tables can pin the data they view: the
+// shared_ptr copy returned by getArrowData()/getArrowRelData() keeps the
+// underlying Arrow buffers alive even if another thread unregisters (erases)
+// the registry entry concurrently (CWE-416/667, issue #933).
+struct ArrowTableData {
+    ArrowSchemaWrapper schema;
+    std::vector<ArrowArrayWrapper> arrays;
+};
+
 // Result of creating an arrow table view
 struct ArrowTableCreationResult {
     std::unique_ptr<main::QueryResult> queryResult;
@@ -37,12 +47,15 @@ public:
     // Register Arrow relationship data and return an ID
     static std::string registerArrowRelData(ArrowRelTableData data);
 
-    // Retrieve Arrow data by ID (returns pointers to data in registry)
-    static bool getArrowData(const std::string& id, ArrowSchemaWrapper*& schema,
-        std::vector<ArrowArrayWrapper>*& arrays);
+    // Retrieve Arrow data by ID. Returns a shared_ptr pinning the registry
+    // entry's lifetime: the caller may safely dereference it after the
+    // registry lock is released, even if another thread concurrently
+    // unregisters the same ID. Returns nullptr when the ID is unknown.
+    static std::shared_ptr<ArrowTableData> getArrowData(const std::string& id);
 
-    // Retrieve Arrow relationship data by ID (returns pointer to data in registry)
-    static bool getArrowRelData(const std::string& id, ArrowRelTableData*& data);
+    // Retrieve Arrow relationship data by ID (same lifetime semantics as
+    // getArrowData above). Returns nullptr when the ID is unknown.
+    static std::shared_ptr<ArrowRelTableData> getArrowRelData(const std::string& id);
 
     // Unregister Arrow data by ID
     static void unregisterArrowData(const std::string& id);

--- a/src/storage/storage_manager.cpp
+++ b/src/storage/storage_manager.cpp
@@ -211,24 +211,19 @@ void StorageManager::createNodeTable(NodeTableCatalogEntry* entry, main::ClientC
             // Extract Arrow ID from storage string
             std::string arrowId = entry->getStorage().substr(8);
 
-            // Retrieve Arrow data from registry (as pointers to registry data)
-            ArrowSchemaWrapper* schema = nullptr;
-            std::vector<ArrowArrayWrapper>* arrays = nullptr;
-            if (!ArrowTableSupport::getArrowData(arrowId, schema, arrays)) {
+            // Retrieve Arrow data from registry. The returned shared_ptr pins
+            // the entry's lifetime past the registry lock, so a concurrent
+            // DROP TABLE / unregister cannot free the buffers while we build
+            // the table's shallow views below (issue #933).
+            auto arrowData = ArrowTableSupport::getArrowData(arrowId);
+            if (!arrowData) {
                 throw common::RuntimeException("Failed to retrieve Arrow data for ID: " + arrowId);
             }
 
-            // Create wrappers that reference registry memory while registry keeps ownership.
-            ArrowSchemaWrapper schemaCopy = createShallowCopy(*schema);
-            std::vector<ArrowArrayWrapper> arraysCopy;
-            arraysCopy.reserve(arrays->size());
-            for (const auto& arr : *arrays) {
-                arraysCopy.push_back(createShallowCopy(arr));
-            }
-
-            // Create Arrow-backed node table
+            // Create Arrow-backed node table (it keeps its own pin plus
+            // shallow non-owning views into the pinned data).
             tables[entry->getTableID()] = std::make_unique<ArrowNodeTable>(this, entry,
-                &memoryManager, std::move(schemaCopy), std::move(arraysCopy), arrowId);
+                &memoryManager, std::move(arrowData), arrowId);
         } else {
             throw common::RuntimeException(
                 "Unsupported storage option for node table: " + entry->getStorage());
@@ -262,8 +257,8 @@ void StorageManager::addRelTable(RelGroupCatalogEntry* entry, const RelTableCata
     } else if (!entry->getStorage().empty()) {
         if (entry->getStorage().substr(0, 8) == "arrow://") {
             std::string arrowId = entry->getStorage().substr(8);
-            ArrowRelTableData* relData = nullptr;
-            if (!ArrowTableSupport::getArrowRelData(arrowId, relData)) {
+            auto relData = ArrowTableSupport::getArrowRelData(arrowId);
+            if (!relData) {
                 throw common::RuntimeException("Failed to retrieve Arrow data for ID: " + arrowId);
             }
             if (!tables.contains(info.nodePair.srcTableID) ||
@@ -277,23 +272,9 @@ void StorageManager::addRelTable(RelGroupCatalogEntry* entry, const RelTableCata
                 throw common::RuntimeException(
                     "Arrow rel table currently supports only regular node tables");
             }
-            ArrowSchemaWrapper schemaCopy = createShallowCopy(relData->schema);
-            std::vector<ArrowArrayWrapper> arraysCopy;
-            arraysCopy.reserve(relData->arrays.size());
-            for (const auto& arr : relData->arrays) {
-                arraysCopy.push_back(createShallowCopy(arr));
-            }
-            ArrowSchemaWrapper indptrSchemaCopy = createShallowCopy(relData->indptrSchema);
-            std::vector<ArrowArrayWrapper> indptrArraysCopy;
-            indptrArraysCopy.reserve(relData->indptrArrays.size());
-            for (const auto& arr : relData->indptrArrays) {
-                indptrArraysCopy.push_back(createShallowCopy(arr));
-            }
             tables[info.oid] = std::make_unique<ArrowRelTable>(entry, info.nodePair.srcTableID,
                 info.nodePair.dstTableID, this, &memoryManager, fromNodeTable, toNodeTable,
-                relData->layout, std::move(schemaCopy), std::move(arraysCopy),
-                std::move(indptrSchemaCopy), std::move(indptrArraysCopy), arrowId,
-                relData->dstColumnName);
+                std::move(relData), arrowId);
         } else {
             throw common::RuntimeException(
                 "Unsupported storage option for rel table: " + entry->getStorage());

--- a/src/storage/table/arrow_node_table.cpp
+++ b/src/storage/table/arrow_node_table.cpp
@@ -41,11 +41,21 @@ static std::vector<std::optional<common::ArrowLogicalTypeInfo>> resolveColumnLog
 
 ArrowNodeTable::ArrowNodeTable(const StorageManager* storageManager,
     const catalog::NodeTableCatalogEntry* nodeTableEntry, MemoryManager* memoryManager,
-    ArrowSchemaWrapper schema, std::vector<ArrowArrayWrapper> arrays, std::string arrowId)
+    std::shared_ptr<ArrowTableData> arrowData, std::string arrowId)
     : ColumnarNodeTableBase{storageManager, nodeTableEntry, memoryManager,
           std::make_unique<ArrowNodeTableScanSharedState>(scanMorselSize)},
-      schema{std::move(schema)}, arrays{std::move(arrays)}, totalRows{0},
-      arrowId{std::move(arrowId)} {
+      arrowData{std::move(arrowData)}, totalRows{0}, arrowId{std::move(arrowId)} {
+    if (!this->arrowData) {
+        throw common::RuntimeException("Arrow data is null");
+    }
+    // Shallow non-owning views into the pinned registry data. Safe because
+    // `arrowData` keeps the underlying Arrow buffers alive for the table's
+    // lifetime, even after the registry entry is erased.
+    this->schema = createShallowCopy(this->arrowData->schema);
+    this->arrays.reserve(this->arrowData->arrays.size());
+    for (const auto& array : this->arrowData->arrays) {
+        this->arrays.push_back(createShallowCopy(array));
+    }
     // Note: release may be nullptr if schema is managed by registry
     if (!this->schema.format) {
         throw common::RuntimeException("Arrow schema format cannot be null");

--- a/src/storage/table/arrow_rel_table.cpp
+++ b/src/storage/table/arrow_rel_table.cpp
@@ -108,14 +108,27 @@ void ArrowRelTableScanState::setToTable(const transaction::Transaction* transact
 
 ArrowRelTable::ArrowRelTable(catalog::RelGroupCatalogEntry* relGroupEntry, table_id_t fromTableID,
     table_id_t toTableID, const StorageManager* storageManager, MemoryManager* memoryManager,
-    const NodeTable* fromNodeTable, const NodeTable* toNodeTable, ArrowRelTableLayout layout,
-    ArrowSchemaWrapper schema, std::vector<ArrowArrayWrapper> arrays,
-    ArrowSchemaWrapper indptrSchema, std::vector<ArrowArrayWrapper> indptrArrays,
-    std::string arrowId, std::string dstColumnName)
+    const NodeTable* fromNodeTable, const NodeTable* toNodeTable,
+    std::shared_ptr<ArrowRelTableData> arrowData, std::string arrowId)
     : ColumnarRelTableBase{relGroupEntry, fromTableID, toTableID, storageManager, memoryManager},
-      fromNodeTable{fromNodeTable}, toNodeTable{toNodeTable}, layout{layout},
-      schema{std::move(schema)}, arrays{std::move(arrays)}, indptrSchema{std::move(indptrSchema)},
-      indptrArrays{std::move(indptrArrays)}, arrowId{std::move(arrowId)} {
+      fromNodeTable{fromNodeTable}, toNodeTable{toNodeTable}, arrowData{std::move(arrowData)},
+      arrowId{std::move(arrowId)} {
+    if (!this->arrowData) {
+        throw RuntimeException("Arrow relationship data is null");
+    }
+    // Shallow non-owning views into the pinned registry data (see ArrowNodeTable).
+    this->layout = this->arrowData->layout;
+    const std::string dstColumnName = this->arrowData->dstColumnName;
+    this->schema = createShallowCopy(this->arrowData->schema);
+    this->arrays.reserve(this->arrowData->arrays.size());
+    for (const auto& array : this->arrowData->arrays) {
+        this->arrays.push_back(createShallowCopy(array));
+    }
+    this->indptrSchema = createShallowCopy(this->arrowData->indptrSchema);
+    this->indptrArrays.reserve(this->arrowData->indptrArrays.size());
+    for (const auto& array : this->arrowData->indptrArrays) {
+        this->indptrArrays.push_back(createShallowCopy(array));
+    }
     if (!this->schema.format) {
         throw RuntimeException("Arrow schema format cannot be null");
     }

--- a/src/storage/table/arrow_table_support.cpp
+++ b/src/storage/table/arrow_table_support.cpp
@@ -12,16 +12,18 @@ namespace lbug {
 
 // Global registry for Arrow table data
 // Memory Management:
-// - Registry owns the Arrow data (ArrowSchemaWrapper/ArrowArrayWrapper with release callbacks)
-// - Arrow-backed tables store shallow copies (no release callbacks) and the arrowId
+// - Registry owns the Arrow data via shared_ptr (ArrowSchemaWrapper/ArrowArrayWrapper with
+//   release callbacks). getArrowData()/getArrowRelData() return a shared_ptr copy taken under
+//   the mutex, so callers pin the data past the lock scope; erasing the map entry only drops
+//   the registry's reference while live tables keep buffers valid (issue #933).
+// - Arrow-backed tables hold a shared_ptr pin plus shallow copies (no release callbacks) and
+//   the arrowId
 // - When a table is dropped (via DROP TABLE or unregisterArrowTable), the table's
 //   destructor automatically calls unregisterArrowData to clean up the registry entry
 // - The wrappers' destructors call the release callbacks to free the actual Arrow memory
 static std::mutex g_arrowRegistryMutex;
-static std::unordered_map<std::string,
-    std::pair<ArrowSchemaWrapper, std::vector<ArrowArrayWrapper>>>
-    g_arrowRegistry;
-static std::unordered_map<std::string, ArrowRelTableData> g_arrowRelRegistry;
+static std::unordered_map<std::string, std::shared_ptr<ArrowTableData>> g_arrowRegistry;
+static std::unordered_map<std::string, std::shared_ptr<ArrowRelTableData>> g_arrowRelRegistry;
 
 std::string join(const std::vector<std::string>& strings, const std::string& delimiter) {
     if (strings.empty())
@@ -58,8 +60,11 @@ std::string ArrowTableSupport::registerArrowData(ArrowSchemaWrapper schema,
     static size_t nextId = 0;
     std::string id = "arrow_" + std::to_string(nextId++);
 
-    // Store in registry
-    g_arrowRegistry[id] = std::make_pair(std::move(schema), std::move(arrays));
+    // Store in registry (shared ownership so live tables can pin the data).
+    auto entry = std::make_shared<ArrowTableData>();
+    entry->schema = std::move(schema);
+    entry->arrays = std::move(arrays);
+    g_arrowRegistry[id] = std::move(entry);
 
     return id;
 }
@@ -69,34 +74,33 @@ std::string ArrowTableSupport::registerArrowRelData(ArrowRelTableData data) {
 
     static size_t nextRelId = 0;
     std::string id = "arrow_rel_" + std::to_string(nextRelId++);
-    g_arrowRelRegistry[id] = std::move(data);
+    auto entry = std::make_shared<ArrowRelTableData>(std::move(data));
+    g_arrowRelRegistry[id] = std::move(entry);
     return id;
 }
 
-bool ArrowTableSupport::getArrowData(const std::string& id, ArrowSchemaWrapper*& schema,
-    std::vector<ArrowArrayWrapper>*& arrays) {
+std::shared_ptr<ArrowTableData> ArrowTableSupport::getArrowData(const std::string& id) {
     std::lock_guard<std::mutex> lock(g_arrowRegistryMutex);
 
     auto it = g_arrowRegistry.find(id);
     if (it == g_arrowRegistry.end()) {
-        return false;
+        return nullptr;
     }
 
-    // Return pointers to the data in the registry (not copies)
-    schema = &it->second.first;
-    arrays = &it->second.second;
-    return true;
+    // Copy the shared_ptr under the lock: the caller pins the data's lifetime
+    // past the lock scope, so a concurrent unregisterArrowData() (erase)
+    // cannot free the buffers out from under it.
+    return it->second;
 }
 
-bool ArrowTableSupport::getArrowRelData(const std::string& id, ArrowRelTableData*& data) {
+std::shared_ptr<ArrowRelTableData> ArrowTableSupport::getArrowRelData(const std::string& id) {
     std::lock_guard<std::mutex> lock(g_arrowRegistryMutex);
 
     auto it = g_arrowRelRegistry.find(id);
     if (it == g_arrowRelRegistry.end()) {
-        return false;
+        return nullptr;
     }
-    data = &it->second;
-    return true;
+    return it->second;
 }
 
 void ArrowTableSupport::unregisterArrowData(const std::string& id) {


### PR DESCRIPTION
Fixes #933.

## Problem
`getArrowData()`/`getArrowRelData()` in `src/storage/table/arrow_table_support.cpp` returned raw pointers into the process-wide registry maps after the `lock_guard` went out of scope. The mutex protected individual map operations, not the lifetime of data a caller already held a pointer into. A concurrent `DROP TABLE` → `unregisterArrowData()` → `unordered_map::erase` left the other thread with a dangling pointer (CWE-416 use-after-free, CWE-667 improper locking).

## Fix
- Registry payloads are now `shared_ptr<ArrowTableData>` / `shared_ptr<ArrowRelTableData>`.
- `getArrowData()`/`getArrowRelData()` return a `shared_ptr` copy taken under the mutex, so callers pin the buffers past the lock scope; erasing the map entry only drops the registry's reference.
- `ArrowNodeTable`/`ArrowRelTable` each hold a pin plus shallow non-owning views into the pinned data; table destructors still call `unregisterArrowData()` for cleanup, now safe under concurrency.
- `StorageManager` creation path uses the pinning getters, closing the get-then-copy TOCTOU.

## Testing
- `make release` clean.
- `build/release/test/api/api_test --gtest_filter="*Arrow*:*arrow*"` → 141 passed, 21 skipped (pre-existing skips).
- Targeted drop/recreate tests pass.