### PR TITLE
Fix WAL checksum entry-buffer resize dropping buffered bytes

### DIFF
--- a/src/storage/wal/checksum_reader.cpp
+++ b/src/storage/wal/checksum_reader.cpp
@@ -17,12 +17,14 @@ ChecksumReader::ChecksumReader(common::FileInfo& fileInfo, MemoryManager& memory
       entryBuffer(memoryManager.allocateBuffer(false, INITIAL_BUFFER_SIZE)),
       checksumMismatchMessage(checksumMismatchMessage) {}
 
-static void resizeBufferIfNeeded(std::unique_ptr<MemoryBuffer>& entryBuffer,
+static void resizeBufferIfNeeded(std::unique_ptr<MemoryBuffer>& entryBuffer, uint64_t currentSize,
     uint64_t requestedSize) {
     const auto currentBufferSize = entryBuffer->getBuffer().size_bytes();
     if (requestedSize > currentBufferSize) {
         auto* memoryManager = entryBuffer->getMemoryManager();
-        entryBuffer = memoryManager->allocateBuffer(false, std::bit_ceil(requestedSize));
+        auto newBuffer = memoryManager->allocateBuffer(false, std::bit_ceil(requestedSize));
+        std::memcpy(newBuffer->getData(), entryBuffer->getData(), currentSize);
+        entryBuffer = std::move(newBuffer);
     }
 }
 
@@ -36,7 +38,7 @@ void ChecksumReader::read(uint8_t* data, uint64_t size) {
         throw;
     }
     if (currentEntrySize.has_value()) {
-        resizeBufferIfNeeded(entryBuffer, *currentEntrySize + size);
+        resizeBufferIfNeeded(entryBuffer, *currentEntrySize, *currentEntrySize + size);
         std::memcpy(entryBuffer->getData() + *currentEntrySize, data, size);
         *currentEntrySize += size;
     }

--- a/src/storage/wal/checksum_writer.cpp
+++ b/src/storage/wal/checksum_writer.cpp
@@ -14,18 +14,20 @@ ChecksumWriter::ChecksumWriter(std::shared_ptr<common::Writer> outputWriter,
     : outputSerializer(std::move(outputWriter)),
       entryBuffer(memoryManager.allocateBuffer(false, INITIAL_BUFFER_SIZE)) {}
 
-static void resizeBufferIfNeeded(std::unique_ptr<MemoryBuffer>& entryBuffer,
+static void resizeBufferIfNeeded(std::unique_ptr<MemoryBuffer>& entryBuffer, uint64_t currentSize,
     uint64_t requestedSize) {
     const auto currentBufferSize = entryBuffer->getBuffer().size_bytes();
     if (requestedSize > currentBufferSize) {
         auto* memoryManager = entryBuffer->getMemoryManager();
-        entryBuffer = memoryManager->allocateBuffer(false, std::bit_ceil(requestedSize));
+        auto newBuffer = memoryManager->allocateBuffer(false, std::bit_ceil(requestedSize));
+        std::memcpy(newBuffer->getData(), entryBuffer->getData(), currentSize);
+        entryBuffer = std::move(newBuffer);
     }
 }
 
 void ChecksumWriter::write(const uint8_t* data, uint64_t size) {
     if (currentEntrySize.has_value()) {
-        resizeBufferIfNeeded(entryBuffer, *currentEntrySize + size);
+        resizeBufferIfNeeded(entryBuffer, *currentEntrySize, *currentEntrySize + size);
         std::memcpy(entryBuffer->getData() + *currentEntrySize, data, size);
         *currentEntrySize += size;
     } else {

--- a/test/transaction/wal_test.cpp
+++ b/test/transaction/wal_test.cpp
@@ -812,3 +812,58 @@ TEST_F(WalTest, ReadOnlyRecoveryNoWALFile) {
     ASSERT_TRUE(res->isSuccess());
     ASSERT_EQ(res->getNumTuples(), 0);
 }
+
+// Regression test for https://github.com/LadybugDB/ladybug/issues/771.
+// A single WAL record larger than the 4KB checksum entry buffer must survive
+// WAL replay. ChecksumWriter/ChecksumReader used to discard the already
+// buffered bytes when growing the entry buffer, corrupting the record framing
+// (writer) and failing checksum verification (reader).
+TEST_F(WalTest, LargeWALRecordReplay) {
+    if (inMemMode || systemConfig->checkpointThreshold == 0) {
+        GTEST_SKIP();
+    }
+    systemConfig->throwOnWalReplayFailure = true;
+    conn->query("CALL force_checkpoint_on_close=false");
+    conn->query("CREATE NODE TABLE test(id INT64 PRIMARY KEY, content STRING);");
+    const std::string big(5000, 'x');
+    {
+        // Destroy the result before tearing down the DB below.
+        auto insertRes = conn->query(std::format("CREATE (:test {{id: 1, content: '{}'}});", big));
+        ASSERT_TRUE(insertRes->isSuccess()) << insertRes->getErrorMessage();
+    }
+    conn.reset();
+    database.reset();
+
+    createDBAndConn();
+    auto res = conn->query("MATCH (n:test) RETURN n.content;");
+    ASSERT_TRUE(res->isSuccess()) << res->getErrorMessage();
+    ASSERT_EQ(res->getNumTuples(), 1);
+    ASSERT_TRUE(res->hasNext());
+    EXPECT_EQ(res->getNext()->getValue(0)->getValue<std::string>(), big);
+}
+
+// Same as above, but the original Database is still alive when the second one
+// replays the WAL (e.g. undisposed handles keeping the first instance around).
+TEST_F(WalTest, LargeWALRecordReplayWithPreviousDBAlive) {
+    if (inMemMode || systemConfig->checkpointThreshold == 0) {
+        GTEST_SKIP();
+    }
+    conn->query("CALL force_checkpoint_on_close=false");
+    conn->query("CREATE NODE TABLE test(id INT64 PRIMARY KEY, content STRING);");
+    const std::string big(5000, 'x');
+    {
+        auto insertRes = conn->query(std::format("CREATE (:test {{id: 1, content: '{}'}});", big));
+        ASSERT_TRUE(insertRes->isSuccess()) << insertRes->getErrorMessage();
+    }
+
+    lbug::main::SystemConfig roConfig = *systemConfig;
+    roConfig.readOnly = true;
+    roConfig.throwOnWalReplayFailure = true;
+    auto db2 = std::make_unique<lbug::main::Database>(databasePath, roConfig);
+    auto conn2 = std::make_unique<lbug::main::Connection>(db2.get());
+    auto res = conn2->query("MATCH (n:test) RETURN n.content;");
+    ASSERT_TRUE(res->isSuccess()) << res->getErrorMessage();
+    ASSERT_EQ(res->getNumTuples(), 1);
+    ASSERT_TRUE(res->hasNext());
+    EXPECT_EQ(res->getNext()->getValue(0)->getValue<std::string>(), big);
+}


### PR DESCRIPTION
Fixes #771.

## Root cause
A single WAL record larger than ~4KB failed replay with `Checksum verification failed` / `Corrupted wal file. Read out invalid WAL record type`.

`ChecksumWriter`/`ChecksumReader` accumulate each WAL record in a 4KB entry buffer and grow it in `resizeBufferIfNeeded`. The resize allocated a fresh uninitialized buffer **without copying the already-buffered bytes**, so the record-length prefix was lost on write (corrupting the WAL file on disk) and the checksum was computed over garbage on read. The 4KB threshold is the entry buffer's initial size (`LBUG_PAGE_SIZE`), matching the issue's per-record threshold observation. The same-process/GC/file-hash observations in the report follow from the corruption living in the WAL file plus uninitialized-memory nondeterminism — I reproduced the failure at the C++ level and even a fresh-process reopen failed on the corrupted WAL.

## Fix
Copy the valid prefix into the new buffer on resize (same pattern as `ColumnChunkData::resize`), in both `checksum_writer.cpp` and `checksum_reader.cpp`.

## Tests
- New regression tests `WalTest.LargeWALRecordReplay` and `WalTest.LargeWALRecordReplayWithPreviousDBAlive` (5KB STRING record, replay after close and while the first DB is still alive). Verified they fail without the fix with the exact error from the issue, and pass with it.
- Full `WalTest` suite: 31/31 pass. Broader CI will cover the rest.