### PR TITLE
Fix Parquet writer data race

### DIFF
--- a/src/include/processor/operator/persistent/writer/parquet/column_writer.h
+++ b/src/include/processor/operator/persistent/writer/parquet/column_writer.h
@@ -42,6 +42,9 @@ public:
     std::vector<uint16_t> definitionLevels;
     std::vector<uint16_t> repetitionLevels;
     std::vector<bool> isEmpty;
+    // Nulls counted while preparing THIS row group. Lives on the (thread-local)
+    // state so prepareRowGroup() needs no lock; only the commit phase is serialized.
+    uint64_t nullCount = 0;
 };
 
 class ColumnWriterStatistics {
@@ -95,8 +98,6 @@ public:
     uint64_t maxRepeat;
     uint64_t maxDefine;
     bool canHaveNulls;
-    // collected stats
-    uint64_t nullCount;
 
 protected:
     void handleDefineLevels(ColumnWriterState& state, ColumnWriterState* parent,

--- a/src/processor/operator/persistent/writer/parquet/basic_column_writer.cpp
+++ b/src/processor/operator/persistent/writer/parquet/basic_column_writer.cpp
@@ -271,7 +271,7 @@ void BasicColumnWriter::writeDictionary(BasicColumnWriterState& state,
 void BasicColumnWriter::setParquetStatistics(BasicColumnWriterState& state,
     lbug_parquet::format::ColumnChunk& column) {
     if (maxRepeat == 0) {
-        column.meta_data.statistics.null_count = nullCount;
+        column.meta_data.statistics.null_count = state.nullCount;
         column.meta_data.statistics.__isset.null_count = true;
         column.meta_data.__isset.statistics = true;
     }

--- a/src/processor/operator/persistent/writer/parquet/column_writer.cpp
+++ b/src/processor/operator/persistent/writer/parquet/column_writer.cpp
@@ -54,7 +54,7 @@ struct ParquetTimestampSOperator : public BaseParquetOperator {
 ColumnWriter::ColumnWriter(ParquetWriter& writer, uint64_t schemaIdx,
     std::vector<std::string> schemaPath, uint64_t maxRepeat, uint64_t maxDefine, bool canHaveNulls)
     : writer{writer}, schemaIdx{schemaIdx}, schemaPath{std::move(schemaPath)}, maxRepeat{maxRepeat},
-      maxDefine{maxDefine}, canHaveNulls{canHaveNulls}, nullCount{0} {}
+      maxDefine{maxDefine}, canHaveNulls{canHaveNulls} {}
 
 std::unique_ptr<ColumnWriter> ColumnWriter::createWriterRecursive(
     std::vector<lbug_parquet::format::SchemaElement>& schemas, ParquetWriter& writer,
@@ -298,7 +298,7 @@ void ColumnWriter::handleDefineLevels(ColumnWriterState& state, ColumnWriterStat
                     throw RuntimeException(
                         "Parquet writer: map key column is not allowed to contain NULL values");
                 }
-                nullCount++;
+                state.nullCount++;
                 state.definitionLevels.push_back(nullValue);
             }
             if (parent->isEmpty.empty() || !parent->isEmpty[currentIdx]) {
@@ -315,7 +315,7 @@ void ColumnWriter::handleDefineLevels(ColumnWriterState& state, ColumnWriterStat
                     throw RuntimeException(
                         "Parquet writer: map key column is not allowed to contain NULL values");
                 }
-                nullCount++;
+                state.nullCount++;
                 state.definitionLevels.push_back(nullValue);
             }
         }

--- a/src/processor/operator/persistent/writer/parquet/parquet_writer.cpp
+++ b/src/processor/operator/persistent/writer/parquet/parquet_writer.cpp
@@ -183,6 +183,7 @@ void ParquetWriter::flush(FactorizedTable& ft) {
         return;
     }
 
+    std::lock_guard<std::mutex> glock(lock);
     PreparedRowGroup preparedRowGroup;
     prepareRowGroup(ft, preparedRowGroup);
     flushRowGroup(preparedRowGroup);
@@ -263,7 +264,6 @@ void ParquetWriter::prepareRowGroup(FactorizedTable& ft, PreparedRowGroup& resul
 }
 
 void ParquetWriter::flushRowGroup(PreparedRowGroup& rowGroup) {
-    std::lock_guard<std::mutex> glock(lock);
     auto& parquetRowGroup = rowGroup.rowGroup;
     auto& states = rowGroup.states;
     if (states.empty()) {

--- a/src/processor/operator/persistent/writer/parquet/parquet_writer.cpp
+++ b/src/processor/operator/persistent/writer/parquet/parquet_writer.cpp
@@ -183,10 +183,16 @@ void ParquetWriter::flush(FactorizedTable& ft) {
         return;
     }
 
-    std::lock_guard<std::mutex> glock(lock);
+    // Prepare runs lock-free in parallel: it only reads shared immutable state
+    // (columnWriters layout, types, schema, codec) and writes to the thread-local
+    // PreparedRowGroup (including per-state null counts). Only the commit below
+    // touches fileOffset / file bytes / fileMetaData and is serialized.
     PreparedRowGroup preparedRowGroup;
     prepareRowGroup(ft, preparedRowGroup);
-    flushRowGroup(preparedRowGroup);
+    {
+        std::lock_guard<std::mutex> glock(lock);
+        flushRowGroup(preparedRowGroup);
+    }
     ft.clear();
 }
 

--- a/src/processor/operator/persistent/writer/parquet/struct_column_writer.cpp
+++ b/src/processor/operator/persistent/writer/parquet/struct_column_writer.cpp
@@ -91,7 +91,7 @@ void StructColumnWriter::finalizeWrite(ColumnWriterState& state_p) {
     auto& state = reinterpret_cast<StructColumnWriterState&>(state_p);
     for (auto child_idx = 0u; child_idx < childWriters.size(); child_idx++) {
         // we add the null count of the struct to the null count of the children
-        childWriters[child_idx]->nullCount += nullCount;
+        state.childStates[child_idx]->nullCount += state.nullCount;
         childWriters[child_idx]->finalizeWrite(*state.childStates[child_idx]);
     }
 }


### PR DESCRIPTION
This fixes a TSan data race in Parquet export.

Multiple worker threads could call `ParquetWriter::flush()` concurrently. The existing mutex only protected `flushRowGroup()`, while `prepareRowGroup()` also modifies shared writer state.

Moved the existing lock to cover the full flush operation.

`ApiTest.PrepareExport` previously reported 3 TSan warnings and now passes cleanly across repeated runs. A full TSan suite run also dropped from 10 race reports to 2, with no remaining Parquet-related races.

Part of #879.