### PR TITLE
fix(storage): fail fast on out-of-bounds PIP/header page reads

### DIFF
--- a/src/include/storage/file_handle.h
+++ b/src/include/storage/file_handle.h
@@ -12,12 +12,14 @@
 #include "common/concurrent_vector.h"
 #include "common/constants.h"
 #include "common/copy_constructors.h"
+#include "common/exception/runtime.h"
 #include "common/file_system/file_info.h"
 #include "common/types/types.h"
 #include "storage/buffer_manager/page_state.h"
 #include "storage/buffer_manager/vm_region.h"
 #include "storage/enums/page_read_policy.h"
 #include "storage/page_manager.h"
+#include <format>
 
 namespace lbug {
 namespace main {
@@ -91,6 +93,17 @@ public:
     void readPageFromDisk(uint8_t* frame, common::page_idx_t pageIdx) const {
         DASSERT(!isInMemoryMode());
         DASSERT(pageIdx < numPages);
+        // Fail fast with an actionable error instead of issuing a wild pread far
+        // beyond EOF (issue #843: a corrupted PIP chain turned into
+        // "Cannot read from file ... position: 4727899947008"). DASSERT alone is
+        // stripped in release builds.
+        if (pageIdx >= numPages) {
+            const auto numPagesSnapshot = numPages.load();
+            throw common::RuntimeException(
+                std::format("Cannot read page {} from disk: out of bounds for file with {} pages. "
+                            "The database file may be corrupted.",
+                    pageIdx, numPagesSnapshot));
+        }
         fileInfo->readFromFile(frame, getPageSize(), pageIdx * getPageSize());
     }
     void writePageToFile(const uint8_t* buffer, common::page_idx_t pageIdx) {

--- a/src/storage/disk_array.cpp
+++ b/src/storage/disk_array.cpp
@@ -33,6 +33,14 @@ PageStorageInfo::PageStorageInfo(uint64_t elementSize)
 
 PIPWrapper::PIPWrapper(const FileHandle& fileHandle, page_idx_t pipPageIdx)
     : pipPageIdx(pipPageIdx) {
+    // Validate before issuing the read so a corrupted PIP pointer fails fast with
+    // the offending index instead of a wild pread beyond EOF (issue #843).
+    if (pipPageIdx >= fileHandle.getNumPages()) {
+        throw RuntimeException(std::format("Cannot read PIP page {} from disk: out of bounds "
+                                           "for file with {} pages. The database file may be "
+                                           "corrupted.",
+            pipPageIdx, fileHandle.getNumPages()));
+    }
     fileHandle.readPageFromDisk(reinterpret_cast<uint8_t*>(&pipContents), pipPageIdx);
 }
 

--- a/src/storage/disk_array_collection.cpp
+++ b/src/storage/disk_array_collection.cpp
@@ -7,6 +7,7 @@
 #include "common/types/types.h"
 #include "storage/file_handle.h"
 #include "storage/shadow_utils.h"
+#include <format>
 
 using namespace lbug::common;
 
@@ -29,6 +30,14 @@ DiskArrayCollection::DiskArrayCollection(FileHandle& fileHandle, ShadowFile& sha
     // Read headers from disk (no external state in lambda: optimistic read may run multiple times)
     page_idx_t headerPageIdx = firstHeaderPage;
     do {
+        // Fail fast on a corrupted nextHeaderPage link instead of issuing a wild
+        // read far beyond EOF (issue #843).
+        if (headerPageIdx >= fileHandle.getNumPages()) {
+            throw RuntimeException(std::format("Cannot read header page {} from disk: out of "
+                                               "bounds for file with {} pages. The database file "
+                                               "may be corrupted.",
+                headerPageIdx, fileHandle.getNumPages()));
+        }
         std::unique_ptr<HeaderPage> headerPage;
         page_idx_t nextHeaderPageIdx = INVALID_PAGE_IDX;
         fileHandle.optimisticReadPage(headerPageIdx, [&](auto* frame) {


### PR DESCRIPTION
Related to #843.

A corrupted page-index-pointer (PIP) chain turned into a wild pread far beyond EOF (`position: 4727899947008` on a 2884-page file), surfacing as a cryptic IO error on every open, including `read_only`.

- `FileHandle::readPageFromDisk`: runtime bounds check throwing `RuntimeException` naming the offending page and file size (`DASSERT` alone is stripped in release).
- `PIPWrapper` ctor and `DiskArrayCollection` header-chain walk: validate PIP/header indices before reading.

This converts an unopenable database with a misleading offset into an actionable corruption error, following the existing `validateCheckpointPageRange` pattern in `checkpointer.cpp`. It does not fix the original misdirected write — that writer is still unknown — but it bounds the blast radius and makes the next occurrence diagnosable.