### PR TITLE
Fix unaligned string hash access

### DIFF
--- a/src/include/function/hash/hash_functions.h
+++ b/src/include/function/hash/hash_functions.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstdint>
+#include <cstring>
 #include <functional>
 #include <unordered_set>
 
@@ -139,9 +140,10 @@ inline void Hash::operation(const float& key, common::hash_t& result) {
 template<>
 inline void Hash::operation(const std::string_view& key, common::hash_t& result) {
     common::hash_t hashValue = 0;
-    auto data64 = reinterpret_cast<const uint64_t*>(key.data());
     for (size_t i = 0u; i < key.size() / 8; i++) {
-        auto blockHash = lbug::function::murmurhash64(*(data64 + i));
+        uint64_t block = 0;
+        std::memcpy(&block, key.data() + i * sizeof(block), sizeof(block));
+        auto blockHash = lbug::function::murmurhash64(block);
         hashValue = lbug::function::combineHashScalar(hashValue, blockHash);
     }
     uint64_t last = 0;

--- a/test/common/CMakeLists.txt
+++ b/test/common/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_lbug_test(types_test
+        hash_test.cpp
         int128_test.cpp
         uint128_test.cpp
         date_test.cpp

--- a/test/common/hash_test.cpp
+++ b/test/common/hash_test.cpp
@@ -1,0 +1,29 @@
+#include <cstdint>
+#include <cstring>
+#include <string_view>
+
+#include "function/hash/hash_functions.h"
+#include "gtest/gtest.h"
+
+// Regression test for the UBSAN misaligned uint64_t load in
+// Hash::operation<std::string_view> (issue #879). Ladybug's inline
+// short-string storage can hand out character data that is only 4-byte
+// aligned, so the hash must not dereference it as uint64_t*.
+TEST(HashTest, UnalignedStringViewHashMatchesAligned) {
+    constexpr std::string_view bytes = "Elizabeth0123456789"; // 19 bytes: multi-block + tail
+    static_assert(bytes.size() >= 8u);
+    alignas(uint64_t) char alignedBacking[32];
+    alignas(uint64_t) char unalignedBacking[32];
+    ASSERT_LT(bytes.size() + 1, sizeof(unalignedBacking));
+    std::memcpy(alignedBacking, bytes.data(), bytes.size());
+    std::memcpy(unalignedBacking + 1, bytes.data(), bytes.size());
+    std::string_view aligned(alignedBacking, bytes.size());
+    std::string_view unaligned(unalignedBacking + 1, bytes.size());
+    ASSERT_EQ(reinterpret_cast<uintptr_t>(aligned.data()) % alignof(uint64_t), 0u);
+    ASSERT_NE(reinterpret_cast<uintptr_t>(unaligned.data()) % alignof(uint64_t), 0u);
+    lbug::common::hash_t alignedHash = 0;
+    lbug::common::hash_t unalignedHash = 0;
+    lbug::function::Hash::operation(aligned, alignedHash);
+    lbug::function::Hash::operation(unaligned, unalignedHash);
+    EXPECT_EQ(unalignedHash, alignedHash);
+}


### PR DESCRIPTION
This fixes a UBSAN error in string hashing.

The hash code was reading string data as `uint64_t` blocks, but the string data isn't always 8-byte aligned. This happens with Ladybug's inline short strings and causes UBSAN to abort.

I changed the 8-byte load to use `memcpy` into a local `uint64_t` instead.

Also added a regression test that hashes the same bytes from aligned and intentionally misaligned memory and checks that the result is the same.

Part of #879.