### PR TITLE
Fix use-after-free: reusable ResultSet outlived its Database

### DIFF
--- a/src/include/processor/processor.h
+++ b/src/include/processor/processor.h
@@ -1,15 +1,48 @@
 #pragma once
 
+#include <mutex>
+#include <thread>
+#include <unordered_map>
+
 #include "common/task_system/task_scheduler.h"
 
 namespace lbug {
 namespace main {
 class QueryResult;
 }
+namespace storage {
+class MemoryManager;
+}
 namespace processor {
 class FactorizedTable;
 class PhysicalPlan;
 class PhysicalOperator;
+class ResultSet;
+struct ResultSetDescriptor;
+
+// Per-database pool of reusable ResultSets, one slot per executing thread. A cached ResultSet
+// owns ValueVectors whose buffers belong to this database's MemoryManager, so the pool must be
+// owned by (and destroyed with) the database rather than living in a process-wide thread_local:
+// a thread_local slot outlives Database::~Database and later releases (or worse, reuses) buffers
+// through a dangling MemoryManager pointer when the next database runs a query on that thread.
+class ResultSetPool {
+public:
+    // Returns the ResultSet cached for the calling thread when its descriptor id matches,
+    // otherwise allocates a fresh one and caches it. The caller must keep the returned
+    // shared_ptr for as long as it uses the ResultSet: a nested query on the same thread may
+    // replace the slot, and the pool's own reference is dropped when this database closes.
+    std::shared_ptr<ResultSet> getOrCreate(ResultSetDescriptor* descriptor,
+        storage::MemoryManager* memoryManager);
+
+private:
+    struct Entry {
+        uint64_t descriptorID = UINT64_MAX;
+        std::shared_ptr<ResultSet> resultSet;
+    };
+    std::mutex mtx;
+    std::unordered_map<std::thread::id, Entry> entries;
+};
+
 class QueryProcessor {
 
 public:
@@ -20,6 +53,7 @@ public:
 #endif
 
     common::TaskScheduler* getTaskScheduler() { return taskScheduler.get(); }
+    ResultSetPool& getResultSetPool() { return resultSetPool; }
 
     std::unique_ptr<main::QueryResult> execute(PhysicalPlan* physicalPlan,
         ExecutionContext* context);
@@ -30,6 +64,10 @@ private:
     void initTask(common::Task* task);
 
 private:
+    // Declared before the scheduler so worker threads are joined before the pool is destroyed.
+    // The pool never outlives the buffers it caches because Database destroys its QueryProcessor
+    // before its MemoryManager.
+    ResultSetPool resultSetPool;
     std::unique_ptr<common::TaskScheduler> taskScheduler;
 };
 

--- a/src/include/processor/result/result_set_descriptor.h
+++ b/src/include/processor/result/result_set_descriptor.h
@@ -27,13 +27,13 @@ struct DataChunkDescriptor {
 
 struct LBUG_API ResultSetDescriptor {
     // Monotonically increasing identity that survives pointer reuse (ABA
-    // prevention).  Thread-local ResultSet caching in ProcessorTask::run()
+    // prevention).  Per-database ResultSet pooling in ProcessorTask::run()
     // compares this ID instead of the raw pointer so that a descriptor
     // allocated at the same address as a freed one is never confused with it.
     // copy() preserves the id: a copy semantically represents the same descriptor
     // slot (same plan position, same content). In particular the per-execution
     // re-attach of cached-plan sink descriptors (ClientContext::attachSinkDescriptors)
-    // must carry the same id across executions, otherwise the thread-local cache
+    // must carry the same id across executions, otherwise the per-database ResultSetPool
     // would miss on every execution of the same prepared statement.
     static inline std::atomic<uint64_t> nextID{0};
     uint64_t id;

--- a/src/processor/processor.cpp
+++ b/src/processor/processor.cpp
@@ -6,12 +6,44 @@
 #include "processor/operator/sink.h"
 #include "processor/physical_plan.h"
 #include "processor/processor_task.h"
+#include "processor/result/result_set.h"
 
 using namespace lbug::common;
 using namespace lbug::storage;
 
 namespace lbug {
 namespace processor {
+
+std::shared_ptr<ResultSet> ResultSetPool::getOrCreate(ResultSetDescriptor* descriptor,
+    MemoryManager* memoryManager) {
+    const auto threadID = std::this_thread::get_id();
+    std::shared_ptr<ResultSet> reusable;
+    {
+        std::lock_guard lock{mtx};
+        auto& entry = entries[threadID];
+        if (entry.resultSet && entry.descriptorID == descriptor->id) {
+            reusable = entry.resultSet;
+        }
+    }
+    if (reusable) {
+        // Same prepared statement on this thread: reuse the allocation. Only this thread touches
+        // its slot's ResultSet, so the reset happens after the lock is released.
+        reusable->resetForReuse();
+        return reusable;
+    }
+    // First time on this thread, or a different prepared statement: allocate fresh outside the
+    // lock, then swap it in and release the previous ResultSet after unlocking.
+    auto resultSet = std::make_shared<ResultSet>(descriptor, memoryManager);
+    std::shared_ptr<ResultSet> previous;
+    {
+        std::lock_guard lock{mtx};
+        auto& entry = entries[threadID];
+        previous = std::move(entry.resultSet);
+        entry.resultSet = resultSet;
+        entry.descriptorID = descriptor->id;
+    }
+    return resultSet;
+}
 
 #if defined(__APPLE__)
 QueryProcessor::QueryProcessor(uint64_t numThreads, uint32_t threadQos) {

--- a/src/processor/processor_task.cpp
+++ b/src/processor/processor_task.cpp
@@ -2,8 +2,10 @@
 
 #include "common/task_system/progress_bar.h"
 #include "main/client_context.h"
+#include "main/database.h"
 #include "main/settings.h"
 #include "processor/execution_context.h"
+#include "processor/processor.h"
 #include "processor/result/result_set.h"
 #include "storage/buffer_manager/memory_manager.h"
 
@@ -33,30 +35,21 @@ void ProcessorTask::run() {
     //     for i in range(n): conn.execute("RETURN $i", {"i": i})
     // that's a 16KB+ calloc on every iteration.
     //
-    // We instead keep a thread-local shared_ptr<ResultSet> whose descriptor
-    // matches this sink's, so each thread of a multi-threaded task gets
-    // its own allocation-free slot. The thread owns the ResultSet outright
-    // (no aliasing), so the lifetime is straightforward: dropped when the
-    // thread exits, or when a different prepared statement runs on this
-    // thread and the descriptor pointer no longer matches.
+    // The reusable ResultSet is cached per executing thread in the database-owned
+    // ResultSetPool (see QueryProcessor), never in a process-wide thread_local: the cached
+    // vectors' buffers belong to this database's MemoryManager, and a thread_local slot would
+    // outlive Database::~Database and free (or reuse) them through a dangling MemoryManager the
+    // next time any database runs a query on this thread. Holding the shared_ptr here keeps the
+    // ResultSet alive even if a nested query on this thread replaces the slot.
     ResultSet* resultSetPtr = nullptr;
     std::unique_ptr<ResultSet> ownedResultSet;
+    std::shared_ptr<ResultSet> pooledResultSet;
+    auto* clientContext = executionContext->clientContext;
     if (auto* desc = sink->getDescriptor()) {
-        thread_local uint64_t cachedDescID = UINT64_MAX;
-        thread_local std::shared_ptr<processor::ResultSet> cachedResultSet;
-        if (cachedDescID == desc->id && cachedResultSet) {
-            // Same prepared statement on this thread: reuse the allocation.
-            cachedResultSet->resetForReuse();
-            resultSetPtr = cachedResultSet.get();
-        } else {
-            // First time on this thread, or a different prepared statement:
-            // allocate fresh. Owning shared_ptr; lifetime ends with the
-            // thread (or when the descriptor changes).
-            cachedResultSet = std::make_shared<processor::ResultSet>(desc,
-                storage::MemoryManager::Get(*executionContext->clientContext));
-            cachedDescID = desc->id;
-            resultSetPtr = cachedResultSet.get();
-        }
+        pooledResultSet =
+            clientContext->getDatabase()->getQueryProcessor()->getResultSetPool().getOrCreate(desc,
+                storage::MemoryManager::Get(*clientContext));
+        resultSetPtr = pooledResultSet.get();
     } else {
         // No descriptor (e.g. OrderByMerge): fall back to per-call allocation.
         ownedResultSet =

--- a/src/processor/result/result_set_descriptor.cpp
+++ b/src/processor/result/result_set_descriptor.cpp
@@ -28,8 +28,8 @@ std::unique_ptr<ResultSetDescriptor> ResultSetDescriptor::copy() const {
         std::make_unique<ResultSetDescriptor>(std::move(dataChunkDescriptorsCopy));
     // A copy is the same descriptor slot with identical content (copies are never mutated
     // afterwards), so it inherits the source's identity. This keeps the id stable across
-    // executions of a prepared statement's cached plan, letting the thread-local ResultSet
-    // cache in ProcessorTask::run() actually hit. Two live descriptors with the same id are
+    // executions of a prepared statement's cached plan, letting the per-database ResultSetPool
+    // used by ProcessorTask::run() actually hit. Two live descriptors with the same id are
     // by construction content-identical, so cache reuse remains safe.
     descriptorCopy->id = id;
     return descriptorCopy;

--- a/test/api/system_config_test.cpp
+++ b/test/api/system_config_test.cpp
@@ -148,3 +148,57 @@ TEST_F(SystemConfigTest, testDisableDefaultHashIndexFromDBConfig) {
     auto& nodeTable = db->getStorageManager()->getTable(entry->getTableID())->cast<NodeTable>();
     ASSERT_EQ(nodeTable.tryGetPKIndex(), nullptr);
 }
+
+// Regression: the per-thread reusable ResultSet used to live in a process-wide thread_local, so
+// on single-threaded builds (where the calling thread runs ProcessorTask::run, e.g. the
+// single-threaded Wasm package) it outlived Database::~Database and released (or reused)
+// ValueVector buffers through the destroyed database's MemoryManager the next time any database
+// ran a query on that thread. That is a heap-use-after-free under AddressSanitizer and silent heap
+// corruption otherwise; on Wasm it surfaced as "RuntimeError: null function" after a
+// prepared-write / close / reopen sequence. The pool is now owned by the database. On
+// multithreaded builds worker threads (and their former thread_local) are joined with the
+// database, so this test only demonstrates the bug in a SINGLE_THREADED (+ASan) configuration;
+// elsewhere it still checks reuse and data visibility across the reopen.
+TEST_F(SystemConfigTest, testResultSetReuseDoesNotOutliveDatabase) {
+    if (databasePath == "" || databasePath == ":memory:") {
+        GTEST_SKIP() << "Requires an on-disk database that can be closed and reopened";
+    }
+    systemConfig->readOnly = false;
+    for (auto round = 0u; round < 3; ++round) {
+        auto db = std::make_unique<Database>(databasePath, *systemConfig);
+        auto con = std::make_unique<Connection>(db.get());
+        if (round == 0) {
+            assertQuery(
+                *con->query("CREATE NODE TABLE Meta(key STRING, value STRING, PRIMARY KEY(key))"));
+        }
+        // Prepared write executed once: the executing thread caches a ResultSet whose
+        // string buffers belong to this database's MemoryManager.
+        auto del = con->prepare("MATCH (m:Meta) WHERE m.key = $key DELETE m");
+        assertQuery(*con->execute(del.get(),
+            std::make_pair(std::string("key"), std::string("graphIdentitySchemaVersion"))));
+        auto ins = con->prepare("CREATE (:Meta {key: $key, value: $value})");
+        assertQuery(*con->execute(ins.get(),
+            std::make_pair(std::string("key"), std::string("graphIdentitySchemaVersion")),
+            std::make_pair(std::string("value"), std::string("qualified-scope-id-v2-round-x"))));
+        // Reuse across executions of the same prepared statement must still work.
+        assertQuery(*con->execute(del.get(),
+            std::make_pair(std::string("key"), std::string("graphIdentitySchemaVersion"))));
+        assertQuery(*con->execute(ins.get(),
+            std::make_pair(std::string("key"), std::string("graphIdentitySchemaVersion")),
+            std::make_pair(std::string("value"), std::string("qualified-scope-id-v2"))));
+        del.reset();
+        ins.reset();
+        con.reset();
+        db.reset();
+        // Reopen on the same thread and run a query with a different descriptor: before the fix
+        // this released the previous database's cached ResultSet through a dangling
+        // MemoryManager.
+        db = std::make_unique<Database>(databasePath, *systemConfig);
+        con = std::make_unique<Connection>(db.get());
+        auto result = con->query("MATCH (m:Meta) RETURN m.key, m.value ORDER BY m.key");
+        assertQuery(*result);
+        ASSERT_EQ(result->getNumTuples(), 1u);
+        ASSERT_EQ(result->getNext()->toString(),
+            "graphIdentitySchemaVersion|qualified-scope-id-v2\n");
+    }
+}


### PR DESCRIPTION
### What goes wrong

Prepared statement → close → reopen → any query crashes the single-threaded Wasm build (null function). A cached ResultSet outlives its database's MemoryManager. Fix: own the cache per database.

`ProcessorTask::run` keeps the reusable `ResultSet` (the "Phase 3" optimisation that avoids
re-allocating DataChunks for repeated prepared-statement executions) in a process-wide
`thread_local`. That `ResultSet` owns `ValueVector`s whose buffers were allocated by the
`MemoryManager` of the database that created it.

Nothing clears the slot when that database is closed. On multithreaded builds the worker threads
are joined when the database's `TaskScheduler` goes away, which takes the `thread_local` with
them, so this stays hidden. On single-threaded builds (`SINGLE_THREADED`, e.g. the
single-threaded Wasm package) the calling thread runs the tasks, and the slot lives on. The next
query on that thread — in a new database, or the same one reopened — has a different descriptor
id, so the old `ResultSet` is released and its buffers are freed through a `MemoryManager*` that
no longer exists. That is a heap-use-after-free. If the descriptor id happens to match instead, the stale `ResultSet` is
reused, and its buffers are written through the same dangling pointer.

On native single-threaded builds this is silent heap corruption. On the single-threaded
WebAssembly build it surfaces as `RuntimeError: null function` or `table index is out of bounds` a few statements
later, when whatever object landed in the corrupted memory (in our case a parsed statement's
`shared_ptr` control block) is destroyed. Whether it crashes at all depends on allocation
history — path length, how many prepared statements ran, etc. — which made it hard to pin down.

Minimal sequence (browser Wasm, one thread):

1. open database, create a node table with STRING columns
2. `prepare` + `execute` any write, e.g. `CREATE (:T {key: $key, value: $value})`
3. close the database
4. reopen it and run any query (`CALL show_tables() RETURN name;` is enough)

AddressSanitizer on the Wasm build reports:

```
heap-use-after-free in MemoryManager::updateUsedMemoryForFreedBlock
  ~MemoryBuffer ← ~BufferBlock ← ~StringAuxiliaryBuffer ← ~ValueVector ← ~ResultSet
  ← ProcessorTask::run   (region freed by Database::~Database)
```

### The fix

Move the cache into the database: `QueryProcessor` now owns a small `ResultSetPool` with one
slot per executing thread (a `std::unordered_map<std::thread::id, …>` behind a mutex). It is
destroyed with the `QueryProcessor`, which `Database` tears down before its `MemoryManager`, so
a cached `ResultSet` can never outlive the allocator that backs it.

Two details:

- `ProcessorTask::run` holds the returned `shared_ptr` for the duration of the task, so a
  nested query on the same thread (e.g. from a table function) can replace the slot without
  pulling the `ResultSet` out from under the outer task.
- Reuse behaviour is unchanged: repeated executions of the same prepared statement on the same
  thread still get the same `ResultSet` after `resetForReuse()`.

The lock is taken once per task run; the cost is negligible next to the 16 KB+ allocation the
cache exists to avoid.

### Test

`SystemConfigTest.testResultSetReuseDoesNotOutliveDatabase` runs prepared writes, closes and
reopens the database on the same thread, and queries again, three times over. It skips in
in-memory mode (nothing to reopen). Under ASan in a `SINGLE_THREADED` build it fails before this
change and passes after; on multithreaded builds, and without ASan, it exercises the reuse path
and checks the data survives the reopen.

### Verified

- Wasm (Emscripten 6.0.9, single-threaded, `-fsanitize=address`): the sequence above and a
  58-operation close/reopen/vector stress produce zero reports with this change; the unpatched
  build reports the use-after-free on the first reopen.
- Release Wasm build: the original failing sequences pass through both the sync and async
  browser APIs.
