### PR TITLE
Centralize Node Offset Validation in NodeTable::isVisibleNoLock

### DIFF
--- a/src/storage/table/node_table.cpp
+++ b/src/storage/table/node_table.cpp
@@ -867,6 +867,10 @@ bool NodeTable::isVisible(const Transaction* transaction, offset_t offset) const
 }
 
 bool NodeTable::isVisibleNoLock(const Transaction* transaction, offset_t offset) const {
+    if (offset == INVALID_OFFSET) {
+        throw RuntimeException(
+            "Index contains an invalid node offset. Please drop and rebuild the index.");
+    }
     if (transaction && transaction->isUnCommitted(tableID, offset)) {
         const auto localTable = transaction->getLocalStorage()->getLocalTable(tableID);
         DASSERT(localTable);
@@ -874,11 +878,13 @@ bool NodeTable::isVisibleNoLock(const Transaction* transaction, offset_t offset)
     }
     auto [nodeGroupIdx, offsetInGroup] = StorageUtils::getNodeGroupIdxAndOffsetInChunk(offset);
     if (nodeGroupIdx >= nodeGroups->getNumNodeGroupsNoLock()) {
-        return false;
+        throw RuntimeException(
+            "Index contains an invalid node offset. Please drop and rebuild the index.");
     }
     const auto* nodeGroup = getNodeGroupNoLock(nodeGroupIdx);
-    if (nodeGroup == nullptr) {
-        return false;
+    if (nodeGroup == nullptr || offsetInGroup >= nodeGroup->getNumRows()) {
+        throw RuntimeException(
+            "Index contains an invalid node offset. Please drop and rebuild the index.");
     }
     return nodeGroup->isVisibleNoLock(transaction, offsetInGroup);
 }
@@ -931,32 +937,7 @@ bool NodeTable::lookupPK(const Transaction* transaction, ValueVector* keyVector,
     }
     if (auto* pkIndex = tryGetPrimaryKeyIndex()) {
         return pkIndex->lookupPrimaryKey(transaction, keyVector, vectorPos, result,
-            [&](offset_t offset) {
-                // A stale/corrupt PK index entry must not reach isVisibleNoLock(), where an
-                // invalid node offset could otherwise be dereferenced in a release build. Keep
-                // this validation O(1) on the normal lookup path and fail the transaction instead
-                // of treating a corrupt entry as a missing key.
-                if (offset == INVALID_OFFSET) {
-                    throw RuntimeException(
-                        "Primary-key index contains an invalid node offset. Please drop and "
-                        "rebuild the _PK index.");
-                }
-                const auto nodeGroupIdx = StorageUtils::getNodeGroupIdx(offset);
-                if (nodeGroupIdx >= nodeGroups->getNumNodeGroupsNoLock()) {
-                    throw RuntimeException(
-                        "Primary-key index points to a missing node group. Please drop and "
-                        "rebuild the _PK index.");
-                }
-                const auto* nodeGroup = getNodeGroupNoLock(nodeGroupIdx);
-                const auto offsetInGroup =
-                    offset - StorageUtils::getStartOffsetOfNodeGroup(nodeGroupIdx);
-                if (nodeGroup == nullptr || offsetInGroup >= nodeGroup->getNumRows()) {
-                    throw RuntimeException(
-                        "Primary-key index contains an out-of-range node offset. Please drop "
-                        "and rebuild the _PK index.");
-                }
-                return isVisibleNoLock(transaction, offset);
-            });
+            [&](offset_t offset) { return isVisibleNoLock(transaction, offset); });
     }
     auto keyToLookup = keyVector->getAsValue(vectorPos);
     ColumnPredicateSet predicateSet;

--- a/test/api/drop_index_test.cpp
+++ b/test/api/drop_index_test.cpp
@@ -75,6 +75,18 @@ TEST_F(DropIndexTest, DropDefaultHashIndex) {
     EXPECT_EQ(TestHelper::convertResultToString(*countRes), std::vector<std::string>{"3"});
 }
 
+// An index entry can point into the allocated capacity of a node group while still being past
+// its actual row count. Visibility checks must reject that offset before reading version arrays.
+TEST_F(DropIndexTest, RejectOutOfRangeNodeOffsetInVisibilityCheck) {
+    auto& con = *conn;
+    assertQuery(*con.query("CREATE NODE TABLE invalid_offset_person(ID INT64, PRIMARY KEY(ID))"));
+    assertQuery(*con.query("CREATE (:invalid_offset_person {ID: 1})"));
+
+    EXPECT_THROW(
+        getNodeTable("invalid_offset_person").isVisibleNoLock(&DUMMY_CHECKPOINT_TRANSACTION, 1),
+        RuntimeException);
+}
+
 // Dropping a non-existent index without IF EXISTS must error.
 TEST_F(DropIndexTest, DropNonExistentIndexThrows) {
     auto& con = *conn;


### PR DESCRIPTION
follow suggestion : https://github.com/LadybugDB/ladybug/pull/932  

Changes:

1. Centralized index offset validation in `NodeTable::isVisibleNoLock`:
   - Rejects `INVALID_OFFSET`.
   - Rejects missing node groups.
   - Rejects offsets where `offsetInGroup >= nodeGroup->getNumRows()`.

2. Invalid index offsets now consistently throw an error instructing users to drop and rebuild the index.

3. Removed the duplicated validation from the `lookupPK` visibility lambda. It now reuses `isVisibleNoLock`.

4. `lookupPKRange`, `lookupIndexRange`, and `lookupIndex` already use `isVisibleNoLock`, so they now receive the same protection automatically.

5. The existing validation in `LocalNodeTable` remains unchanged for transaction-local, uncommitted nodes.

Formatting was checked with the CI clang-format command.

Added a regression test and verified formatting.

The new test in [drop_index_test.cpp](/home/eric/project/ladybug/test/api/drop_index_test.cpp:78) verifies that:

- A node group has allocated capacity.
- It contains only one actual row.
- An offset of `1` is passed, which is beyond `getNumRows()` but may still fall within the chunk's allocated capacity.
- `isVisibleNoLock` throws `RuntimeException` rather than returning `false` or accessing version arrays out of bounds.