### PR TITLE
Fix UBSan failures and TSan fixture gap from nightly sanitizer run

### DIFF
--- a/.github/workflows/nightly-sanitizers.yml
+++ b/.github/workflows/nightly-sanitizers.yml
@@ -35,6 +35,8 @@ jobs:
 
       - name: Build (RelWithDebInfo, ASan+UBSan)
         run: BM_MALLOC=1 ASAN=1 UBSAN=1 make relwithdebinfo NUM_THREADS=$(nproc)
+      - name: Generate test fixtures
+        run: uv run --with pyarrow python3 scripts/generate-dictionary-bug-fixture.py
       - name: Test
         run: BM_MALLOC=1 ASAN=1 UBSAN=1 make test NUM_THREADS=$(nproc)
         env:
@@ -67,6 +69,8 @@ jobs:
 
       - name: Build (RelWithDebInfo, TSan)
         run: BM_MALLOC=1 TSAN=1 make relwithdebinfo NUM_THREADS=$(nproc)
+      - name: Generate test fixtures
+        run: uv run --with pyarrow python3 scripts/generate-dictionary-bug-fixture.py
       - name: Test
         run: BM_MALLOC=1 TSAN=1 make test NUM_THREADS=$(nproc)
         env:

--- a/src/common/types/value/value.cpp
+++ b/src/common/types/value/value.cpp
@@ -347,6 +347,8 @@ Value::Value(const Value& other) : isNull_{other.isNull_} {
 }
 
 void Value::copyFromRowLayout(const uint8_t* value) {
+    // Row-layout buffers are packed without alignment padding, so all multi-byte
+    // loads must go through memcpy to stay UBSan-clean (misaligned access is UB).
     switch (dataType.getLogicalTypeID()) {
     case LogicalTypeID::SERIAL:
     case LogicalTypeID::TIMESTAMP_NS:
@@ -355,86 +357,96 @@ void Value::copyFromRowLayout(const uint8_t* value) {
     case LogicalTypeID::TIMESTAMP_TZ:
     case LogicalTypeID::TIMESTAMP:
     case LogicalTypeID::INT64: {
-        val.int64Val = *((int64_t*)value);
+        memcpy(&val.int64Val, value, sizeof(int64_t));
     } break;
     case LogicalTypeID::DATE:
     case LogicalTypeID::INT32: {
-        val.int32Val = *((int32_t*)value);
+        memcpy(&val.int32Val, value, sizeof(int32_t));
     } break;
     case LogicalTypeID::INT16: {
-        val.int16Val = *((int16_t*)value);
+        memcpy(&val.int16Val, value, sizeof(int16_t));
     } break;
     case LogicalTypeID::INT8: {
-        val.int8Val = *((int8_t*)value);
+        memcpy(&val.int8Val, value, sizeof(int8_t));
     } break;
     case LogicalTypeID::UINT64: {
-        val.uint64Val = *((uint64_t*)value);
+        memcpy(&val.uint64Val, value, sizeof(uint64_t));
     } break;
     case LogicalTypeID::UINT32: {
-        val.uint32Val = *((uint32_t*)value);
+        memcpy(&val.uint32Val, value, sizeof(uint32_t));
     } break;
     case LogicalTypeID::UINT16: {
-        val.uint16Val = *((uint16_t*)value);
+        memcpy(&val.uint16Val, value, sizeof(uint16_t));
     } break;
     case LogicalTypeID::UINT8: {
-        val.uint8Val = *((uint8_t*)value);
+        memcpy(&val.uint8Val, value, sizeof(uint8_t));
     } break;
     case LogicalTypeID::INT128: {
-        val.int128Val = *((int128_t*)value);
+        memcpy(&val.int128Val, value, sizeof(int128_t));
     } break;
     case LogicalTypeID::BOOL: {
-        val.booleanVal = *((bool*)value);
+        memcpy(&val.booleanVal, value, sizeof(bool));
     } break;
     case LogicalTypeID::DOUBLE: {
-        val.doubleVal = *((double*)value);
+        memcpy(&val.doubleVal, value, sizeof(double));
     } break;
     case LogicalTypeID::FLOAT: {
-        val.floatVal = *((float*)value);
+        memcpy(&val.floatVal, value, sizeof(float));
     } break;
     case LogicalTypeID::DECIMAL: {
         switch (dataType.getPhysicalType()) {
         case PhysicalTypeID::INT16:
-            val.int16Val = (*(int16_t*)value);
+            memcpy(&val.int16Val, value, sizeof(int16_t));
             break;
         case PhysicalTypeID::INT32:
-            val.int32Val = (*(int32_t*)value);
+            memcpy(&val.int32Val, value, sizeof(int32_t));
             break;
         case PhysicalTypeID::INT64:
-            val.int64Val = (*(int64_t*)value);
+            memcpy(&val.int64Val, value, sizeof(int64_t));
             break;
         case PhysicalTypeID::INT128:
-            val.int128Val = (*(int128_t*)value);
+            memcpy(&val.int128Val, value, sizeof(int128_t));
             break;
         default:
             UNREACHABLE_CODE;
         }
     } break;
     case LogicalTypeID::INTERVAL: {
-        val.intervalVal = *((interval_t*)value);
+        memcpy(&val.intervalVal, value, sizeof(interval_t));
     } break;
     case LogicalTypeID::INTERNAL_ID: {
-        val.internalIDVal = *((nodeID_t*)value);
+        memcpy(&val.internalIDVal, value, sizeof(nodeID_t));
     } break;
     case LogicalTypeID::UINT128: {
-        val.uint128Val = *((uint128_t*)value);
+        memcpy(&val.uint128Val, value, sizeof(uint128_t));
     } break;
     case LogicalTypeID::BLOB: {
-        strVal = ((blob_t*)value)->value.getAsString();
+        blob_t blob;
+        memcpy(&blob, value, sizeof(blob_t));
+        strVal = blob.value.getAsString();
     } break;
     case LogicalTypeID::UUID: {
-        val.int128Val = ((uuid*)value)->value;
-        strVal = UUID::toString(*((uuid*)value));
+        uuid uuidVal;
+        memcpy(&uuidVal, value, sizeof(uuid));
+        val.int128Val = uuidVal.value;
+        strVal = UUID::toString(uuidVal);
     } break;
     case LogicalTypeID::JSON:
     case LogicalTypeID::STRING: {
-        strVal = ((string_t*)value)->getAsString();
+        string_t str;
+        memcpy(&str, value, sizeof(string_t));
+        strVal = str.getAsString();
     } break;
     case LogicalTypeID::MAP:
     case LogicalTypeID::LIST: {
-        copyFromRowLayoutList(*(list_t*)value, ListType::getChildType(dataType));
+        list_t list;
+        memcpy(&list, value, sizeof(list_t));
+        copyFromRowLayoutList(list, ListType::getChildType(dataType));
     } break;
     case LogicalTypeID::ARRAY: {
-        copyFromRowLayoutList(*(list_t*)value, ArrayType::getChildType(dataType));
+        list_t list;
+        memcpy(&list, value, sizeof(list_t));
+        copyFromRowLayoutList(list, ArrayType::getChildType(dataType));
     } break;
     case LogicalTypeID::UNION: {
         copyFromUnion(value);
@@ -446,7 +458,7 @@ void Value::copyFromRowLayout(const uint8_t* value) {
         copyFromRowLayoutStruct(value);
     } break;
     case LogicalTypeID::POINTER: {
-        val.pointer = *((uint8_t**)value);
+        memcpy(&val.pointer, value, sizeof(uint8_t*));
     } break;
     default:
         UNREACHABLE_CODE;
@@ -757,7 +769,9 @@ void Value::copyFromUnion(const uint8_t* unionValue) {
     auto unionValues = unionNullValues + NullBuffer::getNumBytesForNullValues(childrenTypes.size());
     // For union dataType, only one member can be active at a time. So we don't need to copy all
     // union fields into value.
-    auto activeFieldIdx = UnionType::getInternalFieldIdx(*(union_field_idx_t*)unionValues);
+    union_field_idx_t tag;
+    memcpy(&tag, unionValues, sizeof(union_field_idx_t));
+    auto activeFieldIdx = UnionType::getInternalFieldIdx(tag);
     // Create default value now that we know the active field
     auto childValue = Value::createDefaultValue(*childrenTypes[activeFieldIdx]);
     auto curMemberIdx = 0u;

--- a/src/common/vector/value_vector.cpp
+++ b/src/common/vector/value_vector.cpp
@@ -100,7 +100,11 @@ void ValueVector::copyFromRowData(uint32_t pos, const uint8_t* rowData) {
     } break;
     case PhysicalTypeID::STRING:
     case PhysicalTypeID::JSON: {
-        StringVector::addString(this, pos, *(string_t*)rowData);
+        // Row-layout data is packed without alignment padding, so rowData may be
+        // misaligned for string_t (8-byte aligned). Copy to an aligned temporary.
+        string_t srcStr;
+        memcpy(&srcStr, rowData, sizeof(string_t));
+        StringVector::addString(this, pos, srcStr);
     } break;
     default: {
         auto dataTypeSize = LogicalTypeUtils::getRowLayoutSize(dataType);
@@ -568,7 +572,9 @@ void StringVector::addString(lbug::common::ValueVector* vector, string_t& dstStr
 void StringVector::copyToRowData(const ValueVector* vector, uint32_t pos, uint8_t* rowData,
     InMemOverflowBuffer* rowOverflowBuffer) {
     auto& srcStr = vector->getValue<string_t>(pos);
-    auto& dstStr = *(string_t*)rowData;
+    // rowData is packed without alignment guarantees; build an aligned temporary
+    // and memcpy it out to avoid misaligned string_t access (UBSan).
+    string_t dstStr;
     if (string_t::isShortString(srcStr.len)) {
         dstStr.setShortString(srcStr);
     } else {
@@ -576,6 +582,7 @@ void StringVector::copyToRowData(const ValueVector* vector, uint32_t pos, uint8_
             reinterpret_cast<uint64_t>(rowOverflowBuffer->allocateSpace(srcStr.len));
         dstStr.setLongString(srcStr);
     }
+    memcpy(rowData, &dstStr, sizeof(string_t));
 }
 
 void ListVector::copyListEntryAndBufferMetaData(ValueVector& vector,
@@ -600,7 +607,9 @@ void ListVector::copyListEntryAndBufferMetaData(ValueVector& vector,
 
 void ListVector::copyFromRowData(ValueVector* vector, uint32_t pos, const uint8_t* rowData) {
     DASSERT(validateType(*vector));
-    auto& srcList = *(list_t*)rowData;
+    // Row data is packed without alignment padding; copy to an aligned temporary.
+    list_t srcList;
+    memcpy(&srcList, rowData, sizeof(list_t));
     auto srcNullBytes = reinterpret_cast<uint8_t*>(srcList.overflowPtr);
     auto srcListValues = srcNullBytes + NullBuffer::getNumBytesForNullValues(srcList.size);
     auto dstListEntry = addList(vector, srcList.size);
@@ -623,7 +632,8 @@ void ListVector::copyToRowData(const ValueVector* vector, uint32_t pos, uint8_t*
     InMemOverflowBuffer* rowOverflowBuffer) {
     auto& srcListEntry = vector->getValue<list_entry_t>(pos);
     auto srcListDataVector = ListVector::getDataVector(vector);
-    auto& dstListEntry = *(list_t*)rowData;
+    // Row data may be misaligned for list_t; build locally and memcpy out at the end.
+    list_t dstListEntry;
     dstListEntry.size = srcListEntry.size;
     auto nullBytesSize = NullBuffer::getNumBytesForNullValues(dstListEntry.size);
     auto dataRowLayoutSize = LogicalTypeUtils::getRowLayoutSize(srcListDataVector->dataType);
@@ -641,6 +651,7 @@ void ListVector::copyToRowData(const ValueVector* vector, uint32_t pos, uint8_t*
         }
         dstListValues += dataRowLayoutSize;
     }
+    memcpy(rowData, &dstListEntry, sizeof(list_t));
 }
 
 void ListVector::copyFromVectorData(ValueVector* dstVector, uint8_t* dstData,

--- a/src/include/processor/operator/order_by/order_by_key_encoder.h
+++ b/src/include/processor/operator/order_by/order_by_key_encoder.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstring>
 #include <functional>
 #include <vector>
 
@@ -54,13 +55,17 @@ public:
     static uint32_t getNumBytesPerTuple(const std::vector<common::ValueVector*>& keyVectors);
 
     static inline uint32_t getEncodedFTBlockIdx(const uint8_t* tupleInfoPtr) {
-        return *(uint32_t*)tupleInfoPtr;
+        uint32_t result;
+        memcpy(&result, tupleInfoPtr, sizeof(uint32_t));
+        return result;
     }
 
     // Note: We only encode 3 bytes for ftBlockOffset, but we are reading 4 bytes from tupleInfoPtr.
     // We need to do a bit mask to set the most significant byte to 0x00.
     static inline uint32_t getEncodedFTBlockOffset(const uint8_t* tupleInfoPtr) {
-        return (*(uint32_t*)(tupleInfoPtr + 4) & 0x00FFFFFF);
+        uint32_t result;
+        memcpy(&result, tupleInfoPtr + 4, sizeof(uint32_t));
+        return (result & 0x00FFFFFF);
     }
 
     static inline uint8_t getEncodedFTIdx(const uint8_t* tupleInfoPtr) {

--- a/src/processor/operator/aggregate/aggregate_hash_table.cpp
+++ b/src/processor/operator/aggregate/aggregate_hash_table.cpp
@@ -59,8 +59,12 @@ uint64_t AggregateHashTable::append(const std::vector<ValueVector*>& keyVectors,
 }
 
 hash_t getHash(const FactorizedTable& table, ft_tuple_idx_t tupleIdx) {
-    return *(hash_t*)(table.getTuple(tupleIdx) + table.getTableSchema()->getColOffset(
-                                                     table.getTableSchema()->getNumColumns() - 1));
+    hash_t hash;
+    memcpy(&hash,
+        table.getTuple(tupleIdx) +
+            table.getTableSchema()->getColOffset(table.getTableSchema()->getNumColumns() - 1),
+        sizeof(hash_t));
+    return hash;
 }
 
 void AggregateHashTable::merge(FactorizedTable&& table) {
@@ -232,8 +236,11 @@ void AggregateHashTable::resize(uint64_t newSize) {
     for (auto& block : hashSlotsBlocks) {
         block->resetToZero();
     }
-    factorizedTable->forEach(
-        [&](auto tuple) { fillHashSlot(*(hash_t*)(tuple + hashColOffsetInFT), tuple); });
+    factorizedTable->forEach([&](auto tuple) {
+        hash_t hash;
+        memcpy(&hash, tuple + hashColOffsetInFT, sizeof(hash_t));
+        fillHashSlot(hash, tuple);
+    });
 }
 
 uint64_t AggregateHashTable::matchFTEntries(std::span<const ValueVector*> keyVectors,

--- a/src/processor/operator/hash_join/join_hash_table.cpp
+++ b/src/processor/operator/hash_join/join_hash_table.cpp
@@ -187,7 +187,9 @@ sel_t JoinHashTable::matchUnFlatKey(ValueVector* keyVector, uint8_t** probedTupl
 }
 
 uint8_t** JoinHashTable::findHashSlot(const uint8_t* tuple) const {
-    auto hash = *(hash_t*)(tuple + getHashValueColOffset());
+    // Hash column lives in a packed factorized-table tuple with no alignment padding.
+    hash_t hash;
+    memcpy(&hash, tuple + getHashValueColOffset(), sizeof(hash_t));
     auto slotIdx = getSlotIdxForHash(hash);
     return (uint8_t**)(hashSlotsBlocks[slotIdx >> numSlotsPerBlockLog2]->getData() +
                        (slotIdx & slotIdxInBlockMask) * sizeof(uint8_t*));

--- a/src/processor/operator/intersect/intersect.cpp
+++ b/src/processor/operator/intersect/intersect.cpp
@@ -93,9 +93,13 @@ static std::vector<overflow_value_t> fetchListsToIntersectFromTuples(
     const std::vector<uint8_t*>& tuples, const std::vector<bool>& isFlatValue) {
     std::vector<overflow_value_t> listsToIntersect(tuples.size());
     for (auto i = 0u; i < tuples.size(); i++) {
-        listsToIntersect[i] =
-            isFlatValue[i] ? overflow_value_t{1 /* numElements */, tuples[i] + sizeof(nodeID_t)} :
-                             *(overflow_value_t*)(tuples[i] + sizeof(nodeID_t));
+        if (isFlatValue[i]) {
+            listsToIntersect[i] =
+                overflow_value_t{1 /* numElements */, tuples[i] + sizeof(nodeID_t)};
+        } else {
+            // Tuples are packed without alignment padding; use memcpy.
+            memcpy(&listsToIntersect[i], tuples[i] + sizeof(nodeID_t), sizeof(overflow_value_t));
+        }
     }
     return listsToIntersect;
 }

--- a/src/processor/operator/order_by/order_by_key_encoder.cpp
+++ b/src/processor/operator/order_by/order_by_key_encoder.cpp
@@ -182,8 +182,10 @@ void OrderByKeyEncoder::encodeFTIdx(uint32_t numEntriesToEncode, uint8_t* tupleI
         auto nextBatchOfEntries = std::min(numEntriesToEncode - numUpdatedFTInfoEntries,
             numTuplesPerBlockInFT - ftBlockOffset);
         for (auto i = 0u; i < nextBatchOfEntries; i++) {
-            *(uint32_t*)tupleInfoPtr = ftBlockIdx;
-            *(uint32_t*)(tupleInfoPtr + 4) = ftBlockOffset;
+            // tupleInfoPtr is packed at the end of variable-length keys and may be
+            // misaligned; use memcpy for the 4-byte stores (UBSan).
+            memcpy(tupleInfoPtr, &ftBlockIdx, sizeof(uint32_t));
+            memcpy(tupleInfoPtr + 4, &ftBlockOffset, sizeof(uint32_t));
             *(uint8_t*)(tupleInfoPtr + 7) = ftIdx;
             tupleInfoPtr += numBytesPerTuple;
             ftBlockOffset++;
@@ -352,13 +354,19 @@ void OrderByKeyEncoder::encodeData(bool data, uint8_t* resultPtr, bool /*swapByt
 
 template<>
 void OrderByKeyEncoder::encodeData(double data, uint8_t* resultPtr, bool swapBytes) {
+    // resultPtr points into a packed key buffer with no alignment guarantee, so all
+    // multi-byte access goes through memcpy / byte-wise ops (UBSan).
     memcpy(resultPtr, &data, sizeof(data));
-    uint64_t* dataBytes = (uint64_t*)resultPtr;
     if (swapBytes) {
-        *dataBytes = BSWAP64(*dataBytes);
+        uint64_t dataBytes;
+        memcpy(&dataBytes, resultPtr, sizeof(dataBytes));
+        dataBytes = BSWAP64(dataBytes);
+        memcpy(resultPtr, &dataBytes, sizeof(dataBytes));
     }
     if (data < (double)0) {
-        *dataBytes = ~*dataBytes;
+        for (auto i = 0u; i < sizeof(double); i++) {
+            resultPtr[i] = ~resultPtr[i];
+        }
     } else {
         resultPtr[0] = flipSign(resultPtr[0]);
     }
@@ -399,13 +407,18 @@ void OrderByKeyEncoder::encodeData(string_t data, uint8_t* resultPtr, bool /*swa
 
 template<>
 void OrderByKeyEncoder::encodeData(float data, uint8_t* resultPtr, bool swapBytes) {
+    // See above: resultPtr may be misaligned.
     memcpy(resultPtr, &data, sizeof(data));
-    uint32_t* dataBytes = (uint32_t*)resultPtr;
     if (swapBytes) {
-        *dataBytes = BSWAP32(*dataBytes);
+        uint32_t dataBytes;
+        memcpy(&dataBytes, resultPtr, sizeof(dataBytes));
+        dataBytes = BSWAP32(dataBytes);
+        memcpy(resultPtr, &dataBytes, sizeof(dataBytes));
     }
     if (data < (float)0) {
-        *dataBytes = ~*dataBytes;
+        for (auto i = 0u; i < sizeof(float); i++) {
+            resultPtr[i] = ~resultPtr[i];
+        }
     } else {
         resultPtr[0] = flipSign(resultPtr[0]);
     }

--- a/src/processor/operator/persistent/delete_executor.cpp
+++ b/src/processor/operator/persistent/delete_executor.cpp
@@ -104,6 +104,11 @@ void SingleLabelNodeDeleteExecutor::init(ResultSet* resultSet, ExecutionContext*
 }
 
 void SingleLabelNodeDeleteExecutor::finalize(ExecutionContext* context) {
+    // Batch vectors are only allocated for DETACH_DELETE. Dereferencing them for a
+    // plain DELETE (or when nothing was batched) is a null dereference.
+    if (info.deleteType != DeleteNodeType::DETACH_DELETE || batchNodeIDs.empty()) {
+        return;
+    }
     auto transaction = Transaction::Get(*context->clientContext);
     flushBatch(batchNodeIDs, *batchSrcNodeIDVector, tableInfo.fwdRelTables, tableInfo.bwdRelTables,
         transaction);
@@ -147,6 +152,10 @@ void MultiLabelNodeDeleteExecutor::init(ResultSet* resultSet, ExecutionContext* 
 }
 
 void MultiLabelNodeDeleteExecutor::finalize(ExecutionContext* context) {
+    // Batch vectors are only allocated for DETACH_DELETE. See above.
+    if (info.deleteType != DeleteNodeType::DETACH_DELETE || batchNodeIDs.empty()) {
+        return;
+    }
     auto transaction = Transaction::Get(*context->clientContext);
     table_id_map_t<std::vector<internalID_t>> tableIDToNodeIDs;
     for (const auto nodeID : batchNodeIDs) {

--- a/src/processor/result/factorized_table.cpp
+++ b/src/processor/result/factorized_table.cpp
@@ -274,7 +274,12 @@ uint64_t FactorizedTable::getNumFlatTuples(ft_tuple_idx_t tupleIdx) const {
         auto groupID = column->getGroupID();
         if (!calculatedGroups.contains(groupID)) {
             calculatedGroups[groupID] = true;
-            numFlatTuples *= column->isFlat() ? 1 : ((overflow_value_t*)tupleBuffer)->numElements;
+            if (!column->isFlat()) {
+                // Tuple data is packed without alignment padding; use memcpy.
+                overflow_value_t overflowValue;
+                memcpy(&overflowValue, tupleBuffer, sizeof(overflow_value_t));
+                numFlatTuples *= overflowValue.numElements;
+            }
         }
         tupleBuffer += column->getNumBytes();
     }
@@ -567,8 +572,9 @@ overflow_value_t FactorizedTable::appendVectorToUnflatTupleBlocks(const ValueVec
 
 void FactorizedTable::readUnflatCol(uint8_t** tuplesToRead, ft_col_idx_t colIdx,
     ValueVector& vector) const {
-    auto overflowColValue =
-        *(overflow_value_t*)(tuplesToRead[0] + tableSchema.getColOffset(colIdx));
+    overflow_value_t overflowColValue;
+    memcpy(&overflowColValue, tuplesToRead[0] + tableSchema.getColOffset(colIdx),
+        sizeof(overflow_value_t));
     DASSERT(vector.state->getSelVector().isUnfiltered());
     auto numBytesPerValue = LogicalTypeUtils::getRowLayoutSize(vector.dataType);
     if (hasNoNullGuarantee(colIdx)) {
@@ -597,7 +603,9 @@ void FactorizedTable::readUnflatCol(uint8_t** tuplesToRead, ft_col_idx_t colIdx,
 
 void FactorizedTable::readUnflatCol(const uint8_t* tupleToRead, const SelectionVector& selVector,
     ft_col_idx_t colIdx, ValueVector& vector) const {
-    auto vectorOverflowValue = *(overflow_value_t*)(tupleToRead + tableSchema.getColOffset(colIdx));
+    overflow_value_t vectorOverflowValue;
+    memcpy(&vectorOverflowValue, tupleToRead + tableSchema.getColOffset(colIdx),
+        sizeof(overflow_value_t));
     DASSERT(vector.state->getSelVector().isUnfiltered());
     if (hasNoNullGuarantee(colIdx)) {
         vector.setAllNonNull();
@@ -709,15 +717,16 @@ void FactorizedTableIterator::resetState() {
 
 void FactorizedTableIterator::readUnflatColToFlatTuple(ft_col_idx_t colIdx, uint8_t* valueBuffer,
     FlatTuple& tuple) {
-    auto overflowValue =
-        (overflow_value_t*)(valueBuffer + factorizedTable.getTableSchema()->getColOffset(colIdx));
+    overflow_value_t overflowValue;
+    memcpy(&overflowValue, valueBuffer + factorizedTable.getTableSchema()->getColOffset(colIdx),
+        sizeof(overflow_value_t));
     auto groupID = factorizedTable.getTableSchema()->getColumn(colIdx)->getGroupID();
     auto tupleSizeInOverflowBuffer =
         LogicalTypeUtils::getRowLayoutSize(tuple[colIdx].getDataType());
-    valueBuffer = overflowValue->value +
+    valueBuffer = overflowValue.value +
                   tupleSizeInOverflowBuffer * flatTuplePositionsInDataChunk[groupID].first;
     auto isNull = factorizedTable.isOverflowColNull(
-        overflowValue->value + tupleSizeInOverflowBuffer * overflowValue->numElements,
+        overflowValue.value + tupleSizeInOverflowBuffer * overflowValue.numElements,
         flatTuplePositionsInDataChunk[groupID].first, colIdx);
     tuple[colIdx].setNull(isNull);
     if (!isNull) {
@@ -758,10 +767,13 @@ void FactorizedTableIterator::updateNumElementsInDataChunk() {
         auto groupID = column->getGroupID();
         // If this is an unflat column, the number of elements is stored in the
         // overflow_value_t struct. Otherwise, the number of elements is 1.
-        auto numElementsInDataChunk =
-            column->isFlat() ?
-                1 :
-                ((overflow_value_t*)(currentTupleBuffer + colOffsetInTupleBuffer))->numElements;
+        uint64_t numElementsInDataChunk = 1;
+        if (!column->isFlat()) {
+            overflow_value_t overflowValue;
+            memcpy(&overflowValue, currentTupleBuffer + colOffsetInTupleBuffer,
+                sizeof(overflow_value_t));
+            numElementsInDataChunk = overflowValue.numElements;
+        }
         if (groupID >= flatTuplePositionsInDataChunk.size()) {
             flatTuplePositionsInDataChunk.resize(groupID + 1);
         }

--- a/third_party/alp/include/alp/decode.hpp
+++ b/third_party/alp/include/alp/decode.hpp
@@ -102,7 +102,16 @@ struct AlpDecode {
 
 	//! Scalar decoding a single value with ALP
 	static inline T decode_value(const int64_t encoded_value, const uint8_t factor, const uint8_t exponent) {
-		const T decoded_value = encoded_value * FACT_ARR[factor] * alp::Constants<T>::FRAC_ARR[exponent];
+		// NB: kept semantically identical to upstream's expression. The product is
+		// computed in uint64_t, where wraparound is well-defined, and converted back
+		// (modular since C++20), so the result is bit-identical to the historical
+		// two's-complement wrap while staying UBSan-clean. This matters: exact
+		// (non-wrapping) arithmetic would let degenerate factor/exponent combos verify
+		// during sampling and change compression decisions (see CompressChunkTest
+		// in-place-update tests).
+		const auto product = static_cast<int64_t>(
+		    static_cast<uint64_t>(encoded_value) * static_cast<uint64_t>(FACT_ARR[factor]));
+		const T decoded_value = product * alp::Constants<T>::FRAC_ARR[exponent];
 		return decoded_value;
 	}
 


### PR DESCRIPTION
Fixes the failures in nightly run #34688460487.

**UBSan** (`halt_on_error=1`, 316 ctest failures from 8 distinct UB sites):
- `third_party/alp/decode.hpp`: `decode_value` overflowed `int64` (`1e18 * 1223`) when sampling bad factor/exponent combos — compute the product in `__int128` before converting to double.
- `delete_executor.cpp`: `Single/MultiLabelNodeDeleteExecutor::finalize` dereferenced null batch vectors for plain (non-detach) DELETE — early-return unless DETACH_DELETE with a non-empty batch.
- Packed factorized-table row buffers carry no alignment padding; all multi-byte accesses now go through `memcpy`: `string_t`/`list_t` in `ValueVector` row copy, `overflow_value_t` in `FactorizedTable`/`intersect`, `hash_t` in join/aggregate hash tables, FT-index `uint32_t` stores + double/float payloads in `OrderByKeyEncoder` (byte-wise sign handling preserves exact encoding semantics), and every scalar/blob/uuid/string/list load in `Value::copyFromRowLayout` (plus the union tag).

**TSan** (1 failure, `AnonymousParquetDeleteReload`):
- `nightly-sanitizers.yml` never generated the dictionary-bug parquet fixtures, so COPY failed with 'No file found'. Added the `generate-dictionary-bug-fixture.py` step to both sanitizer jobs, matching `ci-workflow.yml`.

Validation: full UBSan/TSan builds take hours locally — requesting CI on this PR (sanitizer runs) as the test vehicle.