### PR TITLE
fix(alp): bound the encodable range and the sentinel by ENCODED_TYPE

### DIFF
--- a/test/common/CMakeLists.txt
+++ b/test/common/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_lbug_test(types_test
+        alp_encode_test.cpp
         hash_test.cpp
         int128_test.cpp
         uint128_test.cpp

--- a/test/common/alp_encode_test.cpp
+++ b/test/common/alp_encode_test.cpp
@@ -1,0 +1,57 @@
+#include <cmath>
+#include <cstdint>
+#include <limits>
+
+#include "alp/encode.hpp"
+#include "gtest/gtest.h"
+
+// Regression tests for the float-cast-overflow in alp::AlpEncode<float>::encode_value
+// (issue #879). ALP's encodable-range check and its "impossible to encode" sentinel both
+// used the int64-scale ENCODING_UPPER_LIMIT/ENCODING_LOWER_LIMIT, but AlpEncode<float>
+// encodes to int32_t, so casting that sentinel -- or any value merely inside the int64
+// range -- into ENCODED_TYPE was undefined. UBSAN reported it from
+// ColumnChunkData::getMetadataToFlush() on any FLOAT column containing such a value.
+
+namespace {
+constexpr int64_t kInt32Min = std::numeric_limits<int32_t>::lowest();
+constexpr int64_t kInt32Max = std::numeric_limits<int32_t>::max();
+
+int64_t encodeFloat(float value) {
+    return static_cast<int64_t>(alp::AlpEncode<float>::encode_value<true>(value, 0, 0));
+}
+} // namespace
+
+TEST(AlpEncodeTest, FloatSpecialValuesStayInEncodedRange) {
+    // Values ALP cannot encode: the sentinel it returns must itself fit in int32_t.
+    EXPECT_EQ(encodeFloat(std::numeric_limits<float>::quiet_NaN()), kInt32Max);
+    EXPECT_EQ(encodeFloat(std::numeric_limits<float>::infinity()), kInt32Max);
+    EXPECT_EQ(encodeFloat(-0.0f), kInt32Max);
+}
+
+TEST(AlpEncodeTest, FloatOutsideInt32RangeIsTreatedAsImpossible) {
+    // Finite, and well inside the int64 range, but not representable as int32_t. The old
+    // range check let these through and the cast at the end of encode_value was undefined.
+    for (const float value : {1e12f, -1e12f, 3e9f, -3e9f}) {
+        const int64_t encoded = encodeFloat(value);
+        EXPECT_GE(encoded, kInt32Min);
+        EXPECT_LE(encoded, kInt32Max);
+    }
+}
+
+TEST(AlpEncodeTest, OrdinaryFloatsStillEncode) {
+    EXPECT_EQ(encodeFloat(3.5f), 4);
+    EXPECT_EQ(encodeFloat(0.0f), 0);
+    EXPECT_EQ(encodeFloat(-2.25f), -2);
+}
+
+TEST(AlpEncodeTest, DoubleBehaviourUnchanged) {
+    // AlpEncode<double> encodes to int64_t, where the original constants were already
+    // correct; this pins that the fix did not move that boundary.
+    using D = alp::AlpEncode<double>;
+    constexpr double kSentinel = 9223372036854774784.0;
+    EXPECT_EQ(D::encode_value<true>(std::numeric_limits<double>::quiet_NaN(), 0, 0),
+        static_cast<int64_t>(kSentinel));
+    EXPECT_EQ(D::encode_value<true>(-0.0, 0, 0), static_cast<int64_t>(kSentinel));
+    EXPECT_EQ(D::encode_value<true>(1e12, 0, 0), 1000000000000LL);
+    EXPECT_EQ(D::encode_value<true>(3.5, 0, 0), 4);
+}

--- a/third_party/alp/include/alp/encode.hpp
+++ b/third_party/alp/include/alp/encode.hpp
@@ -11,6 +11,7 @@
 #include <cfloat>
 #include <cmath>
 #include <cstdint>
+#include <limits>
 #include <map>
 #include <utility>
 #include <vector>
@@ -34,12 +35,27 @@ struct AlpEncode {
 	static constexpr uint8_t EXACT_TYPE_BITSIZE = sizeof(EXACT_TYPE) * 8;
 
 	/*
+	 * Bounds of values that can be cast to ENCODED_TYPE without undefined behaviour, as a double.
+	 * ENCODING_UPPER_LIMIT / ENCODING_LOWER_LIMIT are int64-scale, which is correct for
+	 * AlpEncode<double> (ENCODED_TYPE = int64_t) but ~4e9x too permissive for AlpEncode<float>,
+	 * whose ENCODED_TYPE is int32_t. Both int32 bounds are exactly representable as doubles, so
+	 * they can be used directly; the int64 ones cannot, which is why the existing constants are
+	 * the largest doubles strictly inside the int64 range rather than INT64_MIN/MAX.
+	 */
+	static constexpr double ENCODED_TYPE_UPPER_LIMIT =
+	    sizeof(ENCODED_TYPE) == 8 ? ENCODING_UPPER_LIMIT
+	                              : static_cast<double>(std::numeric_limits<int32_t>::max());
+	static constexpr double ENCODED_TYPE_LOWER_LIMIT =
+	    sizeof(ENCODED_TYPE) == 8 ? ENCODING_LOWER_LIMIT
+	                              : static_cast<double>(std::numeric_limits<int32_t>::lowest());
+
+	/*
 	 * Check for special values which are impossible for ALP to encode
-	 * because they cannot be cast to int64 without an undefined behaviour
+	 * because they cannot be cast to ENCODED_TYPE without an undefined behaviour
 	 */
 	static inline bool is_impossible_to_encode(const T n) {
-		return !std::isfinite(n) || std::isnan(n) || n > ENCODING_UPPER_LIMIT || n < ENCODING_LOWER_LIMIT ||
-		       (n == 0.0 && std::signbit(n)); //! Verification for -0.0
+		return !std::isfinite(n) || std::isnan(n) || n > ENCODED_TYPE_UPPER_LIMIT ||
+		       n < ENCODED_TYPE_LOWER_LIMIT || (n == 0.0 && std::signbit(n)); //! Verification for -0.0
 	}
 
 	//! Scalar encoding a single value with ALP
@@ -47,7 +63,9 @@ struct AlpEncode {
 	static ENCODED_TYPE encode_value(const T value, const factor_idx_t factor_idx, const exponent_idx_t exponent_idx) {
 		T tmp_encoded_value = value * Constants<T>::EXP_ARR[exponent_idx] * Constants<T>::FRAC_ARR[factor_idx];
 		if constexpr (SAFE) {
-			if (is_impossible_to_encode(tmp_encoded_value)) { return static_cast<ENCODED_TYPE>(ENCODING_UPPER_LIMIT); }
+			if (is_impossible_to_encode(tmp_encoded_value)) {
+				return static_cast<ENCODED_TYPE>(ENCODED_TYPE_UPPER_LIMIT);
+			}
 		}
 		tmp_encoded_value = tmp_encoded_value + Constants<T>::MAGIC_NUMBER - Constants<T>::MAGIC_NUMBER;
 		return static_cast<ENCODED_TYPE>(tmp_encoded_value);


### PR DESCRIPTION
Fixes the ALP `float`-cast UB I reported in #879. @Saiteja64 said in
https://github.com/LadybugDB/ladybug/issues/879#issuecomment-5614234423 that this one was not on
their list, so I picked it up; I have not touched the UBSan or TSan sites they are working through.

## The bug

`FloatingToEncodedType` maps `double` to `int64_t` and `float` to `int32_t`, but the encodable-range
check and the "impossible to encode" sentinel were both hardcoded to the int64-scale
`ENCODING_UPPER_LIMIT` / `ENCODING_LOWER_LIMIT`. For `AlpEncode<float>` that makes two casts
undefined:

1. the SAFE fallback casts ~9.22e18 into `int32_t` for **every** value ALP declares unencodable — which `is_impossible_to_encode()` defines as any non-finite value, `-0.0`, or anything outside the limits;
2. a finite value inside the int64 range but outside int32 (`1e12f`, `3e9f`) passes the check and then overflows in the final cast.

UBSan, reached from the checkpoint path:

```
third_party/alp/include/alp/encode.hpp:50:87: runtime error:
9.22337e+18 is outside the range of representable values of type 'int'

  #0 int alp::AlpEncode<float>::encode_value<true>(float, unsigned char, unsigned char)
  #1 alp::AlpEncode<float>::find_top_k_combinations(float const*, alp::state&)
  #2 lbug::storage::GetFloatCompressionMetadata<float>::operator()(...)
  #4 lbug::storage::ColumnChunkData::getMetadataToFlush()   column_chunk_data.cpp:291
```

Any `FLOAT` column containing a NaN or `-0.0` hits it on the next checkpoint, and with the nightly's
`UBSAN_OPTIONS: halt_on_error=1` that kills the job.

## The fix

Derive both bounds from `ENCODED_TYPE`. int32's bounds are exactly representable as doubles so they
are used directly; the int64 case keeps the existing constants, which are deliberately the largest
doubles strictly *inside* the int64 range rather than `INT64_MIN`/`MAX`. `AlpEncode<double>` is
therefore unchanged in both range and sentinel — that is pinned by a test.

## Not benign before the fix

Worth noting the old casts were not merely theoretical UB. Unpatched, the NaN and `-0.0` sentinel
evaluates to **0** on arm64 and **INT32_MIN** on x86-64, neither of which is the saturated marker the
code intends:

| case | unpatched (arm64) | unpatched (x86-64) | patched |
|---|---|---|---|
| NaN, `-0.0` | `0` | `INT32_MIN` | `INT32_MAX` |
| `1e12f` | `INT32_MAX` (saturates) | `INT32_MIN` | `INT32_MAX` |
| `3.5f` | `4` | `4` | `4` |

## Verification

- `test/common/alp_encode_test.cpp` added, 4 tests, following the shape of `hash_test.cpp` from `6c292d2b`. The first case fails on unpatched builds on **both** architectures, so it is a real regression test and not only a UBSan tripwire.
- Full `types_test` binary: 74 passed, 2 skipped (pre-existing environment skips).
- The standalone UBSan probe that produced the report above is clean after the patch for NaN, `±inf`, `-0.0`, `±1e12f`, `±3e9f`, and unchanged for ordinary values.
- End to end through the engine: a `FLOAT` and a `DOUBLE` column loaded with NaN, `-0.0`, `inf`, `1e12`, `-1e12`, `3e9`, `1e-8`, `3.5`, `-2.25`, checkpointed and read back — all nine round-trip exactly (float values to their `float32` representation).

`third_party/` is outside the `clang-format` CI scope, so the vendored header keeps ALP's existing
tab style. This is a local patch to vendored code and is worth sending upstream to the ALP project
as well — happy to do that if you would like.
