### PR TITLE
Fix Windows-only CardinalityTest and WalTest failures

### DIFF
--- a/src/common/file_system/local_file_system.cpp
+++ b/src/common/file_system/local_file_system.cpp
@@ -118,8 +118,17 @@ std::unique_ptr<FileInfo> LocalFileSystem::openFile(const std::string& path, Fil
         DWORD dwFlags = flags.lockType == FileLockType::READ_LOCK ?
                             LOCKFILE_FAIL_IMMEDIATELY :
                             LOCKFILE_FAIL_IMMEDIATELY | LOCKFILE_EXCLUSIVE_LOCK;
+        // Lock a single byte near INT64_MAX, far beyond any data page. Locking byte 0
+        // overlaps the database header/first page, so on Windows (mandatory locking) a second
+        // handle in the same process (e.g. a read-only Database opened while the read-write
+        // Database is still alive, as in WalTest.LargeWALRecordReplayWithPreviousDBAlive)
+        // fails reads with ERROR_LOCK_VIOLATION (33) even though POSIX fcntl locks (per-process)
+        // allow same-process shared access. Locking outside the data range preserves mutual
+        // exclusion at open time (both sides lock the same byte) without blocking I/O at
+        // offsets 0..filesize.
         OVERLAPPED overlapped = {};
-        overlapped.Offset = 0;
+        overlapped.Offset = 0xFFFFFFFE;
+        overlapped.OffsetHigh = 0x7FFFFFFF;
         BOOL rc = LockFileEx(handle, dwFlags, 0 /*reserved*/, 1 /*numBytesLow*/, 0 /*numBytesHigh*/,
             &overlapped);
         if (!rc) {

--- a/src/processor/map/map_aggregate.cpp
+++ b/src/processor/map/map_aggregate.cpp
@@ -1,3 +1,5 @@
+#include <algorithm>
+
 #include "binder/expression/aggregate_function_expression.h"
 #include "binder/expression/literal_expression.h"
 #include "binder/expression/scalar_function_expression.h"
@@ -215,6 +217,29 @@ static std::unique_ptr<PhysicalOperator> tryMapPackedFilteredCount(PlanMapper& m
         return nullptr;
     }
     const auto keyGroupPos = packedChildSchema->getGroupPos(*key);
+    // The GROUP BY key must live in one of the predicate's groups (the parent/bound group).
+    // Otherwise fall back to the regular aggregate plan.
+    if (!dependentGroups.contains(keyGroupPos)) {
+        return nullptr;
+    }
+    // Match predicate inputs to parent/child groups deterministically. ADD is commutative so
+    // its child order does not reliably indicate which input belongs to the parent (bound)
+    // vs child (nbr) chunk; binder/planner normalization can surface them in different orders
+    // on different STLs (MSVC vs libstdc++). Resolve via the schema instead: the input in the
+    // key (parent) group is lhs, the other is rhs.
+    const auto firstGroupPos = packedChildSchema->getGroupPos(*predicateInputs->first);
+    const auto secondGroupPos = packedChildSchema->getGroupPos(*predicateInputs->second);
+    std::shared_ptr<Expression> lhsExpr;
+    std::shared_ptr<Expression> rhsExpr;
+    if (firstGroupPos == keyGroupPos && secondGroupPos != keyGroupPos) {
+        lhsExpr = predicateInputs->first;
+        rhsExpr = predicateInputs->second;
+    } else if (secondGroupPos == keyGroupPos && firstGroupPos != keyGroupPos) {
+        lhsExpr = predicateInputs->second;
+        rhsExpr = predicateInputs->first;
+    } else {
+        return nullptr;
+    }
     std::vector<data_chunk_pos_t> multiplicityChunks;
     for (auto groupPos : packedChildSchema->getGroupsPosInScope()) {
         if (groupPos == keyGroupPos || dependentGroups.contains(groupPos) ||
@@ -223,15 +248,19 @@ static std::unique_ptr<PhysicalOperator> tryMapPackedFilteredCount(PlanMapper& m
         }
         multiplicityChunks.push_back(groupPos);
     }
+    std::sort(multiplicityChunks.begin(), multiplicityChunks.end());
+    // Sort for cross-platform determinism: unordered_set iteration order differs between MSVC
+    // and libstdc++, which otherwise yields different select/flat assignments and plans.
     std::vector<data_chunk_pos_t> dependentGroupsVector{dependentGroups.begin(),
         dependentGroups.end()};
+    std::sort(dependentGroupsVector.begin(), dependentGroupsVector.end());
     auto sharedState = std::make_shared<PackedFilteredCountSharedState>();
     auto info = PackedFilteredCountInfo{DataPos{packedChildSchema->getExpressionPos(*key)},
         DataPos{agg.getSchema()->getExpressionPos(*key)},
         DataPos{agg.getSchema()->getExpressionPos(*aggregate)},
-        DataPos{packedChildSchema->getExpressionPos(*predicateInputs->first)},
-        DataPos{packedChildSchema->getExpressionPos(*predicateInputs->second)},
-        dependentGroupsVector[0], dependentGroupsVector[1], std::move(multiplicityChunks)};
+        DataPos{packedChildSchema->getExpressionPos(*lhsExpr)},
+        DataPos{packedChildSchema->getExpressionPos(*rhsExpr)}, dependentGroupsVector[0],
+        dependentGroupsVector[1], std::move(multiplicityChunks)};
     auto packedChildPhysicalOp = mapper.mapOperator(packedChild);
     // Enable multi-parent packed batches on the underlying rel scan (if it is a single-table
     // ScanRelTable): PackedFilteredCount is packed-aware and consumes the PackedChildSlices


### PR DESCRIPTION
Fixes the two Windows-only failures from run 34680716229:

- `CardinalityTest.TestMultiParentPackedScan`: `tryMapPackedFilteredCount` assigned lhs/rhs from ADD child order, which can differ between MSVC and libstdc++ STLs. Resolve predicate inputs to parent/child groups via the schema (input in the GROUP BY key group is lhs) and fall back to the regular aggregate plan when ambiguous. Also sort group vectors for cross-platform deterministic plans.
- `WalTest.LargeWALRecordReplayWithPreviousDBAlive`: on Windows, locking byte 0 overlaps the DB header, so a second same-process read-only handle fails reads with ERROR_LOCK_VIOLATION (33). POSIX fcntl locks are per-process, but Windows LockFileEx is per-handle/mandatory. Lock a byte near INT64_MAX instead, preserving mutual exclusion at open time without blocking I/O at data offsets.