### PR TITLE
fix(storage): guard chunk scan against zero-length memcpy on empty chunks

### DIFF
--- a/src/storage/table/column_chunk_data.cpp
+++ b/src/storage/table/column_chunk_data.cpp
@@ -375,7 +375,15 @@ void ColumnChunkData::initializeScanState(SegmentState& state, const Column* col
 
 void ColumnChunkData::scan(ValueVector& output, offset_t offset, length_t length,
     sel_t posInOutputVector) const {
+    // Scanning zero rows must not touch data buffers: empty (e.g. freshly created)
+    // chunks may hold null/zero-size buffers, and memcpy with a null source is UB
+    // even when the byte count is 0 (issue #840: SIGSEGV in memmove under
+    // NodeTableScanState::scanNext on empty tables via a parallel scan morsel).
+    if (length == 0) {
+        return;
+    }
     DASSERT(offset + length <= numValues);
+    DASSERT(getData() != nullptr);
     if (nullData) {
         nullData->scan(output, offset, length, posInOutputVector);
     }
@@ -785,6 +793,9 @@ std::unique_ptr<NullChunkData> NullChunkData::deserialize(MemoryManager& memoryM
 
 void NullChunkData::scan(ValueVector& output, offset_t offset, length_t length,
     sel_t posInOutputVector) const {
+    if (length == 0) {
+        return;
+    }
     output.setNullFromBits(getNullMask().getData(), offset, posInOutputVector, length);
 }
 


### PR DESCRIPTION
Fixes #840.

A parallel scan worker could draw a morsel for an empty table/node group, reaching `ColumnChunkData::scan` with `length == 0` and a null/zero-size data buffer. `memcpy(dst, null, 0)` is UB and faulted as a null-pointer `memmove` under `NodeTableScanState::scanNext` (glibc routes `memcpy` through `memmove`).

- `ColumnChunkData::scan`: early return on `length == 0`, plus `DASSERT(getData() != nullptr)` when scanning.
- `NullChunkData::scan`: same zero-length early return.

The empty-morsel path in `NodeGroup::scan` already returns `NODE_GROUP_SCAN_EMPTY_RESULT` on current main; this guards the copy itself so any future zero-length scan is safe. Read-only path — no corruption, matches the issue (DB opens cleanly after the crash).