### PR TITLE
Fix data race in OptimisticAllocator during parallel COPY

### DIFF
--- a/src/include/storage/optimistic_allocator.h
+++ b/src/include/storage/optimistic_allocator.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <mutex>
+#include <vector>
+
 #include "storage/page_allocator.h"
 
 namespace lbug {
@@ -10,7 +13,8 @@ class PageManager;
 /**
  * Manages any optimistically allocated pages (e.g. during COPY) so that they can be freed if a
  * rollback occurs.
- * This class is designed to be thread-local so accesses are not guaranteed to be thread-safe.
+ * Instances are shared across worker threads (LocalStorage caches one allocator per
+ * StorageManager), so all accesses to the tracked page ranges are synchronized internally.
  */
 class OptimisticAllocator : public PageAllocator {
 public:
@@ -25,6 +29,7 @@ public:
 
 private:
     PageManager& pageManager;
+    std::mutex mtx;
     std::vector<PageRange> optimisticallyAllocatedPages;
 };
 } // namespace storage

--- a/src/storage/optimistic_allocator.cpp
+++ b/src/storage/optimistic_allocator.cpp
@@ -9,6 +9,7 @@ OptimisticAllocator::OptimisticAllocator(PageManager& pageManager)
 PageRange OptimisticAllocator::allocatePageRange(common::page_idx_t numPages) {
     auto pageRange = pageManager.allocatePageRange(numPages);
     if (numPages > 0) {
+        std::unique_lock lck{mtx};
         optimisticallyAllocatedPages.push_back(pageRange);
     }
     return pageRange;
@@ -19,6 +20,7 @@ void OptimisticAllocator::freePageRange(PageRange block) {
 }
 
 void OptimisticAllocator::rollback() {
+    std::unique_lock lck{mtx};
     for (const auto& entry : optimisticallyAllocatedPages) {
         pageManager.freeImmediatelyRewritablePageRange(pageManager.getDataFH(), entry);
     }
@@ -26,6 +28,7 @@ void OptimisticAllocator::rollback() {
 }
 
 void OptimisticAllocator::commit() {
+    std::unique_lock lck{mtx};
     optimisticallyAllocatedPages.clear();
 }
 } // namespace lbug::storage


### PR DESCRIPTION
## Symptom

Parallel COPY (16 workers) intermittently aborts with a glibc `sysmalloc` assertion. The crashing thread is typically inside an unrelated later `malloc` — e.g. `InMemChunkedNodeGroupCollection::merge` growing `chunkedGroups` during the rel partitioner merge — while another worker waits on the merge mutex. Classic use-after-corruption: the heap was already trashed by an earlier bad write.

## Root cause

Blame: ba6614049

`LocalStorage::addOptimisticAllocator()` caches **one `OptimisticAllocator` per StorageManager** and hands the same instance to every COPY worker thread (node and rel paths). But `OptimisticAllocator::allocatePageRange()` did an unsynchronized `push_back` onto `optimisticallyAllocatedPages`, despite the class being documented as thread-local-only. Concurrent vector mutation corrupts the heap; the crash detonates at the next malloc that touches it.

ThreadSanitizer report (TSan + BM_MALLOC build, LSQB SF=1 load):

```
WARNING: ThreadSanitizer: data race
  Write of size 8 ... by thread T1:
    #0 OptimisticAllocator::allocatePageRange
    #1 Column::flushData ... NodeBatchInsert::executeInternal
    #2 ProcessorTask::run / TaskScheduler::runWorkerThread
  Previous write ... by thread T16 (same stacks)
```

## Fix

Synchronize the internally-tracked page ranges with a mutex in `allocatePageRange()`, `rollback()` and `commit()`. The underlying `PageManager::allocatePageRange` is already internally synchronized, so this is the only unprotected layer. Allocation happens per flushed chunk group, so lock contention is negligible. Also updates the stale thread-local docstring.

## Verification

- Pre-fix TSan build: race reported during parallel node COPY (Message table).
- Post-fix TSan build: full LSQB SF=1 load (10 node + 21 edge COPYs) completes, exit 0, zero TSan reports, row counts correct.
- Post-fix release shell (previously crashed every run): full load completes, counts correct.
- clang-format clean.