### PR TITLE
Extend hash-join SIP with rel-scan semi masks

### DIFF
--- a/src/include/planner/operator/sip/semi_mask_target_type.h
+++ b/src/include/planner/operator/sip/semi_mask_target_type.h
@@ -11,6 +11,9 @@ enum class SemiMaskTargetType : uint8_t {
     RECURSIVE_EXTEND_OUTPUT_NODE = 3,
     RECURSIVE_EXTEND_PATH_NODE = 4,
     GDS_GRAPH_NODE = 5,
+    // Semi mask on the neighbour node of a (packed) extend, i.e. filter the rel scan
+    // output by the join key instead of materializing every expanded edge.
+    EXTEND_NBR_NODE = 6,
 };
 
 }

--- a/src/include/processor/operator/scan/scan_multi_rel_tables.h
+++ b/src/include/processor/operator/scan/scan_multi_rel_tables.h
@@ -91,13 +91,12 @@ public:
 private:
     void resetState();
     void initCurrentScanner(const common::nodeID_t& nodeID);
+    // Thin wrappers over the shared ScanTable nbr-node semi mask helpers.
     common::sel_t applyNbrNodeMask();
     void refreshNbrMaskCache();
 
 private:
     std::shared_ptr<common::NodeOffsetMaskMap> nbrNodeMaskMap;
-    std::vector<std::pair<common::table_id_t, common::SemiMask*>> nbrEnabledMasks;
-    common::SemiMask* nbrSingleEnabledMask = nullptr;
 
     DirectionInfo directionInfo;
     std::unique_ptr<storage::RelTableScanState> scanState;

--- a/src/include/processor/operator/scan/scan_multi_rel_tables.h
+++ b/src/include/processor/operator/scan/scan_multi_rel_tables.h
@@ -72,15 +72,33 @@ public:
     bool getNextTuplesInternal(ExecutionContext* context) override;
 
     std::unique_ptr<PhysicalOperator> copy() override {
-        return make_unique<ScanMultiRelTable>(opInfo.copy(), directionInfo.copy(),
+        auto result = make_unique<ScanMultiRelTable>(opInfo.copy(), directionInfo.copy(),
             copyUnorderedMap(scanners), children[0]->copy(), id, printInfo->copy(), operatorType);
+        result->nbrNodeMaskMap = nbrNodeMaskMap;
+        return result;
+    }
+
+    void setNbrNodeMaskMap(std::shared_ptr<common::NodeOffsetMaskMap> maskMap) {
+        nbrNodeMaskMap = std::move(maskMap);
+    }
+    common::table_id_map_t<common::SemiMask*> getNbrNodeMasks() const {
+        if (nbrNodeMaskMap == nullptr) {
+            return {};
+        }
+        return nbrNodeMaskMap->getMasks();
     }
 
 private:
     void resetState();
     void initCurrentScanner(const common::nodeID_t& nodeID);
+    common::sel_t applyNbrNodeMask();
+    void refreshNbrMaskCache();
 
 private:
+    std::shared_ptr<common::NodeOffsetMaskMap> nbrNodeMaskMap;
+    std::vector<std::pair<common::table_id_t, common::SemiMask*>> nbrEnabledMasks;
+    common::SemiMask* nbrSingleEnabledMask = nullptr;
+
     DirectionInfo directionInfo;
     std::unique_ptr<storage::RelTableScanState> scanState;
 

--- a/src/include/processor/operator/scan/scan_rel_table.h
+++ b/src/include/processor/operator/scan/scan_rel_table.h
@@ -150,15 +150,12 @@ public:
     }
 
 protected:
-    // Filter the current scan output batch by the nbr node mask. Returns the number of
-    // rows surviving the filter (0 means the caller should keep scanning).
+    // Thin wrappers over the shared ScanTable helpers; ScanRelTable additionally skips
+    // filtering for multi-parent packed batches (packed output violates the one-parent-
+    // per-batch contract the filter assumes).
     common::sel_t applyNbrNodeMask();
-    // Lazily (re-)evaluated per execution: which nbr masks are enabled, plus a
-    // single-table fast path. Masks are enabled once at map time, before execution.
     void refreshNbrMaskCache();
     std::shared_ptr<common::NodeOffsetMaskMap> nbrNodeMaskMap;
-    std::vector<std::pair<common::table_id_t, common::SemiMask*>> nbrEnabledMasks;
-    common::SemiMask* nbrSingleEnabledMask = nullptr;
 
     ScanRelTableInfo tableInfo;
     std::unique_ptr<storage::RelTableScanState> scanState;

--- a/src/include/processor/operator/scan/scan_rel_table.h
+++ b/src/include/processor/operator/scan/scan_rel_table.h
@@ -115,6 +115,7 @@ public:
                 children[0]->copy(), id, printInfo->copy(), operatorType);
         }
         result->multiParentPackedScanEnabled = multiParentPackedScanEnabled;
+        result->nbrNodeMaskMap = nbrNodeMaskMap;
         return result;
     }
 
@@ -134,7 +135,31 @@ protected:
 public:
     void setMultiParentPackedScanEnabled(bool enabled) { multiParentPackedScanEnabled = enabled; }
 
+    // Semi mask on the neighbour node (outVectors[0]). Created at map time for every
+    // extend that scans the nbr ID; enabled (populated) only when a hash-join SIP
+    // SemiMasker targets this operator. Shared across plan copies so every copy filters
+    // by the same masks, mirroring ScanNodeTableSharedState behaviour.
+    void setNbrNodeMaskMap(std::shared_ptr<common::NodeOffsetMaskMap> maskMap) {
+        nbrNodeMaskMap = std::move(maskMap);
+    }
+    common::table_id_map_t<common::SemiMask*> getNbrNodeMasks() const {
+        if (nbrNodeMaskMap == nullptr) {
+            return {};
+        }
+        return nbrNodeMaskMap->getMasks();
+    }
+
 protected:
+    // Filter the current scan output batch by the nbr node mask. Returns the number of
+    // rows surviving the filter (0 means the caller should keep scanning).
+    common::sel_t applyNbrNodeMask();
+    // Lazily (re-)evaluated per execution: which nbr masks are enabled, plus a
+    // single-table fast path. Masks are enabled once at map time, before execution.
+    void refreshNbrMaskCache();
+    std::shared_ptr<common::NodeOffsetMaskMap> nbrNodeMaskMap;
+    std::vector<std::pair<common::table_id_t, common::SemiMask*>> nbrEnabledMasks;
+    common::SemiMask* nbrSingleEnabledMask = nullptr;
+
     ScanRelTableInfo tableInfo;
     std::unique_ptr<storage::RelTableScanState> scanState;
     std::vector<storage::NodeTable*> sourceNodeTables;

--- a/src/include/processor/operator/scan/scan_table.h
+++ b/src/include/processor/operator/scan/scan_table.h
@@ -3,6 +3,7 @@
 #include <optional>
 
 #include "binder/expression/expression.h"
+#include "common/mask.h"
 #include "processor/operator/physical_operator.h"
 #include "storage/table/table.h"
 
@@ -110,6 +111,21 @@ public:
 
 protected:
     void initLocalStateInternal(ResultSet*, ExecutionContext*) override;
+
+    // Shared helpers for neighbour-node semi masks (SemiMaskTargetType::EXTEND_NBR_NODE),
+    // used by both ScanRelTable and ScanMultiRelTable. The mask map itself lives on the
+    // subclasses (created at map time for every extend that scans the nbr ID; enabled and
+    // populated by a hash-join SIP SemiMasker).
+    // Lazily (re-)evaluated per execution: which nbr masks are enabled, plus a single-table
+    // fast path. Masks are enabled once at map time, before execution.
+    void refreshNbrMasks(const common::NodeOffsetMaskMap* maskMap);
+    // Filter the current scan output batch by the nbr node mask (nbrVector is
+    // outVectors[0]). Returns the number of rows surviving the filter (0 means the caller
+    // should keep scanning); returns selSize untouched when no mask is enabled.
+    common::sel_t applyNbrMaskFilter(common::SelectionVector& selVector,
+        common::ValueVector* nbrVector) const;
+    std::vector<std::pair<common::table_id_t, common::SemiMask*>> nbrEnabledMasks;
+    common::SemiMask* nbrSingleEnabledMask = nullptr;
 
 protected:
     ScanOpInfo opInfo;

--- a/src/optimizer/acc_hash_join_optimizer.cpp
+++ b/src/optimizer/acc_hash_join_optimizer.cpp
@@ -2,7 +2,10 @@
 
 #include "binder/expression/expression_util.h"
 #include "catalog/catalog_entry/table_catalog_entry.h"
+#include "common/constants.h"
 #include "optimizer/logical_operator_collector.h"
+#include "planner/operator/extend/base_logical_extend.h"
+#include "planner/operator/extend/logical_extend.h"
 #include "planner/operator/extend/logical_recursive_extend.h"
 #include "planner/operator/logical_accumulate.h"
 #include "planner/operator/logical_hash_join.h"
@@ -41,6 +44,11 @@ static std::vector<table_id_t> getTableIDs(const LogicalOperator* op,
     switch (op->getOperatorType()) {
     case LogicalOperatorType::SCAN_NODE_TABLE: {
         return op->constCast<LogicalScanNodeTable>().getTableIDs();
+    }
+    case LogicalOperatorType::EXTEND:
+    case LogicalOperatorType::PACKED_EXTEND: {
+        DASSERT(targetType == SemiMaskTargetType::EXTEND_NBR_NODE);
+        return getTableIDs(op->constCast<BaseLogicalExtend>().getNbrNode()->getEntries());
     }
     case LogicalOperatorType::RECURSIVE_EXTEND: {
         auto& bindData = op->constCast<LogicalRecursiveExtend>().getBindData();
@@ -264,8 +272,47 @@ static std::vector<LogicalOperator*> getRecursiveExtendOutputNodeCandidates(
     return result;
 }
 
+// Find all (packed) extends under root whose neighbour node is parameter nodeID. The
+// neighbour IDs are produced by the rel scan, so a semi mask on them prunes the scan
+// itself instead of materializing every expanded edge. PACKED_EXTEND is not covered by
+// the operator visitor, hence the manual traversal.
+static void collectExtendNbrCandidates(const Expression& nodeID, LogicalOperator* root,
+    std::vector<LogicalOperator*>& result) {
+    auto type = root->getOperatorType();
+    if (type == LogicalOperatorType::EXTEND || type == LogicalOperatorType::PACKED_EXTEND) {
+        // LogicalPackedExtend derives from LogicalExtend, so this cast covers both.
+        auto& extend = root->constCast<LogicalExtend>();
+        // The mask filters outVectors[0], which only holds neighbour IDs when the
+        // extend scans them.
+        if (extend.shouldScanNbrID() &&
+            nodeID.getUniqueName() == extend.getNbrNode()->getInternalID()->getUniqueName()) {
+            result.push_back(root);
+        }
+    }
+    for (auto i = 0u; i < root->getNumChildren(); ++i) {
+        collectExtendNbrCandidates(nodeID, root->getChild(i).get(), result);
+    }
+}
+
+static bool sanityCheckExtendCandidates(const std::vector<LogicalOperator*>& ops) {
+    DASSERT(!ops.empty());
+    for (auto op : ops) {
+        auto type = op->getOperatorType();
+        if (type != LogicalOperatorType::EXTEND && type != LogicalOperatorType::PACKED_EXTEND) {
+            return false;
+        }
+    }
+    return haveSameTableIDs(ops, SemiMaskTargetType::EXTEND_NBR_NODE);
+}
+
+// Probe-to-build SIP materializes and rescans the probe side, which costs ~1ms even for
+// tiny probes. Only target build-side rel scans whose estimated output is large enough
+// to amortize that: a bounded chain expanding a few hundred edges is already cheap, so
+// masking it is pure overhead (e.g. a single-tag probe masking a 274-edge expand).
+static constexpr cardinality_t MIN_EXTEND_OUTPUT_FOR_PROBE_TO_BUILD_SIP = 10000;
+
 static std::shared_ptr<LogicalOperator> tryApplySemiMask(std::shared_ptr<Expression> nodeID,
-    std::shared_ptr<LogicalOperator> fromRoot, LogicalOperator* toRoot) {
+    std::shared_ptr<LogicalOperator> fromRoot, LogicalOperator* toRoot, bool isProbeToBuild) {
     // TODO(Xiyang): Check if a semi mask can/need to be applied to ScanNodeTable, RecursiveJoin &
     // GDS at the same time
     auto recursiveExtendInputNodeCandidates =
@@ -290,11 +337,34 @@ static std::shared_ptr<LogicalOperator> tryApplySemiMask(std::shared_ptr<Express
             recursiveExtendNodeCandidates, std::move(fromRoot));
     }
     auto scanNodeCandidates = getScanNodeCandidates(*nodeID, toRoot);
-    if (!scanNodeCandidates.empty()) {
-        return appendSemiMasker(SemiMaskKeyType::NODE, SemiMaskTargetType::SCAN_NODE,
-            std::move(nodeID), scanNodeCandidates, std::move(fromRoot));
+    std::vector<LogicalOperator*> extendNbrCandidates;
+    collectExtendNbrCandidates(*nodeID, toRoot, extendNbrCandidates);
+    if (isProbeToBuild) {
+        std::erase_if(extendNbrCandidates, [](const LogicalOperator* op) {
+            return op->getCardinality() < MIN_EXTEND_OUTPUT_FOR_PROBE_TO_BUILD_SIP;
+        });
     }
-    return nullptr;
+    if (scanNodeCandidates.empty() && extendNbrCandidates.empty()) {
+        return nullptr;
+    }
+    // Chain one masker per target kind; each masker passes its input through, so a
+    // single pass over fromRoot fills both the node-table and the rel-scan masks.
+    auto result = std::move(fromRoot);
+    auto hasSemiMaskApplied = false;
+    if (!scanNodeCandidates.empty()) {
+        result = appendSemiMasker(SemiMaskKeyType::NODE, SemiMaskTargetType::SCAN_NODE, nodeID,
+            scanNodeCandidates, std::move(result));
+        hasSemiMaskApplied = true;
+    }
+    if (!extendNbrCandidates.empty() && sanityCheckExtendCandidates(extendNbrCandidates)) {
+        result = appendSemiMasker(SemiMaskKeyType::NODE, SemiMaskTargetType::EXTEND_NBR_NODE,
+            nodeID, extendNbrCandidates, std::move(result));
+        hasSemiMaskApplied = true;
+    }
+    if (!hasSemiMaskApplied) {
+        return nullptr;
+    }
+    return result;
 }
 
 // The pushed limit is result-preserving only if every probe row matches exactly one build
@@ -330,7 +400,8 @@ static bool tryProbeToBuildHJSIP(LogicalOperator* op,
     auto buildRoot = hashJoin.getChild(1);
     auto hasSemiMaskApplied = false;
     for (auto& nodeID : hashJoin.getJoinNodeIDs()) {
-        auto newProbeRoot = tryApplySemiMask(nodeID, probeRoot, buildRoot.get());
+        auto newProbeRoot =
+            tryApplySemiMask(nodeID, probeRoot, buildRoot.get(), true /* isProbeToBuild */);
         if (newProbeRoot != nullptr) {
             probeRoot = newProbeRoot;
             hasSemiMaskApplied = true;
@@ -372,20 +443,33 @@ static bool isBuildSideQualified(LogicalOperator* buildRoot) {
     return op->getOperatorType() == LogicalOperatorType::RECURSIVE_EXTEND;
 }
 
+// A build without filters can still seed an effective semi mask when it is far smaller
+// than the probe side (e.g. a PK-anchored chain of a few thousand rows vs a multi-million
+// row probe scan): the mask then prunes the bulk of the probe scan. This mirrors the
+// planner's SIP_RATIO guard, which prohibits the reverse (probe-to-build) direction when
+// the probe outweighs the build by the same ratio.
+static bool isBuildSmallRelativeToProbe(LogicalOperator* op) {
+    auto& hashJoin = op->cast<LogicalHashJoin>();
+    const auto probeCard = hashJoin.getChild(0)->getCardinality();
+    const auto buildCard = hashJoin.getChild(1)->getCardinality();
+    return probeCard / PlannerKnobs::SIP_RATIO > buildCard;
+}
+
 static bool tryBuildToProbeHJSIP(LogicalOperator* op) {
     auto& hashJoin = op->cast<LogicalHashJoin>();
     if (hashJoin.getJoinType() != JoinType::INNER) {
         return false;
     }
     if (hashJoin.getSIPInfo().direction != SIPDirection::FORCE_BUILD_TO_PROBE &&
-        !isBuildSideQualified(op->getChild(1).get())) {
+        !isBuildSideQualified(op->getChild(1).get()) && !isBuildSmallRelativeToProbe(op)) {
         return false;
     }
     auto probeRoot = hashJoin.getChild(0);
     auto buildRoot = hashJoin.getChild(1);
     auto hasSemiMaskApplied = false;
     for (auto& nodeID : hashJoin.getJoinNodeIDs()) {
-        auto newBuildRoot = tryApplySemiMask(nodeID, buildRoot, probeRoot.get());
+        auto newBuildRoot =
+            tryApplySemiMask(nodeID, buildRoot, probeRoot.get(), false /* isProbeToBuild */);
         if (newBuildRoot != nullptr) {
             buildRoot = newBuildRoot;
             hasSemiMaskApplied = true;

--- a/src/processor/map/map_extend.cpp
+++ b/src/processor/map/map_extend.cpp
@@ -4,6 +4,7 @@
 #include "catalog/catalog.h"
 #include "common/constants.h"
 #include "common/enums/extend_direction_util.h"
+#include "common/mask.h"
 #include "main/attached_database.h"
 #include "main/client_context.h"
 #include "main/database_manager.h"
@@ -151,6 +152,24 @@ static bool scanSingleRelTable(const RelExpression& rel, const NodeExpression& b
            extendDirection != ExtendDirection::BOTH;
 }
 
+// Nbr-node semi masks backing hash-join SIP on extend output (SemiMaskTargetType::
+// EXTEND_NBR_NODE). One mask per nbr node table, filled by a SemiMasker on the other
+// side of the join. Unconditionally created (like ScanNodeTable masks) but left
+// disabled until a SemiMasker targets this extend; while disabled the scan ignores them.
+// No mask is created when the extend does not scan the nbr ID, since outVectors[0]
+// would not hold neighbour IDs to filter on.
+static std::shared_ptr<NodeOffsetMaskMap> createNbrNodeMaskMap(PlanMapper* mapper,
+    const NodeExpression& nbrNode, bool shouldScanNbrID) {
+    if (!shouldScanNbrID) {
+        return nullptr;
+    }
+    auto maskMap = std::make_shared<NodeOffsetMaskMap>();
+    for (auto tableID : nbrNode.getTableIDs()) {
+        maskMap->addMask(tableID, mapper->createSemiMask(tableID));
+    }
+    return maskMap;
+}
+
 static ScanNodeTableInfo getNodeTableScanInfo(const LogicalScanNodeTable& scan,
     storage::NodeTable* table, const catalog::TableCatalogEntry* tableEntry,
     main::ClientContext* clientContext) {
@@ -284,29 +303,40 @@ std::unique_ptr<PhysicalOperator> PlanMapper::mapExtend(const LogicalOperator* l
                     auto sourceNodeScanInfo =
                         ScanOpInfo(inNodeIDPos, std::move(sourceOutVectorsPos));
                     auto progressSharedState = std::make_shared<ScanNodeTableProgressSharedState>();
-                    return std::make_unique<ScanRelTable>(std::move(scanInfo),
-                        std::move(scanRelInfo), std::move(sourceNodeTableInfos),
-                        std::move(sourceNodeSharedStates), std::move(progressSharedState),
-                        std::move(sourceNodeScanInfo), getOperatorID(), printInfo->copy(),
-                        physicalOperatorType);
+                    auto scanRel =
+                        std::make_unique<ScanRelTable>(std::move(scanInfo), std::move(scanRelInfo),
+                            std::move(sourceNodeTableInfos), std::move(sourceNodeSharedStates),
+                            std::move(progressSharedState), std::move(sourceNodeScanInfo),
+                            getOperatorID(), printInfo->copy(), physicalOperatorType);
+                    scanRel->setNbrNodeMaskMap(
+                        createNbrNodeMaskMap(this, *nbrNode, extend->shouldScanNbrID()));
+                    return scanRel;
                 }
                 // Only apply the existing no-property optimization if scan node is not already
                 // mapped (e.g., by a semi-masker).
                 if (!sourceNodeTables.empty() &&
                     !logicalOpToPhysicalOpMap.contains(logicalOperator->getChild(0).get())) {
                     if (!scanNode->getProperties().empty()) {
-                        return std::make_unique<ScanRelTable>(std::move(scanInfo),
+                        auto scanRel = std::make_unique<ScanRelTable>(std::move(scanInfo),
                             std::move(scanRelInfo), std::move(prevOperator), getOperatorID(),
                             printInfo->copy(), physicalOperatorType);
+                        scanRel->setNbrNodeMaskMap(
+                            createNbrNodeMaskMap(this, *nbrNode, extend->shouldScanNbrID()));
+                        return scanRel;
                     }
-                    return std::make_unique<ScanRelTable>(std::move(scanInfo),
+                    auto sourceScanRel = std::make_unique<ScanRelTable>(std::move(scanInfo),
                         std::move(scanRelInfo), std::move(sourceNodeTables), getOperatorID(),
                         printInfo->copy(), physicalOperatorType);
+                    sourceScanRel->setNbrNodeMaskMap(
+                        createNbrNodeMaskMap(this, *nbrNode, extend->shouldScanNbrID()));
+                    return sourceScanRel;
                 }
             }
         }
-        return std::make_unique<ScanRelTable>(std::move(scanInfo), std::move(scanRelInfo),
+        auto scanRel = std::make_unique<ScanRelTable>(std::move(scanInfo), std::move(scanRelInfo),
             std::move(prevOperator), getOperatorID(), printInfo->copy(), physicalOperatorType);
+        scanRel->setNbrNodeMaskMap(createNbrNodeMaskMap(this, *nbrNode, extend->shouldScanNbrID()));
+        return scanRel;
     }
     // map to generic extend
     auto directionInfo = DirectionInfo();
@@ -333,9 +363,12 @@ std::unique_ptr<PhysicalOperator> PlanMapper::mapExtend(const LogicalOperator* l
             }
         }
     }
-    return std::make_unique<ScanMultiRelTable>(std::move(scanInfo), std::move(directionInfo),
-        std::move(scanners), std::move(prevOperator), getOperatorID(), printInfo->copy(),
-        physicalOperatorType);
+    auto scanMultiRel = std::make_unique<ScanMultiRelTable>(std::move(scanInfo),
+        std::move(directionInfo), std::move(scanners), std::move(prevOperator), getOperatorID(),
+        printInfo->copy(), physicalOperatorType);
+    scanMultiRel->setNbrNodeMaskMap(
+        createNbrNodeMaskMap(this, *nbrNode, extend->shouldScanNbrID()));
+    return scanMultiRel;
 }
 
 } // namespace processor

--- a/src/processor/map/map_semi_masker.cpp
+++ b/src/processor/map/map_semi_masker.cpp
@@ -1,7 +1,9 @@
 #include "function/gds/gds.h"
 #include "planner/operator/sip/logical_semi_masker.h"
 #include "processor/operator/recursive_extend.h"
+#include "processor/operator/scan/scan_multi_rel_tables.h"
 #include "processor/operator/scan/scan_node_table.h"
+#include "processor/operator/scan/scan_rel_table.h"
 #include "processor/operator/semi_masker.h"
 #include "processor/operator/table_function_call.h"
 #include "processor/plan_mapper.h"
@@ -46,6 +48,22 @@ std::unique_ptr<PhysicalOperator> PlanMapper::mapSemiMasker(
             DASSERT(semiMasker.getTargetType() == SemiMaskTargetType::SCAN_NODE);
             auto scan = physicalOp->ptrCast<ScanNodeTable>();
             initMask(masksPerTable, scan->getSemiMasks());
+        } break;
+        case PhysicalOperatorType::SCAN_REL_TABLE: {
+            DASSERT(semiMasker.getTargetType() == SemiMaskTargetType::EXTEND_NBR_NODE);
+            // ScanMultiRelTable shares the SCAN_REL_TABLE physical type; both
+            // expose nbr-node masks with identical semantics.
+            if (auto multiRel = dynamic_cast<ScanMultiRelTable*>(physicalOp)) {
+                initMask(masksPerTable, multiRel->getNbrNodeMasks());
+            } else {
+                auto scanRel = physicalOp->ptrCast<ScanRelTable>();
+                initMask(masksPerTable, scanRel->getNbrNodeMasks());
+            }
+        } break;
+        case PhysicalOperatorType::PACKED_EXTEND: {
+            DASSERT(semiMasker.getTargetType() == SemiMaskTargetType::EXTEND_NBR_NODE);
+            auto scanRel = physicalOp->ptrCast<ScanRelTable>();
+            initMask(masksPerTable, scanRel->getNbrNodeMasks());
         } break;
         case PhysicalOperatorType::TABLE_FUNCTION_CALL: {
             auto sharedState = physicalOp->ptrCast<TableFunctionCall>()->getSharedState();

--- a/src/processor/map/map_semi_masker.cpp
+++ b/src/processor/map/map_semi_masker.cpp
@@ -49,21 +49,20 @@ std::unique_ptr<PhysicalOperator> PlanMapper::mapSemiMasker(
             auto scan = physicalOp->ptrCast<ScanNodeTable>();
             initMask(masksPerTable, scan->getSemiMasks());
         } break;
-        case PhysicalOperatorType::SCAN_REL_TABLE: {
+        case PhysicalOperatorType::SCAN_REL_TABLE:
+        case PhysicalOperatorType::PACKED_EXTEND: {
             DASSERT(semiMasker.getTargetType() == SemiMaskTargetType::EXTEND_NBR_NODE);
-            // ScanMultiRelTable shares the SCAN_REL_TABLE physical type; both
-            // expose nbr-node masks with identical semantics.
+            // Both physical types map to either concrete class: mapExtend assigns
+            // SCAN_REL_TABLE to the generic (multi-rel) extend and PACKED_EXTEND to
+            // the packed one, so e.g. a multi-rel packed extend is a ScanMultiRelTable
+            // carrying the PACKED_EXTEND type. Dispatch on the concrete class rather
+            // than the physical type.
             if (auto multiRel = dynamic_cast<ScanMultiRelTable*>(physicalOp)) {
                 initMask(masksPerTable, multiRel->getNbrNodeMasks());
             } else {
                 auto scanRel = physicalOp->ptrCast<ScanRelTable>();
                 initMask(masksPerTable, scanRel->getNbrNodeMasks());
             }
-        } break;
-        case PhysicalOperatorType::PACKED_EXTEND: {
-            DASSERT(semiMasker.getTargetType() == SemiMaskTargetType::EXTEND_NBR_NODE);
-            auto scanRel = physicalOp->ptrCast<ScanRelTable>();
-            initMask(masksPerTable, scanRel->getNbrNodeMasks());
         } break;
         case PhysicalOperatorType::TABLE_FUNCTION_CALL: {
             auto sharedState = physicalOp->ptrCast<TableFunctionCall>()->getSharedState();

--- a/src/processor/operator/scan/scan_multi_rel_tables.cpp
+++ b/src/processor/operator/scan/scan_multi_rel_tables.cpp
@@ -61,57 +61,11 @@ bool RelTableCollectionScanner::scan(main::ClientContext* context, RelTableScanS
 }
 
 void ScanMultiRelTable::refreshNbrMaskCache() {
-    nbrEnabledMasks.clear();
-    nbrSingleEnabledMask = nullptr;
-    if (nbrNodeMaskMap == nullptr) {
-        return;
-    }
-    for (auto& [tableID, mask] : nbrNodeMaskMap->getMasks()) {
-        if (mask->isEnabled()) {
-            nbrEnabledMasks.emplace_back(tableID, mask);
-        }
-    }
-    if (nbrEnabledMasks.size() == 1) {
-        nbrSingleEnabledMask = nbrEnabledMasks[0].second;
-    }
+    refreshNbrMasks(nbrNodeMaskMap.get());
 }
 
 common::sel_t ScanMultiRelTable::applyNbrNodeMask() {
-    auto& selVector = scanState->outState->getSelVectorUnsafe();
-    const auto selSize = selVector.getSelSize();
-    if (nbrSingleEnabledMask == nullptr && nbrEnabledMasks.empty()) {
-        return selSize;
-    }
-    auto* nbrVector = outVectors[0];
-    auto buffer = selVector.getMutableBuffer();
-    sel_t selectedSize = 0;
-    if (nbrSingleEnabledMask != nullptr) {
-        for (auto i = 0u; i < selSize; ++i) {
-            auto pos = selVector[i];
-            buffer[selectedSize] = pos;
-            selectedSize +=
-                nbrSingleEnabledMask->isMasked(nbrVector->getValue<nodeID_t>(pos).offset);
-        }
-    } else {
-        for (auto i = 0u; i < selSize; ++i) {
-            auto pos = selVector[i];
-            auto nbrID = nbrVector->getValue<nodeID_t>(pos);
-            buffer[selectedSize] = pos;
-            auto keep = true;
-            for (auto& [tableID, mask] : nbrEnabledMasks) {
-                if (nbrID.tableID == tableID) {
-                    keep = mask->isMasked(nbrID.offset);
-                    break;
-                }
-            }
-            selectedSize += keep;
-        }
-    }
-    if (selectedSize == selSize) {
-        return selSize;
-    }
-    selVector.setToFiltered(selectedSize);
-    return selectedSize;
+    return applyNbrMaskFilter(scanState->outState->getSelVectorUnsafe(), outVectors[0]);
 }
 
 void ScanMultiRelTable::initLocalStateInternal(ResultSet* resultSet, ExecutionContext* context) {

--- a/src/processor/operator/scan/scan_multi_rel_tables.cpp
+++ b/src/processor/operator/scan/scan_multi_rel_tables.cpp
@@ -60,8 +60,63 @@ bool RelTableCollectionScanner::scan(main::ClientContext* context, RelTableScanS
     }
 }
 
+void ScanMultiRelTable::refreshNbrMaskCache() {
+    nbrEnabledMasks.clear();
+    nbrSingleEnabledMask = nullptr;
+    if (nbrNodeMaskMap == nullptr) {
+        return;
+    }
+    for (auto& [tableID, mask] : nbrNodeMaskMap->getMasks()) {
+        if (mask->isEnabled()) {
+            nbrEnabledMasks.emplace_back(tableID, mask);
+        }
+    }
+    if (nbrEnabledMasks.size() == 1) {
+        nbrSingleEnabledMask = nbrEnabledMasks[0].second;
+    }
+}
+
+common::sel_t ScanMultiRelTable::applyNbrNodeMask() {
+    auto& selVector = scanState->outState->getSelVectorUnsafe();
+    const auto selSize = selVector.getSelSize();
+    if (nbrSingleEnabledMask == nullptr && nbrEnabledMasks.empty()) {
+        return selSize;
+    }
+    auto* nbrVector = outVectors[0];
+    auto buffer = selVector.getMutableBuffer();
+    sel_t selectedSize = 0;
+    if (nbrSingleEnabledMask != nullptr) {
+        for (auto i = 0u; i < selSize; ++i) {
+            auto pos = selVector[i];
+            buffer[selectedSize] = pos;
+            selectedSize +=
+                nbrSingleEnabledMask->isMasked(nbrVector->getValue<nodeID_t>(pos).offset);
+        }
+    } else {
+        for (auto i = 0u; i < selSize; ++i) {
+            auto pos = selVector[i];
+            auto nbrID = nbrVector->getValue<nodeID_t>(pos);
+            buffer[selectedSize] = pos;
+            auto keep = true;
+            for (auto& [tableID, mask] : nbrEnabledMasks) {
+                if (nbrID.tableID == tableID) {
+                    keep = mask->isMasked(nbrID.offset);
+                    break;
+                }
+            }
+            selectedSize += keep;
+        }
+    }
+    if (selectedSize == selSize) {
+        return selSize;
+    }
+    selVector.setToFiltered(selectedSize);
+    return selectedSize;
+}
+
 void ScanMultiRelTable::initLocalStateInternal(ResultSet* resultSet, ExecutionContext* context) {
     ScanTable::initLocalStateInternal(resultSet, context);
+    refreshNbrMaskCache();
     auto clientContext = context->clientContext;
     boundNodeIDVector = resultSet->getValueVector(opInfo.nodeIDPos).get();
     auto nbrNodeIDVector = outVectors[0];
@@ -115,7 +170,11 @@ bool ScanMultiRelTable::getNextTuplesInternal(ExecutionContext* context) {
     while (true) {
         if (currentScanner != nullptr &&
             currentScanner->scan(context->clientContext, *scanState, outVectors)) {
-            metrics->numOutputTuple.increase(scanState->outState->getSelVector().getSelSize());
+            const auto filteredSize = applyNbrNodeMask();
+            if (filteredSize == 0) {
+                continue;
+            }
+            metrics->numOutputTuple.increase(filteredSize);
             return true;
         }
         if (!children[0]->getNextTuple(context)) {

--- a/src/processor/operator/scan/scan_rel_table.cpp
+++ b/src/processor/operator/scan/scan_rel_table.cpp
@@ -85,8 +85,64 @@ void ScanRelTableInfo::initScanState(TableScanState& scanState,
     initScanStateVectors(scanState, outVectors, MemoryManager::Get(*context));
 }
 
+void ScanRelTable::refreshNbrMaskCache() {
+    nbrEnabledMasks.clear();
+    nbrSingleEnabledMask = nullptr;
+    if (nbrNodeMaskMap == nullptr) {
+        return;
+    }
+    for (auto& [tableID, mask] : nbrNodeMaskMap->getMasks()) {
+        if (mask->isEnabled()) {
+            nbrEnabledMasks.emplace_back(tableID, mask);
+        }
+    }
+    if (nbrEnabledMasks.size() == 1) {
+        nbrSingleEnabledMask = nbrEnabledMasks[0].second;
+    }
+}
+
+common::sel_t ScanRelTable::applyNbrNodeMask() {
+    auto& selVector = scanState->outState->getSelVectorUnsafe();
+    const auto selSize = selVector.getSelSize();
+    if (multiParentPackedScanEnabled ||
+        (nbrSingleEnabledMask == nullptr && nbrEnabledMasks.empty())) {
+        return selSize;
+    }
+    auto* nbrVector = outVectors[0];
+    auto buffer = selVector.getMutableBuffer();
+    sel_t selectedSize = 0;
+    if (nbrSingleEnabledMask != nullptr) {
+        for (auto i = 0u; i < selSize; ++i) {
+            auto pos = selVector[i];
+            buffer[selectedSize] = pos;
+            selectedSize +=
+                nbrSingleEnabledMask->isMasked(nbrVector->getValue<nodeID_t>(pos).offset);
+        }
+    } else {
+        for (auto i = 0u; i < selSize; ++i) {
+            auto pos = selVector[i];
+            auto nbrID = nbrVector->getValue<nodeID_t>(pos);
+            buffer[selectedSize] = pos;
+            auto keep = true;
+            for (auto& [tableID, mask] : nbrEnabledMasks) {
+                if (nbrID.tableID == tableID) {
+                    keep = mask->isMasked(nbrID.offset);
+                    break;
+                }
+            }
+            selectedSize += keep;
+        }
+    }
+    if (selectedSize == selSize) {
+        return selSize;
+    }
+    selVector.setToFiltered(selectedSize);
+    return selectedSize;
+}
+
 void ScanRelTable::initLocalStateInternal(ResultSet* resultSet, ExecutionContext* context) {
     ScanTable::initLocalStateInternal(resultSet, context);
+    refreshNbrMaskCache();
     auto clientContext = context->clientContext;
     auto boundNodeIDVector = resultSet->getValueVector(opInfo.nodeIDPos).get();
     auto nbrNodeIDVector = outVectors[0];
@@ -257,9 +313,13 @@ bool ScanRelTable::getNextTuplesInternal(ExecutionContext* context) {
             while (tableInfo.table->scan(transaction, *scanState)) {
                 const auto outputSize = scanState->outState->getSelVector().getSelSize();
                 if (outputSize > 0) {
-                    updatePackedChildSlices(outputSize);
+                    const auto filteredSize = applyNbrNodeMask();
+                    if (filteredSize == 0) {
+                        continue;
+                    }
+                    updatePackedChildSlices(filteredSize);
                     tableInfo.castColumns();
-                    metrics->numOutputTuple.increase(outputSize);
+                    metrics->numOutputTuple.increase(filteredSize);
                     return true;
                 }
             }
@@ -272,9 +332,13 @@ bool ScanRelTable::getNextTuplesInternal(ExecutionContext* context) {
         while (tableInfo.table->scan(transaction, *scanState)) {
             const auto outputSize = scanState->outState->getSelVector().getSelSize();
             if (outputSize > 0) {
-                updatePackedChildSlices(outputSize);
+                const auto filteredSize = applyNbrNodeMask();
+                if (filteredSize == 0) {
+                    continue;
+                }
+                updatePackedChildSlices(filteredSize);
                 tableInfo.castColumns();
-                metrics->numOutputTuple.increase(outputSize);
+                metrics->numOutputTuple.increase(filteredSize);
                 return true;
             }
         }

--- a/src/processor/operator/scan/scan_rel_table.cpp
+++ b/src/processor/operator/scan/scan_rel_table.cpp
@@ -86,58 +86,14 @@ void ScanRelTableInfo::initScanState(TableScanState& scanState,
 }
 
 void ScanRelTable::refreshNbrMaskCache() {
-    nbrEnabledMasks.clear();
-    nbrSingleEnabledMask = nullptr;
-    if (nbrNodeMaskMap == nullptr) {
-        return;
-    }
-    for (auto& [tableID, mask] : nbrNodeMaskMap->getMasks()) {
-        if (mask->isEnabled()) {
-            nbrEnabledMasks.emplace_back(tableID, mask);
-        }
-    }
-    if (nbrEnabledMasks.size() == 1) {
-        nbrSingleEnabledMask = nbrEnabledMasks[0].second;
-    }
+    refreshNbrMasks(nbrNodeMaskMap.get());
 }
 
 common::sel_t ScanRelTable::applyNbrNodeMask() {
-    auto& selVector = scanState->outState->getSelVectorUnsafe();
-    const auto selSize = selVector.getSelSize();
-    if (multiParentPackedScanEnabled ||
-        (nbrSingleEnabledMask == nullptr && nbrEnabledMasks.empty())) {
-        return selSize;
+    if (multiParentPackedScanEnabled) {
+        return scanState->outState->getSelVector().getSelSize();
     }
-    auto* nbrVector = outVectors[0];
-    auto buffer = selVector.getMutableBuffer();
-    sel_t selectedSize = 0;
-    if (nbrSingleEnabledMask != nullptr) {
-        for (auto i = 0u; i < selSize; ++i) {
-            auto pos = selVector[i];
-            buffer[selectedSize] = pos;
-            selectedSize +=
-                nbrSingleEnabledMask->isMasked(nbrVector->getValue<nodeID_t>(pos).offset);
-        }
-    } else {
-        for (auto i = 0u; i < selSize; ++i) {
-            auto pos = selVector[i];
-            auto nbrID = nbrVector->getValue<nodeID_t>(pos);
-            buffer[selectedSize] = pos;
-            auto keep = true;
-            for (auto& [tableID, mask] : nbrEnabledMasks) {
-                if (nbrID.tableID == tableID) {
-                    keep = mask->isMasked(nbrID.offset);
-                    break;
-                }
-            }
-            selectedSize += keep;
-        }
-    }
-    if (selectedSize == selSize) {
-        return selSize;
-    }
-    selVector.setToFiltered(selectedSize);
-    return selectedSize;
+    return applyNbrMaskFilter(scanState->outState->getSelVectorUnsafe(), outVectors[0]);
 }
 
 void ScanRelTable::initLocalStateInternal(ResultSet* resultSet, ExecutionContext* context) {

--- a/src/processor/operator/scan/scan_table.cpp
+++ b/src/processor/operator/scan/scan_table.cpp
@@ -3,7 +3,6 @@
 #include "binder/expression/scalar_function_expression.h"
 #include "common/json_utils.h"
 #include "common/vector/value_vector.h"
-
 using namespace lbug::common;
 using namespace lbug::storage;
 
@@ -84,6 +83,59 @@ void ScanTableInfo::initScanStateVectors(TableScanState& scanState,
             scanState.outputVectors.push_back(caster.getVectorBeforeCasting());
         }
     }
+}
+
+void ScanTable::refreshNbrMasks(const common::NodeOffsetMaskMap* maskMap) {
+    nbrEnabledMasks.clear();
+    nbrSingleEnabledMask = nullptr;
+    if (maskMap == nullptr) {
+        return;
+    }
+    for (auto& [tableID, mask] : maskMap->getMasks()) {
+        if (mask->isEnabled()) {
+            nbrEnabledMasks.emplace_back(tableID, mask);
+        }
+    }
+    if (nbrEnabledMasks.size() == 1) {
+        nbrSingleEnabledMask = nbrEnabledMasks[0].second;
+    }
+}
+
+common::sel_t ScanTable::applyNbrMaskFilter(common::SelectionVector& selVector,
+    common::ValueVector* nbrVector) const {
+    const auto selSize = selVector.getSelSize();
+    if (nbrSingleEnabledMask == nullptr && nbrEnabledMasks.empty()) {
+        return selSize;
+    }
+    auto buffer = selVector.getMutableBuffer();
+    sel_t selectedSize = 0;
+    if (nbrSingleEnabledMask != nullptr) {
+        for (auto i = 0u; i < selSize; ++i) {
+            auto pos = selVector[i];
+            buffer[selectedSize] = pos;
+            selectedSize +=
+                nbrSingleEnabledMask->isMasked(nbrVector->getValue<nodeID_t>(pos).offset);
+        }
+    } else {
+        for (auto i = 0u; i < selSize; ++i) {
+            auto pos = selVector[i];
+            auto nbrID = nbrVector->getValue<nodeID_t>(pos);
+            buffer[selectedSize] = pos;
+            auto keep = true;
+            for (auto& [tableID, mask] : nbrEnabledMasks) {
+                if (nbrID.tableID == tableID) {
+                    keep = mask->isMasked(nbrID.offset);
+                    break;
+                }
+            }
+            selectedSize += keep;
+        }
+    }
+    if (selectedSize == selSize) {
+        return selSize;
+    }
+    selVector.setToFiltered(selectedSize);
+    return selectedSize;
 }
 
 void ScanTable::initLocalStateInternal(ResultSet*, ExecutionContext*) {

--- a/src/storage/table/node_group.cpp
+++ b/src/storage/table/node_group.cpp
@@ -219,11 +219,15 @@ NodeGroupScanResult NodeGroup::scan(const Transaction* transaction, TableScanSta
     }
     bool enableSemiMask =
         state.source == TableScanSource::COMMITTED && state.semiMask && state.semiMask->isEnabled();
+    const auto startNodeOffset = nodeGroupScanState.nextRowToScan +
+                                 StorageUtils::getStartOffsetOfNodeGroup(state.nodeGroupIdx);
     if (enableSemiMask) {
-        const auto startNodeOffset = nodeGroupScanState.nextRowToScan +
-                                     StorageUtils::getStartOffsetOfNodeGroup(state.nodeGroupIdx);
-        NodeTable::applySemiMaskFilter(state, startNodeOffset, numRowsToScan,
-            state.outState->getSelVectorUnsafe());
+        // Cheap chunk pre-check: skip column I/O entirely when the chunk holds no masked
+        // row. Reset the selection first: it still holds the previous chunk's (possibly
+        // filtered) state, which applySemiMaskFilter would otherwise intersect with.
+        auto& selVector = state.outState->getSelVectorUnsafe();
+        selVector.setToUnfiltered(numRowsToScan);
+        NodeTable::applySemiMaskFilter(state, startNodeOffset, numRowsToScan, selVector);
         if (state.outState->getSelVector().getSelSize() == 0) {
             state.nodeGroupScanState->nextRowToScan += numRowsToScan;
             return NodeGroupScanResult{nodeGroupScanState.nextRowToScan, 0};
@@ -233,6 +237,18 @@ NodeGroupScanResult NodeGroup::scan(const Transaction* transaction, TableScanSta
         numRowsToScan);
     const auto startRow = nodeGroupScanState.nextRowToScan;
     nodeGroupScanState.nextRowToScan += numRowsToScan;
+    if (enableSemiMask) {
+        // The chunk scan above resets the selection (visibility/zonemap), discarding the
+        // pre-check's subset. Intersect the mask with the surviving rows so only masked
+        // rows are materialized instead of the whole chunk. Like the pre-check above,
+        // report an empty chunk as {nextRow, 0} (not EMPTY) so the caller keeps scanning
+        // the rest of the node group.
+        NodeTable::applySemiMaskFilter(state, startNodeOffset, numRowsToScan,
+            state.outState->getSelVectorUnsafe());
+        if (state.outState->getSelVector().getSelSize() == 0) {
+            return NodeGroupScanResult{nodeGroupScanState.nextRowToScan, 0};
+        }
+    }
     return NodeGroupScanResult{startRow, numRowsToScan};
 }
 
@@ -240,23 +256,42 @@ NodeGroupScanResult NodeGroup::scan(Transaction* transaction, TableScanState& st
     offset_t startOffsetInGroup, offset_t numRowsToScan) const {
     bool enableSemiMask =
         state.source == TableScanSource::COMMITTED && state.semiMask && state.semiMask->isEnabled();
+    const auto startNodeOffset =
+        startOffsetInGroup + StorageUtils::getStartOffsetOfNodeGroup(state.nodeGroupIdx);
     if (enableSemiMask) {
-        const auto startNodeOffset =
-            startOffsetInGroup + StorageUtils::getStartOffsetOfNodeGroup(state.nodeGroupIdx);
-        NodeTable::applySemiMaskFilter(state, startNodeOffset, numRowsToScan,
-            state.outState->getSelVectorUnsafe());
+        // See the sequential overload above: reset the selection first so the chunk
+        // pre-check does not intersect with a stale selection, then skip column I/O
+        // when the range holds no masked row.
+        auto& selVector = state.outState->getSelVectorUnsafe();
+        selVector.setToUnfiltered(numRowsToScan);
+        NodeTable::applySemiMaskFilter(state, startNodeOffset, numRowsToScan, selVector);
         if (state.outState->getSelVector().getSelSize() == 0) {
             state.nodeGroupScanState->nextRowToScan += numRowsToScan;
             return NodeGroupScanResult{state.nodeGroupScanState->nextRowToScan, 0};
         }
     }
+    NodeGroupScanResult scanResult;
     if (state.outputVectors.size() == 0) {
         DASSERT(scanInternal(chunkedGroups.lock(), transaction, state, startOffsetInGroup,
                     numRowsToScan) == NodeGroupScanResult(startOffsetInGroup, numRowsToScan));
-        return NodeGroupScanResult{startOffsetInGroup, numRowsToScan};
+        scanResult = NodeGroupScanResult{startOffsetInGroup, numRowsToScan};
+    } else {
+        scanResult = scanInternal(chunkedGroups.lock(), transaction, state, startOffsetInGroup,
+            numRowsToScan);
     }
-    return scanInternal(chunkedGroups.lock(), transaction, state, startOffsetInGroup,
-        numRowsToScan);
+    // With no output vectors no chunk scan populates the selection, so the pre-check's
+    // subset above stands as is.
+    if (enableSemiMask && !state.outputVectors.empty()) {
+        // scanInternal resets the selection; intersect the mask with the surviving rows.
+        // Only the actually scanned prefix (scanResult.numRows) is valid: the requested
+        // range may span chunked groups while a single call scans the first one.
+        NodeTable::applySemiMaskFilter(state, startNodeOffset, scanResult.numRows,
+            state.outState->getSelVectorUnsafe());
+        if (state.outState->getSelVector().getSelSize() == 0) {
+            return NodeGroupScanResult{state.nodeGroupScanState->nextRowToScan, 0};
+        }
+    }
+    return scanResult;
 }
 
 NodeGroupScanResult NodeGroup::scanInternal(const UniqLock& lock, Transaction* transaction,

--- a/src/storage/table/node_group.cpp
+++ b/src/storage/table/node_group.cpp
@@ -279,12 +279,13 @@ NodeGroupScanResult NodeGroup::scan(Transaction* transaction, TableScanState& st
         scanResult = scanInternal(chunkedGroups.lock(), transaction, state, startOffsetInGroup,
             numRowsToScan);
     }
-    // With no output vectors no chunk scan populates the selection, so the pre-check's
-    // subset above stands as is.
-    if (enableSemiMask && !state.outputVectors.empty()) {
-        // scanInternal resets the selection; intersect the mask with the surviving rows.
-        // Only the actually scanned prefix (scanResult.numRows) is valid: the requested
-        // range may span chunked groups while a single call scans the first one.
+    // scanInternal resets the selection (visibility/zonemap), clobbering the pre-check's
+    // subset even when outputVectors is empty (the anchor sel vector is rewritten before
+    // the column loop). Intersect the mask with the surviving rows in all cases so only
+    // masked rows are reported. Only the actually scanned prefix (scanResult.numRows) is
+    // valid: the requested range may span chunked groups while a single call scans the
+    // first one.
+    if (enableSemiMask) {
         NodeTable::applySemiMaskFilter(state, startNodeOffset, scanResult.numRows,
             state.outState->getSelVectorUnsafe());
         if (state.outState->getSelVector().getSelSize() == 0) {


### PR DESCRIPTION
Implements the semi-mask SIP optimization from the LDBC analysis: let a small leg mask a large leg during scans so big intermediate results are never materialized.

## What

**1. Extend-side semi masks (`EXTEND_NBR_NODE`)** — the SIP optimizer previously only targeted `SCAN_NODE_TABLE`, so a join leg like `SCAN Place -> EXPAND Comment` (2M edges) could never be pruned. New target type + candidate collection over `EXTEND`/`PACKED_EXTEND` (nbr node = join key), with masks owned by `ScanRelTable`/`ScanMultiRelTable` (created at map time, wired in `mapSemiMasker`, filtered per output batch with a single-table fast path).

**2. Small-build qualification** — `tryBuildToProbeHJSIP` required a filter/index/recursive op on the build side, so selective PK-anchored chains (e.g. 3229 Berlin comments vs 2M probe scan) never seeded masks. Falls back to a cardinality check mirroring the planner's `SIP_RATIO` intent (`probe/5 > build`), INNER joins only.

**3. Row-level node-table masks** — `ChunkedNodeGroup::scan` resets the selection vector, discarding the pre-scan mask subset: chunks with >=1 masked row were emitted whole (measured 287x2048 / 688x2048 exact multiples). The mask now also intersects post-scan (plus a state-independent pre-check), so e.g. q12's probe emits exactly 3229 rows instead of 1.4M.

**4. Probe-to-build guard** — skip extend targets whose estimated output is < 10k rows; materializing + rescanning the probe to prune an already-cheap bounded chain (q7: 1-row probe, 274-edge expand) is pure overhead.

## Measured (LDBC SF1, medians of 5, post-ANALYZE)

   | Query | 0.20.4 (ms) | Local engine (ms) | Speedup |
   |-------|-------------|-------------------|---------|
   | q10 | 47.91 | 4.56 | 10.5x |
   | q7 | 81.18 | 9.04 | 9.0x |
   | q13 | 83.73 | 14.67 | 5.7x |
   | q30 | 737.43 | 178.42 | 4.1x |
   | q12 | 42.06 | 14.28 | 2.9x |
   | q19 | 30.60 | 12.80 | 2.4x |
   | q22 | 41.57 | 23.41 | 1.8x |
   | q27 | 30.07 | 20.01 | 1.5x |
   | q1 | 3.68 | 2.53 | 1.45x |
   | q11 | 18.04 | 12.90 | 1.4x |

All 30 LDBC queries return identical results to baseline (verified against `graph-benchmark-ldbc` expectations). Will validate in CI.