### PR TITLE
Enable malloc buffer manager in sanitizer workflow

### DIFF
--- a/.github/workflows/nightly-sanitizers.yml
+++ b/.github/workflows/nightly-sanitizers.yml
@@ -24,9 +24,9 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y cmake ninja-build python3 python3-pip git ccache curl
       - name: Build (RelWithDebInfo, ASan+UBSan)
-        run: ASAN=1 UBSAN=1 make relwithdebinfo NUM_THREADS=$(nproc)
+        run: BM_MALLOC=1 ASAN=1 UBSAN=1 make relwithdebinfo NUM_THREADS=$(nproc)
       - name: Test
-        run: ASAN=1 UBSAN=1 make test NUM_THREADS=$(nproc)
+        run: BM_MALLOC=1 ASAN=1 UBSAN=1 make test NUM_THREADS=$(nproc)
         env:
           ASAN_OPTIONS: detect_leaks=0:abort_on_error=1
           UBSAN_OPTIONS: print_stacktrace=1:halt_on_error=1
@@ -46,8 +46,8 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y cmake ninja-build python3 python3-pip git ccache curl
       - name: Build (RelWithDebInfo, TSan)
-        run: TSAN=1 make relwithdebinfo NUM_THREADS=$(nproc)
+        run: BM_MALLOC=1 TSAN=1 make relwithdebinfo NUM_THREADS=$(nproc)
       - name: Test
-        run: TSAN=1 make test NUM_THREADS=$(nproc)
+        run: BM_MALLOC=1 TSAN=1 make test NUM_THREADS=$(nproc)
         env:
           TSAN_OPTIONS: halt_on_error=0


### PR DESCRIPTION
The nightly sanitizer workflow was not enabling the malloc-backed buffer manager.

- Add `BM_MALLOC=1` to the ASan+UBSan build and test steps.
- Add `BM_MALLOC=1` to the TSan build and test steps.

This makes the sanitizer jobs run with the intended buffer manager configuration.

Part of #879.