### PR TITLE
fix(storage): validate allocated page ranges and page indices on the write path

### DIFF
--- a/src/storage/page_manager.cpp
+++ b/src/storage/page_manager.cpp
@@ -1,23 +1,60 @@
 #include "storage/page_manager.h"
 
+#include "common/exception/runtime.h"
 #include "common/uniq_lock.h"
 #include "storage/file_handle.h"
 #include "storage/storage_manager.h"
+#include <format>
 
 namespace lbug::storage {
 static constexpr bool ENABLE_FSM = true;
+
+namespace {
+// An allocated page index is turned straight into a file offset by the write path, so a range
+// that does not belong to this file silently extends it rather than failing (issue #948: page
+// 233,877,254 of a 2884-page database left an 11.8 MB file reporting 892 GiB of apparent size,
+// which only surfaces once a copy or backup materialises the sparse hole). The free list is
+// deserialized from the database file, so a corrupted entry lands here first: fail at the
+// source, where the offending range can still be named.
+//
+// The file does shrink, via FreeSpaceManager::handleLastPageRange ->
+// FileHandle::removePageIdxAndTruncateIfNecessary, but that path truncates to the start of the
+// trailing free range and drops that range instead of re-adding it, and every surviving entry
+// sorts below it, so a legitimate free entry stays inside the file.
+void validateAllocatedPageRange(const PageRange& range, const FileHandle& fileHandle,
+    const char* source) {
+    if (range.numPages == 0) {
+        // A zero-page allocation writes nothing, and its start index legitimately sits at the
+        // current end of the file.
+        return;
+    }
+    const auto numPages = fileHandle.getNumPages();
+    if (range.startPageIdx >= numPages || range.numPages > numPages - range.startPageIdx) {
+        throw common::RuntimeException(
+            std::format("Page allocation from {} returned pages [{}, {}), which are out of "
+                        "bounds for a data file with {} pages. The database file may be "
+                        "corrupted.",
+                source, range.startPageIdx,
+                static_cast<uint64_t>(range.startPageIdx) + range.numPages, numPages));
+    }
+}
+} // namespace
 
 PageRange PageManager::allocatePageRange(common::page_idx_t numPages) {
     if constexpr (ENABLE_FSM) {
         common::UniqLock lck{mtx};
         auto allocatedFreeChunk = freeSpaceManager->popFreePages(numPages);
         if (allocatedFreeChunk.has_value()) {
+            validateAllocatedPageRange(*allocatedFreeChunk, *fileHandle, "the free page list");
             version.fetch_add(1, std::memory_order_relaxed);
             return {*allocatedFreeChunk};
         }
     }
     auto startPageIdx = fileHandle->addNewPages(numPages);
+    // DASSERT alone is stripped in release builds, and this invariant guards a file offset.
     DASSERT(fileHandle->getNumPages() >= startPageIdx + numPages);
+    validateAllocatedPageRange(PageRange(startPageIdx, numPages), *fileHandle,
+        "the page extension path");
     return PageRange(startPageIdx, numPages);
 }
 


### PR DESCRIPTION
Fixes #948.

## Symptom

A single bad page index extends the data file far past its end. On the database from #843 an
11.8 MB file ends up reporting **892.2 GiB** of apparent size while only ~12 MiB is allocated.
The database still opens and queries fine, so nothing looks wrong — until something copies or
archives it and the sparse hole is materialised. That is how I found it: one `shutil.copy2()`
filled a 926 GiB volume to 100% (523 MiB free) before failing with `ENOSPC`. A backup tool,
`tar`, or a container build would do the same.

Reproduced identically on 0.19.1, 0.20.2 and main, always the same byte count.

## Root cause

A page index becomes a file offset on the write path exactly as it does on the read path, but
only reads were validated (#946). Nothing checked the ranges the allocator handed out.

I traced the actual write with a backtrace on an instrumented build. It is not the shadow-replay
path I first suspected:

```
LocalFileSystem::writeFile(offset=957961232384)
  <- CompressedFlushBuffer::operator()(span<const uint8_t>, FileHandle*, const PageRange&, const ColumnChunkMetadata&)
  <- ColumnChunkData::flush(PageAllocator&)
  <- Column::checkpointColumnChunkOutOfPlace(...)  /  StringColumn::checkpointSegment(...)
  <- ColumnChunk::checkpoint(...) <- NodeGroup::checkpointInMemAndOnDisk(...)
  <- NodeTable::checkpoint(...) <- StorageManager::checkpoint(...) <- Checkpointer::checkpointStorage()
```

The range came from `PageManager::allocatePageRange`, which returns whatever
`FreeSpaceManager::popFreePages` yields. That free list is deserialized from the database file, so
a corrupted entry is handed out as if it were real: on this database, page **212,650,604** of a
**2884-page** file. The checkpoint flush then writes there and the file grows to 892 GiB.

This also closes a gap in #843: the guard's message proves that database's free page list is
corrupted, which is the missing link between the page corruption reported there and the file
inflation reported in #948.

## Fix

`PageManager::allocatePageRange` rejects a range that is not inside the data file, naming the
range and the file's page count. This is where a corrupted free list surfaces first, and nothing
shrinks the data file, so a legitimate free entry is always inside it. The existing `DASSERT` on
the extension path is kept and backed by a real check, since `DASSERT` is stripped in release
builds. Zero-page allocations are exempt — they write nothing, and their start index legitimately
sits at the current end of the file. Style and message shape follow #946.

An earlier revision of this PR also guarded the `FileHandle` write paths and both shadow-replay
writes as defense in depth. **I removed those**, because your CI showed the recovery-path bound
was simply wrong: `FlakyCheckpointerTest.RecoverFromCheckpointApplyingShadowFailure` legitimately
replays a shadow page into data page 266 of a file that currently has 265 pages — extending the
data file is exactly what recovery is for, so there is no sound page-count bound available at
that point. I could not prove the spiller's use of `writePagesToFile` safe either. The remaining
change is the one place with an authoritative bound, and it is the place the fault actually
originates.

## Verification

On the #948 reproducer (a content-scrubbed copy of the #843 database, published at
https://github.com/fabzter/ladybug-948-repro so this is reproducible without my private data):

```
Runtime exception: Page allocation from the free page list returned pages
[212650604, 212650605), which are out of bounds for a data file with 2884 pages.
The free page list may be corrupted.
```

The file stays 11.8 MB instead of reaching 892 GiB, and the error identifies the corrupted free
list instead of surfacing as a SIGSEGV.

False-positive checks (an earlier revision of this patch rejected zero-page allocations, which the
first of these caught):

- 2000-cycle insert + `CHECKPOINT` soak on a clean store carrying FTS and HNSW indexes, seeds 1
  and 2: both complete, row counts correct.
- Smoke covering DDL, 3000 inserts with strings up to 3 KB, deletes that free pages, **reuse of
  those freed pages through the free list** (the path this patch guards), and `EXPORT`/`IMPORT`:
  all pass.

I have not run the C++ suite locally — `BUILD_TESTS` was off in my build directory — so CI is the
first full run. I did not add a unit test because provoking this needs a database whose free list
is already corrupt; happy to add a direct unit test of the guards if you would like one.

## Relationship to the other open reports

- **#946** hardened the read path for exactly this class of fault. This is the same check on the write path, in the same style.
- **#949** (open) fixes an unsynchronized `push_back` in `OptimisticAllocator` that corrupts the heap during parallel COPY. It touches only `optimistic_allocator.{h,cpp}`, so there is no overlap with this change, and the two are complementary: #949 removes a cause of corruption, this fails fast when corrupted allocator state would otherwise reach the disk.
- **#940** is unaffected and not masked: it still reproduces on all 5 seeds with this patch applied. Two findings from testing it alongside this work, in case they help there: under a full ASAN build (core plus FTS and VECTOR extensions all instrumented) the #940 workload runs **clean for 500 cycles**, twice, where the release build dies within ~40 — so it is allocator-layout or timing sensitive rather than a deterministic off-by-one; and applying #949 on top does **not** fix it (5/5 seeds still crash), which rules out that race as its cause.
