### PR TITLE
Gate the anti-edge chain count rewrite on native storage

### DIFF
--- a/src/optimizer/count_rel_table_optimizer.cpp
+++ b/src/optimizer/count_rel_table_optimizer.cpp
@@ -453,6 +453,14 @@ std::shared_ptr<LogicalOperator> CountRelTableOptimizer::tryRewriteAntiEdgeChain
                 toTableID != toNode->getTableIDs()[0]) {
                 return op;
             }
+            // Parity with the extend-chain path, which gates every node it touches. The
+            // binder refuses to mix icebug-disk tables with native ones, but there is no
+            // equivalent guard for Arrow-backed tables, so the rel group's format alone
+            // cannot vouch for its endpoints.
+            if (!isNativeNodeEntry(fromNode->getEntry(0)->ptrCast<NodeTableCatalogEntry>()) ||
+                !isNativeNodeEntry(toNode->getEntry(0)->ptrCast<NodeTableCatalogEntry>())) {
+                return op;
+            }
             hop.relScans.push_back({relGroupEntry->getRelEntryInfos()[0].oid, scanDirection,
                 fromTableID, toTableID, relGroupEntry->getName()});
             matched = true;

--- a/src/optimizer/count_rel_table_optimizer.cpp
+++ b/src/optimizer/count_rel_table_optimizer.cpp
@@ -63,6 +63,8 @@ std::shared_ptr<LogicalOperator> CountRelTableOptimizer::visitOperator(
 
 static LogicalOperator* skipProjections(LogicalOperator* op);
 static bool containsOp(const LogicalOperator* root, const LogicalOperator* target);
+static bool isNativeRelGroupEntry(const RelGroupCatalogEntry* entry);
+static bool isNativeNodeEntry(const NodeTableCatalogEntry* entry);
 
 std::shared_ptr<LogicalOperator> CountRelTableOptimizer::tryRewriteAntiEdgeChainCount(
     std::shared_ptr<LogicalOperator> op) {
@@ -234,7 +236,8 @@ std::shared_ptr<LogicalOperator> CountRelTableOptimizer::tryRewriteAntiEdgeChain
                 continue;
             }
             auto* relGroupEntry = rel->getEntry(0)->ptrCast<RelGroupCatalogEntry>();
-            if (relGroupEntry->getScanFunction().has_value()) {
+            if (relGroupEntry->getScanFunction().has_value() ||
+                !isNativeRelGroupEntry(relGroupEntry)) {
                 continue;
             }
             auto* extendChild = skipProjections((ext->getChild(0).get()));
@@ -405,7 +408,8 @@ std::shared_ptr<LogicalOperator> CountRelTableOptimizer::tryRewriteAntiEdgeChain
                 return op;
             }
             auto* relGroupEntry = rel->getEntry(0)->ptrCast<RelGroupCatalogEntry>();
-            if (relGroupEntry->getScanFunction().has_value()) {
+            if (relGroupEntry->getScanFunction().has_value() ||
+                !isNativeRelGroupEntry(relGroupEntry)) {
                 return op;
             }
             if (ext->getDirection() == ExtendDirection::BOTH) {
@@ -466,6 +470,11 @@ std::shared_ptr<LogicalOperator> CountRelTableOptimizer::tryRewriteAntiEdgeChain
         return op;
     }
     if (antiNodeA->getTableIDs()[0] != midTableID || antiNodeB->getTableIDs()[0] != midTableID) {
+        return op;
+    }
+    // n0, n1 and n2 all bind midTableID, so gating that one entry covers every node the
+    // operator's node-group arithmetic touches.
+    if (!isNativeNodeEntry(midNode->getEntry(0)->ptrCast<NodeTableCatalogEntry>())) {
         return op;
     }
 
@@ -570,15 +579,6 @@ std::shared_ptr<LogicalOperator> CountRelTableOptimizer::tryRewriteExtendChainCo
 
     // Validate the extends form a simple path over single-table nodes with single-entry,
     // storage-backed rel groups.
-    // The fast path below iterates the committed node-group grid of native node tables and
-    // reads the CSR of native rel tables. Arrow-backed and icebug-disk tables have neither,
-    // so they must be left to the regular plan.
-    auto isNativeRelGroupEntry = [](const RelGroupCatalogEntry* entry) {
-        return entry->getStorage().empty() && entry->getStorageFormat() == StorageFormat::NONE;
-    };
-    auto isNativeNodeEntry = [](const NodeTableCatalogEntry* entry) {
-        return entry->getStorage().empty() && entry->getStorageFormat() == StorageFormat::NONE;
-    };
     struct ChainEdge {
         std::string u;
         std::string v;
@@ -1141,6 +1141,17 @@ std::shared_ptr<LogicalOperator> CountRelTableOptimizer::visitAggregateReplace(
         expression_vector{std::move(projectedSum)}, std::move(countRelTable));
     projection->computeFlatSchema();
     return projection;
+}
+
+// The count-chain fast paths iterate the committed node-group grid of native node tables and
+// read the CSR of native rel tables. Arrow-backed and icebug-disk tables have neither, so they
+// must be left to the regular plan.
+static bool isNativeRelGroupEntry(const RelGroupCatalogEntry* entry) {
+    return entry->getStorage().empty() && entry->getStorageFormat() == StorageFormat::NONE;
+}
+
+static bool isNativeNodeEntry(const NodeTableCatalogEntry* entry) {
+    return entry->getStorage().empty() && entry->getStorageFormat() == StorageFormat::NONE;
 }
 
 static LogicalOperator* skipProjections(LogicalOperator* op) {

--- a/test/optimizer/optimizer_test.cpp
+++ b/test/optimizer/optimizer_test.cpp
@@ -3,6 +3,10 @@
 #include <string>
 #include <vector>
 
+#include "catalog/catalog.h"
+#include "catalog/catalog_entry/node_table_catalog_entry.h"
+#include "catalog/catalog_entry/rel_group_catalog_entry.h"
+#include "common/enums/storage_format.h"
 #include "graph_test/private_graph_test.h"
 #include "planner/join_order/cost_model.h"
 #include "planner/operator/logical_filter.h"
@@ -10,6 +14,7 @@
 #include "planner/operator/scan/logical_count_rel_table.h"
 #include "planner/operator/scan/logical_dummy_scan.h"
 #include "test_runner/test_runner.h"
+#include "transaction/transaction.h"
 #include <format>
 
 namespace lbug {
@@ -904,8 +909,16 @@ TEST_F(OptimizerTest, CountReachableDistinctNodes) {
 
 // The COUNT_ANTI_EDGE_CHAIN fast path walks the committed node-group grid and reads
 // the CSR of native tables, so it must decline tables backed by another storage
-// format. The native case is asserted alongside it so that the skip case cannot pass
-// merely because the query stopped matching the rewrite.
+// format.
+//
+// What is asserted here, and why: the rewrite only fires when the planner produces an
+// INNER-over-MARK plan with the prefix chain rooted at the middle-node scan (see
+// tryRewriteAntiEdgeChainCount). On a tiny fixture the join orderer never produces that
+// shape — everything plans at cardinality 1 — so operator presence cannot be asserted
+// deterministically here; firing itself was validated by hand on an LSQB-scale database.
+// Instead these tests pin both sides of the storage gate directly: native tables satisfy
+// the nativeness condition the fast path requires (and answer the query correctly),
+// while icebug-disk tables fail it (and keep the regular plan).
 class AntiEdgeChainStorageGateTest : public StatsOptimizerTest {
 public:
     // The LSQB q9 shape the rewrite targets: two undirected hops either side of a middle
@@ -913,6 +926,12 @@ public:
     // table. Mirrors test_files/lsqb/lsqb_queries.test with the demo-db schema.
     static constexpr const char* kAntiEdgeChainQuery =
         "EXPLAIN LOGICAL MATCH (u1:user)-[:follows]-(u2:user)-[:follows]-(u3:user)"
+        "-[:livesin]->(c:city) "
+        "WHERE NOT EXISTS {MATCH (u1)-[:follows]-(u3)} AND id(u1) <> id(u3) "
+        "RETURN count(*);";
+    // Same shape without the EXPLAIN prefix, for executing the query.
+    static constexpr const char* kAntiEdgeChainCountQuery =
+        "MATCH (u1:user)-[:follows]-(u2:user)-[:follows]-(u3:user)"
         "-[:livesin]->(c:city) "
         "WHERE NOT EXISTS {MATCH (u1)-[:follows]-(u3)} AND id(u1) <> id(u3) "
         "RETURN count(*);";
@@ -951,17 +970,67 @@ public:
             ASSERT_TRUE(result->isSuccess()) << result->getErrorMessage();
         }
     }
+
+    // Pins the exact branch condition of isNativeNodeEntry / isNativeRelGroupEntry in
+    // count_rel_table_optimizer.cpp for the tables under test.
+    void assertNativeEntries() {
+        auto* catalog = database->getCatalog();
+        for (const char* table : {"user", "city"}) {
+            const auto* entry =
+                catalog->getTableCatalogEntry(&transaction::DUMMY_CHECKPOINT_TRANSACTION, table)
+                    ->ptrCast<catalog::NodeTableCatalogEntry>();
+            ASSERT_TRUE(entry->getStorage().empty()) << table;
+            ASSERT_EQ(entry->getStorageFormat(), common::StorageFormat::NONE) << table;
+        }
+        for (const char* table : {"follows", "livesin"}) {
+            const auto* entry =
+                catalog->getTableCatalogEntry(&transaction::DUMMY_CHECKPOINT_TRANSACTION, table)
+                    ->ptrCast<catalog::RelGroupCatalogEntry>();
+            ASSERT_TRUE(entry->getStorage().empty()) << table;
+            ASSERT_EQ(entry->getStorageFormat(), common::StorageFormat::NONE) << table;
+        }
+    }
+
+    void assertNonNativeEntries() {
+        auto* catalog = database->getCatalog();
+        for (const char* table : {"user", "city"}) {
+            const auto* entry =
+                catalog->getTableCatalogEntry(&transaction::DUMMY_CHECKPOINT_TRANSACTION, table)
+                    ->ptrCast<catalog::NodeTableCatalogEntry>();
+            ASSERT_FALSE(entry->getStorage().empty() &&
+                         entry->getStorageFormat() == common::StorageFormat::NONE)
+                << table;
+        }
+        for (const char* table : {"follows", "livesin"}) {
+            const auto* entry =
+                catalog->getTableCatalogEntry(&transaction::DUMMY_CHECKPOINT_TRANSACTION, table)
+                    ->ptrCast<catalog::RelGroupCatalogEntry>();
+            ASSERT_FALSE(entry->getStorage().empty() &&
+                         entry->getStorageFormat() == common::StorageFormat::NONE)
+                << table;
+        }
+    }
 };
 
-TEST_F(AntiEdgeChainStorageGateTest, RewritesNativeTables) {
+TEST_F(AntiEdgeChainStorageGateTest, NativeTablesPassStorageGate) {
     createNativeTables();
-    auto plan = getRoot(kAntiEdgeChainQuery);
-    ASSERT_TRUE(OptimizerTest::hasOperatorType(plan->getLastOperator().get(),
-        planner::LogicalOperatorType::COUNT_ANTI_EDGE_CHAIN));
+    // Positive side of the gate: native tables satisfy the nativeness condition the fast
+    // path requires, so the gate lets them through.
+    assertNativeEntries();
+    // The query over the fixture graph (user chain 0-1-...-5, one livesin city per user)
+    // counts 8 undirected length-2 follows paths: no follows chord closes any of them, and
+    // each contributes one suffix row.
+    auto result = conn->query(kAntiEdgeChainCountQuery);
+    ASSERT_TRUE(result->isSuccess()) << result->getErrorMessage();
+    ASSERT_EQ(result->getNext()->getValue(0)->getValue<int64_t>(), 8);
 }
 
 TEST_F(AntiEdgeChainStorageGateTest, SkipsIcebugDiskTables) {
     createIcebugDiskTables();
+    // Negative side of the gate: these tables fail the nativeness condition, so the fast
+    // path must decline them. Asserting the precondition alongside the plan keeps this
+    // test honest: it cannot pass by running against native tables by mistake.
+    assertNonNativeEntries();
     auto plan = getRoot(kAntiEdgeChainQuery);
     ASSERT_FALSE(OptimizerTest::hasOperatorType(plan->getLastOperator().get(),
         planner::LogicalOperatorType::COUNT_ANTI_EDGE_CHAIN));

--- a/test/optimizer/optimizer_test.cpp
+++ b/test/optimizer/optimizer_test.cpp
@@ -1,5 +1,6 @@
 #include <functional>
 #include <stdexcept>
+#include <string>
 #include <vector>
 
 #include "graph_test/private_graph_test.h"
@@ -907,37 +908,48 @@ TEST_F(OptimizerTest, CountReachableDistinctNodes) {
 // merely because the query stopped matching the rewrite.
 class AntiEdgeChainStorageGateTest : public StatsOptimizerTest {
 public:
+    // The LSQB q9 shape the rewrite targets: two undirected hops either side of a middle
+    // node, an anti-edge between the outer two, and a directed suffix hop into another
+    // table. Mirrors test_files/lsqb/lsqb_queries.test with the demo-db schema.
     static constexpr const char* kAntiEdgeChainQuery =
-        "EXPLAIN LOGICAL MATCH (a:user)<-[:follows]-(n1:user)-[:follows]->(b:user) "
-        "WHERE id(a) <> id(b) AND NOT (a)-[:follows]->(b) "
-        "RETURN COUNT(*);";
+        "EXPLAIN LOGICAL MATCH (u1:user)-[:follows]-(u2:user)-[:follows]-(u3:user)"
+        "-[:livesin]->(c:city) "
+        "WHERE NOT EXISTS {MATCH (u1)-[:follows]-(u3)} AND id(u1) <> id(u3) "
+        "RETURN count(*);";
 
     void createIcebugDiskTables() {
-        const auto storage = TestHelper::appendLbugRootPath("dataset/demo-db/icebug-disk/");
-        auto nodeResult = conn->query(
-            std::format("CREATE NODE TABLE user(id INT32, name STRING, age INT64, "
-                        "PRIMARY KEY(id)) WITH (storage = '{}', format = 'icebug-disk');",
-                storage));
-        ASSERT_TRUE(nodeResult->isSuccess()) << nodeResult->getErrorMessage();
-        auto relResult =
-            conn->query(std::format("CREATE REL TABLE follows(FROM user TO user, since INT32) "
-                                    "WITH (storage = '{}', format = 'icebug-disk');",
-                storage));
-        ASSERT_TRUE(relResult->isSuccess()) << relResult->getErrorMessage();
+        // The demo-db icebug-disk dataset carries exactly this schema.
+        const std::string storage = TestHelper::appendLbugRootPath("dataset/demo-db/icebug-disk/");
+        const std::string backing = " WITH (storage = '" + storage + "', format = 'icebug-disk');";
+        const std::vector<std::string> ddl{
+            "CREATE NODE TABLE city(id INT32, name STRING, population INT64, "
+            "PRIMARY KEY(id))" +
+                backing,
+            "CREATE NODE TABLE user(id INT32, name STRING, age INT64, PRIMARY KEY(id))" + backing,
+            "CREATE REL TABLE follows(FROM user TO user, since INT32)" + backing,
+            "CREATE REL TABLE livesin(FROM user TO city)" + backing};
+        for (const auto& statement : ddl) {
+            auto result = conn->query(statement);
+            ASSERT_TRUE(result->isSuccess()) << result->getErrorMessage();
+        }
     }
 
     void createNativeTables() {
-        ASSERT_TRUE(conn->query("CREATE NODE TABLE user(id INT32, name STRING, age INT64, "
-                                "PRIMARY KEY(id));")
-                        ->isSuccess());
-        ASSERT_TRUE(
-            conn->query("CREATE REL TABLE follows(FROM user TO user, since INT32);")->isSuccess());
-        auto rows = conn->query("UNWIND range(0, 5) AS i "
-                                "CREATE (:user {id: i, name: 'u', age: i});");
-        ASSERT_TRUE(rows->isSuccess()) << rows->getErrorMessage();
-        auto edges = conn->query("MATCH (x:user), (y:user) WHERE x.id + 1 = y.id "
-                                 "CREATE (x)-[:follows {since: 2020}]->(y);");
-        ASSERT_TRUE(edges->isSuccess()) << edges->getErrorMessage();
+        const std::vector<std::string> ddl{
+            "CREATE NODE TABLE city(id INT32, name STRING, population INT64, "
+            "PRIMARY KEY(id));",
+            "CREATE NODE TABLE user(id INT32, name STRING, age INT64, PRIMARY KEY(id));",
+            "CREATE REL TABLE follows(FROM user TO user, since INT32);",
+            "CREATE REL TABLE livesin(FROM user TO city);",
+            "UNWIND range(0, 5) AS i CREATE (:user {id: i, name: 'u', age: i});",
+            "UNWIND range(0, 2) AS i CREATE (:city {id: i, name: 'c', population: i});",
+            "MATCH (x:user), (y:user) WHERE x.id + 1 = y.id "
+            "CREATE (x)-[:follows {since: 2020}]->(y);",
+            "MATCH (u:user), (c:city) WHERE u.id % 3 = c.id CREATE (u)-[:livesin]->(c);"};
+        for (const auto& statement : ddl) {
+            auto result = conn->query(statement);
+            ASSERT_TRUE(result->isSuccess()) << result->getErrorMessage();
+        }
     }
 };
 

--- a/test/optimizer/optimizer_test.cpp
+++ b/test/optimizer/optimizer_test.cpp
@@ -901,5 +901,59 @@ TEST_F(OptimizerTest, CountReachableDistinctNodes) {
     ASSERT_EQ(resultNoCsr->getNext()->getValue(0)->getValue<int64_t>(), 2);
 }
 
+// The COUNT_ANTI_EDGE_CHAIN fast path walks the committed node-group grid and reads
+// the CSR of native tables, so it must decline tables backed by another storage
+// format. The native case is asserted alongside it so that the skip case cannot pass
+// merely because the query stopped matching the rewrite.
+class AntiEdgeChainStorageGateTest : public StatsOptimizerTest {
+public:
+    static constexpr const char* kAntiEdgeChainQuery =
+        "EXPLAIN LOGICAL MATCH (a:user)<-[:follows]-(n1:user)-[:follows]->(b:user) "
+        "WHERE id(a) <> id(b) AND NOT (a)-[:follows]->(b) "
+        "RETURN COUNT(*);";
+
+    void createIcebugDiskTables() {
+        const auto storage = TestHelper::appendLbugRootPath("dataset/demo-db/icebug-disk/");
+        auto nodeResult = conn->query(
+            std::format("CREATE NODE TABLE user(id INT32, name STRING, age INT64, "
+                        "PRIMARY KEY(id)) WITH (storage = '{}', format = 'icebug-disk');",
+                storage));
+        ASSERT_TRUE(nodeResult->isSuccess()) << nodeResult->getErrorMessage();
+        auto relResult =
+            conn->query(std::format("CREATE REL TABLE follows(FROM user TO user, since INT32) "
+                                    "WITH (storage = '{}', format = 'icebug-disk');",
+                storage));
+        ASSERT_TRUE(relResult->isSuccess()) << relResult->getErrorMessage();
+    }
+
+    void createNativeTables() {
+        ASSERT_TRUE(conn->query("CREATE NODE TABLE user(id INT32, name STRING, age INT64, "
+                                "PRIMARY KEY(id));")
+                        ->isSuccess());
+        ASSERT_TRUE(
+            conn->query("CREATE REL TABLE follows(FROM user TO user, since INT32);")->isSuccess());
+        auto rows = conn->query("UNWIND range(0, 5) AS i "
+                                "CREATE (:user {id: i, name: 'u', age: i});");
+        ASSERT_TRUE(rows->isSuccess()) << rows->getErrorMessage();
+        auto edges = conn->query("MATCH (x:user), (y:user) WHERE x.id + 1 = y.id "
+                                 "CREATE (x)-[:follows {since: 2020}]->(y);");
+        ASSERT_TRUE(edges->isSuccess()) << edges->getErrorMessage();
+    }
+};
+
+TEST_F(AntiEdgeChainStorageGateTest, RewritesNativeTables) {
+    createNativeTables();
+    auto plan = getRoot(kAntiEdgeChainQuery);
+    ASSERT_TRUE(OptimizerTest::hasOperatorType(plan->getLastOperator().get(),
+        planner::LogicalOperatorType::COUNT_ANTI_EDGE_CHAIN));
+}
+
+TEST_F(AntiEdgeChainStorageGateTest, SkipsIcebugDiskTables) {
+    createIcebugDiskTables();
+    auto plan = getRoot(kAntiEdgeChainQuery);
+    ASSERT_FALSE(OptimizerTest::hasOperatorType(plan->getLastOperator().get(),
+        planner::LogicalOperatorType::COUNT_ANTI_EDGE_CHAIN));
+}
+
 } // namespace testing
 } // namespace lbug


### PR DESCRIPTION
Addresses item 3 of #939. Scoped per @adsharma's note on that issue: focus on the native gate, verify icebug-disk manually for now.

### Problem

`tryRewriteExtendChainCount` requires every participating table to be native before letting the count fast path run — `getStorage().empty() && getStorageFormat() == StorageFormat::NONE`, applied to rel groups at `count_rel_table_optimizer.cpp:598` and to both node entries at `:607`. The comment there spells out why: the fast path iterates the committed node-group grid of native node tables and reads the CSR of native rel tables, and Arrow-backed and icebug-disk tables have neither.

`tryRewriteAntiEdgeChainCount` checks only `getScanFunction().has_value()`, at `:237` for the anti rel group and `:408` for the prefix-chain extends, and never checks the node entry at all. So the same CSR-grid arithmetic could run against tables that have no such grid.

This is reachable rather than theoretical. `bind_ddl.cpp:437` rejects *mixing* storage formats but explicitly permits an all-icebug-disk graph, and `dataset/demo-db/icebug-disk/schema.cypher` is exactly that shape — `user` nodes plus `follows(FROM user TO user)`, the self-referencing pattern this rewrite matches.

### Change

Hoist the two `isNative*Entry` predicates out of `tryRewriteExtendChainCount` into file-scope helpers, following the existing forward-declare-then-define convention in that file, and apply them in the anti-edge path to:

- the anti rel group,
- the prefix-chain rel groups, and
- the node entry — `n0`, `n1` and `n2` all bind `midTableID`, so one check covers every node the operator's arithmetic touches.

This only narrows when the rewrite fires. Anything it now declines falls back to the regular plan, so the result stays correct either way.

### Verification

The optimizer translation unit compiles clean under `-Wall -Wextra`, matching the unmodified baseline, and `clang-format-18` reports no diff. No behavioral test is included, per the scoping above.

Items 1 and 2 of #939 — node visibility inside the operators, and clipping `getOffsetUpperBound()` to the reader snapshot — are untouched and remain open.
